### PR TITLE
fix line chart shows time beyond 24 hours, add max prop

### DIFF
--- a/ui/components/src/LineChart.tsx
+++ b/ui/components/src/LineChart.tsx
@@ -213,7 +213,7 @@ export function LineChart({
       xAxis: {
         type: 'category',
         data: data.xAxis,
-        max: (value: { min: number; max: number }) => value.max,
+        max: data.xAxisMax,
         axisLabel: {
           margin: 15,
           color: theme.palette.text.primary,

--- a/ui/components/src/LineChart.tsx
+++ b/ui/components/src/LineChart.tsx
@@ -307,7 +307,7 @@ function getFormattedDate(value: number, rangeMs: number) {
   const dateFormatOptions: Intl.DateTimeFormatOptions = {
     hour: 'numeric',
     minute: 'numeric',
-    hour12: false,
+    hourCycle: 'h23',
   };
   const thirtyMinMs = 1800000;
   const dayMs = 86400000;

--- a/ui/components/src/model/graph-model.ts
+++ b/ui/components/src/model/graph-model.ts
@@ -29,5 +29,6 @@ export interface EChartsTimeSeries extends Omit<LineSeriesOption, 'data'> {
 export type EChartsDataFormat = {
   timeSeries: EChartsTimeSeries[];
   xAxis: number[];
+  xAxisMax?: number | 'dataMax';
   rangeMs?: number;
 };


### PR DESCRIPTION
This PR fixes a bug where xAxis date formatting for LineChart shows 12:30 AM as 24:30. Now Intl.DateTimeFormat params have been updated to instead show it as 0:30

More info about fix: https://stackoverflow.com/questions/65604554/intl-datetimeformat-returns-an-hour-over-24/65604634#65604634

An optional prop to customize xAxis.max is also added for more control when switching query duration.