### PR TITLE
LineChart: echarts trigger item tooltip, uplot custom tooltip

### DIFF
--- a/ui/app/sample-data/benchmarkDashboard.ts
+++ b/ui/app/sample-data/benchmarkDashboard.ts
@@ -23,7 +23,6 @@ const benchmarkDashboard: DashboardResource = {
   },
   spec: {
     datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
-    // TODO: Should duration actually be a time range?
     duration: '24h',
     variables: {
       job: {
@@ -103,9 +102,9 @@ const benchmarkDashboard: DashboardResource = {
           unit: { kind: 'Bytes' },
         },
       },
-      filesystemFullness: {
+      basicEx: {
         kind: 'LineChart',
-        display: { name: 'Filesystem Fullness' },
+        display: { name: 'Single Query' },
         options: {
           queries: [
             {
@@ -170,7 +169,7 @@ const benchmarkDashboard: DashboardResource = {
             y: 0,
             width: 12,
             height: 6,
-            content: { $ref: '#/panels/filesystemFullness' },
+            content: { $ref: '#/panels/basicEx' },
           },
         ],
       },
@@ -184,13 +183,13 @@ const benchmarkDashboard: DashboardResource = {
             height: 6,
             content: { $ref: '#/panels/seriesTestAlt' },
           },
-          // {
-          //   x: 12,
-          //   y: 0,
-          //   width: 12,
-          //   height: 6,
-          //   content: { $ref: '#/panels/multiQueries' },
-          // },
+          {
+            x: 12,
+            y: 0,
+            width: 12,
+            height: 6,
+            content: { $ref: '#/panels/multiQueries' },
+          },
         ],
       },
     ],

--- a/ui/app/sample-data/benchmarkDashboard.ts
+++ b/ui/app/sample-data/benchmarkDashboard.ts
@@ -23,7 +23,7 @@ const benchmarkDashboard: DashboardResource = {
   },
   spec: {
     datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
-    duration: '24h',
+    duration: '1h',
     variables: {
       job: {
         kind: 'PrometheusLabelValues',
@@ -78,8 +78,8 @@ const benchmarkDashboard: DashboardResource = {
             {
               kind: 'PrometheusGraphQuery',
               options: {
-                query: 'caddy_http_request_duration_seconds_bucket',
-                // query: 'rate(caddy_http_request_duration_seconds_bucket[$interval])',
+                query: 'rate(caddy_http_request_duration_seconds_bucket[$interval])',
+                // query: 'caddy_http_request_duration_seconds_bucket',
               },
             },
           ],
@@ -94,7 +94,7 @@ const benchmarkDashboard: DashboardResource = {
             {
               kind: 'PrometheusGraphQuery',
               options: {
-                query: 'caddy_http_response_duration_seconds_sum',
+                query: 'rate(caddy_http_response_duration_seconds_sum[$interval])',
                 // query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[$interval]))',
               },
             },

--- a/ui/app/sample-data/benchmarkDashboard.ts
+++ b/ui/app/sample-data/benchmarkDashboard.ts
@@ -73,13 +73,14 @@ const benchmarkDashboard: DashboardResource = {
     panels: {
       seriesTest: {
         kind: 'LineChart',
-        display: { name: '1572 Series' },
+        display: { name: '1500+ Series' },
         options: {
           queries: [
             {
               kind: 'PrometheusGraphQuery',
               options: {
-                query: 'rate(caddy_http_request_duration_seconds_bucket[$interval])',
+                query: 'caddy_http_request_duration_seconds_bucket',
+                // query: 'rate(caddy_http_request_duration_seconds_bucket[$interval])',
               },
             },
           ],
@@ -88,13 +89,14 @@ const benchmarkDashboard: DashboardResource = {
       },
       seriesTestAlt: {
         kind: 'LineChart',
-        display: { name: '131 Series' },
+        display: { name: '~130 Series' },
         options: {
           queries: [
             {
               kind: 'PrometheusGraphQuery',
               options: {
-                query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[$interval]))',
+                query: 'caddy_http_response_duration_seconds_sum',
+                // query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[$interval]))',
               },
             },
           ],
@@ -156,13 +158,13 @@ const benchmarkDashboard: DashboardResource = {
       {
         kind: 'Grid',
         items: [
-          // {
-          //   x: 0,
-          //   y: 0,
-          //   width: 12,
-          //   height: 6,
-          //   content: { $ref: '#/panels/seriesTest' },
-          // },
+          {
+            x: 0,
+            y: 0,
+            width: 12,
+            height: 6,
+            content: { $ref: '#/panels/seriesTest' },
+          },
           {
             x: 12,
             y: 0,
@@ -175,13 +177,13 @@ const benchmarkDashboard: DashboardResource = {
       {
         kind: 'Grid',
         items: [
-          // {
-          //   x: 0,
-          //   y: 0,
-          //   width: 12,
-          //   height: 6,
-          //   content: { $ref: '#/panels/seriesTestAlt' },
-          // },
+          {
+            x: 0,
+            y: 0,
+            width: 12,
+            height: 6,
+            content: { $ref: '#/panels/seriesTestAlt' },
+          },
           // {
           //   x: 12,
           //   y: 0,

--- a/ui/app/sample-data/benchmarkDashboard.ts
+++ b/ui/app/sample-data/benchmarkDashboard.ts
@@ -1,0 +1,198 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AnyVariableDefinition, DashboardResource } from '@perses-ui/core';
+
+const benchmarkDashboard: DashboardResource = {
+  kind: 'Dashboard',
+  metadata: {
+    name: 'Node Stats',
+    project: 'perses',
+    created_at: '2021-11-09',
+    updated_at: '2021-11-09',
+  },
+  spec: {
+    datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
+    // TODO: Should duration actually be a time range?
+    duration: '24h',
+    variables: {
+      job: {
+        kind: 'PrometheusLabelValues',
+        options: {
+          label_name: 'job',
+          match: ['node_uname_info'],
+        },
+        display: {
+          label: 'Job',
+        },
+        selection: {
+          default_value: 'node',
+        },
+      } as AnyVariableDefinition,
+      instance: {
+        kind: 'PrometheusLabelValues',
+        options: {
+          label_name: 'instance',
+          match: ['node_uname_info{job="node"}'],
+        },
+        display: {
+          label: 'Node',
+        },
+        selection: {
+          default_value: ['demo.do.prometheus.io:9100'],
+          all_value: '$__all',
+        },
+      } as AnyVariableDefinition,
+      interval: {
+        kind: 'Interval',
+        options: {
+          values: ['1m', '5m', '10m', '1h'],
+          auto: {
+            step_count: 50,
+            min_interval: '1m',
+          },
+        },
+        display: {
+          label: 'Interval',
+        },
+        selection: {
+          default_value: '1m',
+        },
+      } as AnyVariableDefinition,
+    },
+    panels: {
+      seriesTest: {
+        kind: 'LineChart',
+        display: { name: '1572 Series' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'rate(caddy_http_request_duration_seconds_bucket[$interval])',
+              },
+            },
+          ],
+          unit: { kind: 'Bytes' },
+        },
+      },
+      seriesTestAlt: {
+        kind: 'LineChart',
+        display: { name: '131 Series' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[$interval]))',
+              },
+            },
+          ],
+          unit: { kind: 'Bytes' },
+        },
+      },
+      filesystemFullness: {
+        kind: 'LineChart',
+        display: { name: 'Filesystem Fullness' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query:
+                  '1 - node_filesystem_free_bytes{job="node",instance="$instance",fstype!="rootfs",mountpoint!~"/(run|var).*",mountpoint!=""} / node_filesystem_size_bytes{job="node",instance="$instance"}',
+              },
+            },
+          ],
+          unit: { kind: 'Percent' },
+        },
+      },
+      multiQueries: {
+        kind: 'LineChart',
+        display: { name: 'Multi Queries' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query:
+                  'node_memory_MemTotal_bytes{job="node",instance="$instance"} - node_memory_MemFree_bytes{job="node",instance="$instance"} - node_memory_Buffers_bytes{job="node",instance="$instance"} - node_memory_Cached_bytes{job="node",instance="$instance"}',
+              },
+            },
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
+              },
+            },
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'node_memory_Cached_bytes{job="node",instance="$instance"}',
+              },
+            },
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'node_memory_MemFree_bytes{job="node",instance="$instance"}',
+              },
+            },
+          ],
+          unit: { kind: 'Bytes' },
+        },
+      },
+    },
+    layouts: [
+      {
+        kind: 'Grid',
+        items: [
+          // {
+          //   x: 0,
+          //   y: 0,
+          //   width: 12,
+          //   height: 6,
+          //   content: { $ref: '#/panels/seriesTest' },
+          // },
+          {
+            x: 12,
+            y: 0,
+            width: 12,
+            height: 6,
+            content: { $ref: '#/panels/filesystemFullness' },
+          },
+        ],
+      },
+      {
+        kind: 'Grid',
+        items: [
+          // {
+          //   x: 0,
+          //   y: 0,
+          //   width: 12,
+          //   height: 6,
+          //   content: { $ref: '#/panels/seriesTestAlt' },
+          // },
+          // {
+          //   x: 12,
+          //   y: 0,
+          //   width: 12,
+          //   height: 6,
+          //   content: { $ref: '#/panels/multiQueries' },
+          // },
+        ],
+      },
+    ],
+  },
+};
+
+export default benchmarkDashboard;

