### PR TITLE
upgrade to go v1.18

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - uses: actions/cache@v3.0.2
         with:
           path: ~/go/pkg/mod
@@ -121,7 +121,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --snapshot --rm-dist
+          args: release --snapshot --rm-dist --parallelism 1
       - name: Publish Release and binaries
         ## This step will only run when a new tag is pushed.
         ## It will build the Go binaries and the docker images and then publish:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     - name: install golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
     - uses: actions/cache@v3.0.2
       with:
         path: ~/go/pkg/mod
@@ -40,7 +40,7 @@ jobs:
     - name: install golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
     - uses: actions/cache@v3.0.2
       with:
         path: ~/go/pkg/mod
@@ -61,7 +61,7 @@ jobs:
     - name: install golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
     - name: generate files
       run: make generate
     - name: golangci-lint


### PR DESCRIPTION
This PR is upgrading go to the last version (v1.18).

In the changes, it says to `goreleaser` to not build the different binaries in parallel. It's because in a Github action, it totally fails and I have no idea why. I'm not able to reproduce it locally and I have even tried in other CI/CD and other docker images with memory and cpu limitation (like less than 1GB of memory) same result.

So until it is magically fixed or someone has an explanation, we will remain like that. The build is a bit slower (1min more), so it's not a huge issue to remove the parallel build.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>