### PR TITLE
Fix plugin registry to render children while waiting on plugin list load

### DIFF
--- a/ui/plugin-system/src/components/PluginLoadingBoundary/PluginLoader.tsx
+++ b/ui/plugin-system/src/components/PluginLoadingBoundary/PluginLoader.tsx
@@ -29,7 +29,18 @@ export function PluginLoader(props: PluginLoaderProps) {
 
   // Load the plugin and throw any loading/not found errors
   const { loadPlugin } = usePluginRegistry();
-  const { error } = useQuery(`PluginLoader:${pluginType}_${kind}`, () => loadPlugin(pluginType, kind));
+  const { error } = useQuery(
+    `PluginLoader:${pluginType}_${kind}`,
+    () => {
+      // The enabled option below should prevent this from being run until loadPlugin is available, but check here to
+      // make Typescript happy
+      if (loadPlugin === undefined) {
+        throw new Error('PluginRegistry loadPlugin not available');
+      }
+      return loadPlugin(pluginType, kind);
+    },
+    { enabled: loadPlugin !== undefined }
+  );
   if (error !== undefined && error !== null) {
     throw error;
   }

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -38,7 +38,7 @@ export function PluginRegistry(props: PluginRegistryProps) {
       const plugin = plugins[pluginType].get(kind);
       if (plugin !== undefined) return;
 
-      // Is it a valid plugin we know about? (TODO: What about when plugin list is loading?)
+      // Is it a valid plugin we know about?
       const resource = loadablePlugins[pluginType].get(kind);
       if (resource === undefined) {
         throw new Error(`No ${pluginType} plugin is available for kind ${kind}`);
@@ -51,19 +51,27 @@ export function PluginRegistry(props: PluginRegistryProps) {
     [plugins, loadablePlugins, importPluginModule, register]
   );
 
-  const registry: PluginRegistryContextType = useMemo(() => ({ plugins, loadPlugin }), [plugins, loadPlugin]);
-
-  // TODO: Fix this so loadPlugin takes into account list still loading
-  if (installedPlugins.isLoading) return null;
+  const registry: PluginRegistryContextType = useMemo(
+    () => ({ plugins, loadPlugin: installedPlugins.isLoading ? undefined : loadPlugin }),
+    [installedPlugins.isLoading, plugins, loadPlugin]
+  );
 
   return <PluginRegistryContext.Provider value={registry}>{children}</PluginRegistryContext.Provider>;
 }
 
 const PluginRegistryContext = createContext<PluginRegistryContextType | undefined>(undefined);
 
-interface PluginRegistryContextType {
+export interface PluginRegistryContextType {
+  /**
+   * Plugins that have already been loaded and are available for use.
+   */
   plugins: LoadedPluginsByTypeAndKind;
-  loadPlugin: (pluginType: PluginType, kind: string) => Promise<void>;
+
+  /**
+   * Asks the plugin registry to load the specified plugin. This will be undefined until the list of available plugins
+   * has finished loading.
+   */
+  loadPlugin?: (pluginType: PluginType, kind: string) => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
This is a small improvement to plugin loading that allows the `PluginRegistry` component to render its children while it's waiting on the list of available plugins to load. This way we don't have to block the rendering of a screen (e.g. a Dashboard) while that list is still being fetched.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>