### PR TITLE
Switch bundle output directory back

### DIFF
--- a/ui/app/webpack.common.ts
+++ b/ui/app/webpack.common.ts
@@ -20,7 +20,7 @@ import ESLintWebpackPlugin from 'eslint-webpack-plugin';
 export const commonConfig: Configuration = {
   entry: path.resolve(__dirname, './src/bundle.ts'),
   output: {
-    path: path.resolve(__dirname, './dist/bundle'),
+    path: path.resolve(__dirname, './dist'),
     publicPath: '/',
   },
   resolve: {


### PR DESCRIPTION
I'm an idiot and left the wrong bundle output directory in webpack from when I added all the `@perses-dev` packages in #315. 😂   Sorry for breaking this!

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>