### PR TITLE
temp bugfix for tooltip label colors readability

### DIFF
--- a/ui/components/src/tooltip/SeriesInfo.tsx
+++ b/ui/components/src/tooltip/SeriesInfo.tsx
@@ -40,7 +40,7 @@ export function SeriesInfo(props: SeriesInfoProps) {
             flexDirection: 'row',
             alignItems: 'center',
             justifyContent: 'left',
-            color: theme.palette.grey[300],
+            color: theme.palette.common.white,
             fontSize: '11px',
           })}
         >
@@ -66,7 +66,7 @@ export function SeriesInfo(props: SeriesInfoProps) {
         />
         <Box
           sx={(theme) => ({
-            color: theme.palette.grey[300],
+            color: theme.palette.common.white,
           })}
         >
           {formattedSeriesLabels.split(',').map((name) => {

--- a/ui/components/src/tooltip/TooltipContent.tsx
+++ b/ui/components/src/tooltip/TooltipContent.tsx
@@ -33,7 +33,7 @@ export function TooltipContent(props: TooltipContentProps) {
         <Typography
           variant="caption"
           sx={(theme) => ({
-            color: theme.palette.grey[300],
+            color: theme.palette.common.white,
           })}
         >
           {month}, {year} –


### PR DESCRIPTION
Temporary bugfix for unreadable date and value tooltp label colors when inheriting an app's theme. 
Changed the date and value labels to white until I figure out how to get theme colors to be inherited correctly. 

Planning to add proper theme support in v0.4

