### PR TITLE
Try setting env var that setup-node writes to .npmrc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,16 +49,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: "ui/.nvmrc"
+          registry-url: "https://registry.npmjs.org"
       - name: Download react build
         uses: actions/download-artifact@v2
         with:
           name: ui-libs
       - name: Copy files before publishing libs
         run: ./scripts/ui_release.sh --copy
-      - name: Login to npm registry
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - name: Publish libraries
         run: ./scripts/ui_release.sh --publish
+        env:
+          # The setup-node action writes an .npmrc file with this env variable
+          # as the placeholder for the auth token
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   go-release:
     name: "go and github release"


### PR DESCRIPTION
The `setup-node` action writes an `.npmrc` file with `NODE_AUTH_TOKEN` as a placeholder for use when doing things like publishing packages. See https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm for an example. Let's see if this fixes the auth issue in the libs release.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>