### PR TITLE
governance doc table update

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -42,6 +42,7 @@ The current team members are:
 | Steven Cobb | [sjcobb](https://github.com/sjcobb) | Chronosphere |
 | Julius Volz | [juliusv](https://github.com/juliusv) | PromLabs |
 | Antoine Thebaud | [AntoineThebaud](https://github.com/AntoineThebaud) | Amadeus IT Group |
+| Eunice Wong | [eunicorn](https://github.com/eunicorn) | Chronosphere |
 
 ## Maintainers
 


### PR DESCRIPTION
Update table in GOVERNANCE.md to match MAINTAINERS.md. 

@Nexucis are both of these tables with info about team members needed? Seems like the one in MAINTAINERS.md will be easier to remember to update