### PR TITLE
line chart tooltip performance improvement

### DIFF
--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -13,7 +13,7 @@
 
 import { AnyVariableDefinition, DashboardResource } from '@perses-dev/core';
 
-const benchmarkDashboard: DashboardResource = {
+const demoDashboard: DashboardResource = {
   kind: 'Dashboard',
   metadata: {
     name: 'Node Stats',
@@ -100,10 +100,7 @@ const benchmarkDashboard: DashboardResource = {
               },
             },
           ],
-          unit: {
-            kind: 'Decimal',
-            decimal_places: 4,
-          },
+          unit: { kind: 'Bytes' },
         },
       },
       basicEx: {
@@ -119,10 +116,7 @@ const benchmarkDashboard: DashboardResource = {
               },
             },
           ],
-          unit: {
-            kind: 'PercentDecimal',
-            decimal_places: 0,
-          },
+          unit: { kind: 'Percent' },
         },
       },
       legendEx: {
@@ -425,7 +419,7 @@ const benchmarkDashboard: DashboardResource = {
           display: {
             title: 'Row 1',
             collapse: {
-              open: true,
+              open: false,
             },
           },
           items: [
@@ -444,20 +438,6 @@ const benchmarkDashboard: DashboardResource = {
               width: 12,
               height: 6,
               content: { $ref: '#/spec/panels/basicEx' },
-            },
-            {
-              x: 0,
-              y: 6,
-              width: 12,
-              height: 6,
-              content: { $ref: '#/spec/panels/seriesTestAlt' },
-            },
-            {
-              x: 12,
-              y: 6,
-              width: 12,
-              height: 6,
-              content: { $ref: '#/spec/panels/seriesTestAlt' },
             },
           ],
         },
@@ -495,7 +475,7 @@ const benchmarkDashboard: DashboardResource = {
           display: {
             title: 'Row 3',
             collapse: {
-              open: false,
+              open: true,
             },
           },
           items: [
@@ -550,4 +530,4 @@ const benchmarkDashboard: DashboardResource = {
   },
 };
 
-export default benchmarkDashboard;
+export default demoDashboard;

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -40,7 +40,6 @@ import { EChart, OnEventsType } from '../EChart';
 import { PROGRESSIVE_MODE_SERIES_LIMIT, EChartsDataFormat } from '../model/graph';
 import { formatValue, UnitOptions } from '../model/units';
 import { useChartsTheme } from '../context/ChartsThemeProvider';
-import { emptyTooltipData } from '../Tooltip/tooltip-model';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { enableDataZoom, restoreChart, getDateRange, getFormattedDate, ZoomEventData } from './utils';
 
@@ -191,9 +190,7 @@ export function LineChart({ height, data, unit, grid, legend, visualMap, onDataZ
       onMouseLeave={handleOnMouseLeave}
       onMouseEnter={handleOnMouseEnter}
     >
-      {showTooltip === true && (
-        <Tooltip chartRef={chartRef} tooltipData={emptyTooltipData} chartData={data} wrapLabels={true}></Tooltip>
-      )}
+      {showTooltip === true && <Tooltip chartRef={chartRef} chartData={data} wrapLabels={true}></Tooltip>}
 
       <EChart
         sx={{

--- a/ui/components/src/Tooltip/Tooltip.tsx
+++ b/ui/components/src/Tooltip/Tooltip.tsx
@@ -29,7 +29,10 @@ interface TooltipProps {
 const Tooltip = React.memo(function Tooltip({ chartRef, chartData, wrapLabels }: TooltipProps) {
   const [pinnedPos, setPinnedPos] = useState<CursorCoordinates | null>(null);
   const mousePos = useMousePosition();
+
   if (mousePos === null || mousePos.target === null) return null;
+
+  // ensure user is hovering over a chart before checking for nearby series
   if ((mousePos.target as HTMLElement).tagName !== 'CANVAS') return null;
 
   const chart = chartRef.current;

--- a/ui/components/src/Tooltip/focused-series.ts
+++ b/ui/components/src/Tooltip/focused-series.ts
@@ -43,7 +43,7 @@ export function getNearbySeries(data: EChartsDataFormat, pointInGrid: number[], 
   if (Array.isArray(data.xAxis) && Array.isArray(data.timeSeries)) {
     for (let seriesIdx = 0; seriesIdx < data.timeSeries.length; seriesIdx++) {
       const currentSeries = data.timeSeries[seriesIdx];
-      if (currentFocusedData.length > TOOLTIP_MAX_ITEMS) break;
+      if (currentFocusedData.length >= TOOLTIP_MAX_ITEMS) break;
       if (currentSeries !== undefined) {
         const currentSeriesName = currentSeries.name ? currentSeries.name.toString() : '';
         const markerColor = currentSeries.color ?? '#000';

--- a/ui/components/src/Tooltip/tooltip-model.ts
+++ b/ui/components/src/Tooltip/tooltip-model.ts
@@ -18,7 +18,7 @@ export const TOOLTIP_MAX_WIDTH = 650;
 export const TOOLTIP_MAX_HEIGHT = 230;
 export const TOOLTIP_LABELS_MAX_WIDTH = TOOLTIP_MAX_WIDTH - 150;
 
-export const TOOLTIP_MAX_ITEMS = 50;
+export const TOOLTIP_MAX_ITEMS = 20;
 
 export const TOOLTIP_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',

--- a/ui/components/src/Tooltip/utils.ts
+++ b/ui/components/src/Tooltip/utils.ts
@@ -1,0 +1,57 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CursorCoordinates, CursorData, TOOLTIP_MAX_WIDTH } from './tooltip-model';
+
+export function assembleTransform(
+  mousePos: CursorData['coords'],
+  seriesNum: number,
+  chartWidth: number,
+  chartHeight: number,
+  pinnedPos: CursorCoordinates | null
+) {
+  if (mousePos === null) {
+    return 'translate3d(0, 0)';
+  }
+
+  if (pinnedPos !== null) {
+    mousePos = pinnedPos;
+  }
+
+  const cursorPaddingX = 32;
+  const cursorPaddingY = 16;
+  const x = mousePos.viewport.x;
+  let y = mousePos.viewport.y + cursorPaddingY;
+
+  const isCloseToBottom = mousePos.viewport.y > window.innerHeight * 0.8;
+  const yPosAdjustThreshold = chartHeight * 0.75;
+  // adjust so tooltip does not get cut off at bottom of chart, reduce multiplier to move up
+  if (isCloseToBottom === true) {
+    if (seriesNum > 6) {
+      y = mousePos.viewport.y * 0.65;
+    } else {
+      y = mousePos.viewport.y * 0.75;
+    }
+  } else if (mousePos.plotCanvas.y > yPosAdjustThreshold) {
+    y = mousePos.viewport.y * 0.85;
+  }
+
+  // use tooltip width to determine when to repos from right to left (width is narrower when only 1 focused series since labels wrap)
+  const tooltipWidth = seriesNum > 1 ? TOOLTIP_MAX_WIDTH : TOOLTIP_MAX_WIDTH / 2;
+  const xPosAdjustThreshold = chartWidth - tooltipWidth * 0.9;
+
+  // reposition so tooltip is never too close to right side of chart or left side of browser window
+  return mousePos.plotCanvas.x > xPosAdjustThreshold && x > TOOLTIP_MAX_WIDTH
+    ? `translate3d(${x - cursorPaddingX}px, ${y}px, 0) translateX(-100%)`
+    : `translate3d(${x + cursorPaddingX}px, ${y}px, 0)`;
+}

--- a/ui/components/src/Tooltip/utils.ts
+++ b/ui/components/src/Tooltip/utils.ts
@@ -13,6 +13,9 @@
 
 import { CursorCoordinates, CursorData, TOOLTIP_MAX_WIDTH } from './tooltip-model';
 
+/**
+ * Determine position of tooltip depending on chart dimensions and the number of focused series
+ */
 export function assembleTransform(
   mousePos: CursorData['coords'],
   seriesNum: number,


### PR DESCRIPTION
We noticed performance issues when using Perses on dashboard with many charts, where multiple queries returned thousands of series. The way the tooltip is implemented is the main cause, this PR doesn't fix the issue completely but has a few improvements. I'm planning to look into additional tooltip fixes and adding lazy loading [using IntersectionObserver](https://stackoverflow.com/questions/53757229/reactjs-how-to-render-a-component-only-when-scroll-down-and-reach-it-on-the-page/65628717#65628717)

### Commits Summary
- add React.memo in Tooltip.tsx
- remove an unnecessary prop
- add check in Tooltip.tsx for if the cursor is over a canvas element (using mousePos.target)
  - there is already a check in getFocusedSeriesData for whether the current target is a chart, but adding the condition in Tooltip.tsx allows getFocusedSeriesData to not be called as often