--- a/ui/app/sample-data/nodeExporterDashboard.ts
+++ b/ui/app/sample-data/nodeExporterDashboard.ts
@@ -239,24 +239,6 @@ const nodeExporterDashboard: DashboardResource = {
         display: { name: 'Empty Example 3' },
         options: {},
       },
-      seriesTest: {
-        kind: 'LineChart',
-        display: { name: 'Series Test' },
-        options: {
-          queries: [
-            {
-              kind: 'PrometheusGraphQuery',
-              options: {
-                // query: 'caddy_http_request_duration_seconds_bucket',
-                query: 'rate(caddy_http_request_duration_seconds_bucket[5m])',
-                // query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[5m]))',
-                // query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
-              },
-            },
-          ],
-          unit: { kind: 'Bytes' },
-        },
-      },
       cpu: {
         kind: 'LineChart',
         display: { name: 'CPU' },
@@ -405,7 +387,6 @@ const nodeExporterDashboard: DashboardResource = {
             width: 12,
             height: 6,
             content: { $ref: '#/panels/cpu' },
-            // content: { $ref: '#/panels/seriesTest' },
           },
           {
             x: 12,

--- a/ui/app/sample-data/nodeExporterDashboard.ts
+++ b/ui/app/sample-data/nodeExporterDashboard.ts
@@ -239,6 +239,24 @@ const nodeExporterDashboard: DashboardResource = {
         display: { name: 'Empty Example 3' },
         options: {},
       },
+      seriesTest: {
+        kind: 'LineChart',
+        display: { name: 'Series Test' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                // query: 'caddy_http_request_duration_seconds_bucket',
+                query: 'rate(caddy_http_request_duration_seconds_bucket[5m])',
+                // query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[5m]))',
+                // query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
+              },
+            },
+          ],
+          unit: { kind: 'Bytes' },
+        },
+      },
       cpu: {
         kind: 'LineChart',
         display: { name: 'CPU' },
@@ -387,6 +405,7 @@ const nodeExporterDashboard: DashboardResource = {
             width: 12,
             height: 6,
             content: { $ref: '#/panels/cpu' },
+            // content: { $ref: '#/panels/seriesTest' },
           },
           {
             x: 12,

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
@@ -84,6 +84,9 @@ function LineChart(props: LineChartProps) {
     }
 
     return {
+      title: {
+        show: false,
+      },
       series,
       xAxis: {
         type: 'category',
@@ -153,6 +156,12 @@ function LineChart(props: LineChartProps) {
   useLayoutEffect(() => {
     // Can't set options if no chart yet
     if (chart === undefined) return;
+
+    if (option.series === undefined) {
+      chart.showLoading();
+    } else {
+      chart.hideLoading();
+    }
 
     chart.setOption(option);
   }, [chart, option]);

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
@@ -78,8 +78,8 @@ function LineChart(props: LineChartProps) {
           data: yValues,
           sampling: 'lttb', // use Largest-Triangle-Three-Bucket algorithm to filter points
           progressiveThreshold: 1,
+          symbol: 'rect',
           // connectNulls: true,
-          showAllSymbol: false,
         });
       }
     }

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
@@ -76,6 +76,7 @@ function LineChart(props: LineChartProps) {
           type: 'line',
           name: timeSeries.name,
           data: yValues,
+          sampling: 'lttb', // use Largest-Triangle-Three-Bucket algorithm to filter points
           // connectNulls: true,
           showAllSymbol: false,
         });

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
@@ -14,14 +14,14 @@
 import * as echarts from 'echarts/core';
 import type { EChartsOption } from 'echarts';
 import { LineChart as EChartsLineChart } from 'echarts/charts';
-import { GridComponent, DataZoomComponent, TooltipComponent, TooltipComponentOption } from 'echarts/components';
+import { GridComponent, TooltipComponent, TooltipComponentOption } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 import { useMemo, useState, useLayoutEffect, useRef } from 'react';
 import { Box } from '@mui/material';
 import { useRunningGraphQueries } from './GraphQueryRunner';
 import { getCommonTimeScale, getXValues } from './data-transform';
 
-echarts.use([EChartsLineChart, GridComponent, DataZoomComponent, TooltipComponent, CanvasRenderer]);
+echarts.use([EChartsLineChart, GridComponent, TooltipComponent, CanvasRenderer]);
 
 export interface LineChartProps {
   width: number;
@@ -107,6 +107,7 @@ function LineChart(props: LineChartProps) {
         containLabel: true,
       },
       animation: false,
+      // TODO (sjcobb): move shared tooltip styles to chart theme
       tooltip: {
         show: true,
         trigger: 'item',

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
@@ -78,7 +78,8 @@ function LineChart(props: LineChartProps) {
           data: yValues,
           sampling: 'lttb', // use Largest-Triangle-Three-Bucket algorithm to filter points
           progressiveThreshold: 1,
-          symbol: 'rect',
+          symbol: 'image://',
+          symbolSize: 35,
           // connectNulls: true,
         });
       }

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
@@ -38,9 +38,11 @@ const tooltipFormatter: TooltipFormatterCallback = (params: TooltipFormatterPara
   const seriesName = params.seriesName ?? '';
   const formattedNames = seriesName.split(',').join('<br />');
   const formattedTime = echarts.format.formatTime('yyyy-MM-dd hh:mm:ss', Number(params.name));
+  const customMarker = `<span style="float:left; width:9px; height:9px; margin:5px 6px 0 0; background-color:${params.color};"></span>`;
   return `
     <h4 style="margin: 2px 0 3px;">${formattedTime}</h4>
-    <div>${params.marker}${formattedNames}</div>
+    <div>${customMarker}<span>value: ${params.value}</span></div>
+    <div style="margin-bottom:4px; font-size:10px; font-weight:300;">${formattedNames}</div>
   `;
 };
 
@@ -108,12 +110,12 @@ function LineChart(props: LineChartProps) {
       tooltip: {
         show: true,
         trigger: 'item',
-        enterable: true,
+        enterable: false,
         confine: true,
         extraCssText: 'max-height: 220px; max-width: 350px; overflow: auto;',
-        showDelay: 20,
+        showDelay: 0,
         hideDelay: 100,
-        transitionDuration: 0.4,
+        transitionDuration: 0.2,
         backgroundColor: '#333',
         borderColor: '#333',
         borderRadius: 2,
@@ -123,7 +125,7 @@ function LineChart(props: LineChartProps) {
           color: '#fff',
           fontFamily: '"Lato", sans-serif',
           fontSize: 11,
-          fontWeight: 300,
+          fontWeight: 400,
         },
         formatter: tooltipFormatter,
       },

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.tsx
@@ -77,6 +77,7 @@ function LineChart(props: LineChartProps) {
           name: timeSeries.name,
           data: yValues,
           sampling: 'lttb', // use Largest-Triangle-Three-Bucket algorithm to filter points
+          progressiveThreshold: 1,
           // connectNulls: true,
           showAllSymbol: false,
         });

--- a/ui/panels-plugin/src/plugins/line-chart/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/data-transform.ts
@@ -13,7 +13,7 @@
 
 import { AbsoluteTimeRange, GraphSeries } from '@perses-ui/core';
 import { gcd } from 'mathjs';
-import { QueryState } from '../GraphQueryRunner';
+import { QueryState } from './GraphQueryRunner';
 
 export interface TimeScale {
   startMs: number;

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotChart.tsx
@@ -13,7 +13,7 @@
 
 import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';
-import { useState, useMemo, useLayoutEffect, useRef } from 'react';
+import { useMemo } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { useRunningGraphQueries } from '../GraphQueryRunner';
 import { getCommonTimeScale, getXValues, getYValues } from '../data-transform';
@@ -37,7 +37,6 @@ export interface UPlotChartProps {
  */
 function UPlotChart(props: UPlotChartProps) {
   const { width, height } = props;
-  const plotInstance = useRef<uPlot>();
   const theme = useTheme();
   const queries = useRunningGraphQueries();
 
@@ -107,29 +106,11 @@ function UPlotChart(props: UPlotChartProps) {
     };
   }, [queries, width, height, theme]);
 
-  const [containerRef, setContainerRef] = useState<HTMLDivElement | null>();
-  const [, setPlot] = useState<uPlot | undefined>(undefined);
-
-  // Create the plot in the container div and recreate whenever data or options change
-  useLayoutEffect(() => {
-    if (containerRef === null) return;
-    if (data === undefined || options === undefined) return;
-
-    plotInstance.current = new uPlot(options, data, containerRef);
-    setPlot(plotInstance.current);
-
-    return () => {
-      if (plotInstance.current) {
-        plotInstance.current.destroy();
-      }
-    };
-  }, [containerRef, data, options]);
-
   if (data === undefined || options === undefined) {
     return <p>Chart loading...</p>;
   }
   return (
-    <Box ref={setContainerRef} sx={{ width, height, position: 'relative' }}>
+    <Box sx={{ width, height, position: 'relative' }}>
       <UPlotContextProvider {...options} data={data}>
         <TooltipPlugin />
       </UPlotContextProvider>

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotChart.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotChart.tsx
@@ -16,7 +16,7 @@ import 'uplot/dist/uPlot.min.css';
 import { useState, useMemo, useLayoutEffect } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { useRunningGraphQueries } from '../GraphQueryRunner';
-import { getCommonTimeScale, getXValues, getYValues } from './data-transform';
+import { getCommonTimeScale, getXValues, getYValues } from '../data-transform';
 
 // Formatter for dates on the X axis
 const XAXIS_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContext.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContext.tsx
@@ -1,3 +1,16 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { useContext } from 'react';
 import uPlot, { AlignedData, Series, Plugin } from 'uplot';
 

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContext.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContext.tsx
@@ -1,0 +1,41 @@
+import React, { useContext } from 'react';
+import uPlot, { AlignedData, Series, Plugin } from 'uplot';
+
+interface PlotContextType {
+  getPlotInstance: () => uPlot | undefined;
+  addPlotEventListeners: (id: string, listeners: Plugin['hooks']) => () => void;
+  getSeries: () => Series[];
+  plotCanvas: HTMLDivElement | null;
+  data: AlignedData;
+}
+
+export const PlotContext = React.createContext<PlotContextType | undefined>(undefined);
+
+export const usePlotContext = (): PlotContextType => {
+  const ctx = useContext(PlotContext);
+  if (ctx === undefined) {
+    throw new Error('No PlotContext found. Did you forget the provider?');
+  }
+  return ctx;
+};
+
+export const buildPlotContext = (
+  plotCanvas: HTMLDivElement | null,
+  data: AlignedData,
+  addPlotEventListeners: PlotContextType['addPlotEventListeners'],
+  getPlotInstance: () => uPlot | undefined
+): PlotContextType => {
+  return {
+    plotCanvas,
+    data,
+    addPlotEventListeners,
+    getPlotInstance,
+    getSeries: () => {
+      const plotInstance = getPlotInstance();
+      if (plotInstance !== undefined) {
+        return plotInstance.series;
+      }
+      return [];
+    },
+  };
+};

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContextProvider.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContextProvider.tsx
@@ -1,0 +1,70 @@
+import React, { useRef, useLayoutEffect, useMemo, useCallback, useState } from 'react';
+import uPlot from 'uplot';
+import 'uplot/dist/uPlot.min.css';
+import { buildPlotContext, PlotContext } from './UPlotContext';
+
+interface UPlotProps extends Omit<uPlot.Options, 'plugins'> {
+  children: React.ReactNode;
+  data: uPlot.AlignedData;
+}
+
+function UPlotContextProvider({ data, children, ...options }: UPlotProps) {
+  const plotInstance = useRef<uPlot>();
+  const [plugins, setPlugins] = useState<Map<string, uPlot.Plugin>>(new Map());
+  const [plotCanvas, setPlotCanvas] = useState<HTMLDivElement | null>(null);
+  const plotRef = useCallback((node: HTMLDivElement | null) => {
+    if (node !== null) {
+      setPlotCanvas(node);
+    }
+  }, []);
+
+  const getPlotInstance = useCallback(() => {
+    return plotInstance.current;
+  }, []);
+
+  const registerPlugin = useCallback((id, hooks: uPlot.Plugin['hooks']) => {
+    const plugin = { hooks };
+    setPlugins((plugins) => {
+      return new Map([...plugins, [id, plugin]]);
+    });
+
+    return function unregister() {
+      setPlugins((plugins) => {
+        plugins.delete(id);
+        return new Map([...plugins]);
+      });
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (plotInstance.current) {
+      plotInstance.current.destroy();
+    }
+
+    if (plotCanvas === null) {
+      return;
+    }
+
+    plotInstance.current = new uPlot(
+      {
+        ...options,
+        plugins: Array.from(plugins.values()),
+      },
+      data,
+      plotCanvas
+    );
+  }, [data, options, plugins, plotCanvas]);
+
+  const plotContext = useMemo(() => {
+    return buildPlotContext(plotCanvas, data, registerPlugin, getPlotInstance);
+  }, [plotCanvas, data, getPlotInstance, registerPlugin]);
+
+  return (
+    <PlotContext.Provider value={plotContext}>
+      <div ref={plotRef} />
+      {children}
+    </PlotContext.Provider>
+  );
+}
+
+export default UPlotContextProvider;

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContextProvider.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/UPlotContextProvider.tsx
@@ -1,3 +1,16 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { useRef, useLayoutEffect, useMemo, useCallback, useState } from 'react';
 import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipContent.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipContent.tsx
@@ -1,0 +1,77 @@
+import { Box, Theme } from '@mui/material';
+import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
+import { TooltipSeriesInfo } from './graph-tooltip';
+
+const MAX_TOOLTIP_WIDTH = 400;
+
+const tooltipMetricStyle: SxProps<Theme> = {
+  maxWidth: MAX_TOOLTIP_WIDTH,
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  flexGrow: 1,
+};
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  hour12: true,
+});
+
+function SeriesInfo(props: { focusedSeries: TooltipSeriesInfo | TooltipSeriesInfo[] }) {
+  // TODO (sjcobb): add color badge marker
+  let seriesInfo = props.focusedSeries;
+  if (!Array.isArray(seriesInfo)) {
+    seriesInfo = [seriesInfo];
+  }
+  return (
+    <>
+      {seriesInfo.map(({ name, y }) => (
+        <Box display="flex" flex="column" alignItems="center" key={name}>
+          <Box sx={tooltipMetricStyle}>{name}</Box>
+          <Box>{y}</Box>
+        </Box>
+      ))}
+    </>
+  );
+}
+
+function TooltipContent(props: {
+  top: number;
+  left: number;
+  x: number;
+  focusedSeries: TooltipSeriesInfo | TooltipSeriesInfo[];
+}) {
+  const { focusedSeries, x, top, left } = props;
+  // TODO (sjcobb): add isTooltipOffscreen check using container width instead of window.innerWidth
+  const leftPosAdjusted = left + 15;
+
+  return (
+    <Box
+      sx={{
+        padding: (theme) => theme.spacing(1, 2),
+        position: 'absolute',
+        top: top,
+        left: leftPosAdjusted,
+        borderRadius: 2,
+        maxWidth: MAX_TOOLTIP_WIDTH,
+        backgroundColor: '#000',
+        opacity: 0.9,
+        fontSize: '11px',
+        color: '#fff',
+        zIndex: 1,
+      }}
+    >
+      <Box>
+        <b>{DATE_FORMAT.format(x * 1000)}</b>
+      </Box>
+      <SeriesInfo focusedSeries={focusedSeries} />
+    </Box>
+  );
+}
+
+export default TooltipContent;

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipContent.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipContent.tsx
@@ -1,3 +1,16 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Box, Theme } from '@mui/material';
 import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
 import { TooltipSeriesInfo } from './graph-tooltip';

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipPlugin.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipPlugin.tsx
@@ -1,3 +1,16 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { usePlotContext } from '../UPlotContext';
 import { useGraphCursorPosition, useOverlappingSeries } from './graph-cursor';
 import TooltipContent from './TooltipContent';

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipPlugin.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/TooltipPlugin.tsx
@@ -1,0 +1,26 @@
+import { usePlotContext } from '../UPlotContext';
+import { useGraphCursorPosition, useOverlappingSeries } from './graph-cursor';
+import TooltipContent from './TooltipContent';
+
+/**
+ * Listens for update to current Cursor position and renders a Tooltip with the relevant data
+ */
+function TooltipPlugin() {
+  const { data, getSeries } = usePlotContext();
+  const cursor = useGraphCursorPosition();
+  const focusedSeries = useOverlappingSeries(cursor, getSeries(), data);
+
+  if (!cursor) {
+    return null;
+  }
+
+  const { focusedSeriesIdx, focusedPointIdx, coords } = cursor;
+  if (!focusedPointIdx || !focusedSeriesIdx) {
+    return null;
+  }
+
+  const x = data[0][focusedPointIdx] ?? 0;
+  return <TooltipContent top={coords.plotCanvas.y} left={coords.plotCanvas.x} x={x} focusedSeries={focusedSeries} />;
+}
+
+export default TooltipPlugin;

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-cursor.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-cursor.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { AlignedData, Series } from 'uplot';
+import { usePlotContext } from '../UPlotContext';
+import { TooltipSeriesInfo } from './graph-tooltip';
+
+interface Coordinate {
+  x: number;
+  y: number;
+}
+
+export interface GraphCursorPositionValues {
+  focusedSeriesIdx: number | null;
+  focusedPointIdx: number | null;
+
+  coords: {
+    plotCanvas: Coordinate; // coords relative to plot canvas, css px
+    viewport: Coordinate; // coords relative to viewport , css px
+  };
+}
+
+/**
+ * Exposes API for the Graph cursor position
+ */
+export function useGraphCursorPosition(): GraphCursorPositionValues | null {
+  const { plotCanvas, addPlotEventListeners } = usePlotContext();
+  const plotCanvasBBox = useRef({
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+  });
+
+  // nearest time series to the cursor
+  const [focusedSeriesIdx, setFocusedSeriesIdx] = useState<number | null>(null);
+  // nearest x-value to the cursor
+  const [focusedPointIdx, setFocusedPointIdx] = useState<number | null>(null);
+  const [coords, setCoords] = useState<{
+    viewport: Coordinate;
+    plotCanvas: Coordinate;
+  } | null>(null);
+
+  const clearCoords = useCallback(() => {
+    setCoords(null);
+  }, [setCoords]);
+
+  useEffect(() => {
+    const onMouseCapture = (e: MouseEvent) => {
+      setCoords({
+        plotCanvas: {
+          x: e.clientX - plotCanvasBBox.current.left,
+          y: e.clientY - plotCanvasBBox.current.top,
+        },
+        viewport: {
+          x: e.clientX,
+          y: e.clientY,
+        },
+      });
+    };
+
+    if (plotCanvas) {
+      plotCanvasBBox.current = plotCanvas.getBoundingClientRect();
+      plotCanvas.addEventListener('mousemove', onMouseCapture);
+      plotCanvas.addEventListener('mouseleave', clearCoords);
+    }
+
+    return () => {
+      if (plotCanvas) {
+        plotCanvas.removeEventListener('mousemove', onMouseCapture);
+      }
+    };
+  }, [plotCanvas, clearCoords]);
+
+  // on mount - initialize plugin listeners
+  useEffect(() => {
+    const unregister = addPlotEventListeners('cursor', {
+      // What is the nearest x value to the cursor
+      setCursor: ({ cursor }) => {
+        setFocusedPointIdx(cursor.idx === undefined ? null : cursor.idx);
+      },
+      // What is the nearest y-value and what series is it in
+      setSeries: (u, index) => {
+        setFocusedSeriesIdx(index);
+      },
+    });
+
+    return () => {
+      unregister();
+    };
+  }, [addPlotEventListeners]);
+
+  // only render children if we are interacting with the canvas
+  return coords
+    ? {
+        focusedSeriesIdx,
+        focusedPointIdx,
+        coords,
+      }
+    : null;
+}
+
+/**
+ * Since the uPlot only finds a single series, this method finds
+ * all values that are equal to the cursor's focused value.
+ *
+ * @param focusedSeriesIdx The index of the series that is focused by the cursor
+ * @param focusedPointIdx The current index along the x axis
+ */
+export function getOverlappingSeriesIndices(
+  focusedSeriesIdx: number | null,
+  focusedPointIdx: number | null,
+  data: AlignedData
+) {
+  const overlappingIndices: number[] = [];
+
+  if (focusedSeriesIdx === null || focusedPointIdx === null) {
+    return overlappingIndices;
+  }
+
+  const dataFocusedSeriesIdx = data[focusedSeriesIdx];
+  if (dataFocusedSeriesIdx) {
+    const focusedValue = dataFocusedSeriesIdx[focusedPointIdx];
+    for (let seriesIdx = 0; seriesIdx < data.length; seriesIdx++) {
+      const dataSeriesIdx = data[seriesIdx];
+      if (dataSeriesIdx && dataSeriesIdx[focusedPointIdx] === focusedValue) {
+        overlappingIndices.push(seriesIdx);
+      }
+    }
+  }
+
+  return overlappingIndices;
+}
+
+export function getFocusedSeriesInfo(
+  overlappingIndices: number[],
+  focusedPointIdx: number | null,
+  series: Series[],
+  data: AlignedData
+) {
+  const focusedSeries: TooltipSeriesInfo[] = [];
+  if (focusedPointIdx === null) {
+    return focusedSeries;
+  }
+  for (const seriesIdx of overlappingIndices) {
+    const overlapSeries = series[seriesIdx];
+    const label = overlapSeries && overlapSeries.label !== undefined ? overlapSeries.label : '';
+
+    let y = 0;
+    if (data[seriesIdx]) {
+      const seriesData = data[seriesIdx] ?? [];
+      y = seriesData[focusedPointIdx] ?? 0;
+    }
+
+    focusedSeries.push({ y, name: label ?? '', seriesId: label ?? '' });
+  }
+  return focusedSeries;
+}
+
+export function useOverlappingSeries(cursor: GraphCursorPositionValues | null, series: Series[], data: AlignedData) {
+  return useMemo(() => {
+    if (cursor === null || cursor?.focusedPointIdx === null || cursor?.focusedSeriesIdx === null) return [];
+    const { focusedSeriesIdx, focusedPointIdx } = cursor;
+    const overlappingSeriesIndices = getOverlappingSeriesIndices(focusedSeriesIdx, focusedPointIdx, data);
+    return getFocusedSeriesInfo(overlappingSeriesIndices, focusedPointIdx, series, data);
+  }, [data, cursor, series]);
+}

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-cursor.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-cursor.tsx
@@ -1,3 +1,16 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { AlignedData, Series } from 'uplot';
 import { usePlotContext } from '../UPlotContext';

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-tooltip.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-tooltip.ts
@@ -1,0 +1,5 @@
+export interface TooltipSeriesInfo {
+  y: number;
+  name: string;
+  seriesId: string;
+}

--- a/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-tooltip.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/uplot/tooltip/graph-tooltip.ts
@@ -1,3 +1,16 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export interface TooltipSeriesInfo {
   y: number;
   name: string;


### PR DESCRIPTION
When comparing our LineChart implementation with ECharts benchmarks in Chronosphere's UI, I noticed some performance discrepancies. The main issue is [a bug](https://github.com/apache/echarts/issues/14305) in how `xAxis.type: 'time'` works with axisLabel intervals, which results in symbols always rendering since [series-line.showAllSymbol](https://echarts.apache.org/en/option.html#series-line.showAllSymbol) relys on that interval strategy to determine when to hide symbols. This meant line charts with 1500+ series were taking ~30 seconds to load--_now ECharts is competitive with uPlot in performance again_.

Previously, the workaround here was to hide symbols using `symbol: 'none' or showSymbol: false`, but this is no longer an option since [trigger: 'item'](https://echarts.apache.org/en/option.html#tooltip.trigger) tooltips need symbols to be visible in order to show tooltip content on hover (and trigger 'axis' tooltips can't be used with so many series). LineChart now uses the more stable 'category' xAxis.type implementation, as well as passing data in series.data instead of dataset. Other proposed performance improvements are to enable the LTTB [downsampling property](https://echarts.apache.org/en/option.html#series-line.sampling).

See: https://localhost:3000/?dashboard=benchmarkDashboard

![echarts_tooltip_screenshot](https://user-images.githubusercontent.com/9369625/145279452-d0403961-f1e8-4452-9c93-d4123ef2d915.png)

**TODO**: 
- tooltip content: fix metric name showing beside marker 
- show closest series in tooltip even when not focused on data point ([this feature](https://github.com/apache/echarts/issues/15080) is on EChart's roadmap already)
- separate PR with uPlot tooltip for comparison