### PR TITLE
Update usePlugin to only need kind, not definition

### DIFF
--- a/ui/plugin-system/src/components/PluginLoadingBoundary/PluginLoadingBoundary.tsx
+++ b/ui/plugin-system/src/components/PluginLoadingBoundary/PluginLoadingBoundary.tsx
@@ -14,7 +14,7 @@
 import { JsonObject } from '@perses-dev/core';
 import { Fragment, createContext, useContext, useMemo, useCallback, useEffect } from 'react';
 import { useImmer } from 'use-immer';
-import { PluginType, ALL_PLUGIN_TYPES, PluginDefinition, PluginImplementation } from '../../model';
+import { PluginType, ALL_PLUGIN_TYPES, PluginImplementation } from '../../model';
 import { usePluginRegistry } from '../PluginRegistry';
 import { PluginLoader } from './PluginLoader';
 

--- a/ui/plugin-system/src/components/PluginLoadingBoundary/PluginLoadingBoundary.tsx
+++ b/ui/plugin-system/src/components/PluginLoadingBoundary/PluginLoadingBoundary.tsx
@@ -122,15 +122,15 @@ export function usePluginLoadingBoundary() {
  */
 export function usePlugin<Type extends PluginType>(
   pluginType: Type,
-  definition: PluginDefinition<Type, JsonObject>
+  kind: string
 ): PluginImplementation<Type, JsonObject> | undefined {
   // Tell the loading boundary about the dependency
   const { registerPluginDependency } = usePluginLoadingBoundary();
   useEffect(() => {
-    registerPluginDependency(pluginType, definition.kind);
-  }, [pluginType, definition.kind, registerPluginDependency]);
+    registerPluginDependency(pluginType, kind);
+  }, [pluginType, kind, registerPluginDependency]);
 
   // Get the plugin, which could be undefined if it hasn't loaded yet
   const { plugins } = usePluginRegistry();
-  return plugins[pluginType][definition.kind];
+  return plugins[pluginType][kind];
 }

--- a/ui/plugin-system/src/model/graph-queries.ts
+++ b/ui/plugin-system/src/model/graph-queries.ts
@@ -58,7 +58,7 @@ export type GraphSeriesValueTuple = [timestamp: UnixTimeMs, value: number];
  * Use a Graph Query's results from a graph query plugin at runtime.
  */
 export const useGraphQuery: GraphQueryPlugin['useGraphQuery'] = (definition) => {
-  const plugin = usePlugin('GraphQuery', definition);
+  const plugin = usePlugin('GraphQuery', definition.kind);
   if (plugin === undefined) {
     // Provide default values while the plugin is being loaded
     return { loading: true };

--- a/ui/plugin-system/src/model/panels.tsx
+++ b/ui/plugin-system/src/model/panels.tsx
@@ -36,7 +36,7 @@ export interface PanelProps<Options extends JsonObject> {
  * Renders a PanelComponent from a panel plugin at runtime.
  */
 export const PanelComponent: PanelPlugin['PanelComponent'] = (props) => {
-  const plugin = usePlugin('Panel', props.definition);
+  const plugin = usePlugin('Panel', props.definition.kind);
   if (plugin === undefined) {
     return null;
   }

--- a/ui/plugin-system/src/model/variables.ts
+++ b/ui/plugin-system/src/model/variables.ts
@@ -35,7 +35,7 @@ export type UseVariableOptionsHook<Options extends JsonObject> = (definition: Va
  * Use the variable options from a variable plugin at runtime.
  */
 export const useVariableOptions: VariablePlugin['useVariableOptions'] = (definition) => {
-  const plugin = usePlugin('Variable', definition);
+  const plugin = usePlugin('Variable', definition.kind);
   if (plugin === undefined) {
     // Provide default values while the plugin is being loaded
     return { data: [], loading: true };


### PR DESCRIPTION
When using a plugin (i.e. the `usePlugin` hook), you really only need the plugin type and kind, not a full-blown definition object. This just updates that API to reflect that. This will be particularly important when you _don't_ have a definition object yet, for example, when you're adding a panel and you need to get the plugin in order to create the initial options for the panel (which ultimately results in a definition object).

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>