### PR TITLE
define a build-all directive in Makefile

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image:
   file: .gitpod.Dockerfile
 tasks:
   - init: | # runs during prebuild
-      make build
+      make build-api
       make build-cli
     command: |
       cd ./dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ bash populate.sh
 
 ```bash
 cd ../
-make build
+make build-api
 ```
 
 * Finally, run the built binary by using the simple configuration file from the `dev` folder:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ COVER_PROFILE := coverage.txt
 PKG_LDFLAGS   := github.com/prometheus/common/version
 LDFLAGS       := -ldflags "-X ${PKG_LDFLAGS}.Version=${VERSION} -X ${PKG_LDFLAGS}.Revision=${COMMIT} -X ${PKG_LDFLAGS}.BuildDate=${DATE} -X ${PKG_LDFLAGS}.Branch=${BRANCH}"
 
-all: build-ui build-cli build
+all: clean build
 
 .PHONY: checkformat
 checkformat:
@@ -55,7 +55,10 @@ coverage-html: integration-test
 	$(GO) tool cover -html=$(COVER_PROFILE)
 
 .PHONY: build
-build: generate
+build: build-ui build-api build-cli
+
+.PHONY: build-api
+build-api: generate
 	@echo ">> build the perses api"
 	CGO_ENABLED=0 GOARCH=${GOARCH} $(GO) build ${LDFLAGS} -o ./bin/perses ./cmd/perses
 


### PR DESCRIPTION
Like that when you just want to build the whole project you just to do : 

`make` or `make build`. It wasn't coherent that `make build` was just building the API and not the UI or the CLI.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>