### PR TITLE
Implement the layout on the backend side

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -58,6 +58,25 @@
             ]
           }
         }
+      },
+      "layouts": {
+        "main": {
+          "kind": "Expand",
+          "parameter": {
+            "open": true,
+            "children": [
+              {
+                "$ref": "#/spec/panels/upByLabel"
+              },
+              {
+                "$ref": "#/spec/panels/allUP"
+              }
+            ]
+          }
+        }
+      },
+      "entrypoint": {
+        "$ref": "#/spec/layouts/main"
       }
     }
   },
@@ -104,7 +123,7 @@
             "expr": "(((count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode='idle',instance=\"$node\",job=\"$job\"}[5m])))) * 100) / count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu))"
           }
         },
-        "SysLoad5mAVG)": {
+        "SysLoad5mAVG": {
           "kind": "GaugeChart",
           "displayed_name": "Sys Load (5m avg)",
           "chart": {
@@ -139,6 +158,37 @@
             "expr": "100 - ((node_filesystem_avail_bytes{instance=\"$node\",job=\"$job\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{instance=\"$node\",job=\"$job\",mountpoint=\"/\",fstype!=\"rootfs\"})"
           }
         }
+      },
+      "layouts": {
+        "main": {
+          "kind": "Expand",
+          "parameter": {
+            "open": true,
+            "children": [
+              {
+                "$ref": "#/spec/panels/CPUBusy"
+              },
+              {
+                "$ref": "#/spec/panels/SysLoad5mAVG"
+              },
+              {
+                "$ref": "#/spec/panels/SysLoad15mAVG"
+              },
+              {
+                "$ref": "#/spec/panels/RamUsed"
+              },
+              {
+                "$ref": "#/spec/panels/SwapUsed"
+              },
+              {
+                "$ref": "#/spec/panels/RootFSUsed"
+              }
+            ]
+          }
+        }
+      },
+      "entrypoint": {
+        "$ref": "#/spec/layouts/main"
       }
     }
   }

