### PR TITLE
fix line chart xAxis date formatting

### DIFF
--- a/ui/components/src/LineChart.tsx
+++ b/ui/components/src/LineChart.tsx
@@ -309,9 +309,9 @@ function getFormattedDate(value: number, rangeMs: number) {
     minute: 'numeric',
     hour12: false,
   };
-  const fiveMinMs = 300000;
+  const thirtyMinMs = 1800000;
   const dayMs = 86400000;
-  if (rangeMs <= fiveMinMs) {
+  if (rangeMs <= thirtyMinMs) {
     dateFormatOptions.second = 'numeric';
   } else if (rangeMs >= dayMs) {
     dateFormatOptions.month = 'numeric';

--- a/ui/components/src/LineChart.tsx
+++ b/ui/components/src/LineChart.tsx
@@ -201,7 +201,7 @@ export function LineChart({
       delete defaultToolbox.feature.dataZoom.icon;
     }
 
-    const stepMs = data.stepMs ?? getStepInterval(data.xAxis);
+    const rangeMs = getDateRange(data.xAxis);
 
     const option = {
       title: {
@@ -218,7 +218,7 @@ export function LineChart({
           margin: 15,
           color: theme.palette.text.primary,
           formatter: (value: number) => {
-            return getFormattedDate(value, stepMs);
+            return getFormattedDate(value, rangeMs);
           },
         },
         axisTick: {
@@ -293,23 +293,27 @@ export function LineChart({
   );
 }
 
-function getStepInterval(data: number[]) {
-  const defaultInterval = 15000;
-  if (data.length === 0) return defaultInterval;
-  if (data[0] === undefined || data[1] === undefined) return defaultInterval;
-  return data[1] - data[0];
+// fallback when xAxis time range not passed as prop
+function getDateRange(data: number[]) {
+  const defaultRange = 3600000; // hour in ms
+  if (data.length === 0) return defaultRange;
+  const lastDatum = data[data.length - 1];
+  if (data[0] === undefined || lastDatum === undefined) return defaultRange;
+  return lastDatum - data[0];
 }
 
-function getFormattedDate(value: number, stepMs: number) {
+// determines time granularity for axis labels, defaults to hh:mm
+function getFormattedDate(value: number, rangeMs: number) {
   const dateFormatOptions: Intl.DateTimeFormatOptions = {
     hour: 'numeric',
     minute: 'numeric',
     hour12: false,
   };
-  if (stepMs <= 13000) {
+  const fiveMinMs = 300000;
+  const dayMs = 86400000;
+  if (rangeMs <= fiveMinMs) {
     dateFormatOptions.second = 'numeric';
-  } else if (stepMs > 15000) {
-    // 15000 corresponds to greater than 1 day
+  } else if (rangeMs >= dayMs) {
     dateFormatOptions.month = 'numeric';
     dateFormatOptions.day = 'numeric';
   }

--- a/ui/components/src/LineChart.tsx
+++ b/ui/components/src/LineChart.tsx
@@ -201,6 +201,13 @@ export function LineChart({
       delete defaultToolbox.feature.dataZoom.icon;
     }
 
+    let xAxisInterval = 15000;
+    if (data.xAxis.length > 1) {
+      if (data.xAxis[0] !== undefined && data.xAxis[1] !== undefined) {
+        xAxisInterval = data.xAxis[1] - data.xAxis[0];
+      }
+    }
+
     const option = {
       title: {
         show: false,
@@ -216,7 +223,7 @@ export function LineChart({
           margin: 15,
           color: theme.palette.text.primary,
           formatter: (value: number) => {
-            return getFormattedDate(value);
+            return getFormattedDate(value, xAxisInterval);
           },
         },
         axisTick: {
@@ -261,6 +268,7 @@ export function LineChart({
     };
 
     return option;
+    // TODO (sjcobb): consolidate option props using echarts theme to reduce num of items in dep array
   }, [data, theme, grid, legend, toolbox, dataZoomEnabled, visualMap]);
 
   return (
@@ -290,11 +298,20 @@ export function LineChart({
   );
 }
 
-function getFormattedDate(value: number) {
-  const XAXIS_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+function getFormattedDate(value: number, stepMs: number) {
+  const dateFormatOptions: Intl.DateTimeFormatOptions = {
     hour: 'numeric',
     minute: 'numeric',
     hour12: false,
-  });
-  return XAXIS_DATE_FORMAT.format(value * 1000);
+  };
+  if (stepMs <= 13000) {
+    dateFormatOptions.second = 'numeric';
+  } else if (stepMs > 15000) {
+    // 15000 corresponds to greater than 1 day
+    dateFormatOptions.month = 'numeric';
+    dateFormatOptions.day = 'numeric';
+  }
+  const DATE_FORMAT = new Intl.DateTimeFormat(undefined, dateFormatOptions);
+  // remove comma when month / day present
+  return DATE_FORMAT.format(value).replace(/, /g, ' ');
 }

--- a/ui/components/src/LineChart.tsx
+++ b/ui/components/src/LineChart.tsx
@@ -201,7 +201,7 @@ export function LineChart({
       delete defaultToolbox.feature.dataZoom.icon;
     }
 
-    const rangeMs = getDateRange(data.xAxis);
+    const rangeMs = data.rangeMs ?? getDateRange(data.xAxis);
 
     const option = {
       title: {

--- a/ui/components/src/LineChart.tsx
+++ b/ui/components/src/LineChart.tsx
@@ -201,12 +201,7 @@ export function LineChart({
       delete defaultToolbox.feature.dataZoom.icon;
     }
 
-    let xAxisInterval = 15000;
-    if (data.xAxis.length > 1) {
-      if (data.xAxis[0] !== undefined && data.xAxis[1] !== undefined) {
-        xAxisInterval = data.xAxis[1] - data.xAxis[0];
-      }
-    }
+    const stepMs = data.stepMs ?? getStepInterval(data.xAxis);
 
     const option = {
       title: {
@@ -223,7 +218,7 @@ export function LineChart({
           margin: 15,
           color: theme.palette.text.primary,
           formatter: (value: number) => {
-            return getFormattedDate(value, xAxisInterval);
+            return getFormattedDate(value, stepMs);
           },
         },
         axisTick: {
@@ -296,6 +291,13 @@ export function LineChart({
       />
     </Box>
   );
+}
+
+function getStepInterval(data: number[]) {
+  const defaultInterval = 15000;
+  if (data.length === 0) return defaultInterval;
+  if (data[0] === undefined || data[1] === undefined) return defaultInterval;
+  return data[1] - data[0];
 }
 
 function getFormattedDate(value: number, stepMs: number) {

--- a/ui/components/src/model/graph-model.ts
+++ b/ui/components/src/model/graph-model.ts
@@ -29,5 +29,5 @@ export interface EChartsTimeSeries extends Omit<LineSeriesOption, 'data'> {
 export type EChartsDataFormat = {
   timeSeries: EChartsTimeSeries[];
   xAxis: number[];
-  stepMs?: number;
+  rangeMs?: number;
 };

--- a/ui/components/src/model/graph-model.ts
+++ b/ui/components/src/model/graph-model.ts
@@ -29,4 +29,5 @@ export interface EChartsTimeSeries extends Omit<LineSeriesOption, 'data'> {
 export type EChartsDataFormat = {
   timeSeries: EChartsTimeSeries[];
   xAxis: number[];
+  stepMs?: number;
 };

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
@@ -84,6 +84,7 @@ export function LineChartContainer(props: LineChartContainerProps) {
     }
 
     graphData.xAxis = xAxisData;
+    graphData.stepMs = timeScale.startMs;
     return {
       graphData,
       loading: queriesFinished === 0,

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
@@ -84,7 +84,7 @@ export function LineChartContainer(props: LineChartContainerProps) {
     }
 
     graphData.xAxis = xAxisData;
-    graphData.stepMs = timeScale.startMs;
+    graphData.stepMs = timeScale.stepMs;
     return {
       graphData,
       loading: queriesFinished === 0,

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
@@ -84,7 +84,7 @@ export function LineChartContainer(props: LineChartContainerProps) {
     }
 
     graphData.xAxis = xAxisData;
-    graphData.stepMs = timeScale.stepMs;
+    graphData.rangeMs = timeScale.endMs - timeScale.startMs;
     return {
       graphData,
       loading: queriesFinished === 0,


### PR DESCRIPTION
LineChart xAxis labels now show days / seconds when applicable instead of only hours / minutes.

**Screenshot**:

![graph-step-days-ex](https://user-images.githubusercontent.com/9369625/167919822-411aa741-395d-4e5e-b276-c70748a27993.png)

