### PR TITLE
remove @formatjs/intl-numberformat dependency

### DIFF
--- a/ui/components/src/model/units.ts
+++ b/ui/components/src/model/units.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { IsSanctionedSimpleUnitIdentifier } from '@formatjs/ecma402-abstract';
 import { Duration, milliseconds } from 'date-fns';
 
 export type UnitOptions = TimeUnitOptions | PercentUnitOptions | DecimalUnitOptions;
@@ -153,7 +152,7 @@ function isDecimalUnit(unitOptions: UnitOptions): unitOptions is DecimalUnitOpti
 function formatDecimal(value: number, unitOptions: DecimalUnitOptions): string {
   const maximumFractionDigits = unitOptions.decimal_places ?? 2;
   if (unitOptions.suffix !== undefined) {
-    if (IsSanctionedSimpleUnitIdentifier(unitOptions.suffix)) {
+    if (isSanctionedSimpleUnitIdentifier(unitOptions.suffix)) {
       const formatParams: Intl.NumberFormatOptions = {
         style: 'unit',
         minimumFractionDigits: 0,
@@ -189,3 +188,62 @@ export function abbreviateLargeNumber(num: number) {
     ? num / 1e3 + 'k'
     : num;
 }
+
+// Util to check unit name against ECMA standard: https://tc39.es/ecma402/#sec-issanctionedsimpleunitidentifier
+export function isSanctionedSimpleUnitIdentifier(unitIdentifier: string) {
+  return SIMPLE_UNITS.indexOf(unitIdentifier) > -1;
+}
+
+// https://tc39.es/ecma402/#table-sanctioned-simple-unit-identifiers
+export const SANCTIONED_UNITS = [
+  'angle-degree',
+  'area-acre',
+  'area-hectare',
+  'concentr-percent',
+  'digital-bit',
+  'digital-byte',
+  'digital-gigabit',
+  'digital-gigabyte',
+  'digital-kilobit',
+  'digital-kilobyte',
+  'digital-megabit',
+  'digital-megabyte',
+  'digital-petabyte',
+  'digital-terabit',
+  'digital-terabyte',
+  'duration-day',
+  'duration-hour',
+  'duration-millisecond',
+  'duration-minute',
+  'duration-month',
+  'duration-second',
+  'duration-week',
+  'duration-year',
+  'length-centimeter',
+  'length-foot',
+  'length-inch',
+  'length-kilometer',
+  'length-meter',
+  'length-mile-scandinavian',
+  'length-mile',
+  'length-millimeter',
+  'length-yard',
+  'mass-gram',
+  'mass-kilogram',
+  'mass-ounce',
+  'mass-pound',
+  'mass-stone',
+  'temperature-celsius',
+  'temperature-fahrenheit',
+  'volume-fluid-ounce',
+  'volume-gallon',
+  'volume-liter',
+  'volume-milliliter',
+];
+
+// removes the namespace prefix, ex: duration-hour -> hour
+export function removeUnitNamespace(unit: string) {
+  return unit.slice(unit.indexOf('-') + 1);
+}
+
+export const SIMPLE_UNITS = SANCTIONED_UNITS.map(removeUnitNamespace);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2051,42 +2051,6 @@
       "version": "4.5.5",
       "license": "MIT"
     },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.4",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/ecma402-abstract/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.25",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
-    },
-    "node_modules/@formatjs/intl-numberformat": {
-      "version": "7.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/intl-numberformat/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.2",
       "dev": true,
@@ -11736,7 +11700,6 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@formatjs/intl-numberformat": "^7.4.3",
         "@perses-dev/core": "^0.3.0",
         "@perses-dev/plugin-system": "^0.3.0",
         "date-fns": "^2.28.0",
@@ -12947,42 +12910,6 @@
     "@fontsource/lato": {
       "version": "4.5.5"
     },
-    "@formatjs/ecma402-abstract": {
-      "version": "1.11.4",
-      "requires": {
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1"
-        }
-      }
-    },
-    "@formatjs/intl-localematcher": {
-      "version": "0.2.25",
-      "requires": {
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1"
-        }
-      }
-    },
-    "@formatjs/intl-numberformat": {
-      "version": "7.4.3",
-      "requires": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1"
-        }
-      }
-    },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",
       "dev": true,
@@ -13413,7 +13340,6 @@
     "@perses-dev/panels-plugin": {
       "version": "file:panels-plugin",
       "requires": {
-        "@formatjs/intl-numberformat": "^7.4.3",
         "@perses-dev/core": "^0.3.0",
         "@perses-dev/plugin-system": "^0.3.0",
         "date-fns": "^2.28.0",

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -21,7 +21,6 @@
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },
   "dependencies": {
-    "@formatjs/intl-numberformat": "^7.4.3",
     "@perses-dev/core": "^0.3.0",
     "@perses-dev/plugin-system": "^0.3.0",
     "date-fns": "^2.28.0",


### PR DESCRIPTION
In release v0.3.0, units.ts moved from perses-dev/panels-plugin to perses-dev/components, but I forgot to update each package.json with the @formatjs/intl-numberformat dependency that moved (formatjs was added in prev StatChart [PR 307](https://github.com/perses/perses/pull/307)).

To simplify things, I've decided to remove the @formatjs/intl-numberformat dependency since it was only being used for one function.

Commits:
- remove @formatjs/intl-numberformat dependency
- copy IsSanctionedSingleUnitIdentifier util that checks against SANCTIONED_UNITS from: https://tc39.es/ecma402/#table-sanctioned-simple-unit-identifiers