--- a/pkg/model/api/v1/dashboard_layout.go
+++ b/pkg/model/api/v1/dashboard_layout.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+type LayoutKind string
+
+const (
+	KindExpandLayout LayoutKind = "Expand"
+	KindGridLayout   LayoutKind = "Grid"
+)
+
+var layoutKindMap = map[LayoutKind]bool{
+	KindExpandLayout: true,
+	KindGridLayout:   true,
+}
+
+func (k *LayoutKind) UnmarshalJSON(data []byte) error {
+	var tmp LayoutKind
+	type plain LayoutKind
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*k = tmp
+	return nil
+}
+
+func (k *LayoutKind) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp LayoutKind
+	type plain LayoutKind
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*k = tmp
+	return nil
+}
+
+func (k *LayoutKind) validate() error {
+	if len(*k) == 0 {
+		return fmt.Errorf("layout.kind cannot be empty")
+	}
+	if _, ok := layoutKindMap[*k]; !ok {
+		return fmt.Errorf("unknown layout.kind '%s' used", *k)
+	}
+	return nil
+}
+
+type LayoutParameter interface {
+}
+
+type ExpandLayoutParameter struct {
+	LayoutParameter `json:"-" yaml:"-"`
+	Open            bool       `json:"open" yaml:"open"`
+	Children        []*JSONRef `json:"children" yaml:"children"`
+}
+
+type GridCell struct {
+	Width   uint     `json:"width" yaml:"width"`
+	Content *JSONRef `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+type GridLayoutParameter struct {
+	LayoutParameter `json:"-" yaml:"-"`
+	Children        [][]GridCell `json:"children" yaml:"children"`
+}
+
+type tmpDashboardLayout struct {
+	Kind      LayoutKind             `json:"kind" yaml:"kind"`
+	Parameter map[string]interface{} `json:"parameter" yaml:"parameter"`
+}
+
+type DashboardLayout struct {
+	Kind      LayoutKind      `json:"kind" yaml:"kind"`
+	Parameter LayoutParameter `json:"parameter" yaml:"parameter"`
+}
+
+func (d *DashboardLayout) UnmarshalJSON(data []byte) error {
+	jsonUnmarshalFunc := func(panel interface{}) error {
+		return json.Unmarshal(data, panel)
+	}
+	return d.unmarshal(jsonUnmarshalFunc, json.Marshal, json.Unmarshal)
+}
+
+func (d *DashboardLayout) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return d.unmarshal(unmarshal, yaml.Marshal, yaml.Unmarshal)
+}
+
+func (d *DashboardLayout) unmarshal(unmarshal func(interface{}) error, staticMarshal func(interface{}) ([]byte, error), staticUnmarshal func([]byte, interface{}) error) error {
+	var tmpLayout tmpDashboardLayout
+	if err := unmarshal(&tmpLayout); err != nil {
+		return err
+	}
+	d.Kind = tmpLayout.Kind
+
+	if len(tmpLayout.Kind) == 0 {
+		return fmt.Errorf("variable.kind cannot be empty")
+	}
+
+	rawParameter, err := staticMarshal(tmpLayout.Parameter)
+	if err != nil {
+		return err
+	}
+	var parameter interface{}
+	switch tmpLayout.Kind {
+	case KindGridLayout:
+		parameter = &GridLayoutParameter{}
+	case KindExpandLayout:
+		parameter = &ExpandLayoutParameter{}
+	}
+	if err := staticUnmarshal(rawParameter, parameter); err != nil {
+		return err
+	}
+	d.Parameter = parameter
+	return nil
+}

--- a/pkg/model/api/v1/dashboard_layout_test.go
+++ b/pkg/model/api/v1/dashboard_layout_test.go
@@ -1,0 +1,207 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestUnmarshallJSONLayout(t *testing.T) {
+	testSuite := []struct {
+		title  string
+		jason  string
+		result DashboardLayout
+	}{
+		{
+			title: "grid layout",
+			jason: `
+{
+  "kind": "Grid",
+  "parameter": {
+    "children": [
+      [
+        {
+          "width": 1
+        },
+        {
+          "width": 1,
+          "content": {
+            "$ref": "#/panels/cpu"
+          }
+        }
+      ],
+      [
+        {
+          "width": 1,
+          "content": {
+            "$ref": "#/panels/load"
+          }
+        },
+        {
+          "width": 1
+        }
+      ]
+    ]
+  }
+}
+`,
+			result: DashboardLayout{
+				Kind: KindGridLayout,
+				Parameter: &GridLayoutParameter{
+					Children: [][]GridCell{
+						{
+							{
+								Width:   1,
+								Content: nil,
+							},
+							{
+								Width: 1,
+								Content: &JSONRef{
+									Ref:  "#/panels/cpu",
+									Path: []string{"panels", "cpu"},
+								},
+							},
+						},
+						{
+							{
+								Width: 1,
+								Content: &JSONRef{
+									Ref:  "#/panels/load",
+									Path: []string{"panels", "load"},
+								},
+							},
+							{
+								Width: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "expand layout",
+			jason: `
+{
+  "kind": "Expand",
+  "parameter": {
+    "open": true,
+    "children": [
+      {
+        "$ref": "#/layouts/mainGrid"
+      }
+    ]
+  }
+}
+`,
+			result: DashboardLayout{
+				Kind: KindExpandLayout,
+				Parameter: &ExpandLayoutParameter{
+					Open: true,
+					Children: []*JSONRef{
+						{
+							Ref:    "#/layouts/mainGrid",
+							Path:   []string{"layouts", "mainGrid"},
+							Object: nil,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := DashboardLayout{}
+			assert.NoError(t, json.Unmarshal([]byte(test.jason), &result))
+			assert.Equal(t, test.result, result)
+		})
+	}
+}
+
+func TestUnmarshallYAMLLayout(t *testing.T) {
+	testSuite := []struct {
+		title  string
+		yamele string
+		result DashboardLayout
+	}{
+		{
+			title: "grid layout",
+			yamele: `
+kind: "Grid"
+parameter:
+  children:
+  - - width: 1
+    - width: 1
+      content:
+        $ref: "#/panels/cpu"
+  - - width: 1
+      content:
+        $ref: "#/panels/load"
+    - width: 1
+`,
+			result: DashboardLayout{
+				Kind: KindGridLayout,
+				Parameter: &GridLayoutParameter{
+					Children: [][]GridCell{
+						{
+							{
+								Width:   1,
+								Content: nil,
+							},
+							{
+								Width: 1,
+								Content: &JSONRef{
+									Ref:  "#/panels/cpu",
+									Path: []string{"panels", "cpu"},
+								},
+							},
+						},
+						{
+							{
+								Width: 1,
+								Content: &JSONRef{
+									Ref:  "#/panels/load",
+									Path: []string{"panels", "load"},
+								},
+							},
+							{
+								Width: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "expand layout",
+			yamele: `
+kind: "Expand"
+parameter:
+  open: true
+  children:
+  - "$ref": "#/layouts/mainGrid"
+`,
+			result: DashboardLayout{
+				Kind: KindExpandLayout,
+				Parameter: &ExpandLayoutParameter{
+					Open: true,
+					Children: []*JSONRef{
+						{
+							Ref:    "#/layouts/mainGrid",
+							Path:   []string{"layouts", "mainGrid"},
+							Object: nil,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := DashboardLayout{}
+			assert.NoError(t, yaml.Unmarshal([]byte(test.yamele), &result))
+			assert.Equal(t, test.result, result)
+		})
+	}
+}

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -57,6 +57,22 @@ func TestMarshalDashboard(t *testing.T) {
 							},
 						},
 					},
+					Entrypoint: &JSONRef{
+						Ref: "#/spec/layouts/main",
+					},
+					Layouts: map[string]*DashboardLayout{
+						"main": {
+							Kind: KindExpandLayout,
+							Parameter: ExpandLayoutParameter{
+								Open: false,
+								Children: []*JSONRef{
+									{
+										Ref: "#/spec/panels/MyPanel",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			result: `{
@@ -83,6 +99,22 @@ func TestMarshalDashboard(t *testing.T) {
           ]
         }
       }
