### PR TITLE
Implemented edit mode and added react-grid-layout

### DIFF
--- a/ui/app/src/theme/common.ts
+++ b/ui/app/src/theme/common.ts
@@ -57,6 +57,21 @@ export function getTheme(overrides: ThemeOptions = {}) {
         size: 'small',
       },
     },
+    MuiSvgIcon: {
+      defaultProps: {
+        fontSize: 'small',
+      },
+      styleOverrides: {
+        fontSizeSmall: {
+          fontSize: '1rem',
+        },
+      },
+    },
+    MuiCardHeader: {
+      defaultProps: {
+        disableTypography: true,
+      },
+    },
   };
 
   theme.components = merge(components, overrides.components);

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { DashboardResource } from '@perses-dev/core';
-import { DashboardProvider, ViewDashboard as DashboardView } from '@perses-dev/dashboards';
+import { ViewDashboard as DashboardView } from '@perses-dev/dashboards';
 import Footer from '../components/Footer';
 import { useSampleData } from '../utils/temp-sample-data';
 
@@ -30,11 +30,9 @@ function ViewDashboard() {
   }
 
   return (
-    <DashboardProvider initialState={{ dashboardSpec: dashboard.spec }}>
-      <DashboardView dashboardResource={dashboard}>
-        <Footer />
-      </DashboardView>
-    </DashboardProvider>
+    <DashboardView dashboardResource={dashboard}>
+      <Footer />
+    </DashboardView>
   );
 }
 

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { DashboardResource } from '@perses-dev/core';
-import { ViewDashboard as DashboardView } from '@perses-dev/dashboards';
+import { DashboardProvider, ViewDashboard as DashboardView } from '@perses-dev/dashboards';
 import Footer from '../components/Footer';
 import { useSampleData } from '../utils/temp-sample-data';
 
@@ -30,9 +30,11 @@ function ViewDashboard() {
   }
 
   return (
-    <DashboardView dashboardResource={dashboard}>
-      <Footer />
-    </DashboardView>
+    <DashboardProvider initialState={{ dashboardSpec: dashboard.spec }}>
+      <DashboardView dashboardResource={dashboard}>
+        <Footer />
+      </DashboardView>
+    </DashboardProvider>
   );
 }
 

--- a/ui/components/src/EChart.tsx
+++ b/ui/components/src/EChart.tsx
@@ -174,6 +174,14 @@ export const EChart = React.memo(function EChart<T>({
     };
   }, [onEvents]);
 
+  useEffect(() => {
+    const updateSize = debounce(() => {
+      if (chartElement.current === null) return;
+      chartElement.current.resize();
+    }, 200);
+    updateSize();
+  }, [sx]);
+
   return <Box ref={containerRef} sx={sx}></Box>;
 });
 

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -27,21 +27,23 @@
     "@perses-dev/components": "^0.6.0",
     "@perses-dev/core": "^0.6.0",
     "@perses-dev/plugin-system": "^0.6.0",
+    "@types/react-grid-layout": "^1.3.2",
     "immer": "^9.0.15",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react-grid-layout": "^1.3.4",
     "react-intersection-observer": "^9.4.0",
     "use-immer": "^0.7.0",
     "use-resize-observer": "^8.0.0",
     "zustand": "^4.1.1"
   },
   "devDependencies": {
-    "intersection-observer": "^0.12.2"
+    "intersection-observer": "^0.12.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "peerDependencies": {
+    "@mui/material": "^5.5.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "@mui/material": "^5.5.1"
+    "react-dom": "^17.0.2"
   },
   "files": [
     "dist"

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^17.0.2",
     "react-intersection-observer": "^9.4.0",
     "use-immer": "^0.7.0",
-    "use-resize-observer": "^8.0.0"
+    "use-resize-observer": "^8.0.0",
+    "zustand": "^4.1.1"
   },
   "devDependencies": {
     "intersection-observer": "^0.12.2"

--- a/ui/dashboards/src/components/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar.tsx
@@ -1,0 +1,60 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Toolbar, Typography, Stack, Button, Box } from '@mui/material';
+import PencilIcon from 'mdi-material-ui/PencilOutline';
+import AddIcon from 'mdi-material-ui/Plus';
+import { useEditMode } from '../context';
+
+export const DashboardToolbar = () => {
+  const { isEditMode, setEditMode } = useEditMode();
+
+  const onEditButtonClick = () => {
+    setEditMode(true);
+  };
+
+  const onCancelButtonClick = () => {
+    setEditMode(false);
+  };
+
+  return (
+    <Toolbar disableGutters>
+      {isEditMode ? (
+        <Stack spacing={2} sx={{ width: '100%' }}>
+          <Box sx={{ display: 'flex' }}>
+            <Typography variant="h6">Edit Dashboard</Typography>
+            <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
+              <Button variant="outlined" onClick={onCancelButtonClick}>
+                Cancel
+              </Button>
+              <Button variant="contained">Save</Button>
+            </Stack>
+          </Box>
+          <Button
+            sx={{
+              alignSelf: 'flex-end',
+            }}
+          >
+            <AddIcon sx={{ marginRight: '8px' }} />
+            Add Panel
+          </Button>
+        </Stack>
+      ) : (
+        <Button variant="contained" onClick={onEditButtonClick} sx={{ marginLeft: 'auto' }}>
+          <PencilIcon sx={{ marginRight: '8px' }} />
+          Edit
+        </Button>
+      )}
+    </Toolbar>
+  );
+};

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -10,13 +10,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
 
 import { useState } from 'react';
+import { Responsive, WidthProvider } from 'react-grid-layout';
 import { Box, BoxProps, Collapse } from '@mui/material';
 import { GridDefinition, GridItemDefinition } from '@perses-dev/core';
+import { useEditMode } from '../../context';
 import { GridTitle } from './GridTitle';
 
