### PR TITLE
fix tooltip key formatting in line chart

### DIFF
--- a/ui/components/src/tooltip/SeriesInfo.tsx
+++ b/ui/components/src/tooltip/SeriesInfo.tsx
@@ -72,9 +72,10 @@ export function SeriesInfo(props: SeriesInfoProps) {
           {formattedSeriesLabels.split(',').map((name) => {
             if (name) {
               const [key, value] = jsonFormattedSeries ? name.split(':') : name.split('=');
+              const formattedKey = value ? `${key}: ` : key;
               return (
                 <Box key={name} sx={{ display: 'flex', gap: '4px' }}>
-                  <Typography sx={{ fontSize: '11px' }}>{key}:</Typography>
+                  <Typography sx={{ fontSize: '11px' }}>{formattedKey}</Typography>
                   <Typography
                     sx={(theme) => ({
                       color: theme.palette.common.white,

--- a/ui/components/src/tooltip/SeriesInfo.tsx
+++ b/ui/components/src/tooltip/SeriesInfo.tsx
@@ -72,7 +72,7 @@ export function SeriesInfo(props: SeriesInfoProps) {
           {formattedSeriesLabels.split(',').map((name) => {
             if (name) {
               const [key, value] = jsonFormattedSeries ? name.split(':') : name.split('=');
-              const formattedKey = value ? `${key}: ` : key;
+              const formattedKey = value !== undefined ? `${key}: ` : key;
               return (
                 <Box key={name} sx={{ display: 'flex', gap: '4px' }}>
                   <Typography sx={{ fontSize: '11px' }}>{formattedKey}</Typography>


### PR DESCRIPTION
Currently, tooltips with only one focused series has a bug with how keys are displayed. Sometimes a colon is shown after the key even when there is no value following it.

In this PR, a check is added to make sure the value is populated before adding `:`