### PR TITLE
build errors fix - clean dist folders before start

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "test": "npm test --workspaces",
     "lint": "npm run lint --workspaces",
     "lint:fix": "npm run lint:fix --workspaces",
-    "start": "npm run start -w app",
+    "start": "npm run clean && npm run start -w app",
     "clean": "rimraf .build-cache && npm run clean --workspaces"
   },
   "workspaces": [


### PR DESCRIPTION
There are currently intermittent errors when running Perses on our main branch, this PR ensures all previous dist folders are cleaned before `npm run start -w app` is run.

Related to [this discussion](https://matrix.to/#/!XNmgYIAndZOkEvQAbb:matrix.org/$ZAAq5_auqCXrTz79ufphLMKtyqVj39gFvl4iQOA4qnE?via=matrix.org) in #perses-dev.

Install errors Karan ran into: [main_branch_npm_errors_ex.txt](https://github.com/perses/perses/files/9260024/main_branch_npm_errors_ex.txt)

