### PR TITLE
Add prop to wrap tooltip labels

### DIFF
--- a/ui/panels-plugin/src/plugins/line-chart/tooltip/SeriesInfo.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/tooltip/SeriesInfo.tsx
@@ -20,10 +20,11 @@ interface SeriesInfoProps {
   y: number;
   markerColor: string;
   totalSeries: number;
+  wrapLabels?: boolean;
 }
 
 function SeriesInfo(props: SeriesInfoProps) {
-  const { seriesName, y, markerColor, totalSeries } = props;
+  const { seriesName, y, markerColor, totalSeries, wrapLabels } = props;
   // TODO (sjcobb): regex to remove __name__ and quotes, replace = with :`
   const formattedSeriesLabels = seriesName.replaceAll('"', '');
 
@@ -103,7 +104,7 @@ function SeriesInfo(props: SeriesInfoProps) {
             maxWidth: TOOLTIP_LABELS_MAX_WIDTH,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
+            whiteSpace: wrapLabels ? 'normal' : 'nowrap',
             width: 'calc(100% - 20px)',
           }}
         >

--- a/ui/panels-plugin/src/plugins/line-chart/tooltip/Tooltip.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/tooltip/Tooltip.tsx
@@ -28,6 +28,7 @@ function assembleTransform(coords: Coordinate, chartWidth: number) {
 
 interface TooltipProps {
   tooltipData: TooltipData;
+  wrapLabels?: boolean;
 }
 
 function Tooltip(props: TooltipProps) {
@@ -71,7 +72,7 @@ function Tooltip(props: TooltipProps) {
         }}
         onMouseLeave={handleHoverOff}
       >
-        <TooltipContent focusedSeries={focusedSeries} />
+        <TooltipContent focusedSeries={focusedSeries} wrapLabels={props.wrapLabels} />
       </Box>
     </>
   );

--- a/ui/panels-plugin/src/plugins/line-chart/tooltip/TooltipContent.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/tooltip/TooltipContent.tsx
@@ -15,8 +15,13 @@ import { Box, Divider, Stack, Typography } from '@mui/material';
 import { FocusedSeriesArray } from '../utils/focused-series';
 import SeriesInfo from './SeriesInfo';
 
-function TooltipContent(props: { focusedSeries: FocusedSeriesArray | null }) {
-  const { focusedSeries } = props;
+interface TooltipContentProps {
+  focusedSeries: FocusedSeriesArray | null;
+  wrapLabels?: boolean;
+}
+
+function TooltipContent(props: TooltipContentProps) {
+  const { focusedSeries, wrapLabels } = props;
   // let lastDate = focusedSeries[0] && focusedSeries[0].date ? focusedSeries[0].date : '';
   const seriesTime = focusedSeries && focusedSeries[0] && focusedSeries[0].date ? focusedSeries[0].date : false;
 
@@ -55,6 +60,7 @@ function TooltipContent(props: { focusedSeries: FocusedSeriesArray | null }) {
                 y={y}
                 markerColor={markerColor}
                 totalSeries={focusedSeries.length}
+                wrapLabels={wrapLabels}
               />
             );
           })}


### PR DESCRIPTION
Adds prop to wrap labels in `Tooltip`

<img width="720" alt="image" src="https://user-images.githubusercontent.com/170681/155604807-1f335522-85bc-4124-ab81-494e7357cbd1.png">

