### PR TITLE
Governance Proposal

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,14 @@ towards the quorum. Any removal vote can cover only one single person.
 Upon death of a member, they leave the team automatically.
 
 The current team members are:
-TBD
+
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Augustin Husson | [nexucis](https://github.com/Nexucis) | Amadeus IT Group |
+| Luke Tillman | [luketillman](https://github.com/LukeTillman) | Chronosphere |
+| Steven Cobb | [sjcobb](https://github.com/sjcobb) | Chronosphere |
+| Julius Volz | [juliusv](https://github.com/juliusv) | PromLabs |
+| Antoine Thebaud | [AntoineThebaud](https://github.com/AntoineThebaud) | Amadeus IT Group |
 
 ## Maintainers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ To become a Maintainer you need to demonstrate the following:
   * understanding of the project's code base and coding and documentation style.
 
 A new maintainer must be proposed by an existing maintainer by sending an email to the
-private maintainer mailing list (TODO CREATE ML). A majority of existing maintainers
+private maintainer mailing list (perses-team@googlegroups.com). A 2/3 majority of existing maintainers
 must vote to approve a new maintainer. After the new maintainer is approved, they will 
 be added to the private maintainer mailing list.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,18 +34,18 @@ To become a Maintainer you need to demonstrate the following:
   * understanding of how the team works (policies, processes for testing and code review, etc),
   * understanding of the project's code base and coding and documentation style.
 
-A new Maintainer must be proposed by an existing maintainer by creating a new issue in 
-the [Perses repository](https://github.com/perses/perses/issues). The new maintainer
-will be approved after another maintainer (in addition to the one proposing) has endorsed
-the person.
+A new maintainer must be proposed by an existing maintainer by sending an email to the
+private maintainer mailing list (TODO CREATE ML). A majority of existing maintainers
+must vote to approve a new maintainer. After the new maintainer is approved, they will 
+be added to the private maintainer mailing list.
 
 ## Voting
 
 While most business in Perses is conducted by "lazy consensus", periodically
 the Maintainers may need to vote on specific actions or changes.
-A vote can be taken by creating a new issue in the
-[Perses repository](https://github.com/perses/perses/issues).
-Any Maintainer may demand a vote be taken.
+A vote can be taken by emailing the private maintainer mailing list for sensitive
+matters or by creating an issue to allow for public comment from the broader
+community. Any Maintainer may demand a vote be taken.
 
 Most votes require a simple majority of all Maintainers to succeed. Maintainers
 can be removed by a 2/3 majority vote of all Maintainers, and changes to this

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,52 @@
+# Project Governance
+
+This document provides an initial governance structure for the Perses project.
+We've deliberately kept this as simple as possible for now, but 
+we expect the governance to evolve as the project grows.
+
+## Maintainers
+
+Perses maintainers have write access to projects under the Perses GitHub organization.
+They can merge their own patches or patches from others. The current maintainers
+can be found in [MAINTAINERS.md](./MAINTAINERS.md).  Maintainers collectively
+manage the project's resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the Perses project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+## Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews
+    * perform reviews for several non-trivial pull requests,
+    * contribute to several non-trivial pull requests and have them merged,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+
+A new Maintainer must be proposed by an existing maintainer by creating a new issue in 
+the [Perses repository](https://github.com/perses/perses/issues). The new maintainer
+will be approved after another maintainer (in addition to the one proposing) has endorsed
+the person.
+
+## Voting
+
+While most business in Perses is conducted by "lazy consensus", periodically
+the Maintainers may need to vote on specific actions or changes.
+A vote can be taken by creating a new issue in the
+[Perses repository](https://github.com/perses/perses/issues).
+Any Maintainer may demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed. Maintainers
+can be removed by a 2/3 majority vote of all Maintainers, and changes to this
+Governance require a 2/3 vote of all Maintainers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,6 +4,38 @@ This document provides an initial governance structure for the Perses project.
 We've deliberately kept this as simple as possible for now, but 
 we expect the governance to evolve as the project grows.
 
+## Team Members
+
+A Team Member is any member if the private [perses-team](perses-team@googlegroups.com)
+Google Group.
+
+Team member status may be given to those who have made ongoing contributions to
+the project for at least 3 months. Contributions can include 
+code improvements, notable work on documentation, organizing events,
+user support, and other contributions.
+
+New members may be proposed by any existing member by email to 
+[perses-team](perses-team@googlegroups.com).
+
+It is highly desirable to reach consensus about acceptance of a new member.
+However, the proposal is ultimately voted on by a formal 2/3 majority vote.
+
+If the new member proposal is accepted, the proposed team member should be
+contacted privately via email to confirm or deny their acceptance of team
+membership. This email will also be CC'd to perses-team for record-keeping
+purposes.
+
+Team members may retire at any time by emailing the team.
+
+Team members can be removed by 2/3 majority vote on the team mailing list. For
+this vote, the member in question is not eligible to vote and does not count
+towards the quorum. Any removal vote can cover only one single person.
+
+Upon death of a member, they leave the team automatically.
+
+The current team members are:
+TBD
+
 ## Maintainers
 
 Perses maintainers have write access to projects under the Perses GitHub organization.
@@ -34,10 +66,10 @@ To become a Maintainer you need to demonstrate the following:
   * understanding of how the team works (policies, processes for testing and code review, etc),
   * understanding of the project's code base and coding and documentation style.
 
-A new maintainer must be proposed by an existing maintainer by sending an email to the
-private maintainer mailing list (perses-team@googlegroups.com). A 2/3 majority of existing maintainers
+A new maintainer must be proposed by an existing team member by sending an email to the
+private mailing list (perses-team@googlegroups.com). A 2/3 majority of team members
 must vote to approve a new maintainer. After the new maintainer is approved, they will 
-be added to the private maintainer mailing list.
+be added to the private team member mailing list.
 
 ## Voting
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ Upon death of a member, they leave the team automatically.
 
 The current team members are:
 
-| Maintainer | GitHub ID | Affiliation |
+| Team Member | GitHub ID | Affiliation |
 | --------------- | --------- | ----------- |
 | Augustin Husson | [nexucis](https://github.com/Nexucis) | Amadeus IT Group |
 | Luke Tillman | [luketillman](https://github.com/LukeTillman) | Chronosphere |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,7 @@
 # Perses Maintainers
 
 More details about our governance and how maintainers are selected can
-be found in [GOVERNANCE.md](GOVERNANCE.MD).
+be found in [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Maintainers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,15 @@
+# Perses Maintainers
+
+More details about our governance and how maintainers are selected can
+be found in [GOVERNANCE.md](GOVERNANCE.MD).
+
+## Maintainers
+
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Augustin Husson | [nexucis](https://github.com/Nexucis) | Amadeus IT Group |
+| Luke Tillman | [luketillman](https://github.com/LukeTillman) | Chronosphere |
+| Steven Cobb | [sjcobb](https://github.com/sjcobb) | Chronosphere |
+| Julius Volz | [juliusv](https://github.com/juliusv) | PromLabs |
+| Antoine Thebaud | [AntoineThebaud](https://github.com/AntoineThebaud) | Amadeus IT Group |
+


### PR DESCRIPTION
Here is a PR with an initial governance proposal for Perses. I've kept this very simple and short with the idea that we can build on it as the project grows. We can make changes to any of this - please let me know what you do or do not like about this proposal.

I've also suggested that we prune the list of "maintainers" or people who have access to make changes within the Perses org, since based on issue https://github.com/perses/perses/issues/429, a lot of people have access who are no longer active in the project. I've proposed the following 5 people as maintainers based on the feedback from issue https://github.com/perses/perses/issues/429 and my review of existing contributions:

- Antoine Thebaud (@AntoineThebaud)
- Augustin Husson (@Nexucis)
- Luke Tillman (@LukeTillman)
- Steven Cobb (@sjcobb)
- Julius Volz (@juliusv)

If any of you do not want to be maintainers, please let me know, and I'll remove you.

The governance process for adding new maintainers is very simple and just requires endorsement from 2 existing maintainers, so we can easily add maintainers as the project grows.