### PR TITLE
Update CONTRIBUTING and ui/README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,10 @@ Both components can be started and tested individually as described below.
 
 Building and starting the backend API server requires the following tools:
 
-* Go (usually the latest version as we are following upstream Go releases closely)
-* Docker & docker-compose
+* [Go](https://go.dev/doc/install) (usually the latest version as we are following upstream Go releases closely)
+* [Docker](https://docs.docker.com/engine/install/), which includes docker-compose
 * Make
+* [jq](https://stedolan.github.io/jq/download/)
 
 With these dependencies installed, you can proceed as follows:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ cd ../
 make build-api
 ```
 
-* Finally, run the built binary by using the simple configuration file from the `dev` folder:
+* Finally, run the built binary, using the simple configuration file found in the `dev` folder:
 
 ```bash
 ./bin/perses -config ./dev/config.yaml

--- a/ui/README.md
+++ b/ui/README.md
@@ -51,6 +51,8 @@ be available to the local packages that depend on them (e.g. you need to build
 You can also run a script across all packages in the workspace using NPM's
 `--workspaces` flag.
 
+Note: If you are trying to run the app (`npm run start -w app`), you may need to first [setup a local backend server](https://github.com/perses/perses/blob/main/CONTRIBUTING.md).
+
 ## Library Architecture Diagram
 
 Perses is broken up in to a number of separate packages to allow for flexibility when embedding functionality. Below is the current structure of these libraries:


### PR DESCRIPTION
Some updates to the setup docs

## CONTRIBUTING
* Add links to the download pages for Go and Docker
* Add instruction to download `jq`, a dependency used by the `populate.sh` script
* Remove ambiguity about which directory to be in when running a command 
<img width="585" alt="Screen Shot 2022-08-30 at 4 58 43 PM" src="https://user-images.githubusercontent.com/2584129/187564680-cbc158f1-3bd2-4db9-9297-c141e5941417.png">

## ui/README
* Add note in `ui/README` to run backend server before running the frontend server
 <img width="941" alt="Screen Shot 2022-08-30 at 5 06 15 PM" src="https://user-images.githubusercontent.com/2584129/187564683-e535e836-ff79-4c2f-8552-3243bf59523d.png">