### PR TITLE
add the release documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,13 @@ update-go-deps:
 	@for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
 		$(GO) get -d $$m; \
 	done
+
+.PHONY: update-npm-deps
+update-npm-deps:
+	@echo ">> updating npm dependencies"
+	./npm-deps.sh "minor"
+
+.PHONY: upgrade-npm-deps
+upgrade-npm-deps:
+	@echo ">> upgrading npm dependencies"
+	./npm-deps.sh "latest"

--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,10 @@ generate:
 clean:
 	rm -rf ./bin
 	cd ./ui && npm run clean
+
+.PHONY: update-go-deps
+update-go-deps:
+	@echo ">> updating Go dependencies"
+	@for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
+		$(GO) get -d $$m; \
+	done

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,12 +26,19 @@ In case you would like to update manually the dependencies :
 ```bash
 make update-go-deps
 git add go.mod go.sum
-git commit -m "Update dependencies"
+git commit -m "Update Go dependencies"
 ```
 
 ### Updating npm dependencies
 
-TBD
+```bash
+make update-npm-deps
+git add ./ui/package-lock.json ./**/package.json
+git commit -m "Update npm dependencies"
+```
+
+Note: in case you feel it, you can also upgrade the npm dependencies to their latest release (major or minor)
+with `make upgrade-npm-deps`
 
 ### 1. Prepare your release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,7 +44,7 @@ with `make upgrade-npm-deps`
 
 You should start to create a branch that follows the pattern `release/v<X.Y.Z>`
 
-Update the file `Changelog.md` and the different `package.json` with the corresponding version:
+Update the file `CHANGELOG.md` and the different `package.json` with the corresponding version:
 
 ```bash
 version=v0.2.0
@@ -57,7 +57,7 @@ git add ./ui/package-lock.json ./**/package.json
 Do this in a proper PR pointing to the release branch as this gives others the opportunity to chime in on the release in
 general and on the addition to the changelog in particular.
 
-Entries in the `Changelog.md` are meant to be in this order:
+Entries in the `CHANGELOG.md` are meant to be in this order:
 
 * `[FEATURE]`
 * `[ENHANCEMENT]`
@@ -85,4 +85,4 @@ the `-s` flag by `-a` flag of the git tag command to only annotate the tag witho
 Once a tag is created, the release process through the Github Actions will be triggered for this tag.
 
 The Github releases will be created automatically by the Github Action triggered. Probably you will have to edit it to
-put the accurate Changelog.
+put the accurate changelog.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,7 +74,7 @@ Tag the new release via the following commands:
 ```bash
 git checkout release/v<version_to_be_replaced>
 tag="v<version_to_be_replaced>"
-git tag -w "${tag}" -m "${tag}"
+git tag -s "${tag}" -m "${tag}"
 git push origin "${tag}"
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,8 +44,15 @@ with `make upgrade-npm-deps`
 
 You should start to create a branch that follows the pattern `release/v<X.Y.Z>`
 
-Update the file `Changelog.md` and the different `package.json` with the corresponding version. Once you updated
-every `package.json`, you need to run `npm install` at the UI root folder `ui/`.
+Update the file `Changelog.md` and the different `package.json` with the corresponding version:
+
+```bash
+version=v0.2.0
+./ui_release.sh --release "${version}"
+cd ui/
+npm install
+git add ./ui/package-lock.json ./**/package.json
+```
 
 Do this in a proper PR pointing to the release branch as this gives others the opportunity to chime in on the release in
 general and on the addition to the changelog in particular.
@@ -77,4 +84,5 @@ the `-s` flag by `-a` flag of the git tag command to only annotate the tag witho
 
 Once a tag is created, the release process through the Github Actions will be triggered for this tag.
 
-You should then create the Github release associated to the tag and put the content of the `Changelog.md` there.
+The Github releases will be created automatically by the Github Action triggered. Probably you will have to edit it to
+put the accurate Changelog.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,7 +64,7 @@ Entries in the `Changelog.md` are meant to be in this order:
 * `[BUGFIX]`
 * `[BREAKINGCHANGE]`
 
-As we have many libraries we aime to expose, it's better if you also put a clear indication about what lib is concerning
+As we have many libraries we publish, it's better if you also put a clear indication about what library is affected
 by these changes.
 
 ### 2. Draft the new release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,73 @@
+Releases
+========
+
+This page describes the release processes. It's inspired from
+the [Prometheus release process](https://github.com/prometheus/prometheus/blob/main/RELEASE.md)
+
+## How to cut an individual release
+
+### Branch management and versioning strategy
+
+We use [Semantic Versioning](https://semver.org/).
+
+The current flow is to merge new features and bugfixes into the main branch.
+
+As we are in early stage of the project, we don't intend to maintain previous version. Only the last version will be
+patched if we estimate it requires an urgent patch that cannot wait for the next minor release.
+
+### 0. Updating dependencies
+
+We are using dependabot to keep up to date our dependencies (of Go or npm).
+
+In case you would like to update manually the dependencies :
+
+#### Updating Go dependencies
+
+```bash
+make update-go-deps
+git add go.mod go.sum
+git commit -m "Update dependencies"
+```
+
+### Updating npm dependencies
+
+TBD
+
+### 1. Prepare your release
+
+You should start to create a branch that follows the pattern `release/v<X.Y.Z>`
+
+Update the file `Changelog.md` and the different `package.json` with the corresponding version. Once you updated
+every `package.json`, you need to run `npm install` at the UI root folder `ui/`.
+
+Do this in a proper PR pointing to the release branch as this gives others the opportunity to chime in on the release in
+general and on the addition to the changelog in particular.
+
+Entries in the `Changelog.md` are meant to be in this order:
+
+* `[FEATURE]`
+* `[ENHANCEMENT]`
+* `[BUGFIX]`
+* `[BREAKINGCHANGE]`
+
+As we have many libraries we aime to expose, it's better if you also put a clear indication about what lib is concerning
+by these changes.
+
+### 2. Draft the new release
+
+Tag the new release via the following commands:
+
+```bash
+git checkout release/v<version_to_be_replaced>
+tag="v<version_to_be_replaced>"
+git tag -w "${tag}" -m "${tag}"
+git push origin "${tag}"
+```
+
+Signing a tag with a GPG key is appreciated, but in case you can't add a GPG key to your Github account using the
+following [procedure](https://docs.github.com/en/authentication/managing-commit-signature-verification), you can replace
+the `-s` flag by `-a` flag of the git tag command to only annotate the tag without signing.
+
+Once a tag is created, the release process through the Github Actions will be triggered for this tag.
+
+You should then create the Github release associated to the tag and put the content of the `Changelog.md` there.

--- a/npm-deps.sh
+++ b/npm-deps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function ncu() {
+    target=$1
+    npx npm-check-updates -u --target "${target}"
+}
+
+cd ui
+for workspace in $(npm ls --production --depth 1 -json | jq -r '.dependencies[].resolved[11:]'); do
+  cd ${workspace}
+  ncu "$1"
+  cd ../
+done; \
+
+ncu "$1"
+npm install


### PR DESCRIPTION
As part of #331, I'm creating this documentation that is indicating how to release Perses. I took some inspirations from the Prometheus release process.

Probably we can still improve it and automatise some steps.

~~I would be interested if there is some magic command to upgrade the npm dependencies when you are using a monorepo. Would be great to know for Prometheus too.~~

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>