### PR TITLE
reviewing the metadata datamodel 

### DIFF
--- a/ui/app/sample-data/dashboard.ts
+++ b/ui/app/sample-data/dashboard.ts
@@ -17,6 +17,9 @@ const cadvisor: DashboardResource = {
   kind: 'Dashboard',
   metadata: {
     name: 'Kubelet - cAdvisor',
+    project: 'perses',
+    created_at: '2021-10-20',
+    updated_at: '2021-10-20',
   },
   spec: {
     datasource: { name: 'Public Prometheus Demo Server' },

--- a/ui/app/sample-data/datasource.ts
+++ b/ui/app/sample-data/datasource.ts
@@ -17,6 +17,8 @@ const dataSource: DataSourceResource = {
   kind: 'DataSource',
   metadata: {
     name: 'Public Prometheus Demo Server',
+    created_at: '2021-10-20',
+    updated_at: '2021-10-20',
   },
   spec: {
     data_source: {

--- a/ui/app/src/context/DataSourceRegistry.tsx
+++ b/ui/app/src/context/DataSourceRegistry.tsx
@@ -40,19 +40,14 @@ export function DataSourceRegistry(props: DataSourceRegistryProps) {
     return [dataSource];
   }, [dataSource]);
 
-  const getDataSources = useCallback(
-    (selector: ResourceSelector) => {
-      // TODO: Is this how K8s selectors actually work?
-      return dataSources.filter((d) => {
-        for (const key in selector) {
-          const value = selector[key];
-          if (d.metadata[key] !== value) return false;
-        }
-        return true;
-      });
-    },
-    [dataSources]
-  );
+  const getDataSources = useCallback(() => {
+    // TODO: Is this how K8s selectors actually work?
+    // k8s selector is looking at the metadata.labels, which doesn't exist in the current datamodel
+    // TODO @nexucis review the way to fetch the datasources (Global datasource vs Local datasource)
+    return dataSources.filter(() => {
+      return true;
+    });
+  }, [dataSources]);
 
   const context: DataSourceRegistryContextType = useMemo(
     () => ({ getDataSources }),

--- a/ui/app/src/model/perses-client.ts
+++ b/ui/app/src/model/perses-client.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useFetch } from '@perses-ui/core';
-import { URLBuilderUtil } from './url-builder';
+import buildURL from './url-builder';
 
 const healthResource = 'health';
 
@@ -26,6 +26,6 @@ export interface HealthModel {
  * Gets version information from the Perses server API.
  */
 export function useHealth() {
-  const url = new URLBuilderUtil().setResource(healthResource).build();
+  const url = buildURL({ resource: healthResource });
   return useFetch<HealthModel>(url);
 }

--- a/ui/app/src/model/url-builder.test.ts
+++ b/ui/app/src/model/url-builder.test.ts
@@ -11,31 +11,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { URLBuilderUtil } from './url-builder';
+import buildURL from './url-builder';
 
 describe('URLBuilderUtil', () => {
-  let builder: URLBuilderUtil;
+  const testSuite = [
+    {
+      title: 'if no params, should return no params in the uri',
+      expectedURI: '/api/v1/test',
+      parameter: {
+        resource: 'test',
+      },
+    },
+    {
+      title: 'check if set project is considered',
+      expectedURI: '/api/v1/projects/perses/test',
+      parameter: {
+        resource: 'test',
+        project: 'perses',
+      },
+    },
+    {
+      title: 'complete test',
+      expectedURI: '/api/v1/projects/perses/test/superName',
+      parameter: {
+        resource: 'test',
+        project: 'perses',
+        name: 'superName',
+      },
+    },
+  ];
 
-  beforeEach(() => {
-    builder = new URLBuilderUtil();
-  });
-
-  it('if no params, should return no params in the uri', () => {
-    const expectedURI = '/api/v1/test';
-    builder.setResource('test');
-
-    expect(builder.build()).toEqual(expectedURI);
-  });
-
-  it('check if set project is considered', () => {
-    const expectedURI = '/api/v1/projects/perses/test';
-    builder.setProject('perses').setResource('test');
-    expect(builder.build()).toEqual(expectedURI);
-  });
-
-  it('complete test', () => {
-    const expectedURI = '/api/v1/projects/perses/test/superName';
-    builder.setResource('test').setProject('perses').setName('superName');
-    expect(builder.build()).toEqual(expectedURI);
+  testSuite.forEach(({ title, expectedURI, parameter }) => {
+    it(title, () => {
+      expect(buildURL(parameter)).toEqual(expectedURI);
+    });
   });
 });

--- a/ui/app/src/model/url-builder.test.ts
+++ b/ui/app/src/model/url-builder.test.ts
@@ -13,19 +13,19 @@
 
 import buildURL from './url-builder';
 
-describe('URLBuilderUtil', () => {
+describe('buildURL', () => {
   const testSuite = [
     {
       title: 'if no params, should return no params in the uri',
       expectedURI: '/api/v1/test',
-      parameter: {
+      parameters: {
         resource: 'test',
       },
     },
     {
       title: 'check if set project is considered',
       expectedURI: '/api/v1/projects/perses/test',
-      parameter: {
+      parameters: {
         resource: 'test',
         project: 'perses',
       },
@@ -33,7 +33,7 @@ describe('URLBuilderUtil', () => {
     {
       title: 'complete test',
       expectedURI: '/api/v1/projects/perses/test/superName',
-      parameter: {
+      parameters: {
         resource: 'test',
         project: 'perses',
         name: 'superName',
@@ -41,9 +41,9 @@ describe('URLBuilderUtil', () => {
     },
   ];
 
-  testSuite.forEach(({ title, expectedURI, parameter }) => {
+  testSuite.forEach(({ title, expectedURI, parameters }) => {
     it(title, () => {
-      expect(buildURL(parameter)).toEqual(expectedURI);
+      expect(buildURL(parameters)).toEqual(expectedURI);
     });
   });
 });

--- a/ui/app/src/model/url-builder.test.ts
+++ b/ui/app/src/model/url-builder.test.ts
@@ -39,6 +39,23 @@ describe('buildURL', () => {
         name: 'superName',
       },
     },
+    {
+      title: 'a french project name',
+      expectedURI: '/api/v1/projects/%C3%A7a%20marche',
+      parameters: {
+        resource: 'projects',
+        name: 'ça marche',
+      },
+    },
+    {
+      title: 'a french project and a french resource name',
+      expectedURI: '/api/v1/projects/%C3%A7a%20marche/dashboards/h%C3%B4pital',
+      parameters: {
+        resource: 'dashboards',
+        project: 'ça marche',
+        name: 'hôpital',
+      },
+    },
   ];
 
   testSuite.forEach(({ title, expectedURI, parameters }) => {

--- a/ui/app/src/model/url-builder.ts
+++ b/ui/app/src/model/url-builder.ts
@@ -22,11 +22,11 @@ export type URLParams = {
 export default function buildURL(params: URLParams): string {
   let url = apiPrefix;
   if (params.project !== undefined && params.project.length > 0) {
-    url = `${url}/projects/${params.project}`;
+    url = `${url}/projects/${encodeURIComponent(params.project)}`;
   }
   url = `${url}/${params.resource}`;
   if (params.name !== undefined && params.name.length > 0) {
-    url = `${url}/${params.name}`;
+    url = `${url}/${encodeURIComponent(params.name)}`;
   }
   return url;
 }

--- a/ui/app/src/model/url-builder.ts
+++ b/ui/app/src/model/url-builder.ts
@@ -11,21 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const prefixAPI = '/api/v1';
+const apiPrefix = '/api/v1';
 
-export type BuildURLParams = {
+export type URLParams = {
   resource: string;
   name?: string;
   project?: string;
 };
 
-export default function buildURL(params: BuildURLParams): string {
-  let url = prefixAPI;
-  if (params.project && params.project.length > 0) {
+export default function buildURL(params: URLParams): string {
+  let url = apiPrefix;
+  if (params.project !== undefined && params.project.length > 0) {
     url = `${url}/projects/${params.project}`;
   }
   url = `${url}/${params.resource}`;
-  if (params.name && params.name.length > 0) {
+  if (params.name !== undefined && params.name.length > 0) {
     url = `${url}/${params.name}`;
   }
   return url;

--- a/ui/app/src/model/url-builder.ts
+++ b/ui/app/src/model/url-builder.ts
@@ -11,42 +11,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export class URLBuilderUtil {
-  private readonly prefixAPI = '/api/v1';
-  private resource: string;
-  private project: string;
-  private name: string;
+const prefixAPI = '/api/v1';
 
-  constructor() {
-    this.resource = '';
-    this.project = '';
-    this.name = '';
-  }
+export type BuildURLParams = {
+  resource: string;
+  name?: string;
+  project?: string;
+};
 
-  setProject(project: string): URLBuilderUtil {
-    this.project = project;
-    return this;
+export default function buildURL(params: BuildURLParams): string {
+  let url = prefixAPI;
+  if (params.project && params.project.length > 0) {
+    url = `${url}/projects/${params.project}`;
   }
-
-  setName(name: string): URLBuilderUtil {
-    this.name = name;
-    return this;
+  url = `${url}/${params.resource}`;
+  if (params.name && params.name.length > 0) {
+    url = `${url}/${params.name}`;
   }
-
-  setResource(resource: string): URLBuilderUtil {
-    this.resource = resource;
-    return this;
-  }
-
-  build(): string {
-    let url = this.prefixAPI;
-    if (this.project && this.project.length > 0) {
-      url = `${url}/projects/${this.project}`;
-    }
-    url = `${url}/${this.resource}`;
-    if (this.name.length > 0) {
-      url = `${url}/${this.name}`;
-    }
-    return url;
-  }
+  return url;
 }

--- a/ui/core/src/model/dashboard.ts
+++ b/ui/core/src/model/dashboard.ts
@@ -13,14 +13,14 @@
 
 import { LayoutRef, PanelRef } from './json-references';
 import { AnyPanelDefinition } from './panels';
-import { ResourceMetadata, ResourceSelector } from './resource';
+import { ProjectMetadata, ResourceSelector } from './resource';
 import { AnyVariableDefinition } from './variables';
 import { DurationString } from './time';
 import { Definition, JsonObject } from './definitions';
 
 export interface DashboardResource {
   kind: 'Dashboard';
-  metadata: ResourceMetadata;
+  metadata: ProjectMetadata;
   spec: DashboardSpec;
 }
 

--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 import { Definition, JsonObject } from './definitions';
-import { ResourceMetadata } from './resource';
+import { Metadata } from './resource';
 
 export interface DataSourceResource {
   kind: 'DataSource';
-  metadata: ResourceMetadata;
+  metadata: Metadata;
   spec: {
     data_source: AnyDataSourceDefinition;
   };

--- a/ui/core/src/model/resource.ts
+++ b/ui/core/src/model/resource.ts
@@ -13,4 +13,14 @@
 
 export type ResourceSelector = Record<string, string>;
 
+// ResourceMetadata is deprecated and will be removed in favor of Metadata
+// TODO To be removed
 export type ResourceMetadata = Record<string, string> & { name: string };
+
+export type Metadata = {
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectMetadata = Metadata & { project: string };


### PR DESCRIPTION
I started to converge to the current datamodel served by the backend. I started by the metadata.

This PR also includes a refactoring of the `URLBuilder` to avoid to use a new object each time you want to build an URL to contact the API.

this PR should be merged after #104 as it contains the changes from there and so it will depend on the outcome of #104 