### PR TITLE
bugfix line-chart panel query error handling

### DIFF
--- a/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
@@ -42,7 +42,11 @@ export function LineChartContainer(props: LineChartContainerProps) {
   // populate series data based on query results
   const { graphData, loading } = useMemo(() => {
     const timeScale = getCommonTimeScale(queries);
+
     if (timeScale === undefined) {
+      for (const query of queries) {
+        if (query.error !== undefined) throw query.error;
+      }
       return {
         graphData: EMPTY_GRAPH_DATA,
         loading: true,

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
@@ -42,9 +42,9 @@ export function LineChartContainer(props: LineChartContainerProps) {
   // populate series data based on query results
   const { graphData, loading } = useMemo(() => {
     const timeScale = getCommonTimeScale(queries);
-
     if (timeScale === undefined) {
       for (const query of queries) {
+        // does not show error message if any query is successful (due to timeScale check)
         if (query.error !== undefined) throw query.error;
       }
       return {


### PR DESCRIPTION
Throw error when a query fails in LineChart panels instead of hanging in loading state.

Note: `throw error` is added inside timeScale undef condition so if any query is successful the graph will still show.

Screenshot:
![LineChart_error_ex](https://user-images.githubusercontent.com/9369625/178302451-f6cfc14d-b1bf-4598-8a1d-d3d419c912d6.png)