### PR TITLE
CLI: implement apply cmd

### DIFF
--- a/cmd/percli/main.go
+++ b/cmd/percli/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"os"
 
+	"github.com/perses/perses/internal/cli/cmd/apply"
 	"github.com/perses/perses/internal/cli/cmd/describe"
 	"github.com/perses/perses/internal/cli/cmd/get"
 	"github.com/perses/perses/internal/cli/cmd/login"
@@ -38,6 +39,7 @@ func newRootCommand() *cobra.Command {
 	}
 
 	// The list of the commands supported
+	cmd.AddCommand(apply.NewCMD())
 	cmd.AddCommand(describe.NewCMD())
 	cmd.AddCommand(get.NewCMD())
 	cmd.AddCommand(login.NewCMD())

--- a/internal/cli/cmd/apply/apply.go
+++ b/internal/cli/cmd/apply/apply.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apply
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	cmdUtils "github.com/perses/perses/internal/cli/utils"
+	"github.com/perses/perses/internal/cli/utils/file"
+	cmdUtilsService "github.com/perses/perses/internal/cli/utils/service"
+	"github.com/perses/perses/pkg/client/api"
+	"github.com/perses/perses/pkg/client/perseshttp"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	cmdUtils.CMDOption
+	writer    io.Writer
+	file      string
+	project   string
+	apiClient api.ClientInterface
+}
+
+func (o *option) Complete(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("no args are supported by the command 'apply'")
+	}
+
+	// Then, if no particular project has been specified through a flag, let's grab the one defined in the CLI config.
+	if len(o.project) == 0 {
+		o.project = cmdUtils.GlobalConfig.Project
+	}
+
+	// Finally, get the api client we will need later.
+	apiClient, err := cmdUtils.GlobalConfig.GetAPIClient()
+	if err != nil {
+		return err
+	}
+	o.apiClient = apiClient
+	return nil
+}
+
+func (o *option) Validate() error {
+	if len(o.file) == 0 {
+		return fmt.Errorf("file must be provided")
+	}
+	return nil
+}
+
+func (o *option) Execute() error {
+	unmarshaller := file.Unmarshaller{}
+	entities, err := unmarshaller.Unmarshal(o.file)
+	if err != nil {
+		return err
+	}
+	for _, entity := range entities {
+		kind := modelV1.Kind(entity.GetKind())
+		name := entity.GetMetadata().GetName()
+		svc, svcErr := cmdUtilsService.NewService(kind, o.project, o.apiClient)
+		if svcErr != nil {
+			return svcErr
+		}
+
+		// retrieve if exists the entity from the Perses API
+		_, apiError := svc.GetResource(name)
+		if apiError != nil && !errors.Is(apiError, perseshttp.RequestNotFoundError) {
+			return fmt.Errorf("unable to retrieve the %q from the Perses API. %w", kind, apiError)
+		}
+
+		if errors.Is(apiError, perseshttp.RequestNotFoundError) {
+			// the document doesn't exist, so we have to create it.
+			if _, createError := svc.CreateResource(entity); createError != nil {
+				return createError
+			}
+		} else {
+			// the document doesn't exist, so we have to create it.
+			if _, updateError := svc.UpdateResource(entity); updateError != nil {
+				return updateError
+			}
+		}
+
+		if cmdUtils.IsGlobalResource(kind) {
+			if outputErr := cmdUtils.HandleString(o.writer, fmt.Sprintf("object %q %q has been applied", kind, name)); outputErr != nil {
+				return outputErr
+			}
+		} else if outputErr := cmdUtils.HandleString(o.writer, fmt.Sprintf("object %q %q has been applied in the project %q", kind, name, o.project)); outputErr != nil {
+			return outputErr
+		}
+	}
+	return nil
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "apply -f [FILENAME]",
+		Short: "Create or update resources through a file. JSON or YAML format supported",
+		Example: `
+# Create/update the resources from the file resources.json to the remote Perses server.
+percli apply -f ./resources.json
+
+# Apply the JSON passed into stdin to the remote Perses server.
+cat ./resources.json | percli apply -f -
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdUtils.RunCMD(o, cmd, args)
+		},
+	}
+	cmd.Flags().StringVarP(&o.project, "project", "p", o.project, "If present, the project scope for this CLI request.")
+	cmd.Flags().StringVarP(&o.file, "file", "f", o.file, "Path to the file that contains the resources to create/update.")
+	if err := cmd.MarkFlagRequired("file"); err != nil {
+		logrus.Panic(err)
+	}
+	return cmd
+}

--- a/internal/cli/cmd/apply/apply_test.go
+++ b/internal/cli/cmd/apply/apply_test.go
@@ -55,6 +55,7 @@ func TestApplyCMD(t *testing.T) {
 			APIClient:       fake_api.New(),
 			IsErrorExpected: false,
 			ExpectedMessage: `object "Folder" "ff15" has been applied in the project "perses"
+object "Folder" "aoe4" has been applied in the project "game"
 object "Project" "perses" has been applied
 `,
 		},

--- a/internal/cli/cmd/apply/apply_test.go
+++ b/internal/cli/cmd/apply/apply_test.go
@@ -1,0 +1,63 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apply
+
+import (
+	"testing"
+
+	cmdUtilsTest "github.com/perses/perses/internal/cli/utils/test"
+	"github.com/perses/perses/pkg/client/fake_api"
+)
+
+func TestApplyCMD(t *testing.T) {
+	testSuite := []cmdUtilsTest.Suite{
+		{
+			Title:           "empty args",
+			Args:            []string{},
+			IsErrorExpected: true,
+			ExpectedMessage: `required flag(s) "file" not set`,
+		},
+		{
+			Title:           "not connected to any API",
+			Args:            []string{"-f", "test.json"},
+			IsErrorExpected: true,
+			ExpectedMessage: "you are not connected to any API",
+		},
+		{
+			Title:           "apply unknown document",
+			Args:            []string{"-f", "./test/unknown_resource.json"},
+			APIClient:       fake_api.New(),
+			IsErrorExpected: true,
+			ExpectedMessage: `resource "game" not supported by the command`,
+		},
+		{
+			Title:           "apply a single resource",
+			Args:            []string{"-f", "./test/single_resource.json", "--project", "perses"},
+			APIClient:       fake_api.New(),
+			IsErrorExpected: false,
+			ExpectedMessage: `object "Folder" "ff15" has been applied in the project "perses"
+`,
+		},
+		{
+			Title:           "apply multiples different resources",
+			Args:            []string{"-f", "./test/multiple_resources.json", "--project", "perses"},
+			APIClient:       fake_api.New(),
+			IsErrorExpected: false,
+			ExpectedMessage: `object "Folder" "ff15" has been applied in the project "perses"
+object "Project" "perses" has been applied
+`,
+		},
+	}
+	cmdUtilsTest.ExecuteSuiteTest(t, NewCMD, testSuite)
+}

--- a/internal/cli/cmd/apply/test/multiple_resources.json
+++ b/internal/cli/cmd/apply/test/multiple_resources.json
@@ -12,6 +12,19 @@
     ]
   },
   {
+    "kind": "Folder",
+    "metadata": {
+      "name": "aoe4",
+      "project": "game"
+    },
+    "spec": [
+      {
+        "kind": "Dashboard",
+        "name": "node_exporter"
+      }
+    ]
+  },
+  {
     "kind": "Project",
     "metadata": {
       "name": "perses"

--- a/internal/cli/cmd/apply/test/multiple_resources.json
+++ b/internal/cli/cmd/apply/test/multiple_resources.json
@@ -1,0 +1,20 @@
+[
+  {
+    "kind": "Folder",
+    "metadata": {
+      "name": "ff15"
+    },
+    "spec": [
+      {
+        "kind": "Dashboard",
+        "name": "node_exporter"
+      }
+    ]
+  },
+  {
+    "kind": "Project",
+    "metadata": {
+      "name": "perses"
+    }
+  }
+]

--- a/internal/cli/cmd/apply/test/single_resource.json
+++ b/internal/cli/cmd/apply/test/single_resource.json
@@ -1,0 +1,12 @@
+{
+  "kind": "Folder",
+  "metadata": {
+    "name": "ff15"
+  },
+  "spec": [
+    {
+      "kind": "Dashboard",
+      "name": "node_exporter"
+    }
+  ]
+}

--- a/internal/cli/cmd/apply/test/unknown_resource.json
+++ b/internal/cli/cmd/apply/test/unknown_resource.json
@@ -1,0 +1,8 @@
+[
+  {
+    "kind": "game",
+    "metadata": {
+      "name": "AOE4"
+    }
+  }
+]

--- a/internal/cli/cmd/describe/describe.go
+++ b/internal/cli/cmd/describe/describe.go
@@ -71,6 +71,10 @@ func (o *option) Complete(args []string) error {
 }
 
 func (o *option) Validate() error {
+	// check if project should be defined (through the config or through the flag) for the given resource.
+	if len(o.project) == 0 && !cmdUtils.IsGlobalResource(o.kind) {
+		return fmt.Errorf("no project has been defined for the scope of this command")
+	}
 	return cmdUtils.ValidateAndSetOutput(&o.output)
 }
 

--- a/internal/cli/cmd/describe/describe_test.go
+++ b/internal/cli/cmd/describe/describe_test.go
@@ -49,7 +49,7 @@ func TestDescribeCMD(t *testing.T) {
 			ExpectedMessage: "you cannot have more than two arguments for the command 'describe'",
 		},
 		{
-			Title:           "not connected to anyAPI",
+			Title:           "not connected to any API",
 			Args:            []string{"project", "perses", "-ojson"},
 			IsErrorExpected: true,
 			ExpectedMessage: "you are not connected to any API",

--- a/internal/cli/utils/file/file.go
+++ b/internal/cli/utils/file/file.go
@@ -1,0 +1,102 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+
+	cmdUtilsService "github.com/perses/perses/internal/cli/utils/service"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"gopkg.in/yaml.v2"
+)
+
+type Unmarshaller struct {
+	isJSON  bool
+	objects []map[string]interface{}
+}
+
+func (u *Unmarshaller) Unmarshal(file string) ([]modelAPI.Entity, error) {
+	if err := u.read(file); err != nil {
+		return nil, err
+	}
+
+	return u.unmarshalEntity()
+}
+
+func (u *Unmarshaller) read(file string) error {
+	data, isJSON, err := readAndDetect(file)
+	if err != nil {
+		return err
+	}
+	u.isJSON = isJSON
+
+	var objects []map[string]interface{}
+	var object map[string]interface{}
+
+	if u.isJSON {
+		if jsonErr := json.Unmarshal(data, &objects); jsonErr != nil {
+			if jsonErr = json.Unmarshal(data, &object); jsonErr != nil {
+				return newReadFileErr(jsonErr)
+			}
+			objects = append(objects, object)
+		}
+	} else {
+		if yamlErr := yaml.Unmarshal(data, &objects); yamlErr != nil {
+			if yamlErr = yaml.Unmarshal(data, &object); yamlErr != nil {
+				return newReadFileErr(yamlErr)
+			}
+			objects = append(objects, object)
+		}
+	}
+	u.objects = objects
+	return nil
+}
+
+func (u *Unmarshaller) unmarshalEntity() ([]modelAPI.Entity, error) {
+	if len(u.objects) == 0 {
+		return nil, fmt.Errorf("unable to unmarshall data, data is empty")
+	}
+	var result []modelAPI.Entity
+	for i, object := range u.objects {
+		if _, ok := object["kind"]; !ok {
+			return nil, fmt.Errorf("objects[%d] unable to find 'kind' field", i)
+		}
+		kind := modelV1.Kind(fmt.Sprintf("%v", object["kind"]))
+		// we create the service associated to the current resource. It will be used to unmarshal the resource with the accurate struct.
+		svc, err := cmdUtilsService.NewService(kind, "", nil)
+		if err != nil {
+			return nil, err
+		}
+		// Let's marshal the resource, so we can finally unmarshal it with the accurate struct.
+		var data []byte
+		var marshalErr error
+		if u.isJSON {
+			data, marshalErr = json.Marshal(object)
+		} else {
+			data, marshalErr = yaml.Marshal(object)
+		}
+		if marshalErr != nil {
+			return nil, fmt.Errorf("cannot extract %s, marshalling error: %s", kind, marshalErr)
+		}
+		// Then let's use the service to unmarshal the resource.
+		entity, unmarshalErr := svc.Unmarshal(u.isJSON, data)
+		if unmarshalErr != nil {
+			return nil, fmt.Errorf("cannot extract %s, unmarshalling error: %s", kind, unmarshalErr)
+		}
+		result = append(result, entity)
+	}
+	return result, nil
+}

--- a/internal/cli/utils/file/read.go
+++ b/internal/cli/utils/file/read.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+func readAndDetect(file string) (data []byte, isJSON bool, err error) {
+	if file == "-" {
+		data, err = readFromStdout()
+	} else {
+		data, err = os.ReadFile(file) //nolint
+	}
+
+	if err != nil {
+		return
+	}
+
+	// detecting file format
+	isJSON = json.Unmarshal(data, &json.RawMessage{}) == nil
+	return
+}
+
+func readFromStdout() ([]byte, error) {
+	// from https://flaviocopes.com/go-shell-pipes/
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Mode()&os.ModeCharDevice != 0 {
+		return nil, fmt.Errorf("the command is intended to work with pipes")
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	var output []byte
+
+	for {
+		input, readErr := reader.ReadByte()
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return nil, readErr
+		}
+		output = append(output, input)
+	}
+	return output, nil
+}
+
+func newReadFileErr(err error) error {
+	return fmt.Errorf("unable to read file, format invalid: %w", err)
+}

--- a/internal/cli/utils/service/dashboard.go
+++ b/internal/cli/utils/service/dashboard.go
@@ -62,8 +62,3 @@ func (d *dashboard) GetColumHeader() []string {
 		"AGE",
 	}
 }
-
-func (d *dashboard) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
-	entity := &modelV1.Dashboard{}
-	return entity, unmarshalEntity(isJSON, data, entity)
-}

--- a/internal/cli/utils/service/dashboard.go
+++ b/internal/cli/utils/service/dashboard.go
@@ -15,23 +15,30 @@ package service
 
 import (
 	cmdUtils "github.com/perses/perses/internal/cli/utils"
-	"github.com/perses/perses/pkg/client/api"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 type dashboard struct {
 	Service
-	project   string
-	apiClient api.ClientInterface
+	apiClient v1.DashboardInterface
+}
+
+func (d *dashboard) CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Create(entity.(*modelV1.Dashboard))
+}
+
+func (d *dashboard) UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Update(entity.(*modelV1.Dashboard))
 }
 
 func (d *dashboard) ListResource(prefix string) (interface{}, error) {
-	return d.apiClient.V1().Dashboard(d.project).List(prefix)
+	return d.apiClient.List(prefix)
 }
 
 func (d *dashboard) GetResource(name string) (modelAPI.Entity, error) {
-	return d.apiClient.V1().Dashboard(d.project).Get(name)
+	return d.apiClient.Get(name)
 }
 
 func (d *dashboard) BuildMatrix(hits []modelAPI.Entity) [][]string {
@@ -54,4 +61,9 @@ func (d *dashboard) GetColumHeader() []string {
 		"PROJECT",
 		"AGE",
 	}
+}
+
+func (d *dashboard) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
+	entity := &modelV1.Dashboard{}
+	return entity, unmarshalEntity(isJSON, data, entity)
 }

--- a/internal/cli/utils/service/datasource.go
+++ b/internal/cli/utils/service/datasource.go
@@ -15,23 +15,30 @@ package service
 
 import (
 	cmdUtils "github.com/perses/perses/internal/cli/utils"
-	"github.com/perses/perses/pkg/client/api"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 type datasource struct {
 	Service
-	project   string
-	apiClient api.ClientInterface
+	apiClient v1.DatasourceInterface
+}
+
+func (d *datasource) CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Create(entity.(*modelV1.Datasource))
+}
+
+func (d *datasource) UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Update(entity.(*modelV1.Datasource))
 }
 
 func (d *datasource) ListResource(prefix string) (interface{}, error) {
-	return d.apiClient.V1().Datasource(d.project).List(prefix)
+	return d.apiClient.List(prefix)
 }
 
 func (d *datasource) GetResource(name string) (modelAPI.Entity, error) {
-	return d.apiClient.V1().Datasource(d.project).Get(name)
+	return d.apiClient.Get(name)
 }
 
 func (d *datasource) BuildMatrix(hits []modelAPI.Entity) [][]string {
@@ -56,4 +63,9 @@ func (d *datasource) GetColumHeader() []string {
 		"DATASOURCE_TYPE",
 		"AGE",
 	}
+}
+
+func (d *datasource) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
+	entity := &modelV1.Datasource{}
+	return entity, unmarshalEntity(isJSON, data, entity)
 }

--- a/internal/cli/utils/service/datasource.go
+++ b/internal/cli/utils/service/datasource.go
@@ -64,8 +64,3 @@ func (d *datasource) GetColumHeader() []string {
 		"AGE",
 	}
 }
-
-func (d *datasource) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
-	entity := &modelV1.Datasource{}
-	return entity, unmarshalEntity(isJSON, data, entity)
-}

--- a/internal/cli/utils/service/folder.go
+++ b/internal/cli/utils/service/folder.go
@@ -62,8 +62,3 @@ func (f *folder) GetColumHeader() []string {
 		"AGE",
 	}
 }
-
-func (f *folder) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
-	entity := &modelV1.Folder{}
-	return entity, unmarshalEntity(isJSON, data, entity)
-}

--- a/internal/cli/utils/service/folder.go
+++ b/internal/cli/utils/service/folder.go
@@ -15,23 +15,30 @@ package service
 
 import (
 	cmdUtils "github.com/perses/perses/internal/cli/utils"
-	"github.com/perses/perses/pkg/client/api"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 type folder struct {
 	Service
-	project   string
-	apiClient api.ClientInterface
+	apiClient v1.FolderInterface
+}
+
+func (f *folder) CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return f.apiClient.Create(entity.(*modelV1.Folder))
+}
+
+func (f *folder) UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return f.apiClient.Update(entity.(*modelV1.Folder))
 }
 
 func (f *folder) ListResource(prefix string) (interface{}, error) {
-	return f.apiClient.V1().Folder(f.project).List(prefix)
+	return f.apiClient.List(prefix)
 }
 
 func (f *folder) GetResource(name string) (modelAPI.Entity, error) {
-	return f.apiClient.V1().Folder(f.project).Get(name)
+	return f.apiClient.Get(name)
 }
 
 func (f *folder) BuildMatrix(hits []modelAPI.Entity) [][]string {
@@ -54,4 +61,9 @@ func (f *folder) GetColumHeader() []string {
 		"PROJECT",
 		"AGE",
 	}
+}
+
+func (f *folder) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
+	entity := &modelV1.Folder{}
+	return entity, unmarshalEntity(isJSON, data, entity)
 }

--- a/internal/cli/utils/service/globaldatasource.go
+++ b/internal/cli/utils/service/globaldatasource.go
@@ -62,8 +62,3 @@ func (d *globalDatasource) GetColumHeader() []string {
 		"AGE",
 	}
 }
-
-func (d *globalDatasource) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
-	entity := &modelV1.GlobalDatasource{}
-	return entity, unmarshalEntity(isJSON, data, entity)
-}

--- a/internal/cli/utils/service/globaldatasource.go
+++ b/internal/cli/utils/service/globaldatasource.go
@@ -15,22 +15,30 @@ package service
 
 import (
 	cmdUtils "github.com/perses/perses/internal/cli/utils"
-	"github.com/perses/perses/pkg/client/api"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 type globalDatasource struct {
 	Service
-	apiClient api.ClientInterface
+	apiClient v1.GlobalDatasourceInterface
+}
+
+func (d *globalDatasource) CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Create(entity.(*modelV1.GlobalDatasource))
+}
+
+func (d *globalDatasource) UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Update(entity.(*modelV1.GlobalDatasource))
 }
 
 func (d *globalDatasource) ListResource(prefix string) (interface{}, error) {
-	return d.apiClient.V1().GlobalDatasource().List(prefix)
+	return d.apiClient.List(prefix)
 }
 
 func (d *globalDatasource) GetResource(name string) (modelAPI.Entity, error) {
-	return d.apiClient.V1().GlobalDatasource().Get(name)
+	return d.apiClient.Get(name)
 }
 
 func (d *globalDatasource) BuildMatrix(hits []modelAPI.Entity) [][]string {
@@ -53,4 +61,9 @@ func (d *globalDatasource) GetColumHeader() []string {
 		"DATASOURCE_TYPE",
 		"AGE",
 	}
+}
+
+func (d *globalDatasource) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
+	entity := &modelV1.GlobalDatasource{}
+	return entity, unmarshalEntity(isJSON, data, entity)
 }

--- a/internal/cli/utils/service/project.go
+++ b/internal/cli/utils/service/project.go
@@ -15,22 +15,30 @@ package service
 
 import (
 	cmdUtils "github.com/perses/perses/internal/cli/utils"
-	"github.com/perses/perses/pkg/client/api"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 type project struct {
 	Service
-	apiClient api.ClientInterface
+	apiClient v1.ProjectInterface
+}
+
+func (p *project) CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return p.apiClient.Create(entity.(*modelV1.Project))
+}
+
+func (p *project) UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return p.apiClient.Update(entity.(*modelV1.Project))
 }
 
 func (p *project) ListResource(prefix string) (interface{}, error) {
-	return p.apiClient.V1().Project().List(prefix)
+	return p.apiClient.List(prefix)
 }
 
 func (p *project) GetResource(name string) (modelAPI.Entity, error) {
-	return p.apiClient.V1().Project().Get(name)
+	return p.apiClient.Get(name)
 }
 
 func (p *project) BuildMatrix(hits []modelAPI.Entity) [][]string {
@@ -51,4 +59,9 @@ func (p *project) GetColumHeader() []string {
 		"NAME",
 		"AGE",
 	}
+}
+
+func (p *project) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
+	entity := &modelV1.Project{}
+	return entity, unmarshalEntity(isJSON, data, entity)
 }

--- a/internal/cli/utils/service/project.go
+++ b/internal/cli/utils/service/project.go
@@ -60,8 +60,3 @@ func (p *project) GetColumHeader() []string {
 		"AGE",
 	}
 }
-
-func (p *project) Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error) {
-	entity := &modelV1.Project{}
-	return entity, unmarshalEntity(isJSON, data, entity)
-}

--- a/internal/cli/utils/service/service.go
+++ b/internal/cli/utils/service/service.go
@@ -14,46 +14,58 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/perses/perses/pkg/client/api"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"gopkg.in/yaml.v2"
 )
 
+func unmarshalEntity(isJSON bool, data []byte, entity modelAPI.Entity) error {
+	var unmarshalErr error
+	if isJSON {
+		unmarshalErr = json.Unmarshal(data, entity)
+	} else {
+		unmarshalErr = yaml.Unmarshal(data, entity)
+	}
+	return unmarshalErr
+}
+
 type Service interface {
+	CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error)
+	UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error)
 	ListResource(prefix string) (interface{}, error)
 	GetResource(name string) (modelAPI.Entity, error)
 	BuildMatrix(hits []modelAPI.Entity) [][]string
 	GetColumHeader() []string
+	Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error)
 }
 
 func NewService(kind modelV1.Kind, projectName string, apiClient api.ClientInterface) (Service, error) {
 	switch kind {
 	case modelV1.KindDashboard:
 		return &dashboard{
-			project:   projectName,
-			apiClient: apiClient,
+			apiClient: apiClient.V1().Dashboard(projectName),
 		}, nil
 	case modelV1.KindDatasource:
 		return &datasource{
-			project:   projectName,
-			apiClient: apiClient,
+			apiClient: apiClient.V1().Datasource(projectName),
 		}, nil
 	case modelV1.KindFolder:
 		return &folder{
-			project:   projectName,
-			apiClient: apiClient,
+			apiClient: apiClient.V1().Folder(projectName),
 		}, nil
 	case modelV1.KindGlobalDatasource:
 		return &globalDatasource{
-			apiClient: apiClient,
+			apiClient: apiClient.V1().GlobalDatasource(),
 		}, nil
 	case modelV1.KindProject:
 		return &project{
-			apiClient: apiClient,
+			apiClient: apiClient.V1().Project(),
 		}, nil
 	default:
-		return nil, fmt.Errorf("resource %q not supported by get command", kind)
+		return nil, fmt.Errorf("resource %q not supported by the command", kind)
 	}
 }

--- a/internal/cli/utils/service/service.go
+++ b/internal/cli/utils/service/service.go
@@ -14,24 +14,12 @@
 package service
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/perses/perses/pkg/client/api"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
-	"gopkg.in/yaml.v2"
 )
-
-func unmarshalEntity(isJSON bool, data []byte, entity modelAPI.Entity) error {
-	var unmarshalErr error
-	if isJSON {
-		unmarshalErr = json.Unmarshal(data, entity)
-	} else {
-		unmarshalErr = yaml.Unmarshal(data, entity)
-	}
-	return unmarshalErr
-}
 
 type Service interface {
 	CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error)
@@ -40,7 +28,6 @@ type Service interface {
 	GetResource(name string) (modelAPI.Entity, error)
 	BuildMatrix(hits []modelAPI.Entity) [][]string
 	GetColumHeader() []string
-	Unmarshal(isJSON bool, data []byte) (modelAPI.Entity, error)
 }
 
 func NewService(kind modelV1.Kind, projectName string, apiClient api.ClientInterface) (Service, error) {

--- a/pkg/model/api/entity.go
+++ b/pkg/model/api/entity.go
@@ -13,7 +13,12 @@
 
 package api
 
+type Metadata interface {
+	GetName() string
+}
+
 type Entity interface {
+	GetKind() string
 	GenerateID() string
-	GetMetadata() interface{}
+	GetMetadata() Metadata
 }

--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"regexp"
 
+	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
 	"github.com/prometheus/common/model"
@@ -97,8 +98,12 @@ func (d *Dashboard) GenerateID() string {
 	return GenerateDashboardID(d.Metadata.Project, d.Metadata.Name)
 }
 
-func (d *Dashboard) GetMetadata() interface{} {
+func (d *Dashboard) GetMetadata() modelAPI.Metadata {
 	return &d.Metadata
+}
+
+func (d *Dashboard) GetKind() string {
+	return string(d.Kind)
 }
 
 func (d *Dashboard) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/datasource.go
+++ b/pkg/model/api/v1/datasource.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/v1/datasource"
 	"gopkg.in/yaml.v2"
 )
@@ -71,8 +72,12 @@ func (d *GlobalDatasource) GenerateID() string {
 	return GenerateGlobalDatasourceID(d.Metadata.Name)
 }
 
-func (d *GlobalDatasource) GetMetadata() interface{} {
+func (d *GlobalDatasource) GetMetadata() modelAPI.Metadata {
 	return &d.Metadata
+}
+
+func (d *GlobalDatasource) GetKind() string {
+	return string(d.Kind)
 }
 
 func (d *GlobalDatasource) UnmarshalJSON(data []byte) error {
@@ -123,8 +128,12 @@ func (d *Datasource) GenerateID() string {
 	return GenerateDatasourceID(d.Metadata.Project, d.Metadata.Name)
 }
 
-func (d *Datasource) GetMetadata() interface{} {
+func (d *Datasource) GetMetadata() modelAPI.Metadata {
 	return &d.Metadata
+}
+
+func (d *Datasource) GetKind() string {
+	return string(d.Kind)
 }
 
 func (d *Datasource) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/folder.go
+++ b/pkg/model/api/v1/folder.go
@@ -16,6 +16,8 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+
+	modelAPI "github.com/perses/perses/pkg/model/api"
 )
 
 func GenerateFolderID(project string, name string) string {
@@ -81,8 +83,12 @@ func (f *Folder) GenerateID() string {
 	return GenerateDashboardID(f.Metadata.Project, f.Metadata.Name)
 }
 
-func (f *Folder) GetMetadata() interface{} {
+func (f *Folder) GetMetadata() modelAPI.Metadata {
 	return &f.Metadata
+}
+
+func (f *Folder) GetKind() string {
+	return string(f.Kind)
 }
 
 func (f *Folder) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/kind.go
+++ b/pkg/model/api/v1/kind.go
@@ -16,6 +16,8 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+
+	modelAPI "github.com/perses/perses/pkg/model/api"
 )
 
 type Kind string
@@ -72,4 +74,24 @@ func (k *Kind) validate() error {
 		return fmt.Errorf("unknown kind %q used", *k)
 	}
 	return nil
+}
+
+// GetStruct return a pointer to an empty struct that matches the kind passed as a parameter.
+func GetStruct(kind Kind) (modelAPI.Entity, error) {
+	switch kind {
+	case KindDashboard:
+		return &Dashboard{}, nil
+	case KindDatasource:
+		return &Datasource{}, nil
+	case KindFolder:
+		return &Folder{}, nil
+	case KindGlobalDatasource:
+		return &GlobalDatasource{}, nil
+	case KindProject:
+		return &Project{}, nil
+	case KindUser:
+		return &User{}, nil
+	default:
+		return nil, fmt.Errorf("%q has no associated struct", kind)
+	}
 }

--- a/pkg/model/api/v1/metadata.go
+++ b/pkg/model/api/v1/metadata.go
@@ -38,8 +38,16 @@ func (m *Metadata) CreateNow() {
 	m.UpdatedAt = m.CreatedAt
 }
 
+func (m *Metadata) GetName() string {
+	return m.Name
+}
+
 // ProjectMetadata is the metadata struct for resources that belongs to a project.
 type ProjectMetadata struct {
 	Metadata `json:",inline" yaml:",inline"`
 	Project  string `json:"project" yaml:"project"`
+}
+
+func (m *ProjectMetadata) GetName() string {
+	return m.Name
 }

--- a/pkg/model/api/v1/project.go
+++ b/pkg/model/api/v1/project.go
@@ -16,6 +16,8 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+
+	modelAPI "github.com/perses/perses/pkg/model/api"
 )
 
 func GenerateProjectID(name string) string {
@@ -31,8 +33,12 @@ func (p *Project) GenerateID() string {
 	return GenerateProjectID(p.Metadata.Name)
 }
 
-func (p *Project) GetMetadata() interface{} {
+func (p *Project) GetMetadata() modelAPI.Metadata {
 	return &p.Metadata
+}
+
+func (p *Project) GetKind() string {
+	return string(p.Kind)
 }
 
 func (p *Project) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/user.go
+++ b/pkg/model/api/v1/user.go
@@ -16,6 +16,8 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+
+	modelAPI "github.com/perses/perses/pkg/model/api"
 )
 
 func GenerateUserID(name string) string {
@@ -74,8 +76,12 @@ func (p *User) GenerateID() string {
 	return GenerateUserID(p.Metadata.Name)
 }
 
-func (p *User) GetMetadata() interface{} {
+func (p *User) GetMetadata() modelAPI.Metadata {
 	return &p.Metadata
+}
+
+func (p *User) GetKind() string {
+	return string(p.Kind)
 }
 
 func (p *User) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
This PR is implementing a new command in the CLI called `apply`. This command is taking a file as parameter or is reading the stdin.

Every known objects read will be created or updated with this command.

The file or the data format from stdin can be a JSON/YAML array of object or a JSON/YAML object.

I'm wondering if we should use this command to populate the database, that should probably simplify the script `dev/populate.sh`.

Description of the command itself: 

```bash
./bin/percli apply --help
Create or update resources through a file. JSON or YAML format supported

Usage:
  percli apply -f [FILENAME] [flags]

Examples:

# Create/update the resources from the file resources.json to the remote Perses server.
percli apply -f ./resources.json

# Apply the JSON passed into stdin to the remote Perses server.
cat ./resources.json | percli apply -f -


Flags:
  -f, --file string      Path to the file that contains the resources to create/update.
  -h, --help             help for apply
  -p, --project string   If present, the project scope for this CLI request.

Global Flags:
      --log.level string      Set the log verbosity level. Possible values: panic, fatal, error, warning, info, debug, trace (default "info")
      --percliconfig string   Path to the percliconfig file to use for CLI requests. (default "/Users/ahusson/.perses/config.json")
```

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>