### PR TITLE
Add path when downloading artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ui-libs
+          path: ui
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ui-libs
+          path: ui
       - name: Copy files before publishing libs
         run: ./scripts/ui_release.sh --copy
       - name: Publish libraries
@@ -86,6 +87,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ui-libs
+          path: ui
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Set the download path for UI artifacts so that they don't lose the `ui` folder when they're downloaded.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>