### PR TITLE
Add global snackbar provider, convenience hook

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -23,6 +23,7 @@
     "clsx": "^1.1.1",
     "immer": "^9.0.5",
     "mdi-material-ui": "^7.0.0",
+    "notistack": "^2.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^3.1.3",

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { DashboardResource } from '@perses-ui/core';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { PluginRegistry } from './context/plugin-registry';
 import ViewDashboard from './views/dashboard/ViewDashboard';
 import AlertErrorFallback from './components/AlertErrorFallback';
@@ -22,8 +21,6 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import { pluginRuntime } from './model/plugin-runtime';
 
-const queryClient = new QueryClient();
-
 function App() {
   const dashboard = useSampleData<DashboardResource>('dashboard');
   if (dashboard === undefined) {
@@ -31,7 +28,7 @@ function App() {
   }
 
   return (
-    <QueryClientProvider client={queryClient}>
+    <>
       <Header />
       <PluginRegistry
         loadingFallback="Loading..."
@@ -43,7 +40,7 @@ function App() {
         </DataSourceRegistry>
       </PluginRegistry>
       <Footer />
-    </QueryClientProvider>
+    </>
   );
 }
 

--- a/ui/app/src/components/Footer.tsx
+++ b/ui/app/src/components/Footer.tsx
@@ -1,8 +1,8 @@
 import { Box, CircularProgress, Theme } from '@mui/material';
 import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
 import { Github } from 'mdi-material-ui';
+import { useSnackbar } from '../context/SnackbarProvider';
 import { useHealth } from '../model/perses-client';
-import Toast from './Toast';
 
 const style: SxProps<Theme> = {
   display: 'flex',
@@ -24,7 +24,8 @@ const style: SxProps<Theme> = {
 };
 
 export default function Footer(): JSX.Element {
-  const { data, isLoading, error } = useHealth();
+  const { exceptionSnackbar } = useSnackbar();
+  const { data, isLoading } = useHealth({ onError: exceptionSnackbar });
   return (
     <>
       <Box sx={style}>
@@ -50,7 +51,6 @@ export default function Footer(): JSX.Element {
           </li>
         </ul>
       </Box>
-      <Toast loading={isLoading} severity={'error'} message={error?.message} />
     </>
   );
 }

--- a/ui/app/src/context/SnackbarProvider.tsx
+++ b/ui/app/src/context/SnackbarProvider.tsx
@@ -1,0 +1,101 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback } from 'react';
+import {
+  SnackbarProvider as NotistackProvider,
+  ProviderContext as NotistackContext,
+  useSnackbar as useNotistack,
+  SnackbarMessage,
+  OptionsObject,
+  SnackbarKey,
+} from 'notistack';
+
+export interface SnackbarContext extends NotistackContext {
+  errorSnackbar: EnqueueFunction;
+  infoSnackbar: EnqueueFunction;
+  warningSnackbar: EnqueueFunction;
+  successSnackbar: EnqueueFunction;
+
+  /**
+   * Useful for catch blocks where the error will be of type `unknown`, tries
+   * to show the `message` property if passed an instance of `Error`.
+   */
+  exceptionSnackbar: (error: unknown, options?: SnackbarOptions) => SnackbarKey;
+}
+
+type EnqueueFunction = (
+  message: SnackbarMessage,
+  options?: SnackbarOptions
+) => SnackbarKey;
+
+type SnackbarOptions = Omit<OptionsObject, 'variant'>;
+
+/**
+ * Application-wide provider for showing snackbars/toasts.
+ */
+export const SnackbarProvider = NotistackProvider;
+
+/**
+ * Gets the SnackbarContext with methods for displaying snackbars/toasts.
+ */
+export function useSnackbar(): SnackbarContext {
+  const { enqueueSnackbar, closeSnackbar } = useNotistack();
+
+  // Create variant-specific callbacks
+  const errorSnackbar = useEnqueueFunction(enqueueSnackbar, 'error');
+  const infoSnackbar = useEnqueueFunction(enqueueSnackbar, 'info');
+  const warningSnackbar = useEnqueueFunction(enqueueSnackbar, 'warning');
+  const successSnackbar = useEnqueueFunction(enqueueSnackbar, 'success');
+
+  const exceptionSnackbar: SnackbarContext['exceptionSnackbar'] = useCallback(
+    (error, options) => {
+      // Try to use message prop, but fallback to a default message that
+      // will just stringify the error provided
+      const message =
+        error instanceof Error
+          ? error.message
+          : `An unexpected error occurred: ${error}`;
+
+      return errorSnackbar(message, options);
+    },
+    [errorSnackbar]
+  );
+
+  return {
+    enqueueSnackbar,
+    closeSnackbar,
+    errorSnackbar,
+    infoSnackbar,
+    warningSnackbar,
+    successSnackbar,
+    exceptionSnackbar,
+  };
+}
+
+// Helper to create a variant-specific enqueue function
+function useEnqueueFunction(
+  enqueueSnackbar: NotistackContext['enqueueSnackbar'],
+  variant: OptionsObject['variant']
+): EnqueueFunction {
+  return useCallback(
+    (message, options) => {
+      const allOptions: OptionsObject = {
+        ...options,
+        variant,
+      };
+      return enqueueSnackbar(message, allOptions);
+    },
+    [enqueueSnackbar, variant]
+  );
+}

--- a/ui/app/src/index.tsx
+++ b/ui/app/src/index.tsx
@@ -15,16 +15,21 @@ import { ThemeProvider, CssBaseline } from '@material-ui/core';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { enableMapSet } from 'immer';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import App from './App';
 import { createTheme } from './styles/theme';
+
+const queryClient = new QueryClient();
 
 function renderApp() {
   ReactDOM.render(
     <React.StrictMode>
-      <ThemeProvider theme={createTheme()}>
-        <CssBaseline />
-        <App />
-      </ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={createTheme()}>
+          <CssBaseline />
+          <App />
+        </ThemeProvider>
+      </QueryClientProvider>
     </React.StrictMode>,
     document.getElementById('root')
   );

--- a/ui/app/src/index.tsx
+++ b/ui/app/src/index.tsx
@@ -18,6 +18,7 @@ import { enableMapSet } from 'immer';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import App from './App';
 import { createTheme } from './styles/theme';
+import { SnackbarProvider } from './context/SnackbarProvider';
 
 const queryClient = new QueryClient();
 
@@ -26,8 +27,10 @@ function renderApp() {
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={createTheme()}>
-          <CssBaseline />
-          <App />
+          <SnackbarProvider>
+            <CssBaseline />
+            <App />
+          </SnackbarProvider>
         </ThemeProvider>
       </QueryClientProvider>
     </React.StrictMode>,

--- a/ui/app/src/model/perses-client.ts
+++ b/ui/app/src/model/perses-client.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { fetchJson } from '@perses-ui/core';
-import { useQuery } from 'react-query';
+import { useQuery, UseQueryOptions } from 'react-query';
 import buildURL from './url-builder';
 
 const healthResource = 'health';
@@ -23,12 +23,21 @@ export interface HealthModel {
   commit: string;
 }
 
+type HealthOptions = Omit<
+  UseQueryOptions<HealthModel, Error>,
+  'queryKey' | 'queryFn'
+>;
+
 /**
  * Gets version information from the Perses server API.
  */
-export function useHealth() {
-  return useQuery<HealthModel, Error>(healthResource, () => {
-    const url = buildURL({ resource: healthResource });
-    return fetchJson<HealthModel>(url);
-  });
+export function useHealth(options?: HealthOptions) {
+  return useQuery<HealthModel, Error>(
+    healthResource,
+    () => {
+      const url = buildURL({ resource: healthResource });
+      return fetchJson<HealthModel>(url);
+    },
+    options
+  );
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -53,6 +53,7 @@
         "clsx": "^1.1.1",
         "immer": "^9.0.5",
         "mdi-material-ui": "^7.0.0",
+        "notistack": "^2.0.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-error-boundary": "^3.1.3",
@@ -9678,6 +9679,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/notistack": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.3.tgz",
+      "integrity": "sha512-krmVFtTO9kEY1Pa4NrbyexrjiRcV6TqBM2xLx8nuDea1g96Z/OZfkvVLmYKkTvoSJ3jyQntWK16z86ssW5kt4A==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -15301,10 +15330,11 @@
         "html-webpack-plugin": "^5.3.2",
         "immer": "^9.0.5",
         "mdi-material-ui": "^7.0.0",
+        "notistack": "^2.0.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-error-boundary": "^3.1.3",
-        "react-query": "*",
+        "react-query": "^3.31.0",
         "style-loader": "^3.2.1",
         "ts-loader": "^9.2.5",
         "ts-node": "^10.2.0",
@@ -15342,7 +15372,7 @@
         "lezer": "^0.13.5",
         "lezer-promql": "^0.20.0",
         "react": "^17.0.2",
-        "react-query": "*"
+        "react-query": "^3.31.0"
       }
     },
     "@polka/url": {
@@ -20616,6 +20646,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "notistack": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.3.tgz",
+      "integrity": "sha512-krmVFtTO9kEY1Pa4NrbyexrjiRcV6TqBM2xLx8nuDea1g96Z/OZfkvVLmYKkTvoSJ3jyQntWK16z86ssW5kt4A==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "npm-run-path": {
       "version": "4.0.1",


### PR DESCRIPTION
This adds a global `SnackbarProvider` which is basically just the provider from [`notistack`](https://iamhosseindhv.com/notistack) which works with Material UI Snackbars/Toasts. This also contains some convenience methods on the `useSnackbar` hook that we've found useful when working with it in the past. Turns out that these methods actually work really well when attached to `react-query`'s `onError` option. 🎉 

Here's what it looks like in action (when failing to fetch version info for the health check because the server is turned off):

https://user-images.githubusercontent.com/428023/139941378-52789bbe-5450-44dd-a1c2-2bea0017d828.mp4

I've left the default `notistack` options for now, but we can always revisit/tweak those later if we want to.

