### PR TITLE
Fix tag usage in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,4 +59,4 @@ release:
   ids:
     - "default"
   prerelease: auto
-  name_template: "{{.TAG}}/{{.Date}}"
+  name_template: "{{ .Tag }}/{{ .Date }}"


### PR DESCRIPTION
this time it's the right one. I wished Goreleaser wasn't case sensitive :(.