+    },
+    "layouts": {
+      "main": {
+        "kind": "Expand",
+        "parameter": {
+          "open": false,
+          "children": [
+            {
+              "$ref": "#/spec/panels/MyPanel"
+            }
+          ]
+        }
+      }
+    },
+    "entrypoint": {
+      "$ref": "#/spec/layouts/main"
     }
   }
 }`,
@@ -137,6 +169,22 @@ func TestMarshalDashboard(t *testing.T) {
 							},
 						},
 					},
+					Entrypoint: &JSONRef{
+						Ref: "#/spec/layouts/main",
+					},
+					Layouts: map[string]*DashboardLayout{
+						"main": {
+							Kind: KindExpandLayout,
+							Parameter: ExpandLayoutParameter{
+								Open: false,
+								Children: []*JSONRef{
+									{
+										Ref: "#/spec/panels/MyPanel",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			result: `{
@@ -186,6 +234,22 @@ func TestMarshalDashboard(t *testing.T) {
           ]
         }
       }
+    },
+    "layouts": {
+      "main": {
+        "kind": "Expand",
+        "parameter": {
+          "open": false,
+          "children": [
+            {
+              "$ref": "#/spec/panels/MyPanel"
+            }
+          ]
+        }
+      }
+    },
+    "entrypoint": {
+      "$ref": "#/spec/layouts/main"
     }
   }
 }`,

--- a/pkg/model/api/v1/jsonref.go
+++ b/pkg/model/api/v1/jsonref.go
@@ -1,0 +1,69 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+var jsonRefRegexp = regexp.MustCompile(`^#/([a-zA-Z0-9_-]+)(?:/([a-zA-Z0-9_-]+))*$`)
+
+type JSONRef struct {
+	// Ref is the JSON reference. That's the only thing that is used during the marshalling / unmarshalling process.
+	// Other attributes are ignored during these processes.
+	Ref string `json:"$ref" yaml:"$ref"`
+	// Path is a list of string that will be used to find from the root of the struct the object pointed.
+	Path []string `json:"-" yaml:"-"`
+	// Object will contain the pointer to the actual object referenced by Ref
+	Object interface{} `json:"-" yaml:"-"`
+}
+
+func (j *JSONRef) UnmarshalJSON(data []byte) error {
+	var tmp JSONRef
+	type plain JSONRef
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*j = tmp
+	return nil
+}
+
+func (j *JSONRef) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp JSONRef
+	type plain JSONRef
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*j = tmp
+	return nil
+}
+
+func (j *JSONRef) validate() error {
+	if !jsonRefRegexp.MatchString(j.Ref) {
+		return fmt.Errorf("ref '%s' is not accepted", j.Ref)
+	}
+	matches := jsonRefRegexp.FindAllStringSubmatch(j.Ref, -1)[0]
+	for i := 1; i < len(matches); i++ {
+		j.Path = append(j.Path, matches[i])
+	}
+	return nil
+}

