### PR TITLE
support database as file

### DIFF
--- a/cmd/perses/main.go
+++ b/cmd/perses/main.go
@@ -41,13 +41,15 @@ The secure way to configure your monitoring.               <\
 
 func main() {
 	configFile := flag.String("config", "", "Path to the yaml configuration file for the api. Configuration can be overridden when using the environment variable")
+	dbFolder := flag.String("db.folder", "", "Path to the folder that would be used as a database. In case the flag is not used, Perses required to have a connection to ETCD")
+	dbExtension := flag.String("db.extension", "yaml", "The extension of the file to read and use when creating a file. yaml or json are the only value accepted")
 	flag.Parse()
 	// load the config from file or/and from environment
-	conf, err := config.Resolve(*configFile)
+	conf, err := config.Resolve(*configFile, *dbFolder, *dbExtension)
 	if err != nil {
 		logrus.WithError(err).Fatalf("error when reading configuration or from file '%s' or from environment", *configFile)
 	}
-	persistenceManager, err := dependency.NewPersistenceManager(*conf.Etcd)
+	persistenceManager, err := dependency.NewPersistenceManager(conf.Database)
 	if err != nil {
 		logrus.WithError(err).Fatal("unable to instantiate the persistent manager")
 	}

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,6 +1,7 @@
-etcd:
-  protocol: "http"
-  request_timeout: 10
-  connections:
-    - host: 0.0.0.0
-      port: 2379
+database:
+  etcd:
+    protocol: "http"
+    request_timeout: 10
+    connections:
+      - host: 0.0.0.0
+        port: 2379

--- a/internal/api/e2e/project_test.go
+++ b/internal/api/e2e/project_test.go
@@ -36,7 +36,7 @@ func TestCreateProject(t *testing.T) {
 		},
 	}
 
-	server, persistenceManager := utils.CreateServer(t)
+	server, persistenceManager, etcdClient := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -51,7 +51,7 @@ func TestCreateProject(t *testing.T) {
 	// check the document exists in the db
 	_, err := persistenceManager.GetProject().Get(project.Metadata.Name)
 	assert.NoError(t, err)
-	utils.ClearAllKeys(t, persistenceManager.GetETCDClient())
+	utils.ClearAllKeys(t, etcdClient)
 }
 
 func TestCreateProjectWithConflict(t *testing.T) {
@@ -62,7 +62,7 @@ func TestCreateProjectWithConflict(t *testing.T) {
 		},
 	}
 
-	server, persistenceManager := utils.CreateServer(t)
+	server, _, etcdClient := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -81,13 +81,13 @@ func TestCreateProjectWithConflict(t *testing.T) {
 		Expect().
 		Status(http.StatusConflict)
 
-	utils.ClearAllKeys(t, persistenceManager.GetETCDClient())
+	utils.ClearAllKeys(t, etcdClient)
 }
 
 func TestCreateProjectBadRequest(t *testing.T) {
 	project := &v1.Project{Kind: v1.KindProject}
 
-	server, _ := utils.CreateServer(t)
+	server, _, _ := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -109,7 +109,7 @@ func TestUpdateProject(t *testing.T) {
 		},
 	}
 
-	server, persistenceManager := utils.CreateServer(t)
+	server, persistenceManager, etcdClient := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -147,7 +147,7 @@ func TestUpdateProject(t *testing.T) {
 	_, err = persistenceManager.GetProject().Get(project.Metadata.Name)
 	assert.NoError(t, err)
 
-	utils.ClearAllKeys(t, persistenceManager.GetETCDClient())
+	utils.ClearAllKeys(t, etcdClient)
 }
 
 func TestUpdateProjectNotFound(t *testing.T) {
@@ -157,7 +157,7 @@ func TestUpdateProjectNotFound(t *testing.T) {
 			Name: "perses",
 		},
 	}
