### PR TITLE
Fix bug where bytes would be formatted with 'undefined' as unit

### DIFF
--- a/ui/components/src/model/units.ts
+++ b/ui/components/src/model/units.ts
@@ -227,7 +227,9 @@ function formatBytes(bytes: number, decimals = 2) {
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  // Math.max(0, ...) ensures that we don't return -1 as a value for the index.
+  // Why? When the number of bytes are between -1 and 1, Math.floor(Math.log(bytes)/Math.log(1024)) returns -1.
+  const i = Math.max(0, Math.floor(Math.log(bytes) / Math.log(k)));
 
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }


### PR DESCRIPTION
We noticed a bug where bytes were sometimes formatted incorrectly:
![Screen Shot 2022-09-01 at 10 17 55 AM](https://user-images.githubusercontent.com/2584129/187976347-41515687-0313-4ef4-b93f-a7ece999ac39.png)

Turns out, it happens when the number of byes is very small -- between -1 and 1. 
![Screen Shot 2022-09-01 at 10 18 12 AM](https://user-images.githubusercontent.com/2584129/187976535-4e271bc8-8cd8-463a-b861-bd64dce82568.png)

With the fix, we see the correct value and correct unit for bytes:
![Screen Shot 2022-09-01 at 9 00 22 AM](https://user-images.githubusercontent.com/2584129/187976519-dff6e54f-d116-4704-933f-29be619b9e22.png)

## Why?
First, we have an array of units like `['Bytes', 'KB', 'MB', ...]`.

Then, we have a function for getting the index of the unit to use based on the number of bytes. 

When the number of bytes is between -1 and 1, our function returns -1. 

-1 is not an index, and so we get `undefined` as the unit. 

I did a little Wolfram Alpha graphing of this function to see this edge case too:
![Screen Shot 2022-09-01 at 11 33 05 AM](https://user-images.githubusercontent.com/2584129/187987445-e31e0326-b9c8-4389-8602-979ff0426948.png)



Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>