### PR TITLE
fix package.json so core is dependency of components

### DIFF
--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -23,6 +23,7 @@
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },
   "dependencies": {
+    "@perses-dev/core": "^0.4.0",
     "echarts": "^5.3.2",
     "lodash-es": "^4.17.21",
     "react-error-boundary": "^3.1.4"

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -23,7 +23,6 @@
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },
   "dependencies": {
-    "@perses-dev/core": "^0.4.0",
     "date-fns": "^2.28.0",
     "lodash-es": "^4.17.21"
   },

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -91,6 +91,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@perses-dev/core": "^0.4.0",
         "echarts": "^5.3.2",
         "lodash-es": "^4.17.21",
         "react-error-boundary": "^3.1.4"
@@ -105,7 +106,6 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@perses-dev/core": "^0.4.0",
         "date-fns": "^2.28.0",
         "lodash-es": "^4.17.21"
       },
@@ -14691,6 +14691,7 @@
     "@perses-dev/components": {
       "version": "file:components",
       "requires": {
+        "@perses-dev/core": "^0.4.0",
         "echarts": "^5.3.2",
         "lodash-es": "^4.17.21",
         "react-error-boundary": "^3.1.4"
@@ -14699,7 +14700,6 @@
     "@perses-dev/core": {
       "version": "file:core",
       "requires": {
-        "@perses-dev/core": "^0.4.0",
         "@types/lodash-es": "^4.17.6",
         "date-fns": "^2.28.0",
         "lodash-es": "^4.17.21"


### PR DESCRIPTION
This PR fixes issue noted in #perses-dev chat that core is currently is dependency of itself. Both package.json files are updated so now the components package instead pulls from core.

Issue was introduced by me in [PR 425](https://github.com/perses/perses/pull/425)