### PR TITLE
Fix import / TypeScript error issues

### DIFF
--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { DashboardResource } from '@perses-ui/core';
-import { PluginRegistry } from './context/plugin-registry';
+import { PluginRegistry } from './context/plugin-registry/PluginRegistry';
 import DashboardView from './views/dashboard/Dashboard';
 import AlertErrorFallback from './components/AlertErrorFallback';
 import { DataSourceRegistry } from './context/DataSourceRegistry';


### PR DESCRIPTION
The import line change in
https://github.com/perses/perses/commit/bcb29c7b98aa880ce662ee842eed53a9e013866f
breaks the app for some reason ("Uncaught TypeError: Cannot read property
'useChartQuery' of undefined"), although there is an index.ts that exports
everything. Let's just revert that change for now to make things run again.

Signed-off-by: Julius Volz <julius.volz@gmail.com>