-	server, persistenceManager := utils.CreateServer(t)
+	server, _, etcdClient := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -169,7 +169,7 @@ func TestUpdateProjectNotFound(t *testing.T) {
 		Expect().
 		Status(http.StatusNotFound)
 
-	utils.ClearAllKeys(t, persistenceManager.GetETCDClient())
+	utils.ClearAllKeys(t, etcdClient)
 }
 
 func TestUpdateProjectBadRequest(t *testing.T) {
@@ -179,7 +179,7 @@ func TestUpdateProjectBadRequest(t *testing.T) {
 			Name: "perses",
 		},
 	}
-	server, persistenceManager := utils.CreateServer(t)
+	server, _, etcdClient := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -192,7 +192,7 @@ func TestUpdateProjectBadRequest(t *testing.T) {
 		Expect().
 		Status(http.StatusBadRequest)
 
-	utils.ClearAllKeys(t, persistenceManager.GetETCDClient())
+	utils.ClearAllKeys(t, etcdClient)
 }
 
 func TestGetProject(t *testing.T) {
@@ -202,7 +202,7 @@ func TestGetProject(t *testing.T) {
 			Name: "perses",
 		},
 	}
-	server, persistenceManager := utils.CreateServer(t)
+	server, _, etcdClient := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -218,11 +218,11 @@ func TestGetProject(t *testing.T) {
 		Expect().
 		Status(http.StatusOK)
 
-	utils.ClearAllKeys(t, persistenceManager.GetETCDClient())
+	utils.ClearAllKeys(t, etcdClient)
 }
 
 func TestGetProjectNotFound(t *testing.T) {
-	server, _ := utils.CreateServer(t)
+	server, _, _ := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -241,7 +241,7 @@ func TestDeleteProject(t *testing.T) {
 			Name: "perses",
 		},
 	}
-	server, _ := utils.CreateServer(t)
+	server, _, _ := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -259,7 +259,7 @@ func TestDeleteProject(t *testing.T) {
 }
 
 func TestDeleteProjectNotFound(t *testing.T) {
-	server, _ := utils.CreateServer(t)
+	server, _, _ := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
@@ -278,7 +278,7 @@ func TestListProject(t *testing.T) {
 			Name: "perses",
 		},
 	}
-	server, _ := utils.CreateServer(t)
+	server, _, _ := utils.CreateServer(t)
 	defer server.Close()
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,

