### PR TITLE
[app] Move footer component into App vs. ViewDashboard

### DIFF
--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -17,6 +17,7 @@ import { PluginRegistry, PluginBoundary } from '@perses-dev/plugin-system';
 import ViewDashboard from './views/ViewDashboard';
 import { DataSourceRegistry } from './context/DataSourceRegistry';
 import Header from './components/Header';
+import Footer from './components/Footer';
 import { useBundledPlugins } from './model/bundled-plugins';
 
 function App() {
@@ -39,6 +40,7 @@ function App() {
     >
       <Header />
       <Box
+        component="main"
         sx={{
           flexGrow: 1,
           overflow: 'hidden',
@@ -54,6 +56,7 @@ function App() {
           </PluginRegistry>
         </ChartsThemeProvider>
       </Box>
+      <Footer />
     </Box>
   );
 }

--- a/ui/app/src/components/Footer.tsx
+++ b/ui/app/src/components/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer(): JSX.Element {
   const { exceptionSnackbar } = useSnackbar();
   const { data, isLoading } = useHealth({ onError: exceptionSnackbar });
   return (
-    <Box sx={style}>
+    <Box component="footer" sx={style}>
       <ul>
         <li>&copy; The Perses Authors {new Date().getFullYear()}</li>
         <li>

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -13,15 +13,16 @@
 
 import { DashboardResource } from '@perses-dev/core';
 import { ViewDashboard as DashboardView } from '@perses-dev/dashboards';
-import Footer from '../components/Footer';
 import { useSampleData } from '../utils/temp-sample-data';
+
+const DEFAULT_DASHBOARD_ID = 'node-exporter-full';
 
 /**
  * The View for viewing a Dashboard.
  */
 function ViewDashboard() {
   const dashboard = useSampleData<DashboardResource>(
-    new URLSearchParams(window.location.search).get('dashboard') || 'node-exporter-full'
+    new URLSearchParams(window.location.search).get('dashboard') || DEFAULT_DASHBOARD_ID
   );
 
   // TODO: Loading indicator
@@ -29,11 +30,7 @@ function ViewDashboard() {
     return null;
   }
 
-  return (
-    <DashboardView dashboardResource={dashboard}>
-      <Footer />
-    </DashboardView>
-  );
+  return <DashboardView dashboardResource={dashboard} />;
 }
 
 export default ViewDashboard;


### PR DESCRIPTION
Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>

# Changes
* Move footer component from `ViewDashboard.tsx` to `App.tsx`
* Add semantic tags for `main` and `footer`
* Add constant for the default dashboard ID

# Before
<img width="1499" alt="Screen Shot 2022-09-06 at 6 01 00 PM" src="https://user-images.githubusercontent.com/2584129/188766082-2bac6e1c-414c-4a09-ac8c-5507ed182ebc.png">
<img width="1500" alt="Screen Shot 2022-09-06 at 6 00 47 PM" src="https://user-images.githubusercontent.com/2584129/188766076-709cedb2-7d1d-4afe-852e-d7b5f290bead.png">



# After
<img width="1505" alt="Screen Shot 2022-09-06 at 6 00 19 PM" src="https://user-images.githubusercontent.com/2584129/188766107-a42395ad-e949-4416-a8e4-6becbca436c8.png">
<img width="1501" alt="Screen Shot 2022-09-06 at 6 00 30 PM" src="https://user-images.githubusercontent.com/2584129/188766118-a9b6a4df-75f4-47f6-ac94-2ce318c11c0a.png">

