### PR TITLE
Add CommonJS version of all packages we publish

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -37,8 +37,10 @@ jobs:
 
       - name: Install UI deps
         run: cd ./ui && npm install
-      - name: Build the app
+      - name: Build the app and ESM version of packages
         run: cd ./ui && npm run build
+      - name: Build CommonJS version of packages
+        run: cd ./ui && npm run build:cjs
       - name: store react production build
         uses: actions/upload-artifact@v3
         with:

--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -12,10 +12,12 @@
     "url": "https://github.com/perses/perses/issues"
   },
   "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "tsc",
+    "build": "tsc --build",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "test": "echo 'no test to run' && exit 0",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"

--- a/ui/components/tsconfig.cjs.json
+++ b/ui/components/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.cjs.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -12,10 +12,12 @@
     "url": "https://github.com/perses/perses/issues"
   },
   "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "tsc",
+    "build": "tsc --build",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "test": "echo 'no test to run' && exit 0",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"

--- a/ui/core/tsconfig.cjs.json
+++ b/ui/core/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.cjs.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -12,10 +12,12 @@
     "url": "https://github.com/perses/perses/issues"
   },
   "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "tsc",
+    "build": "tsc --build",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "test": "echo 'no test to run' && exit 0",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"

--- a/ui/dashboards/tsconfig.cjs.json
+++ b/ui/dashboards/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.cjs.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "npm run build -w app",
+    "build:cjs": "npm run build:cjs --workspaces --if-present",
     "test": "npm test --workspaces",
     "lint": "npm run lint --workspaces",
     "lint:fix": "npm run lint:fix --workspaces",

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -12,10 +12,12 @@
     "url": "https://github.com/perses/perses/issues"
   },
   "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "tsc",
+    "build": "tsc --build",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "test": "TZ=UTC jest",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"

--- a/ui/panels-plugin/tsconfig.cjs.json
+++ b/ui/panels-plugin/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.cjs.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -12,10 +12,12 @@
     "url": "https://github.com/perses/perses/issues"
   },
   "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "tsc",
+    "build": "tsc --build",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "test": "echo 'no test to run' && exit 0",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"

--- a/ui/plugin-system/tsconfig.cjs.json
+++ b/ui/plugin-system/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.cjs.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -12,10 +12,12 @@
     "url": "https://github.com/perses/perses/issues"
   },
   "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "tsc",
+    "build": "tsc --build",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "test": "echo 'no test to run' && exit 0",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"

--- a/ui/prometheus-plugin/tsconfig.cjs.json
+++ b/ui/prometheus-plugin/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.cjs.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/ui/tsconfig.cjs.json
+++ b/ui/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "composite": false,
+    // Source maps and type declarations are all emitted as part of the regular (ESM) build output, so no need to do
+    // that again for CJS, we just want the JavaScript files
+    "sourceMap": false,
+    "declaration": false,
+    "declarationMap": false
+  }
+}


### PR DESCRIPTION
This adds CommonJS versions/output for all packages that we publish to NPM. This is for a couple reasons:

1. Some common tooling (e.g. Jest) still doesn't support ES Modules, so if someone is trying to use Jest to test things where our packages are imported, it's currently not possible. (Jest basically fails with an error that it can't import from the packages).
2. Some folks (although I suspect not many?) may still not be using ESM in their applications and want to embed Perses components, so this will allow them to do that without needing to switch their entire applications to ESM first.

I think the first reason is probably the more common/primary reason to do this.

In order to do this, I added some compiler configs for doing CJS builds and scripts for running a CJS build with that config for each package. I decided that since our regular app build (which has the side-effect of building all the project references in ESM format) should already have run, it wasn't necessary to make the CJS builds aware of the project references, which would have resulted in a lot more duplicate config for those references.

Instead, we'll just assume that the regular build has always been run first and the CJS builds can then be run after that, taking advantage of the output from the ESM build to make the compiler happy. That means if you were to try and run a CJS build without running a regular one first, you'd likely get errors. But I think that's probably an OK tradeoff for not having to duplicate a bunch of references configs.

Since this is additive to the existing packages, I don't believe it's a breaking change (more of an "enhancement"), so I created this PR to `release/v3` so we can potentially do a patch release that includes it.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>