--- a/internal/api/generate.go
+++ b/internal/api/generate.go
@@ -192,23 +192,21 @@ type Service interface {
 package {{ $package }}
 
 import (
-	"time"
-
 	"github.com/perses/common/etcd"
 	"github.com/perses/perses/internal/api/interface/v1/{{ $package }}"
+	"github.com/perses/perses/internal/api/shared/database"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type dao struct {
 	{{ $package }}.DAO
-	client etcd.DAO
+	client database.DAO
 }
 
-func NewDAO(etcdClient *clientv3.Client, timeout time.Duration) {{ $package }}.DAO {
+func NewDAO(persesDAO database.DAO) {{ $package }}.DAO {
 	client := etcd.NewDAO(etcdClient, timeout)
 	return &dao{
-		client: client,
+		client: persesDAO,
 	}
 }
 
@@ -418,7 +416,6 @@ func generateFile(folder string, fileName string, tpl *template.Template, ept en
 	if !shouldOverride {
 		// only generate the file if it doesn't exist
 		if _, err := os.Stat(file); err == nil {
-			log.Printf("%s already exists, it won't override it\n", file)
 			return
 		}
 	}

--- a/internal/api/impl/v1/dashboard/persistence.go
+++ b/internal/api/impl/v1/dashboard/persistence.go
@@ -14,23 +14,20 @@
 package dashboard
 
 import (
-	"time"
-
 	"github.com/perses/common/etcd"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
+	"github.com/perses/perses/internal/api/shared/database"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type dao struct {
 	dashboard.DAO
-	client etcd.DAO
+	client database.DAO
 }
 
-func NewDAO(etcdClient *clientv3.Client, timeout time.Duration) dashboard.DAO {
-	client := etcd.NewDAO(etcdClient, timeout)
+func NewDAO(persesDAO database.DAO) dashboard.DAO {
 	return &dao{
-		client: client,
+		client: persesDAO,
 	}
 }
 

--- a/internal/api/impl/v1/dashboard/service.go
+++ b/internal/api/impl/v1/dashboard/service.go
@@ -59,7 +59,7 @@ func (s *service) create(entity *v1.Dashboard) (*v1.Dashboard, error) {
 			logrus.Debugf("unable to create the dashboard '%s'. It already exits", entity.Metadata.Name)
 			return nil, shared.ConflictError
 		}
-		logrus.WithError(err).Errorf("unable to perform the creation of the prometheuRule '%s', something wrong with etcd", entity.Metadata.Name)
+		logrus.WithError(err).Errorf("unable to perform the creation of the prometheuRule '%s', something wrong with the database", entity.Metadata.Name)
 		return nil, shared.InternalError
 	}
 	return entity, nil
@@ -98,7 +98,7 @@ func (s *service) update(entity *v1.Dashboard, parameters shared.Parameters) (*v
 	// update the field UpdatedAt with the new time
 	entity.Metadata.UpdatedAt = time.Now().UTC()
 	if err := s.dao.Update(entity); err != nil {
-		logrus.WithError(err).Errorf("unable to perform the update of the dashboard '%s', something wrong with etcd", entity.Metadata.Name)
+		logrus.WithError(err).Errorf("unable to perform the update of the dashboard '%s', something wrong with the database", entity.Metadata.Name)
 		return nil, shared.InternalError
 	}
 	return entity, nil
@@ -110,7 +110,7 @@ func (s *service) Delete(parameters shared.Parameters) error {
 			logrus.Debugf("unable to find the project '%s'", parameters.Name)
 			return shared.NotFoundError
 		}
-		logrus.WithError(err).Errorf("unable to delete the project '%s', something wrong with etcd", parameters.Name)
+		logrus.WithError(err).Errorf("unable to delete the project '%s', something wrong with the database", parameters.Name)
 		return shared.InternalError
 	}
 	return nil
@@ -123,7 +123,7 @@ func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
 			logrus.Debugf("unable to find the project '%s'", parameters.Name)
 			return nil, shared.NotFoundError
 		}
-		logrus.WithError(err).Errorf("unable to find the previous version of the project '%s', something wrong with etcd", parameters.Name)
+		logrus.WithError(err).Errorf("unable to find the previous version of the project '%s', something wrong with the database", parameters.Name)
 		return nil, shared.InternalError
 	}
 	return entity, nil

--- a/internal/api/impl/v1/datasource/persistence.go
+++ b/internal/api/impl/v1/datasource/persistence.go
@@ -14,23 +14,20 @@
 package datasource
 
 import (
-	"time"
-
 	"github.com/perses/common/etcd"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
+	"github.com/perses/perses/internal/api/shared/database"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type dao struct {
 	datasource.DAO
-	client etcd.DAO
+	client database.DAO
 }
 
-func NewDAO(etcdClient *clientv3.Client, timeout time.Duration) datasource.DAO {
-	client := etcd.NewDAO(etcdClient, timeout)
+func NewDAO(persesDAO database.DAO) datasource.DAO {
 	return &dao{
-		client: client,
+		client: persesDAO,
 	}
 }
 

--- a/internal/api/impl/v1/project/persistence.go
+++ b/internal/api/impl/v1/project/persistence.go
@@ -14,23 +14,20 @@
 package project
 
 import (
-	"time"
-
 	"github.com/perses/common/etcd"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/internal/api/shared/database"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type dao struct {
 	project.DAO
-	client etcd.DAO
+	client database.DAO
 }
 
-func NewDAO(etcdClient *clientv3.Client, timeout time.Duration) project.DAO {
-	client := etcd.NewDAO(etcdClient, timeout)
+func NewDAO(persesDAO database.DAO) project.DAO {
 	return &dao{
-		client: client,
+		client: persesDAO,
 	}
 }
 

--- a/internal/api/impl/v1/prometheusrule/persistence.go
+++ b/internal/api/impl/v1/prometheusrule/persistence.go
@@ -14,23 +14,20 @@
 package prometheusrule
 
 import (
-	"time"
-
 	"github.com/perses/common/etcd"
 	"github.com/perses/perses/internal/api/interface/v1/prometheusrule"
+	"github.com/perses/perses/internal/api/shared/database"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type dao struct {
 	prometheusrule.DAO
-	client etcd.DAO
+	client database.DAO
 }
 
-func NewDAO(etcdClient *clientv3.Client, timeout time.Duration) prometheusrule.DAO {
-	client := etcd.NewDAO(etcdClient, timeout)
+func NewDAO(persesDAO database.DAO) prometheusrule.DAO {
 	return &dao{
-		client: client,
+		client: persesDAO,
 	}
 }
 

--- a/internal/api/impl/v1/user/persistence.go
+++ b/internal/api/impl/v1/user/persistence.go
@@ -14,23 +14,20 @@
 package user
 
 import (
-	"time"
-
 	"github.com/perses/common/etcd"
 	"github.com/perses/perses/internal/api/interface/v1/user"
+	"github.com/perses/perses/internal/api/shared/database"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type dao struct {
 	user.DAO
-	client etcd.DAO
+	client database.DAO
 }
 
-func NewDAO(etcdClient *clientv3.Client, timeout time.Duration) user.DAO {
-	client := etcd.NewDAO(etcdClient, timeout)
+func NewDAO(persesDAO database.DAO) user.DAO {
 	return &dao{
-		client: client,
+		client: persesDAO,
 	}
 }
 

--- a/internal/api/shared/database/dao.go
+++ b/internal/api/shared/database/dao.go
@@ -1,0 +1,238 @@
+// Copyright 2021 Amadeus s.a.s
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/perses/common/etcd"
+	"github.com/perses/perses/internal/config"
+	"gopkg.in/yaml.v2"
+)
+
+type DAO interface {
+	Create(key string, entity interface{}) error
+	Upsert(key string, entity interface{}) error
+	Get(key string, entity interface{}) error
+	Query(query etcd.Query, slice interface{}) error
+	Delete(key string) error
+}
+
+func New(conf config.Database) (DAO, error) {
+	if conf.Etcd != nil {
+		timeout := time.Duration(conf.Etcd.RequestTimeoutSeconds) * time.Second
+		etcdClient, err := etcd.NewETCDClient(*conf.Etcd)
+		if err != nil {
+			return nil, err
+		}
+		return etcd.NewDAO(etcdClient, timeout), nil
+	}
+	if conf.File != nil {
+		return &fileDAO{
+			folder:    conf.File.Folder,
+			extension: conf.File.FileExtension,
+		}, nil
+	}
+	return nil, fmt.Errorf("no dao defined")
+}
+
+type fileDAO struct {
+	DAO
+	folder    string
+	extension config.FileExtension
+}
+
+func (d *fileDAO) Create(key string, entity interface{}) error {
+	filePath := d.buildPath(key)
+	if _, err := os.Stat(filePath); err == nil {
+		// The file exists, so we should return a conflict error.
+		// Let's use the etcd error so the caller doesn't have to handle multiple different kind of error
+		// It's an easy hack let's say, but a bit crappy. We should probably at some point defined a higher error to wrap the one coming from the package etcd.
+		return &etcd.Error{Key: key, Code: etcd.ErrorCodeKeyConflict}
+	}
+	return d.Upsert(key, entity)
+}
+func (d *fileDAO) Upsert(key string, entity interface{}) error {
+	filePath := d.buildPath(key)
+	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	var data []byte
+	data, err = d.marshal(entity)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	return file.Sync()
+}
+func (d *fileDAO) Get(key string, entity interface{}) error {
+	filePath := d.buildPath(key)
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &etcd.Error{Key: key, Code: etcd.ErrorCodeKeyNotFound}
+		}
+		return err
+	}
+	return d.unmarshal(data, entity)
+}
+func (d *fileDAO) Query(query etcd.Query, slice interface{}) error {
+	typeParameter := reflect.TypeOf(slice)
+	result := reflect.ValueOf(slice)
+	// to avoid any miss usage when using this method, slice should be a pointer to a slice.
+	// first check if slice is a pointer
+	if typeParameter.Kind() != reflect.Ptr {
+		return fmt.Errorf("slice in parameter is not a pointer to a slice but a '%s'", typeParameter.Kind())
+	}
+
+	// it's a pointer, so move to the actual element behind the pointer.
+	// Having a pointer avoid to get the error:
+	//           reflect.Value.Set using unaddressable value
+	// It's because the slice is usually not initialized and doesn't have any memory allocated.
+	// So it's simpler to required a pointer at the beginning.
+	sliceElem := result.Elem()
+	typeParameter = typeParameter.Elem()
+
+	if typeParameter.Kind() != reflect.Slice {
+		return fmt.Errorf("slice in parameter is not actually a slice but a '%s'", typeParameter.Kind())
+	}
+	q, err := query.Build()
+	if err != nil {
+		return fmt.Errorf("unable to build the query: %s", err)
+	}
+	// the query returned looks like a path and can finish with a partial name.
+	// So we have to figure if the last path is the actual directory to looking for.
+	// Or it's the partial name and it should only be used to filter the list of the document.
+	// For example: `/projects/per`.
+	// `/projects` is the folder we are looking for, `per` is the partial name.
+	folder := path.Join(d.folder, q)
+	prefix := ""
+	// An easy way to achieve is to:
+	// 1. try if the path exist with the given query.
+	if _, err = os.Stat(folder); os.IsNotExist(err) {
+		// The path doesn't exist. So we certainly have to move to the parent path.
+		prefix = filepath.Base(folder)
+		folder = filepath.Dir(folder)
+		// Let's try again if the path exists this time.
+		if _, err = os.Stat(folder); os.IsNotExist(err) {
+			// worst case, there is nothing to return. So let's initialize the slice just to avoid to return a nil slice
+			sliceElem = reflect.MakeSlice(typeParameter, 0, 0)
+			//and finally reset the element of the slice to ensure we didn't disconnect the link between the pointer to the slice and the actual slice
+			result.Elem().Set(sliceElem)
+			return nil
+		}
+	}
+	// so now we have the proper folder to looking for and potentially a filter to use
+	var files []string
+	if err = d.visit(&files, folder, prefix); err != nil {
+		return err
+	}
+	if len(files) <= 0 {
+		// in case the result is empty, let's initialize the slice just to avoid to return a nil slice
+		sliceElem = reflect.MakeSlice(typeParameter, 0, 0)
+	}
+	for _, file := range files {
+		// now read all file and append them to the final result
+		data, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", folder, file))
+		if err != nil {
+			return err
+		}
+		// first create a pointer with the accurate type
+		var value reflect.Value
+		if typeParameter.Elem().Kind() != reflect.Ptr {
+			value = reflect.New(typeParameter.Elem())
+		} else {
+			// in case it's a pointer, then we should create a pointer of the struct and not a pointer of a pointer
+			value = reflect.New(typeParameter.Elem().Elem())
+		}
+		// then get back the actual struct behind the value.
+		obj := value.Interface()
+		if err := d.unmarshal(data, obj); err != nil {
+			return err
+		}
+		sliceElem.Set(reflect.Append(sliceElem, value))
+	}
+	// at the end reset the element of the slice to ensure we didn't disconnect the link between the pointer to the slice and the actual slice
+	result.Elem().Set(sliceElem)
+	return nil
+}
+func (d *fileDAO) Delete(key string) error {
+	filePath := d.buildPath(key)
+	err := os.Remove(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &etcd.Error{Key: key, Code: etcd.ErrorCodeKeyNotFound}
+		}
+		return err
+	}
+	return nil
+}
+
+func (d *fileDAO) buildPath(key string) string {
+	return path.Join(d.folder, fmt.Sprintf("%s.%s", key, d.extension))
+}
+
+func (d *fileDAO) unmarshal(data []byte, entity interface{}) error {
+	if d.extension == config.JSONExtension {
+		return json.Unmarshal(data, entity)
+	}
+	return yaml.Unmarshal(data, entity)
+}
+
+func (d *fileDAO) marshal(entity interface{}) ([]byte, error) {
+	if d.extension == config.JSONExtension {
+		return json.Marshal(entity)
+	}
+	return yaml.Marshal(entity)
+}
+
+func (d *fileDAO) visit(files *[]string, path string, prefix string) error {
+	filesInfo, err := ioutil.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, info := range filesInfo {
+		if info.IsDir() {
+			// we are not interested by a folder and it would be weird to have a folder actually.
+			// So let's skip it
+			return nil
+		}
+		file := info.Name()
+		if filepath.Ext(file) != fmt.Sprintf(".%s", d.extension) {
+			// skip every file that doesn't have the correct extension
+			return nil
+		}
+
+		if len(prefix) == 0 || strings.HasPrefix(file, prefix) {
+			*files = append(*files, file)
+		}
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,11 +18,17 @@ import (
 )
 
 type Config struct {
-	Etcd *config.EtcdConfig `yaml:"etcd"`
+	Database Database `yaml:"database"`
 }
 
-func Resolve(configFile string) (Config, error) {
+func Resolve(configFile string, dbFolder string, dbExtension string) (Config, error) {
 	c := Config{}
+	if len(dbFolder) > 0 {
+		c.Database.File = &File{
+			Folder:        dbFolder,
+			FileExtension: FileExtension(dbExtension),
+		}
+	}
 	return c, config.NewResolver().
 		SetConfigFile(configFile).
 		SetEnvPrefix("PERSES").

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Amadeus s.a.s
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/perses/common/config"
+)
+
+type FileExtension string
+
+const (
+	YAMLExtension FileExtension = "yaml"
+	JSONExtension FileExtension = "json"
+)
+
+type File struct {
+	Folder        string        `yaml:"folder"`
+	FileExtension FileExtension `yaml:"file_extension"`
+}
+
+func (f *File) Verify() error {
+	if len(f.FileExtension) == 0 {
+		f.FileExtension = YAMLExtension
+	}
+	if f.FileExtension != YAMLExtension && f.FileExtension != JSONExtension {
+		return fmt.Errorf("wrong file extension defined when using the filesystem as a database. You can only define json or yaml")
+	}
+	return nil
+}
+
+type Database struct {
+	File *File              `yaml:"file,omitempty"`
+	Etcd *config.EtcdConfig `yaml:"etcd,omitempty"`
+}
+
+func (d *Database) Verify() error {
+	if d.File == nil && d.Etcd == nil {
+		return fmt.Errorf("you must specify if Perses has to use ETCD or filesystem as a database")
+	}
+	if d.File != nil && d.Etcd != nil {
+		return fmt.Errorf("you cannot tel to Perses to use ETCD and the filesystem at the same time")
+	}
+	return nil
+}


### PR DESCRIPTION
It doesn't change so many things, it just use the filesystem instead of etcd.
Not sure about the flags yet. But at least for the moment it's enough.

Supporting filesystem as a database will ease the " As code" and it will provide a local web editor of the prometheusRules / Dashboard.

Basically a developer that is going to change his dashboard in his git repository, he will be able to launch the `perses` binary and use the UI + API to modify locally his dashboard.

/cc @celian-garcia and @AntoineThebaud. I don't expect it impacts something on your side, it's more to let you know about it.