### PR TITLE
WIP: Add hook for saving a dashboard

### DIFF
--- a/ui/dashboards/src/components/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar.tsx
@@ -16,7 +16,7 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import AddIcon from 'mdi-material-ui/Plus';
 import { useEditMode } from '../context';
 
-export const DashboardToolbar = () => {
+export const DashboardToolbar = ({ onSave }) => {
   const { isEditMode, setEditMode } = useEditMode();
 
   const onEditButtonClick = () => {
@@ -25,6 +25,11 @@ export const DashboardToolbar = () => {
 
   const onCancelButtonClick = () => {
     setEditMode(false);
+  };
+
+  const onSaveButtonClick = () => {
+    // Need to be able to pull the entire dashboard resource from context
+    onSave();
   };
 
   return (
@@ -37,7 +42,9 @@ export const DashboardToolbar = () => {
               <Button variant="outlined" onClick={onCancelButtonClick}>
                 Cancel
               </Button>
-              <Button variant="contained">Save</Button>
+              <Button variant="contained" onClick={onSaveButtonClick}>
+                Save
+              </Button>
             </Stack>
           </Box>
           <Button

--- a/ui/dashboards/src/views/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard.tsx
@@ -20,6 +20,7 @@ import { DashboardToolbar } from '../components/DashboardToolbar';
 
 export interface ViewDashboardProps extends BoxProps {
   dashboardResource: DashboardResource;
+  onSave: (dashboardResource: DashboardResource) => void;
 }
 
 /**
@@ -55,7 +56,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
                 flexDirection: 'column',
               }}
             >
-              <DashboardToolbar />
+              <DashboardToolbar onSave={onSave} />
               <VariableList
                 variables={dashboardResource.spec.variables}
                 sx={{ margin: (theme) => theme.spacing(1, 0, 2) }}
@@ -69,3 +70,14 @@ export function ViewDashboard(props: ViewDashboardProps) {
     </DashboardProvider>
   );
 }
+
+ViewDashboard.defaultProps = {
+  onSave: (dashboardResource: DashboardResource) => {
+    fetch('https://jsonplaceholder.typicode.com', {
+      method: 'POST',
+      body: JSON.stringify(dashboardResource),
+    })
+      .then((response) => response.json())
+      .then((json) => console.log(json));
+  },
+};


### PR DESCRIPTION
Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>

@LukeTillman @eunicorn This "PR" has my current ideas so I can get your feedback (I'm not close to merging!)

- It doesn't work yet
- The simplest thing I could think of was just adding `onSave` as a prop to `ViewDashboard`... if we ended up having more hooks, ~we could have a `hooks` prop~, but this seemed alright for now? (Actually, I would do `handlers` prop or something like that, since `hooks` has a special meaning in React.)
- I dunno though, do you see other ways to structure it / would you do it differently? 
- I'm so new to TypeScript everywhere, I added the `defaultProps` because linters were complaining left and right at me
- Will need to extend DashboardProvider so that there is an easy way to get the entire DashboardResource from state