### PR TITLE
refactor mui to echarts theme generate function

### DIFF
--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from '@mui/material';
-import { ErrorAlert, ChartsThemeProvider, useGenerateChartsTheme } from '@perses-dev/components';
+import { Box, useTheme } from '@mui/material';
+import { ErrorAlert, ChartsThemeProvider, generateChartsTheme } from '@perses-dev/components';
 import { PluginRegistry, PluginBoundary } from '@perses-dev/plugin-system';
 import ViewDashboard from './views/ViewDashboard';
 import { DataSourceRegistry } from './context/DataSourceRegistry';
@@ -22,10 +22,12 @@ import { useBundledPlugins } from './model/bundled-plugins';
 function App() {
   const { getInstalledPlugins, importPluginModule } = useBundledPlugins();
 
+  const muiTheme = useTheme();
+
   // app specific echarts option overrides, empty since perses uses default
   // https://apache.github.io/echarts-handbook/en/concepts/style/#theme
   const echartsThemeOverrides = {};
-  const chartsTheme = useGenerateChartsTheme('perses', echartsThemeOverrides);
+  const chartsTheme = generateChartsTheme('perses', muiTheme, echartsThemeOverrides);
 
   return (
     <Box

--- a/ui/components/src/GaugeChart/GaugeChart.tsx
+++ b/ui/components/src/GaugeChart/GaugeChart.tsx
@@ -57,7 +57,6 @@ export function GaugeChart(props: GaugeChartProps) {
           endAngle: -20,
           min: 0,
           max: 100,
-          splitNumber: 12,
           silent: true,
           progress: {
             show: true,

--- a/ui/components/src/model/theme.ts
+++ b/ui/components/src/model/theme.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { EChartsOption, EChartsCoreOption, BarSeriesOption, LineSeriesOption } from 'echarts';
+import type { EChartsOption, EChartsCoreOption, BarSeriesOption, LineSeriesOption, GaugeSeriesOption } from 'echarts';
 
 export interface PersesChartsTheme {
   themeName: string;
@@ -27,4 +27,5 @@ export interface PersesChartsTheme {
 export interface EChartsTheme extends EChartsOption {
   bar?: BarSeriesOption;
   line?: LineSeriesOption;
+  gauge?: GaugeSeriesOption;
 }

--- a/ui/components/src/utils/theme-gen.test.ts
+++ b/ui/components/src/utils/theme-gen.test.ts
@@ -1,0 +1,198 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createTheme } from '@mui/material';
+import { EChartsTheme, PersesChartsTheme } from '../model';
+import { generateChartsTheme } from './theme-gen';
+
+describe('generateChartsTheme', () => {
+  const muiTheme = createTheme({});
+  const echartsThemeOverrides: EChartsTheme = {
+    legend: {
+      textStyle: {
+        color: 'yellow',
+      },
+    },
+    line: {
+      showSymbol: true,
+      smooth: true,
+    },
+  };
+  const chartsTheme: PersesChartsTheme = generateChartsTheme('perses', muiTheme, echartsThemeOverrides);
+
+  it('should return perses specific charts theme from converted MUI theme', () => {
+    expect(chartsTheme).toMatchInlineSnapshot(`
+      Object {
+        "echartsTheme": Object {
+          "bar": Object {
+            "barMaxWidth": 150,
+            "itemStyle": Object {
+              "borderColor": "#e0e0e0",
+              "borderWidth": 0,
+            },
+          },
+          "categoryAxis": Object {
+            "axisLabel": Object {
+              "color": "rgba(0, 0, 0, 0.87)",
+              "margin": 15,
+              "show": true,
+            },
+            "axisLine": Object {
+              "lineStyle": Object {
+                "color": "#757575",
+              },
+              "show": true,
+            },
+            "axisTick": Object {
+              "length": 6,
+              "lineStyle": Object {
+                "color": "#757575",
+              },
+              "show": false,
+            },
+            "show": true,
+            "splitArea": Object {
+              "areaStyle": Object {
+                "color": Array [
+                  "#e0e0e0",
+                ],
+              },
+              "show": false,
+            },
+            "splitLine": Object {
+              "lineStyle": Object {
+                "color": "#e0e0e0",
+                "opacity": 0.6,
+                "width": 0.5,
+              },
+              "show": true,
+            },
+          },
+          "color": Array [
+            "#8dd3c7",
+            "#bebada",
+            "#fb8072",
+            "#80b1d3",
+            "#fdb462",
+          ],
+          "gauge": Object {
+            "detail": Object {
+              "fontSize": 18,
+              "fontWeight": 600,
+              "valueAnimation": false,
+            },
+            "splitLine": Object {
+              "distance": 0,
+              "length": 4,
+              "lineStyle": Object {
+                "width": 1,
+              },
+            },
+            "splitNumber": 12,
+          },
+          "grid": Object {
+            "bottom": 0,
+            "containLabel": true,
+            "left": 20,
+            "right": 20,
+            "top": 5,
+          },
+          "legend": Object {
+            "orient": "horizontal",
+            "pageIconColor": "rgba(0, 0, 0, 0.54)",
+            "pageIconInactiveColor": "rgba(0, 0, 0, 0.26)",
+            "pageTextStyle": Object {
+              "color": "#757575",
+            },
+            "textStyle": Object {
+              "color": "yellow",
+            },
+          },
+          "line": Object {
+            "emphasis": Object {
+              "lineStyle": Object {
+                "width": 1.5,
+              },
+            },
+            "lineStyle": Object {
+              "width": 1,
+            },
+            "showSymbol": true,
+            "smooth": true,
+            "symbol": "circle",
+            "symbolSize": 4,
+          },
+          "textStyle": Object {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+            "fontSize": 12,
+          },
+          "title": Object {
+            "show": false,
+          },
+          "toolbox": Object {
+            "iconStyle": Object {
+              "borderColor": "rgba(0, 0, 0, 0.87)",
+            },
+            "right": 10,
+            "show": true,
+            "top": 10,
+          },
+          "tooltip": Object {},
+          "valueAxis": Object {
+            "axisLabel": Object {
+              "color": "rgba(0, 0, 0, 0.87)",
+              "margin": 12,
+            },
+            "axisLine": Object {
+              "show": false,
+            },
+            "show": true,
+            "splitLine": Object {
+              "lineStyle": Object {
+                "color": "#e0e0e0",
+                "opacity": 0.6,
+                "width": 0.5,
+              },
+              "show": true,
+            },
+          },
+        },
+        "noDataOption": Object {
+          "title": Object {
+            "left": "center",
+            "show": true,
+            "text": "No data",
+            "textStyle": Object {
+              "color": "rgba(0, 0, 0, 0.87)",
+              "fontSize": 16,
+              "fontWeight": 400,
+            },
+            "top": "center",
+          },
+          "xAxis": Object {
+            "show": false,
+          },
+          "yAxis": Object {
+            "show": false,
+          },
+        },
+        "sparkline": Object {
+          "color": "#1976d2",
+          "width": 2,
+        },
+        "themeName": "perses",
+      }
+    `);
+  });
+});

--- a/ui/components/src/utils/theme-gen.ts
+++ b/ui/components/src/utils/theme-gen.ts
@@ -21,12 +21,7 @@ export function generateChartsTheme(
   themeName: string,
   muiTheme: MuiTheme,
   echartsTheme: EChartsTheme
-): PersesChartsTheme | undefined {
-
-  if (muiTheme.typography === undefined || muiTheme.palette === undefined || muiTheme.palette.grey === undefined) {
-    return;
-  }
-
+): PersesChartsTheme {
   const primaryTextColor = muiTheme.palette.text?.primary ?? DEFAULT_TEXT_COLOR;
 
   const muiConvertedTheme: EChartsTheme = {
@@ -147,13 +142,13 @@ export function generateChartsTheme(
         valueAnimation: false,
       },
       splitLine: {
-        splitNumber: 2,
         distance: 0,
         length: 4,
         lineStyle: {
           width: 1,
         },
       },
+      splitNumber: 12,
     },
   };
 

--- a/ui/components/src/utils/theme-gen.ts
+++ b/ui/components/src/utils/theme-gen.ts
@@ -11,17 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useTheme } from '@mui/material';
+import { Theme as MuiTheme } from '@mui/material';
 import merge from 'lodash/merge';
 import { EChartsTheme, PersesChartsTheme } from '../model';
 
 const DEFAULT_TEXT_COLOR = '#222';
 
-export function useGenerateChartsTheme(
+export function generateChartsTheme(
   themeName: string,
-  echartsThemeOverrides: EChartsTheme
+  muiTheme: MuiTheme,
+  echartsTheme: EChartsTheme
 ): PersesChartsTheme | undefined {
-  const muiTheme = useTheme();
 
   if (muiTheme.typography === undefined || muiTheme.palette === undefined || muiTheme.palette.grey === undefined) {
     return;
@@ -159,7 +159,7 @@ export function useGenerateChartsTheme(
 
   return {
     themeName,
-    echartsTheme: merge(muiConvertedTheme, echartsThemeOverrides),
+    echartsTheme: merge(muiConvertedTheme, echartsTheme),
     noDataOption: {
       title: {
         show: true,


### PR DESCRIPTION
Fix remaining [feedback comment from Luke](https://github.com/perses/perses/pull/462#discussion_r907471583) on PR [462](https://github.com/perses/perses/pull/462). Simplify previous useGenerateChartsTheme to pass theme as param into new generateChartsTheme function. Also, fixes invalid gauge series theme property and add unit test (theme-gen.test.ts).