-const COLUMNS = 24;
+const ResponsiveGridLayout = WidthProvider(Responsive);
 
 export interface GridLayoutProps extends BoxProps {
   definition: GridDefinition;
@@ -35,33 +39,18 @@ export function GridLayout(props: GridLayoutProps) {
 
   const [isOpen, setIsOpen] = useState(spec.display?.collapse?.open ?? true);
 
+  const { isEditMode } = useEditMode();
+
   const gridItems: React.ReactNode[] = [];
-  let mobileRowStart = 1;
 
   spec.items.forEach((item, idx) => {
-    // Try to maintain the chart's aspect ratio on mobile
-    const widthScale = COLUMNS / item.width;
-    const mobileRows = Math.floor(item.height * widthScale);
+    const { x, y, width: w, height: h } = item;
 
     gridItems.push(
-      <Box
-        key={idx}
-        sx={{
-          gridColumn: {
-            xs: `1 / span ${COLUMNS}`,
-            sm: `${item.x + 1} / span ${item.width}`,
-          },
-          gridRow: {
-            xs: `${mobileRowStart} / span ${mobileRows}`,
-            sm: `${item.y + 1} / span ${item.height}`,
-          },
-        }}
-      >
+      <div key={idx} data-grid={{ x, y, w, h }}>
         {renderGridItemContent(item)}
-      </Box>
+      </div>
     );
-
-    mobileRowStart += mobileRows;
   });
 
   return (
@@ -77,20 +66,18 @@ export function GridLayout(props: GridLayoutProps) {
         />
       )}
       <Collapse in={isOpen} unmountOnExit>
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(${COLUMNS}, 1fr)`,
-            gridAutoRows: {
-              xs: 24,
-              sm: 36,
-            },
-            columnGap: (theme) => theme.spacing(1),
-            rowGap: (theme) => theme.spacing(1),
-          }}
+        <ResponsiveGridLayout
+          className="layout"
+          breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
+          cols={{ lg: 24, md: 24, sm: 24, xs: 24, xxs: 2 }}
+          rowHeight={30}
+          draggableHandle={'.drag-handle'}
+          resizeHandles={['se']}
+          isDraggable={isEditMode}
+          isResizable={isEditMode}
         >
           {gridItems}
-        </Box>
+        </ResponsiveGridLayout>
       </Collapse>
     </Box>
   );

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -16,6 +16,8 @@ import { PluginRegistrationConfig, PluginRegistry } from '@perses-dev/plugin-sys
 import 'intersection-observer';
 import { screen } from '@testing-library/react';
 import { renderWithContext, mockPluginRegistryProps } from '../../test';
+import testDashboard from '../../test/testDashboard';
+import { DashboardProvider, DashboardStoreProps } from '../../context';
 import { Panel, PanelProps } from './Panel';
 
 const FAKE_PANEL_PLUGIN: PluginRegistrationConfig<JsonObject> = {
@@ -30,6 +32,8 @@ const FAKE_PANEL_PLUGIN: PluginRegistrationConfig<JsonObject> = {
 
 describe('Panel', () => {
   let props: PanelProps;
+  let initialState: DashboardStoreProps;
+
   beforeEach(() => {
     props = {
       definition: {
@@ -41,23 +45,38 @@ describe('Panel', () => {
         options: {},
       },
     };
+
+    initialState = {
+      isEditMode: false,
+      dashboardSpec: testDashboard.spec,
+    };
   });
 
   // Helper to render the panel with some context set
-  const renderPanel = () => {
+  const renderPanel = (initialState: DashboardStoreProps) => {
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
     addMockPlugin(FAKE_PANEL_PLUGIN);
 
     renderWithContext(
-      <PluginRegistry {...pluginRegistryProps}>
-        <Panel {...props} />
-      </PluginRegistry>
+      <DashboardProvider initialState={initialState}>
+        <PluginRegistry {...pluginRegistryProps}>
+          <Panel {...props} />
+        </PluginRegistry>
+      </DashboardProvider>
     );
   };
 
   it('should render name and info icon', async () => {
-    renderPanel();
+    renderPanel(initialState);
     await screen.findByText('Fake Panel');
     screen.queryByLabelText('info-tooltip');
+  });
+
+  it('should render edit icons when in edit mode', async () => {
+    initialState.isEditMode = true;
+    renderPanel(initialState);
+    await screen.queryByLabelText('drag handle');
+    screen.queryByLabelText('edit panel');
+    screen.queryByLabelText('more');
   });
 });

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -19,6 +19,9 @@ import { ErrorAlert, InfoTooltip, TooltipPlacement } from '@perses-dev/component
 import { PanelDefinition } from '@perses-dev/core';
 import { Box, Card, CardProps, CardHeader, CardContent, Typography } from '@mui/material';
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
+import PencilIcon from 'mdi-material-ui/Pencil';
+import MenuIcon from 'mdi-material-ui/DotsVertical';
+import { useEditMode } from '../../context';
 
 export interface PanelProps extends CardProps {
   definition: PanelDefinition;
@@ -47,6 +50,8 @@ export function Panel(props: PanelProps) {
   // TODO: adjust padding for small panels, consistent way to determine isLargePanel here and in StatChart
   const panelPadding = 1.5;
 
+  const { isEditMode } = useEditMode();
+
   return (
     <Card
       ref={ref}
@@ -66,6 +71,7 @@ export function Panel(props: PanelProps) {
             sx={{
               display: 'flex',
               alignItems: 'center',
+              height: '20px',
             }}
           >
             <Typography
@@ -78,19 +84,33 @@ export function Panel(props: PanelProps) {
             >
               {definition.display.name}
             </Typography>
-            {definition.display.description && (
-              <InfoTooltip
-                id="info-tooltip"
-                description={definition.display.description}
-                placement={TooltipPlacement.Right}
-              >
-                <InformationOutlineIcon
-                  aria-describedby="info-tooltip"
-                  aria-hidden={false}
-                  sx={{ fontSize: '1rem', position: 'relative', left: '4px', cursor: 'pointer' }}
-                />
-              </InfoTooltip>
-            )}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                marginLeft: 'auto',
+              }}
+            >
+              {!isEditMode && definition.display.description && (
+                <InfoTooltip
+                  id="info-tooltip"
+                  description={definition.display.description}
+                  placement={TooltipPlacement.Right}
+                >
+                  <InformationOutlineIcon
+                    aria-describedby="info-tooltip"
+                    aria-hidden={false}
+                    sx={{ fontSize: '1rem', cursor: 'pointer', margin: '0 4px' }}
+                  />
+                </InfoTooltip>
+              )}
+              {isEditMode && (
+                <>
+                  <PencilIcon sx={{ fontSize: '1rem', cursor: 'pointer', margin: '0 4px' }} />
+                  <MenuIcon sx={{ fontSize: '1rem', cursor: 'pointer', margin: '0 4px' }} />
+                </>
+              )}
+            </Box>
           </Box>
         }
         sx={{

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -17,10 +17,21 @@ import { useInView } from 'react-intersection-observer';
 import { PluginBoundary, PanelComponent } from '@perses-dev/plugin-system';
 import { ErrorAlert, InfoTooltip, TooltipPlacement } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
-import { Box, Card, CardProps, CardHeader, CardContent, Typography } from '@mui/material';
+import {
+  Box,
+  Card,
+  CardProps,
+  CardHeader,
+  CardContent,
+  Typography,
+  IconButton as MuiIconButton,
+  Stack,
+  styled,
+} from '@mui/material';
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import MenuIcon from 'mdi-material-ui/DotsVertical';
+import DragIcon from 'mdi-material-ui/Drag';
 import { useEditMode } from '../../context';
 
 export interface PanelProps extends CardProps {
@@ -71,7 +82,7 @@ export function Panel(props: PanelProps) {
             sx={{
               display: 'flex',
               alignItems: 'center',
-              height: '20px',
+              minHeight: '24px',
             }}
           >
             <Typography
@@ -95,20 +106,28 @@ export function Panel(props: PanelProps) {
                 <InfoTooltip
                   id="info-tooltip"
                   description={definition.display.description}
-                  placement={TooltipPlacement.Right}
+                  placement={TooltipPlacement.Bottom}
                 >
                   <InformationOutlineIcon
                     aria-describedby="info-tooltip"
                     aria-hidden={false}
-                    sx={{ fontSize: '1rem', cursor: 'pointer', margin: '0 4px' }}
+                    fontSize="small"
+                    sx={{ cursor: 'pointer' }}
                   />
                 </InfoTooltip>
               )}
               {isEditMode && (
-                <>
-                  <PencilIcon sx={{ fontSize: '1rem', cursor: 'pointer', margin: '0 4px' }} />
-                  <MenuIcon sx={{ fontSize: '1rem', cursor: 'pointer', margin: '0 4px' }} />
-                </>
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <IconButton aria-label="drag handle" size="small">
+                    <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
+                  </IconButton>
+                  <IconButton aria-label="edit panel" size="small">
+                    <PencilIcon />
+                  </IconButton>
+                  <IconButton aria-label="more" size="small">
+                    <MenuIcon />
+                  </IconButton>
+                </Stack>
               )}
             </Box>
           </Box>
@@ -139,3 +158,8 @@ export function Panel(props: PanelProps) {
     </Card>
   );
 }
+
+const IconButton = styled(MuiIconButton)(({ theme }) => ({
+  borderRadius: theme.shape.borderRadius,
+  padding: '4px',
+}));

--- a/ui/dashboards/src/context/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider.tsx
@@ -1,0 +1,73 @@
+import create from 'zustand';
+import type { StoreApi } from 'zustand';
+import createZustandContext from 'zustand/context';
+import produce from 'immer';
+import { DashboardSpec, LayoutDefinition, PanelDefinition } from '@perses-dev/core';
+
+interface DashboardState {
+  isEditMode: boolean;
+  layouts: LayoutDefinition[];
+  panels: Record<string, PanelDefinition>;
+}
+
+interface DashboardActions {
+  setEditMode: (isEditMode: boolean) => void;
+  setLayouts: (layouts: LayoutDefinition[]) => void;
+  setPanels: (panels: Record<string, PanelDefinition>) => void;
+  addPanel: (name: string, panel: PanelDefinition) => void;
+}
+
+export type DashboardStoreState = DashboardState & DashboardActions;
+
+interface DashboardProviderProps {
+  initialDashboard: DashboardSpec;
+  children?: React.ReactNode;
+}
+
+const { Provider, useStore } = createZustandContext<StoreApi<DashboardStoreState>>();
+
+export function usePanels() {
+  const { panels, addPanel } = useStore(({ panels, addPanel }) => ({ panels, addPanel }));
+  return { panels, addPanel };
+}
+
+export function useLayouts() {
+  const { layouts, setLayouts } = useStore(({ layouts, setLayouts }) => ({ layouts, setLayouts }));
+  return { layouts, setLayouts };
+}
+
+export function useEditMode() {
+  const { isEditMode, setEditMode } = useStore(({ isEditMode, setEditMode }) => ({ isEditMode, setEditMode }));
+  return { isEditMode, setEditMode };
+}
+
+export function DashboardProvider(props: DashboardProviderProps) {
+  const {
+    children,
+    initialDashboard: { layouts, panels },
+  } = props;
+
+  return (
+    <Provider
+      createStore={() =>
+        create((set) => ({
+          isEditMode: false,
+          layouts,
+          panels,
+          setEditMode: (isEditMode: boolean) => set({ isEditMode }),
+          setLayouts: (layouts: LayoutDefinition[]) => set({ layouts }),
+          setPanels: (panels: Record<string, PanelDefinition>) => set({ panels }),
+          addPanel: (name: string, panel: PanelDefinition) => {
+            set(
+              produce((state: DashboardStoreState) => {
+                state.panels[name] = panel;
+              }, {})
+            );
+          },
+        }))
+      }
+    >
+      {children}
+    </Provider>
+  );
+}

--- a/ui/dashboards/src/context/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider.tsx
@@ -1,3 +1,16 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import create from 'zustand';
 import type { StoreApi } from 'zustand';
 import createZustandContext from 'zustand/context';
@@ -19,8 +32,12 @@ interface DashboardActions {
 
 export type DashboardStoreState = DashboardState & DashboardActions;
 
-interface DashboardProviderProps {
-  initialDashboard: DashboardSpec;
+export interface DashboardStoreProps {
+  dashboardSpec: DashboardSpec;
+  isEditMode?: boolean;
+}
+export interface DashboardProviderProps {
+  initialState: DashboardStoreProps;
   children?: React.ReactNode;
 }
 
@@ -44,16 +61,19 @@ export function useEditMode() {
 export function DashboardProvider(props: DashboardProviderProps) {
   const {
     children,
-    initialDashboard: { layouts, panels },
+    initialState: {
+      dashboardSpec: { layouts, panels },
+      isEditMode,
+    },
   } = props;
 
   return (
     <Provider
       createStore={() =>
         create((set) => ({
-          isEditMode: false,
           layouts,
           panels,
+          isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
           setLayouts: (layouts: LayoutDefinition[]) => set({ layouts }),
           setPanels: (panels: Record<string, PanelDefinition>) => set({ panels }),

--- a/ui/dashboards/src/context/index.ts
+++ b/ui/dashboards/src/context/index.ts
@@ -13,3 +13,4 @@
 
 export * from './TemplateVariablesProvider';
 export * from './TimeRangeStateProvider';
+export * from './DashboardProvider';

--- a/ui/dashboards/src/test/testDashboard.ts
+++ b/ui/dashboards/src/test/testDashboard.ts
@@ -1,0 +1,225 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DashboardResource } from '@perses-dev/core';
+
+const testDashboard: DashboardResource = {
+  kind: 'Dashboard',
+  metadata: {
+    name: 'Node Stats',
+    project: 'perses',
+    created_at: '2021-11-09',
+    updated_at: '2021-11-09',
+    version: 0,
+  },
+  spec: {
+    datasource: { kind: 'Prometheus', global: true, name: 'Public Prometheus Demo Server' },
+    // TODO: Should duration actually be a time range?
+    duration: '24h',
+    variables: {
+      job: {
+        kind: 'PrometheusLabelValues',
+        options: {
+          label_name: 'job',
+          match: ['node_uname_info'],
+        },
+        display: {
+          label: 'Job',
+        },
+        selection: {
+          default_value: 'node',
+        },
+      },
+      instance: {
+        kind: 'PrometheusLabelValues',
+        options: {
+          label_name: 'instance',
+          match: ['node_uname_info{job="node"}'],
+        },
+        display: {
+          label: 'Node',
+        },
+        selection: {
+          default_value: ['demo.do.prometheus.io:9100'],
+          all_value: '$__all',
+        },
+      },
+      interval: {
+        kind: 'Interval',
+        options: {
+          values: ['1m', '5m', '10m', '1h'],
+          auto: {
+            step_count: 50,
+            min_interval: '1m',
+          },
+        },
+        display: {
+          label: 'Interval',
+        },
+        selection: {
+          default_value: '1m',
+        },
+      },
+    },
+    panels: {
+      cpu: {
+        kind: 'LineChart',
+        display: { name: 'CPU' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query:
+                  'avg without (cpu)(rate(node_cpu_seconds_total{job="node",instance="$instance",mode!="idle"}[$interval]))',
+              },
+            },
+          ],
+          unit: { kind: '%' },
+        },
+      },
+      memory: {
+        kind: 'LineChart',
+        display: { name: 'Memory' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query:
+                  'node_memory_MemTotal_bytes{job="node",instance="$instance"} - node_memory_MemFree_bytes{job="node",instance="$instance"} - node_memory_Buffers_bytes{job="node",instance="$instance"} - node_memory_Cached_bytes{job="node",instance="$instance"}',
+              },
+            },
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
+              },
+            },
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'node_memory_Cached_bytes{job="node",instance="$instance"}',
+              },
+            },
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query: 'node_memory_MemFree_bytes{job="node",instance="$instance"}',
+              },
+            },
+          ],
+          unit: { kind: 'Bytes' },
+        },
+      },
+      diskIO: {
+        kind: 'LineChart',
+        display: { name: 'Disk I/O Utilization' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query:
+                  'rate(node_disk_io_time_seconds_total{job="node",instance="$instance",device!~"^(md\\\\d+$|dm-)"}[$interval])',
+              },
+            },
+          ],
+          unit: { kind: 'Percent' },
+        },
+      },
+      filesystemFullness: {
+        kind: 'LineChart',
+        display: { name: 'Filesystem Fullness' },
+        options: {
+          queries: [
+            {
+              kind: 'PrometheusGraphQuery',
+              options: {
+                query:
+                  '1 - node_filesystem_free_bytes{job="node",instance="$instance",fstype!="rootfs",mountpoint!~"/(run|var).*",mountpoint!=""} / node_filesystem_size_bytes{job="node",instance="$instance"}',
+              },
+            },
+          ],
+          unit: { kind: 'Percent' },
+        },
+      },
+    },
+    layouts: [
+      // Regular Title, no collapse enabled
+      {
+        kind: 'Grid',
+        spec: {
+          display: {
+            title: 'CPU Stats',
+          },
+          items: [
+            // First Row
+            {
+              x: 0,
+              y: 0,
+              width: 12,
+              height: 4,
+              content: { $ref: '#/spec/panels/cpu' },
+            },
+          ],
+        },
+      },
+      // No title,
+      {
+        kind: 'Grid',
+        spec: {
+          items: [
+            {
+              x: 8,
+              y: 0,
+              width: 8,
+              height: 3,
+              content: { $ref: '#/spec/panels/memory' },
+            },
+          ],
+        },
+      },
+      // Collapsed
+      {
+        kind: 'Grid',
+        spec: {
+          display: {
+            title: 'Disk Stats',
+            collapse: {
+              open: false,
+            },
+          },
+          items: [
+            {
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 2,
+              content: { $ref: '#/spec/panels/diskIO' },
+            },
+            {
+              x: 18,
+              y: 0,
+              width: 6,
+              height: 2,
+              content: { $ref: '#/spec/panels/filesystemFullness' },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+export default testDashboard;

--- a/ui/dashboards/src/views/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard.tsx
@@ -11,13 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, BoxProps, Button, Stack, Toolbar, Typography } from '@mui/material';
+import { Box, BoxProps } from '@mui/material';
 import { combineSx } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
-import PencilIcon from 'mdi-material-ui/PencilOutline';
-import AddIcon from 'mdi-material-ui/Plus';
-import { TimeRangeStateProvider, TemplateVariablesProvider, useEditMode } from '../context';
+import { TimeRangeStateProvider, TemplateVariablesProvider, DashboardProvider } from '../context';
 import { Dashboard, VariableList } from '../components';
+import { DashboardToolbar } from '../components/DashboardToolbar';
 
 export interface ViewDashboardProps extends BoxProps {
   dashboardResource: DashboardResource;
@@ -29,85 +28,44 @@ export interface ViewDashboardProps extends BoxProps {
 export function ViewDashboard(props: ViewDashboardProps) {
   const { dashboardResource, sx, children, ...others } = props;
 
-  const { isEditMode, setEditMode } = useEditMode();
-
-  const onEditButtonClick = () => {
-    setEditMode(true);
-  };
-
-  const onCancelButtonClick = () => {
-    setEditMode(false);
-  };
-
   return (
-    <TimeRangeStateProvider initialValue={{ pastDuration: dashboardResource.spec.duration }}>
-      <TemplateVariablesProvider variableDefinitions={dashboardResource.spec.variables}>
-        {isEditMode && (
-          <Toolbar sx={{ display: 'flex', paddingLeft: '16px', paddingRight: '16px' }}>
-            <Typography variant="h6" sx={{ marginRight: '1rem' }}>
-              Edit Dashboard
-            </Typography>
-            <Stack direction="row" alignItems="center" spacing={1} sx={{ marginLeft: 'auto' }}>
-              <Button variant="outlined" onClick={onCancelButtonClick}>
-                Cancel
-              </Button>
-              <Button variant="contained">Save</Button>
-            </Stack>
-          </Toolbar>
-        )}
-        <Box
-          sx={combineSx(
-            {
-              display: 'flex',
-              width: '100%',
-              height: '100%',
-              position: 'relative',
-              overflow: 'hidden',
-            },
-            sx
-          )}
-          {...others}
-        >
+    <DashboardProvider initialState={{ dashboardSpec: dashboardResource.spec }}>
+      <TimeRangeStateProvider initialValue={{ pastDuration: dashboardResource.spec.duration }}>
+        <TemplateVariablesProvider variableDefinitions={dashboardResource.spec.variables}>
           <Box
-            sx={{
-              padding: (theme) => theme.spacing(1, 2),
-              flexGrow: 1,
-              overflowX: 'hidden',
-              overflowY: 'auto',
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
-            {isEditMode ? (
-              <Button
-                sx={{
-                  alignSelf: 'flex-end',
-                }}
-              >
-                <AddIcon sx={{ fontSize: '1rem', marginRight: '8px' }} />
-                Add Panel
-              </Button>
-            ) : (
-              <Button
-                variant="contained"
-                sx={{
-                  alignSelf: 'flex-end',
-                }}
-                onClick={onEditButtonClick}
-              >
-                <PencilIcon sx={{ fontSize: '1rem', marginRight: '8px' }} />
-                Edit
-              </Button>
+            sx={combineSx(
+              {
+                display: 'flex',
+                width: '100%',
+                height: '100%',
+                position: 'relative',
+                overflow: 'hidden',
+              },
+              sx
             )}
-            <VariableList
-              variables={dashboardResource.spec.variables}
-              sx={{ margin: (theme) => theme.spacing(1, 0, 2) }}
-            />
-            <Dashboard spec={dashboardResource.spec} />
-            {children}
+            {...others}
+          >
+            <Box
+              sx={{
+                padding: (theme) => theme.spacing(1, 2),
+                flexGrow: 1,
+                overflowX: 'hidden',
+                overflowY: 'auto',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <DashboardToolbar />
+              <VariableList
+                variables={dashboardResource.spec.variables}
+                sx={{ margin: (theme) => theme.spacing(1, 0, 2) }}
+              />
+              <Dashboard spec={dashboardResource.spec} />
+              {children}
+            </Box>
           </Box>
-        </Box>
-      </TemplateVariablesProvider>
-    </TimeRangeStateProvider>
+        </TemplateVariablesProvider>
+      </TimeRangeStateProvider>
+    </DashboardProvider>
   );
 }

--- a/ui/dashboards/src/views/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard.tsx
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, BoxProps } from '@mui/material';
+import { Box, BoxProps, Button, Toolbar, Typography } from '@mui/material';
 import { combineSx } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
-import { TimeRangeStateProvider, TemplateVariablesProvider } from '../context';
+import PencilIcon from 'mdi-material-ui/PencilOutline';
+import AddIcon from 'mdi-material-ui/Plus';
+import { TimeRangeStateProvider, TemplateVariablesProvider, useEditMode } from '../context';
 import { Dashboard, VariableList } from '../components';
 
 export interface ViewDashboardProps extends BoxProps {
@@ -27,9 +29,45 @@ export interface ViewDashboardProps extends BoxProps {
 export function ViewDashboard(props: ViewDashboardProps) {
   const { dashboardResource, sx, children, ...others } = props;
 
+  const { isEditMode, setEditMode } = useEditMode();
+
+  const onEditButtonClick = () => {
+    setEditMode(true);
+  };
+
+  const onCancelButtonClick = () => {
+    setEditMode(false);
+  };
+
   return (
     <TimeRangeStateProvider initialValue={{ pastDuration: dashboardResource.spec.duration }}>
       <TemplateVariablesProvider variableDefinitions={dashboardResource.spec.variables}>
+        {isEditMode && (
+          <Toolbar sx={{ display: 'flex', paddingLeft: '16px', paddingRight: '16px' }}>
+            <Typography variant="h6" sx={{ marginRight: '1rem' }}>
+              Edit Dashboard
+            </Typography>
+            <Box sx={{ marginLeft: 'auto' }}>
+              <Button
+                variant="outlined"
+                sx={{
+                  margin: '0 4px',
+                }}
+                onClick={onCancelButtonClick}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                sx={{
+                  margin: '0 4px',
+                }}
+              >
+                Save
+              </Button>
+            </Box>
+          </Toolbar>
+        )}
         <Box
           sx={combineSx(
             {
@@ -49,8 +87,31 @@ export function ViewDashboard(props: ViewDashboardProps) {
               flexGrow: 1,
               overflowX: 'hidden',
               overflowY: 'auto',
+              display: 'flex',
+              flexDirection: 'column',
             }}
           >
+            {isEditMode ? (
+              <Button
+                sx={{
+                  alignSelf: 'flex-end',
+                }}
+              >
+                <AddIcon sx={{ fontSize: '1rem', marginRight: '8px' }} />
+                Add Panel
+              </Button>
+            ) : (
+              <Button
+                variant="contained"
+                sx={{
+                  alignSelf: 'flex-end',
+                }}
+                onClick={onEditButtonClick}
+              >
+                <PencilIcon sx={{ fontSize: '1rem', marginRight: '8px' }} />
+                Edit
+              </Button>
+            )}
             <VariableList
               variables={dashboardResource.spec.variables}
               sx={{ margin: (theme) => theme.spacing(1, 0, 2) }}

--- a/ui/dashboards/src/views/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, BoxProps, Button, Toolbar, Typography } from '@mui/material';
+import { Box, BoxProps, Button, Stack, Toolbar, Typography } from '@mui/material';
 import { combineSx } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
@@ -47,25 +47,12 @@ export function ViewDashboard(props: ViewDashboardProps) {
             <Typography variant="h6" sx={{ marginRight: '1rem' }}>
               Edit Dashboard
             </Typography>
-            <Box sx={{ marginLeft: 'auto' }}>
-              <Button
-                variant="outlined"
-                sx={{
-                  margin: '0 4px',
-                }}
-                onClick={onCancelButtonClick}
-              >
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ marginLeft: 'auto' }}>
+              <Button variant="outlined" onClick={onCancelButtonClick}>
                 Cancel
               </Button>
-              <Button
-                variant="contained"
-                sx={{
-                  margin: '0 4px',
-                }}
-              >
-                Save
-              </Button>
-            </Box>
+              <Button variant="contained">Save</Button>
+            </Stack>
           </Toolbar>
         )}
         <Box

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -126,15 +126,18 @@
         "@perses-dev/components": "^0.6.0",
         "@perses-dev/core": "^0.6.0",
         "@perses-dev/plugin-system": "^0.6.0",
+        "@types/react-grid-layout": "^1.3.2",
         "immer": "^9.0.15",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react-grid-layout": "^1.3.4",
         "react-intersection-observer": "^9.4.0",
         "use-immer": "^0.7.0",
-        "use-resize-observer": "^8.0.0"
+        "use-resize-observer": "^8.0.0",
+        "zustand": "^4.1.1"
       },
       "devDependencies": {
-        "intersection-observer": "^0.12.2"
+        "intersection-observer": "^0.12.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       },
       "peerDependencies": {
         "@mui/material": "^5.5.1",
@@ -146,6 +149,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -169,6 +173,7 @@
       "version": "7.18.8",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
       "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -177,6 +182,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
       "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -206,6 +212,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -214,6 +221,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
       "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.9",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -227,6 +235,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -265,6 +274,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
       "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.18.8",
         "@babel/helper-validator-option": "^7.18.6",
@@ -282,6 +292,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -355,6 +366,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -375,6 +387,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
       "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.6",
         "@babel/types": "^7.18.9"
@@ -387,6 +400,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -421,6 +435,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
       "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -493,6 +508,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
       "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -516,6 +532,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -535,6 +552,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
       "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -558,6 +576,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
       "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.6",
         "@babel/traverse": "^7.18.9",
@@ -648,6 +667,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
       "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1974,6 +1994,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
       "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.6",
@@ -1987,6 +2008,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
       "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.18.9",
@@ -2007,6 +2029,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2618,6 +2641,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2630,6 +2654,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2638,6 +2663,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2669,12 +2695,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
       "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3736,6 +3764,14 @@
       "dev": true,
       "dependencies": {
         "@types/react": "^17"
+      }
+    },
+    "node_modules/@types/react-grid-layout": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.2.tgz",
+      "integrity": "sha512-ZzpBEOC1JTQ7MGe1h1cPKSLP4jSWuxc+yvT4TsAlEW9+EFPzAf8nxQfFd7ea9gL17Em7PbwJZAsiwfQQBUklZQ==",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-is": {
@@ -4897,6 +4933,7 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
       "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5006,6 +5043,7 @@
       "version": "1.0.30001368",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
       "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5610,6 +5648,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5968,7 +6007,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.196",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
-      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA=="
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
+      "dev": true
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -6115,6 +6155,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7258,6 +7299,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -8980,6 +9022,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -9008,6 +9051,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -9147,6 +9191,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -9447,7 +9496,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -9543,7 +9593,8 @@
     "node_modules/node-releases": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -9984,7 +10035,8 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10436,6 +10488,19 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-error-boundary": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
@@ -10449,6 +10514,22 @@
       },
       "peerDependencies": {
         "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.3.4.tgz",
+      "integrity": "sha512-sB3rNhorW77HUdOjB4JkelZTdJGQKuXLl3gNg+BI8gJkTScspL1myfZzW/EM0dLEn+1eH+xW+wNqk0oIM9o7cw==",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "lodash.isequal": "^4.0.0",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.0.0",
+        "react-resizable": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-intersection-observer": {
@@ -10488,6 +10569,18 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.4.tgz",
+      "integrity": "sha512-StnwmiESiamNzdRHbSSvA65b0ZQJ7eVQpPusrSmcpyGKzC0gojhtO62xxH6YOBmepk9dQTBi9yxidL3W4s3EBA==",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3"
       }
     },
     "node_modules/react-transition-group": {
@@ -12103,6 +12196,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
       "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12152,6 +12246,14 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -12815,6 +12917,29 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
+    "node_modules/zustand": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
+      "integrity": "sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "panels-plugin": {
       "name": "@perses-dev/panels-plugin",
       "version": "0.6.0",
@@ -12881,6 +13006,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -12897,12 +13023,14 @@
     "@babel/compat-data": {
       "version": "7.18.8",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ=="
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "dev": true
     },
     "@babel/core": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.9.tgz",
       "integrity": "sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==",
+      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -12924,7 +13052,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -12932,6 +13061,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
       "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.9",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -12942,6 +13072,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
           "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -12973,6 +13104,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
       "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.18.8",
         "@babel/helper-validator-option": "^7.18.6",
@@ -12983,7 +13115,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -13039,7 +13172,8 @@
     "@babel/helper-environment-visitor": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.18.6",
@@ -13054,6 +13188,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
       "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.18.6",
         "@babel/types": "^7.18.9"
@@ -13063,6 +13198,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -13088,6 +13224,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
       "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -13142,6 +13279,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
       "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -13159,6 +13297,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -13171,7 +13310,8 @@
     "@babel/helper-validator-option": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.18.9",
@@ -13189,6 +13329,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
       "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.18.6",
         "@babel/traverse": "^7.18.9",
@@ -13259,7 +13400,8 @@
     "@babel/parser": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
-      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg=="
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+      "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.18.6",
@@ -14146,6 +14288,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
       "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.6",
@@ -14156,6 +14299,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
       "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.18.9",
@@ -14172,7 +14316,8 @@
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
         }
       }
     },
@@ -14661,6 +14806,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -14669,12 +14815,14 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
     },
     "@jridgewell/source-map": {
       "version": "0.3.2",
@@ -14702,12 +14850,14 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
       "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -14848,8 +14998,7 @@
     "@mui/types": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.4.tgz",
-      "integrity": "sha512-uveM3byMbthO+6tXZ1n2zm0W3uJCQYtwt/v5zV5I77v2v18u0ITkb8xwhsDD2i3V2Kye7SaNR6FFJ6lMuY/WqQ==",
-      "requires": {}
+      "integrity": "sha512-uveM3byMbthO+6tXZ1n2zm0W3uJCQYtwt/v5zV5I77v2v18u0ITkb8xwhsDD2i3V2Kye7SaNR6FFJ6lMuY/WqQ=="
     },
     "@mui/utils": {
       "version": "5.9.1",
@@ -14961,13 +15110,16 @@
         "@perses-dev/components": "^0.6.0",
         "@perses-dev/core": "^0.6.0",
         "@perses-dev/plugin-system": "^0.6.0",
+        "@types/react-grid-layout": "^1.3.2",
         "immer": "^9.0.15",
         "intersection-observer": "^0.12.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-grid-layout": "^1.3.4",
         "react-intersection-observer": "^9.4.0",
         "use-immer": "^0.7.0",
-        "use-resize-observer": "^8.0.0"
+        "use-resize-observer": "^8.0.0",
+        "zustand": "^4.1.1"
       }
     },
     "@perses-dev/panels-plugin": {
@@ -15003,8 +15155,7 @@
       },
       "dependencies": {
         "@prometheus-io/lezer-promql": {
-          "version": "0.37.0",
-          "requires": {}
+          "version": "0.37.0"
         }
       }
     },
@@ -15041,57 +15192,49 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.3.0.tgz",
       "integrity": "sha512-3XzJy0dCVEOE2o2Wn8tF9SdQ2na1Q7jJNzIs3+27RHPpEiuqlClBNhIOhPFKr95+bUGtL6nZIgqY8xBhMw0p6g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.3.0.tgz",
       "integrity": "sha512-zD0sTwXpL78pWaxWxCyqimfukPcJfToKuwW1Po00pUeOYT6KuMQrPnG6XIZpLadydOo+fght8SoxwRb5O9TtWA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.3.0.tgz",
       "integrity": "sha512-COsMIL1BRU/ZxFTvd59NFzJPIdvBkV19Jrn7w1NwFmglOUrpchPRSzfW6FzWUh2C8nzJrnjDn6V7i7klVhHZEA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.3.0.tgz",
       "integrity": "sha512-mKk2uqn1/7dk2I82fYaiLTw12eqmZZ2ZzH3WVhzzLvMXrLIxc9xYFJBNRMrV+77ZDHd791933HWSNChtGeJLQg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.3.0.tgz",
       "integrity": "sha512-jdQJa8DZHfo2POTmgl8ZmDEcpTEz4n6RsANle1DbbC8CGq+1k/RV4MkRL1ceqIJCSOW3ypk23gpG5Q4xlSiY7Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.3.0.tgz",
       "integrity": "sha512-yPogu5hLcF5FXCU3a3sCtsP+lloLBkIxM+xplumKwIdQNN28qb+HmFxVLUkT0+MD3y+77DjTtukJzkEBqL/BsA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.3.0.tgz",
       "integrity": "sha512-Eso0uWFLN8kpR/MB+mD6j0WOTSUPWpyXpEkYt6sg4GItEMvScWgZV8H986CU09oXceaG8AovgPvYdygiJuRsRA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.3.0.tgz",
       "integrity": "sha512-e9tSsPAHibGyZDPqQ8a5OIDuuON2YY6+XeCr6WqxVLwj+nIqbUOmNNZpekNsUv/gZ6UbtzEpGfZMiZavpavqDg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-preset": {
       "version": "6.3.0",
@@ -15565,6 +15708,14 @@
         "@types/react": "^17"
       }
     },
+    "@types/react-grid-layout": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.2.tgz",
+      "integrity": "sha512-ZzpBEOC1JTQ7MGe1h1cPKSLP4jSWuxc+yvT4TsAlEW9+EFPzAf8nxQfFd7ea9gL17Em7PbwJZAsiwfQQBUklZQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-is": {
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
@@ -15915,8 +16066,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
       "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -15931,8 +16081,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
       "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -15990,15 +16139,13 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -16060,8 +16207,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -16476,6 +16622,7 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
       "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001366",
         "electron-to-chromium": "^1.4.188",
@@ -16555,7 +16702,8 @@
     "caniuse-lite": {
       "version": "1.0.30001368",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
-      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ=="
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
+      "dev": true
     },
     "chalk": {
       "version": "4.1.2",
@@ -17002,6 +17150,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -17284,7 +17433,8 @@
     "electron-to-chromium": {
       "version": "1.4.196",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.196.tgz",
-      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA=="
+      "integrity": "sha512-uxMa/Dt7PQsLBVXwH+t6JvpHJnrsYBaxWKi/J6HE+/nBtoHENhwBoNkgkm226/Kfxeg0z1eMQLBRPPKcDH8xWA==",
+      "dev": true
     },
     "emittery": {
       "version": "0.8.1",
@@ -17394,7 +17544,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -17525,8 +17676,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -17719,8 +17869,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -18263,7 +18412,8 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -18637,8 +18787,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ignore": {
       "version": "5.2.0",
@@ -19274,8 +19423,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -19541,7 +19689,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -19563,7 +19712,8 @@
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -19673,6 +19823,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -19786,8 +19941,7 @@
     "mdi-material-ui": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/mdi-material-ui/-/mdi-material-ui-7.4.0.tgz",
-      "integrity": "sha512-MpnviSvboykZJ6j4dQRst9etpuoxf8jJ2XPLL0MdV/Dbui1jAp1VtUiRZyjpH/ap2GKT6PRZcI/9sg79Bxl1IA==",
-      "requires": {}
+      "integrity": "sha512-MpnviSvboykZJ6j4dQRst9etpuoxf8jJ2XPLL0MdV/Dbui1jAp1VtUiRZyjpH/ap2GKT6PRZcI/9sg79Bxl1IA=="
     },
     "mdn-data": {
       "version": "2.0.14",
@@ -19911,7 +20065,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -19994,7 +20149,8 @@
     "node-releases": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -20318,7 +20474,8 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -20407,8 +20564,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -20637,6 +20793,15 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-draggable": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+      "requires": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      }
+    },
     "react-error-boundary": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
@@ -20645,11 +20810,22 @@
         "@babel/runtime": "^7.12.5"
       }
     },
+    "react-grid-layout": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.3.4.tgz",
+      "integrity": "sha512-sB3rNhorW77HUdOjB4JkelZTdJGQKuXLl3gNg+BI8gJkTScspL1myfZzW/EM0dLEn+1eH+xW+wNqk0oIM9o7cw==",
+      "requires": {
+        "clsx": "^1.1.1",
+        "lodash.isequal": "^4.0.0",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.0.0",
+        "react-resizable": "^3.0.4"
+      }
+    },
     "react-intersection-observer": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.0.tgz",
-      "integrity": "sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A==",
-      "requires": {}
+      "integrity": "sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A=="
     },
     "react-is": {
       "version": "17.0.2",
@@ -20665,6 +20841,15 @@
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",
         "match-sorter": "^6.0.2"
+      }
+    },
+    "react-resizable": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.4.tgz",
+      "integrity": "sha512-StnwmiESiamNzdRHbSSvA65b0ZQJ7eVQpPusrSmcpyGKzC0gojhtO62xxH6YOBmepk9dQTBi9yxidL3W4s3EBA==",
+      "requires": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
       }
     },
     "react-transition-group": {
@@ -21442,8 +21627,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylis": {
       "version": "4.0.13",
@@ -21874,6 +22058,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
       "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -21891,8 +22076,7 @@
     "use-immer": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.7.0.tgz",
-      "integrity": "sha512-Re4hjrP3a/2ABZjAc0b7AK9s626bnO+H33RO2VUhiDZ2StBz5B663K6WNNlr4QtHWaGUmvLpwt3whFvvWuolQw==",
-      "requires": {}
+      "integrity": "sha512-Re4hjrP3a/2ABZjAc0b7AK9s626bnO+H33RO2VUhiDZ2StBz5B663K6WNNlr4QtHWaGUmvLpwt3whFvvWuolQw=="
     },
     "use-resize-observer": {
       "version": "8.0.0",
@@ -21901,6 +22085,11 @@
       "requires": {
         "@juggle/resize-observer": "^3.3.1"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -22179,8 +22368,7 @@
           "version": "8.8.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
           "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -22309,8 +22497,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -22381,6 +22568,14 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
           "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
+      }
+    },
+    "zustand": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
+      "integrity": "sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
       }
     }
   }


### PR DESCRIPTION
When edit button is clicked, dashboard is in edit mode. You can then reposition and resize panels. 

Added [zustand](https://github.com/pmndrs/zustand) for state management and [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) for drag and drop. 

![edit-mode](https://user-images.githubusercontent.com/9817826/187001493-a11ba33a-a69b-4d62-81b0-d0c385439130.gif)

