### PR TITLE
add Eunice (eunicorn) in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,4 +12,5 @@ be found in [GOVERNANCE.md](GOVERNANCE.md).
 | Steven Cobb | [sjcobb](https://github.com/sjcobb) | Chronosphere |
 | Julius Volz | [juliusv](https://github.com/juliusv) | PromLabs |
 | Antoine Thebaud | [AntoineThebaud](https://github.com/AntoineThebaud) | Amadeus IT Group |
+| Eunice Wong | [eunicorn](https://github.com/eunicorn) | Chronosphere |
 


### PR DESCRIPTION
This PR adds Eunice Wong in our MAINTAINERS.md file as [discussed here](https://matrix.to/#/!XNmgYIAndZOkEvQAbb:matrix.org/$UeokPXrYaDpNhQlnnGOuGt2oOtpuiHaPoOQocntaMaM?via=matrix.org)

See [governance proposal](https://github.com/perses/perses/pull/431) for context. 