--- a/pkg/model/api/v1/jsonref_test.go
+++ b/pkg/model/api/v1/jsonref_test.go
@@ -44,6 +44,25 @@ func TestUnmarshallJSONRef(t *testing.T) {
 				Object: nil,
 			},
 		},
+		{
+			title: "ref with big path",
+			jason: `
+{
+  "$ref": "#/my/incredible/super/long/path"
+}
+`,
+			result: &JSONRef{
+				Ref: "#/my/incredible/super/long/path",
+				Path: []string{
+					"my",
+					"incredible",
+					"super",
+					"long",
+					"path",
+				},
+				Object: nil,
+			},
+		},
 	}
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
@@ -70,6 +89,23 @@ $ref: "#/panels/load"
 				Path: []string{
 					"panels",
 					"load",
+				},
+				Object: nil,
+			},
+		},
+		{
+			title: "ref with big path",
+			yamele: `
+$ref: "#/my/incredible/super/long/path"
+`,
+			result: &JSONRef{
+				Ref: "#/my/incredible/super/long/path",
+				Path: []string{
+					"my",
+					"incredible",
+					"super",
+					"long",
+					"path",
 				},
 				Object: nil,
 			},
@@ -107,15 +143,6 @@ func TestUnmarshallJSONRefError(t *testing.T) {
 }
 `,
 			err: fmt.Errorf("ref '#/foo/ref with space' is not accepted"),
-		},
-		{
-			title: "reference not starting by #",
-			jsone: `
-{
-  "$ref": "/ref"
-}
-`,
-			err: fmt.Errorf("ref '/ref' is not accepted"),
 		},
 	}
 	for _, test := range testSuite {

--- a/pkg/model/api/v1/jsonref_test.go
+++ b/pkg/model/api/v1/jsonref_test.go
@@ -1,0 +1,127 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestUnmarshallJSONRef(t *testing.T) {
+	testSuite := []struct {
+		title  string
+		jason  string
+		result *JSONRef
+	}{
+		{
+			title: "simple ref",
+			jason: `
+{
+  "$ref": "#/panels/load"
+}
+`,
+			result: &JSONRef{
+				Ref: "#/panels/load",
+				Path: []string{
+					"panels",
+					"load",
+				},
+				Object: nil,
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := &JSONRef{}
+			assert.NoError(t, json.Unmarshal([]byte(test.jason), result))
+			assert.Equal(t, test.result, result)
+		})
+	}
+}
+
+func TestUnmarshallYAMLJSONRef(t *testing.T) {
+	testSuite := []struct {
+		title  string
+		yamele string
+		result *JSONRef
+	}{
+		{
+			title: "simple ref",
+			yamele: `
+$ref: "#/panels/load"
+`,
+			result: &JSONRef{
+				Ref: "#/panels/load",
+				Path: []string{
+					"panels",
+					"load",
+				},
+				Object: nil,
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := &JSONRef{}
+			assert.NoError(t, yaml.Unmarshal([]byte(test.yamele), result))
+			assert.Equal(t, test.result, result)
+		})
+	}
+}
+
+func TestUnmarshallJSONRefError(t *testing.T) {
+	testSuite := []struct {
+		title string
+		jsone string
+		err   error
+	}{
+		{
+			title: "empty reference",
+			jsone: `
+{
+  "$ref": ""
+}
+`,
+			err: fmt.Errorf("ref '' is not accepted"),
+		},
+		{
+			title: "reference with space",
+			jsone: `
+{
+  "$ref": "#/foo/ref with space"
+}
+`,
+			err: fmt.Errorf("ref '#/foo/ref with space' is not accepted"),
+		},
+		{
+			title: "reference not starting by #",
+			jsone: `
+{
+  "$ref": "/ref"
+}
+`,
+			err: fmt.Errorf("ref '/ref' is not accepted"),
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := &JSONRef{}
+			assert.Equal(t, test.err, json.Unmarshal([]byte(test.jsone), result))
+		})
+	}
+}


### PR DESCRIPTION
this PR adds the datamodel for the Dashboard Layout on the backend side. (related to #55)

It checks that the json references are pointing to an existing object.

Note: I'm not sure it will be useful in the future to set the pointer in the JSONRef. I did it today, probably this set won't be useful at all