### PR TITLE
API: add folder management

### DIFF
--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -18,6 +18,7 @@ import (
 	echoUtils "github.com/perses/common/echo"
 	"github.com/perses/perses/internal/api/impl/v1/dashboard"
 	"github.com/perses/perses/internal/api/impl/v1/datasource"
+	"github.com/perses/perses/internal/api/impl/v1/folder"
 	"github.com/perses/perses/internal/api/impl/v1/globaldatasource"
 	"github.com/perses/perses/internal/api/impl/v1/health"
 	"github.com/perses/perses/internal/api/impl/v1/project"
@@ -38,6 +39,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager) echoUtils.Register {
 	endpoints := []endpoint{
 		dashboard.NewEndpoint(serviceManager.GetDashboard()),
 		datasource.NewEndpoint(serviceManager.GetDatasource()),
+		folder.NewEndpoint(serviceManager.GetFolder()),
 		globaldatasource.NewEndpoint(serviceManager.GetGlobalDatasource()),
 		health.NewEndpoint(serviceManager.GetHealth()),
 		project.NewEndpoint(serviceManager.GetProject()),

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -19,3 +19,4 @@ package api
 //go:generate go run generate.go -package=datasource -plural=datasources -kind=Datasource -isProjectResource=true
 //go:generate go run generate.go -package=project -plural=projects -kind=Project
 //go:generate go run generate.go -package=dashboard -plural=dashboards -kind=Dashboard -isProjectResource=true
+//go:generate go run generate.go -package=folder -plural=folders -kind=Folder -isProjectResource=true

--- a/internal/api/impl/v1/folder/persistence.go
+++ b/internal/api/impl/v1/folder/persistence.go
@@ -1,0 +1,59 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package folder
+
+import (
+	"github.com/perses/common/etcd"
+	"github.com/perses/perses/internal/api/interface/v1/folder"
+	"github.com/perses/perses/internal/api/shared/database"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type dao struct {
+	folder.DAO
+	client database.DAO
+}
+
+func NewDAO(persesDAO database.DAO) folder.DAO {
+	return &dao{
+		client: persesDAO,
+	}
+}
+
+func (d *dao) Create(entity *v1.Folder) error {
+	key := entity.GenerateID()
+	return d.client.Create(key, entity)
+}
+
+func (d *dao) Update(entity *v1.Folder) error {
+	key := entity.GenerateID()
+	return d.client.Upsert(key, entity)
+}
+
+func (d *dao) Delete(project string, name string) error {
+	key := v1.GenerateFolderID(project, name)
+	return d.client.Delete(key)
+}
+
+func (d *dao) Get(project string, name string) (*v1.Folder, error) {
+	key := v1.GenerateFolderID(project, name)
+	entity := &v1.Folder{}
+	return entity, d.client.Get(key, entity)
+}
+
+func (d *dao) List(q etcd.Query) ([]*v1.Folder, error) {
+	var result []*v1.Folder
+	err := d.client.Query(q, &result)
+	return result, err
+}

--- a/internal/api/impl/v1/folder/service.go
+++ b/internal/api/impl/v1/folder/service.go
@@ -1,0 +1,122 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package folder
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/perses/common/etcd"
+	"github.com/perses/perses/internal/api/interface/v1/folder"
+	"github.com/perses/perses/internal/api/shared"
+	"github.com/perses/perses/pkg/model/api"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
+)
+
+type service struct {
+	folder.Service
+	dao folder.DAO
+}
+
+func NewService(dao folder.DAO) folder.Service {
+	return &service{
+		dao: dao,
+	}
+}
+
+func (s *service) Create(entity api.Entity) (interface{}, error) {
+	if datasourceObject, ok := entity.(*v1.Folder); ok {
+		return s.create(datasourceObject)
+	}
+	return nil, fmt.Errorf("%w: wrong entity format, attempting Folder format, received '%T'", shared.BadRequestError, entity)
+}
+
+func (s *service) create(entity *v1.Folder) (*v1.Folder, error) {
+	// Update the time contains in the entity
+	entity.Metadata.CreateNow()
+	if err := s.dao.Create(entity); err != nil {
+		if etcd.IsKeyConflict(err) {
+			logrus.Debugf("unable to create the Folder %q. It already exits", entity.Metadata.Name)
+			return nil, shared.ConflictError
+		}
+		logrus.WithError(err).Errorf("unable to perform the creation of the Folder %q, something wrong with etcd", entity.Metadata.Name)
+		return nil, shared.InternalError
+	}
+	return entity, nil
+}
+
+func (s *service) Update(entity api.Entity, parameters shared.Parameters) (interface{}, error) {
+	if FolderObject, ok := entity.(*v1.Folder); ok {
+		return s.update(FolderObject, parameters)
+	}
+	return nil, fmt.Errorf("%w: wrong entity format, attempting Folder format, received '%T'", shared.BadRequestError, entity)
+}
+
+func (s *service) update(entity *v1.Folder, parameters shared.Parameters) (*v1.Folder, error) {
+	if entity.Metadata.Name != parameters.Name {
+		logrus.Debugf("name in Folder %q and coming from the http request: %q doesn't match", entity.Metadata.Name, parameters.Name)
+		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request doesn't match", shared.BadRequestError)
+	}
+	if len(entity.Metadata.Project) == 0 {
+		entity.Metadata.Project = parameters.Project
+	} else if entity.Metadata.Project != parameters.Project {
+		logrus.Debugf("project in folder %q and coming from the http request: %q doesn't match", entity.Metadata.Project, parameters.Project)
+		return nil, fmt.Errorf("%w: metadata.project and the project name in the http path request doesn't match", shared.BadRequestError)
+	}
+	// find the previous version of the Folder
+	oldEntity, err := s.Get(parameters)
+	if err != nil {
+		return nil, err
+	}
+	oldObject := oldEntity.(*v1.Folder)
+	// update the immutable field of the newEntity with the old one
+	entity.Metadata.CreatedAt = oldObject.Metadata.CreatedAt
+	// update the field UpdatedAt with the new time
+	entity.Metadata.UpdatedAt = time.Now().UTC()
+	if err := s.dao.Update(entity); err != nil {
+		logrus.WithError(err).Errorf("unable to perform the update of the Folder %q, something wrong with etcd", entity.Metadata.Name)
+		return nil, shared.InternalError
+	}
+	return entity, nil
+}
+
+func (s *service) Delete(parameters shared.Parameters) error {
+	if err := s.dao.Delete(parameters.Project, parameters.Name); err != nil {
+		if etcd.IsKeyNotFound(err) {
+			logrus.Debugf("unable to find the Folder %q", parameters.Name)
+			return shared.NotFoundError
+		}
+		logrus.WithError(err).Errorf("unable to delete the Folder %q, something wrong with etcd", parameters.Name)
+		return shared.InternalError
+	}
+	return nil
+}
+
+func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
+	entity, err := s.dao.Get(parameters.Project, parameters.Name)
+	if err != nil {
+		if etcd.IsKeyNotFound(err) {
+			logrus.Debugf("unable to find the Folder %q", parameters.Name)
+			return nil, shared.NotFoundError
+		}
+		logrus.WithError(err).Errorf("unable to find the previous version of the Folder %q, something wrong with etcd", parameters.Name)
+		return nil, shared.InternalError
+	}
+	return entity, nil
+}
+
+func (s *service) List(q etcd.Query, _ shared.Parameters) (interface{}, error) {
+	return s.dao.List(q)
+}

--- a/internal/api/interface/v1/folder/interface.go
+++ b/internal/api/interface/v1/folder/interface.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package folder
+
+import (
+	"github.com/perses/common/etcd"
+	"github.com/perses/perses/internal/api/shared"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type Query struct {
+	etcd.Query
+	// NamePrefix is a prefix of the Folders.metadata.name that is used to filter the list of the Folders.
+	// NamePrefix can be empty in case you want to return the full list of Folders available.
+	NamePrefix string `query:"name"`
+	// Project is the exact name of the project.
+	// The value can come from the path of the URL or from the query parameter
+	Project string `param:"project" query:"project"`
+}
+
+func (q *Query) Build() (string, error) {
+	return v1.GenerateFolderID(q.Project, q.NamePrefix), nil
+}
+
+type DAO interface {
+	Create(entity *v1.Folder) error
+	Update(entity *v1.Folder) error
+	Delete(project string, name string) error
+	Get(project string, name string) (*v1.Folder, error)
+	List(q etcd.Query) ([]*v1.Folder, error)
+}
+
+type Service interface {
+	shared.ToolboxService
+}

--- a/internal/api/shared/dependency/persistence_manager.go
+++ b/internal/api/shared/dependency/persistence_manager.go
@@ -16,12 +16,14 @@ package dependency
 import (
 	dashboardImpl "github.com/perses/perses/internal/api/impl/v1/dashboard"
 	datasourceImpl "github.com/perses/perses/internal/api/impl/v1/datasource"
+	folderImpl "github.com/perses/perses/internal/api/impl/v1/folder"
 	globalDatasourceImpl "github.com/perses/perses/internal/api/impl/v1/globaldatasource"
 	healthImpl "github.com/perses/perses/internal/api/impl/v1/health"
 	projectImpl "github.com/perses/perses/internal/api/impl/v1/project"
 	userImpl "github.com/perses/perses/internal/api/impl/v1/user"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
+	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
 	"github.com/perses/perses/internal/api/interface/v1/health"
 	"github.com/perses/perses/internal/api/interface/v1/project"
@@ -33,6 +35,7 @@ import (
 type PersistenceManager interface {
 	GetDashboard() dashboard.DAO
 	GetDatasource() datasource.DAO
+	GetFolder() folder.DAO
 	GetGlobalDatasource() globaldatasource.DAO
 	GetHealth() health.DAO
 	GetPersesDAO() database.DAO
@@ -44,6 +47,7 @@ type persistence struct {
 	PersistenceManager
 	dashboard        dashboard.DAO
 	datasource       datasource.DAO
+	folder           folder.DAO
 	globalDatasource globaldatasource.DAO
 	health           health.DAO
 	perses           database.DAO
@@ -58,6 +62,7 @@ func NewPersistenceManager(conf config.Database) (PersistenceManager, error) {
 	}
 	dashboardDAO := dashboardImpl.NewDAO(persesDAO)
 	datasourceDAO := datasourceImpl.NewDAO(persesDAO)
+	folderDAO := folderImpl.NewDAO(persesDAO)
 	globalDatatasourceDAO := globalDatasourceImpl.NewDAO(persesDAO)
 	healthDAO := healthImpl.NewDAO(persesDAO)
 	projectDAO := projectImpl.NewDAO(persesDAO)
@@ -65,6 +70,7 @@ func NewPersistenceManager(conf config.Database) (PersistenceManager, error) {
 	return &persistence{
 		dashboard:        dashboardDAO,
 		datasource:       datasourceDAO,
+		folder:           folderDAO,
 		globalDatasource: globalDatatasourceDAO,
 		health:           healthDAO,
 		perses:           persesDAO,
@@ -79,6 +85,10 @@ func (p *persistence) GetDashboard() dashboard.DAO {
 
 func (p *persistence) GetDatasource() datasource.DAO {
 	return p.datasource
+}
+
+func (p *persistence) GetFolder() folder.DAO {
+	return p.folder
 }
 
 func (p *persistence) GetGlobalDatasource() globaldatasource.DAO {

--- a/internal/api/shared/dependency/service_manager.go
+++ b/internal/api/shared/dependency/service_manager.go
@@ -18,12 +18,14 @@ package dependency
 import (
 	dashboardImpl "github.com/perses/perses/internal/api/impl/v1/dashboard"
 	datasourceImpl "github.com/perses/perses/internal/api/impl/v1/datasource"
+	folderImpl "github.com/perses/perses/internal/api/impl/v1/folder"
 	globalDatasourceImpl "github.com/perses/perses/internal/api/impl/v1/globaldatasource"
 	healthImpl "github.com/perses/perses/internal/api/impl/v1/health"
 	projectImpl "github.com/perses/perses/internal/api/impl/v1/project"
 	userImpl "github.com/perses/perses/internal/api/impl/v1/user"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
+	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
 	"github.com/perses/perses/internal/api/interface/v1/health"
 	"github.com/perses/perses/internal/api/interface/v1/project"
@@ -33,6 +35,7 @@ import (
 type ServiceManager interface {
 	GetDashboard() dashboard.Service
 	GetDatasource() datasource.Service
+	GetFolder() folder.Service
 	GetGlobalDatasource() globaldatasource.Service
 	GetHealth() health.Service
 	GetProject() project.Service
@@ -43,6 +46,7 @@ type service struct {
 	ServiceManager
 	dashboard        dashboard.Service
 	datasource       datasource.Service
+	folder           folder.Service
 	globalDatasource globaldatasource.Service
 	health           health.Service
 	project          project.Service
@@ -52,6 +56,7 @@ type service struct {
 func NewServiceManager(dao PersistenceManager) ServiceManager {
 	dashboardService := dashboardImpl.NewService(dao.GetDashboard())
 	datasourceService := datasourceImpl.NewService(dao.GetDatasource())
+	folderService := folderImpl.NewService(dao.GetFolder())
 	globalDatasourceService := globalDatasourceImpl.NewService(dao.GetGlobalDatasource())
 	healthService := healthImpl.NewService(dao.GetHealth())
 	projectService := projectImpl.NewService(dao.GetProject())
@@ -59,6 +64,7 @@ func NewServiceManager(dao PersistenceManager) ServiceManager {
 	return &service{
 		dashboard:        dashboardService,
 		datasource:       datasourceService,
+		folder:           folderService,
 		globalDatasource: globalDatasourceService,
 		health:           healthService,
 		project:          projectService,
@@ -72,6 +78,10 @@ func (s *service) GetDashboard() dashboard.Service {
 
 func (s *service) GetDatasource() datasource.Service {
 	return s.datasource
+}
+
+func (s *service) GetFolder() folder.Service {
+	return s.folder
 }
 
 func (s *service) GetGlobalDatasource() globaldatasource.Service {

--- a/internal/api/shared/utils.go
+++ b/internal/api/shared/utils.go
@@ -26,6 +26,7 @@ const (
 	APIV1Prefix          = "/api/v1"
 	PathDashboard        = "dashboards"
 	PathDatasource       = "datasources"
+	PathFolder           = "folders"
 	PathGlobalDatasource = "globaldatasources"
 	PathProject          = "projects"
 	PathUser             = "users"

--- a/pkg/client/api/v1/folder.go
+++ b/pkg/client/api/v1/folder.go
@@ -1,0 +1,105 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated. DO NOT EDIT
+
+package v1
+
+import (
+	"github.com/perses/perses/pkg/client/perseshttp"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+const folderResource = "folders"
+
+type FolderInterface interface {
+	Create(entity *v1.Folder) (*v1.Folder, error)
+	Update(entity *v1.Folder) (*v1.Folder, error)
+	Delete(name string) error
+	// Get is returning an unique Folder.
+	// As such name is the exact value of Folder.metadata.name. It cannot be empty.
+	// If you want to perform a research by prefix, please use the method List
+	Get(name string) (*v1.Folder, error)
+	// prefix is a prefix of the Folder.metadata.name to search for.
+	// It can be empty in case you want to get the full list of Folder available
+	List(prefix string) ([]*v1.Folder, error)
+}
+
+type folder struct {
+	FolderInterface
+	client  *perseshttp.RESTClient
+	project string
+}
+
+func newFolder(client *perseshttp.RESTClient, project string) FolderInterface {
+	return &folder{
+		client:  client,
+		project: project,
+	}
+}
+
+func (c *folder) Create(entity *v1.Folder) (*v1.Folder, error) {
+	result := &v1.Folder{}
+	err := c.client.Post().
+		Resource(folderResource).
+		Project(c.project).
+		Body(entity).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *folder) Update(entity *v1.Folder) (*v1.Folder, error) {
+	result := &v1.Folder{}
+	err := c.client.Put().
+		Resource(folderResource).
+		Name(entity.Metadata.Name).
+		Project(c.project).
+		Body(entity).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *folder) Delete(name string) error {
+	return c.client.Delete().
+		Resource(folderResource).
+		Name(name).
+		Project(c.project).
+		Do().
+		Error()
+}
+
+func (c *folder) Get(name string) (*v1.Folder, error) {
+	result := &v1.Folder{}
+	err := c.client.Get().
+		Resource(folderResource).
+		Name(name).
+		Project(c.project).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *folder) List(prefix string) ([]*v1.Folder, error) {
+	var result []*v1.Folder
+	err := c.client.Get().
+		Resource(folderResource).
+		Query(&query{
+			name: prefix,
+		}).
+		Project(c.project).
+		Do().
+		Object(&result)
+	return result, err
+}

--- a/pkg/model/api/v1/folder.go
+++ b/pkg/model/api/v1/folder.go
@@ -1,0 +1,122 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func GenerateFolderID(project string, name string) string {
+	return generateProjectResourceID("folders", project, name)
+}
+
+type FolderSpec struct {
+	// Kind can only have two values: `Dashboard` or `Folder`
+	Kind Kind `json:"kind" yaml:"kind"`
+	// Name is the reference to the dashboard when `Kind` is equal to `Dashboard`.
+	// When `Kind` is equal to `Folder`, then it's just the name of the folder
+	Name string `json:"name" yaml:"name"`
+	// Spec must only be set when 'Kind' is equal to 'Folder'.
+	Spec []FolderSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+func (f *FolderSpec) UnmarshalJSON(data []byte) error {
+	var tmp FolderSpec
+	type plain FolderSpec
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*f = tmp
+	return nil
+}
+
+func (f *FolderSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp FolderSpec
+	type plain FolderSpec
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*f = tmp
+	return nil
+}
+
+func (f *FolderSpec) validate() error {
+	if f.Kind != KindDashboard && f.Kind != KindFolder {
+		return fmt.Errorf("kind can only be %q or %q but not %q", KindDashboard, KindFolder, f.Kind)
+	}
+	if f.Kind == KindFolder && len(f.Spec) == 0 {
+		return fmt.Errorf("when kind is equal to %q, then spec cannot be empty", KindFolder)
+	}
+	if f.Kind == KindDashboard && len(f.Spec) > 0 {
+		return fmt.Errorf("when kind is equal to %q, then spec must be empty", KindDashboard)
+	}
+	return nil
+}
+
+type Folder struct {
+	Kind     Kind            `json:"kind" yaml:"kind"`
+	Metadata ProjectMetadata `json:"metadata" yaml:"metadata"`
+	Spec     []FolderSpec    `json:"spec" yaml:"spec"`
+}
+
+func (f *Folder) GenerateID() string {
+	return GenerateDashboardID(f.Metadata.Project, f.Metadata.Name)
+}
+
+func (f *Folder) GetMetadata() interface{} {
+	return &f.Metadata
+}
+
+func (f *Folder) UnmarshalJSON(data []byte) error {
+	var tmp Folder
+	type plain Folder
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*f = tmp
+	return nil
+}
+
+func (f *Folder) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp Folder
+	type plain Folder
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*f = tmp
+	return nil
+}
+
+func (f *Folder) validate() error {
+	if f.Kind != KindFolder {
+		return fmt.Errorf("invalid kind: %q for a Folder type", f.Kind)
+	}
+	if len(f.Spec) == 0 {
+		return fmt.Errorf("spec cannot be empty")
+	}
+	return nil
+}

--- a/pkg/model/api/v1/folder.go
+++ b/pkg/model/api/v1/folder.go
@@ -124,7 +124,7 @@ func (f *Folder) validate() error {
 	// Because the number of folders you can describe in this document is not limited but the URL is limited, you won't be able to put the folder tree in the URL.
 	//
 	// So if the dashboard is referenced in multiple sub-folder, the UI won't be able to know from which folder the dashboard is coming from.
-	var folderList []FolderSpec
+	folderList := make([]FolderSpec, len(f.Spec))
 	copy(folderList, f.Spec)
 	dashboardSet := make(map[string]bool)
 	for len(folderList) > 0 {

--- a/pkg/model/api/v1/folder_test.go
+++ b/pkg/model/api/v1/folder_test.go
@@ -1,0 +1,124 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalFolderError(t *testing.T) {
+	testSuite := []struct {
+		title string
+		jason string
+		err   error
+	}{
+		{
+			title: "spec cannot be empty",
+			jason: `
+{
+  "kind": "Folder",
+  "metadata": {
+    "name": "test",
+    "project": "perses"
+  }
+}
+`,
+			err: fmt.Errorf("spec cannot be empty"),
+		},
+		{
+			title: "multiple dashboard references",
+			jason: `
+
+{
+  "kind": "Folder",
+  "metadata": {
+    "name": "test",
+    "project": "perses"
+  },
+  "spec": [
+    {
+       "kind": "Dashboard",
+       "name": "myDashboard"
+    },
+    {
+      "kind": "Folder",
+      "name": "Test",
+      "spec": [
+        {
+          "kind": "Dashboard",
+          "name": "myDashboard"
+        }
+      ]
+    }
+  ]
+}
+`,
+			err: fmt.Errorf("dashboard \"myDashboard\" is referenced multiple times in the folder \"test\""),
+		},
+		{
+			title: "dashboard cannot have a list of sub-folder",
+			jason: `
+
+{
+  "kind": "Folder",
+  "metadata": {
+    "name": "test",
+    "project": "perses"
+  },
+  "spec": [
+    {
+       "kind": "Dashboard",
+       "name": "myDashboard",
+       "spec": [{
+         "kind": "Dashboard",
+         "name": "myDashboard" 
+       }]
+    }
+  ]
+}
+`,
+			err: fmt.Errorf("when kind is equal to \"Dashboard\", then spec must be empty"),
+		},
+		{
+			title: "folder must have a list of specFolder",
+			jason: `
+
+{
+  "kind": "Folder",
+  "metadata": {
+    "name": "test",
+    "project": "perses"
+  },
+  "spec": [
+    {
+       "kind": "Folder",
+       "name": "mySubFolder"
+    }
+  ]
+}
+`,
+			err: fmt.Errorf("when kind is equal to \"Folder\", then spec cannot be empty"),
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := Folder{}
+			assert.Equal(t, test.err, json.Unmarshal([]byte(test.jason), &result))
+		})
+	}
+}

--- a/pkg/model/api/v1/kind.go
+++ b/pkg/model/api/v1/kind.go
@@ -23,6 +23,7 @@ type Kind string
 const (
 	KindDashboard        Kind = "Dashboard"
 	KindDatasource       Kind = "Datasource"
+	KindFolder           Kind = "Folder"
 	KindGlobalDatasource Kind = "GlobalDatasource"
 	KindProject          Kind = "Project"
 	KindUser             Kind = "User"
@@ -31,6 +32,7 @@ const (
 var KindMap = map[Kind]bool{
 	KindDashboard:        true,
 	KindDatasource:       true,
+	KindFolder:           true,
 	KindGlobalDatasource: true,
 	KindProject:          true,
 	KindUser:             true,


### PR DESCRIPTION
This PR is adding a way to manage a sub-folder system in the backend. In the backend it's just a document that describes a folder tree with some references to the dashboard.

It will be used by the frontend to sort the dashboard in the different folders defined.

Note: related to the issue #183 

FYI: @LukeTillman @sjcobb 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>