### PR TITLE
dependabot is checking weekly the deps + increase the max number of PR that can be opened

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,14 @@ version: 2
 updates:
 - package-ecosystem: "gomod"
   directory: "/"
+  open-pull-requests-limit: 10
   schedule:
-    interval: "daily"
+    interval: "weekly"
 - package-ecosystem: "npm"
   directory: "/ui"
+  open-pull-requests-limit: 10
   schedule:
-    interval: "daily"
+    interval: "weekly"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Signed-off-by: Augustin Husson <husson.augustin@gmail.com>