### PR TITLE
Fetch the version from the server

### DIFF
--- a/ui/app/src/Footer.tsx
+++ b/ui/app/src/Footer.tsx
@@ -1,6 +1,7 @@
 import { Box, Theme } from '@mui/material';
 import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
 import { Github } from 'mdi-material-ui';
+import useHealth from './health-client';
 
 const style: SxProps<Theme> = {
   display: 'flex',
@@ -22,6 +23,7 @@ const style: SxProps<Theme> = {
 };
 
 export default function Footer(): JSX.Element {
+  const { response } = useHealth();
   return (
     <Box sx={style}>
       <ul>
@@ -35,7 +37,11 @@ export default function Footer(): JSX.Element {
             <Github sx={{ verticalAlign: 'bottom' }} />
           </a>
         </li>
-        <li>v0.1.0</li>
+        <li>
+          {response && response.version.length > 0
+            ? response.version
+            : 'development version'}
+        </li>
       </ul>
     </Box>
   );

--- a/ui/app/src/Footer.tsx
+++ b/ui/app/src/Footer.tsx
@@ -1,7 +1,8 @@
-import { Box, Theme } from '@mui/material';
+import { Box, CircularProgress, Theme } from '@mui/material';
 import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
 import { Github } from 'mdi-material-ui';
 import useHealth from './health-client';
+import Toast from './components/Toast';
 
 const style: SxProps<Theme> = {
   display: 'flex',
@@ -23,26 +24,33 @@ const style: SxProps<Theme> = {
 };
 
 export default function Footer(): JSX.Element {
-  const { response } = useHealth();
+  const { response, loading, error } = useHealth();
   return (
-    <Box sx={style}>
-      <ul>
-        <li>&copy; The Perses Authors {new Date().getFullYear()}</li>
-        <li>
-          <a
-            href="https://github.com/perses/perses"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <Github sx={{ verticalAlign: 'bottom' }} />
-          </a>
-        </li>
-        <li>
-          {response && response.version.length > 0
-            ? response.version
-            : 'development version'}
-        </li>
-      </ul>
-    </Box>
+    <>
+      <Box sx={style}>
+        <ul>
+          <li>&copy; The Perses Authors {new Date().getFullYear()}</li>
+          <li>
+            <a
+              href="https://github.com/perses/perses"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Github sx={{ verticalAlign: 'bottom' }} />
+            </a>
+          </li>
+          <li>
+            {loading ? (
+              <CircularProgress size="1rem" />
+            ) : response && response.version.length > 0 ? (
+              response.version
+            ) : (
+              'development version'
+            )}
+          </li>
+        </ul>
+      </Box>
+      <Toast loading={loading} severity={'error'} message={error?.message} />
+    </>
   );
 }

--- a/ui/app/src/components/Toast.tsx
+++ b/ui/app/src/components/Toast.tsx
@@ -1,0 +1,45 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Alert, Snackbar } from '@mui/material';
+import { SyntheticEvent, useEffect, useState } from 'react';
+
+export interface ToastProperties {
+  loading: boolean;
+  message?: string;
+  severity: 'error' | 'warning' | 'info' | 'success';
+}
+
+export default function Toast(props: ToastProperties) {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    setOpen(!props.loading && props.message !== undefined);
+  }, [props]);
+
+  const handleClose = (event?: SyntheticEvent, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpen(false);
+  };
+  return (
+    <Snackbar
+      open={open}
+      onClose={handleClose}
+      autoHideDuration={6000}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+    >
+      <Alert severity={props.severity}> {props.message} </Alert>
+    </Snackbar>
+  );
+}

--- a/ui/app/src/health-client.ts
+++ b/ui/app/src/health-client.ts
@@ -1,0 +1,28 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useFetch } from '@perses-ui/core';
+import { URLBuilderUtil } from './utils/url-builder';
+
+const healthResource = 'health';
+
+export interface HealthModel {
+  buildTime: string;
+  version: string;
+  commit: string;
+}
+
+export default function useHealth() {
+  const url = new URLBuilderUtil().setResource(healthResource).build();
+  return useFetch<HealthModel>(url);
+}

--- a/ui/app/webpack.dev.ts
+++ b/ui/app/webpack.dev.ts
@@ -59,6 +59,9 @@ const devConfig: Configuration = {
     open: true,
     https: getHttpsConfig(),
     historyApiFallback: true,
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
   },
   cache: true,
 };


### PR DESCRIPTION
This PR introduced the dev proxy required to query the backend from the frontend and fetch the `health` endpoint that contain the version of Perses.

I'm wondering if we should display the commit ID. What do you think ?