### PR TITLE
fix go build: set parallelism build to 1

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -132,6 +132,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --release-notes GENERATED_CHANGELOG.md
+          args: release --rm-dist --parallelism 1 --release-notes GENERATED_CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR should fix back the build of the binaries for the release
Signed-off-by: Augustin Husson <husson.augustin@gmail.com>