### PR TITLE
Extend panel plugins to add placeholders for visual editing

### DIFF
--- a/ui/dashboards/src/components/AddPanel/PanelOptionsEditor.tsx
+++ b/ui/dashboards/src/components/AddPanel/PanelOptionsEditor.tsx
@@ -1,0 +1,38 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import { usePanelPlugin } from '@perses-dev/plugin-system';
+import { useEffect } from 'react';
+
+export interface PanelOptionsEditorProps {
+  kind: string;
+  value: JsonObject;
+  onChange: (next: JsonObject) => void;
+}
+
+export function PanelOptionsEditor(props: PanelOptionsEditorProps) {
+  const { kind, value, onChange } = props;
+  const { OptionsEditorComponent, createInitialOptions } = usePanelPlugin(kind);
+
+  // When the kind changes, re-init options
+  useEffect(() => {
+    onChange(createInitialOptions());
+
+    // TODO: See if we can switch up plugin loading so this happens as part of selecting the plugin kind so we don't
+    // need this effect at all
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [kind]);
+
+  return <OptionsEditorComponent value={value} onChange={onChange} />;
+}

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -27,6 +27,10 @@ const FAKE_PANEL_PLUGIN: PluginRegistrationConfig<JsonObject> = {
     PanelComponent: () => {
       return <div role="figure">FakePanel chart</div>;
     },
+    OptionsEditorComponent: () => {
+      return <div>Edit options here</div>;
+    },
+    createInitialOptions: () => ({}),
   },
 };
 

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -14,7 +14,7 @@
 import { useState, useMemo } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import { useInView } from 'react-intersection-observer';
-import { PluginBoundary, PanelComponent } from '@perses-dev/plugin-system';
+import { PluginBoundary } from '@perses-dev/plugin-system';
 import { ErrorAlert, InfoTooltip, TooltipPlacement } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
 import {
@@ -33,6 +33,7 @@ import PencilIcon from 'mdi-material-ui/Pencil';
 import MenuIcon from 'mdi-material-ui/DotsVertical';
 import DragIcon from 'mdi-material-ui/Drag';
 import { useEditMode } from '../../context';
+import { PanelContent } from './PanelContent';
 
 export interface PanelProps extends CardProps {
   definition: PanelDefinition;
@@ -152,7 +153,7 @@ export function Panel(props: PanelProps) {
         ref={setContentElement}
       >
         <PluginBoundary loadingFallback="Loading..." ErrorFallbackComponent={ErrorAlert}>
-          {inView === true && <PanelComponent definition={definition} contentDimensions={contentDimensions} />}
+          {inView === true && <PanelContent definition={definition} contentDimensions={contentDimensions} />}
         </PluginBoundary>
       </CardContent>
     </Card>

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -1,0 +1,27 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import { usePanelPlugin, PanelProps } from '@perses-dev/plugin-system';
+
+export type PanelContentProps = PanelProps<JsonObject>;
+
+/**
+ * A small wrapper component that renders the appropriate PanelComponent from a Panel plugin based on the panel
+ * definition's kind. Used so that a PluginLoadingBoundary can be wrapped around this for fallback UI while
+ * the plugin is loading.
+ */
+export function PanelContent(props: PanelContentProps) {
+  const { PanelComponent } = usePanelPlugin(props.definition.kind);
+  return <PanelComponent {...props} />;
+}

--- a/ui/dashboards/src/components/Panel/index.ts
+++ b/ui/dashboards/src/components/Panel/index.ts
@@ -11,9 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './Dashboard';
-export * from './GridLayout';
 export * from './Panel';
-export * from './TimeRangeControls';
-export * from './VariableAutocomplete';
-export * from './VariableList';

--- a/ui/panels-plugin/src/index.ts
+++ b/ui/panels-plugin/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,41 +12,49 @@
 // limitations under the License.
 
 import { PluginSetupFunction } from '@perses-dev/plugin-system';
-import { EmptyChart, EmptyChartKind } from './plugins/empty-chart/EmptyChart';
-import { GaugeChartPanel, GaugeChartKind } from './plugins/gauge-chart/GaugeChartPanel';
-import { LineChartPanel, LineChartKind } from './plugins/line-chart/LineChartPanel';
-import { StatChartKind, StatChartPanel } from './plugins/stat-chart/StatChartPanel';
+import { createInitialEmptyChartOptions, EmptyChart, EmptyChartOptionsEditor } from './plugins/empty-chart';
+import { createInitialGaugeChartOptions, GaugeChartPanel, GaugeChartOptionsEditor } from './plugins/gauge-chart';
+import { LineChartPanel, LineChartOptionsEditor, createInitialLineChartOptions } from './plugins/line-chart';
+import { createInitialStatChartOptions, StatChartOptionsEditor, StatChartPanel } from './plugins/stat-chart';
 
 export const setup: PluginSetupFunction = (registerPlugin) => {
   registerPlugin({
     pluginType: 'Panel',
-    kind: LineChartKind,
+    kind: 'LineChart',
     plugin: {
       PanelComponent: LineChartPanel,
+      OptionsEditorComponent: LineChartOptionsEditor,
+      createInitialOptions: createInitialLineChartOptions,
     },
   });
 
   registerPlugin({
     pluginType: 'Panel',
-    kind: GaugeChartKind,
+    kind: 'GaugeChart',
     plugin: {
       PanelComponent: GaugeChartPanel,
+      OptionsEditorComponent: GaugeChartOptionsEditor,
+      createInitialOptions: createInitialGaugeChartOptions,
     },
   });
 
   registerPlugin({
     pluginType: 'Panel',
-    kind: StatChartKind,
+    kind: 'StatChart',
     plugin: {
       PanelComponent: StatChartPanel,
+      OptionsEditorComponent: StatChartOptionsEditor,
+      createInitialOptions: createInitialStatChartOptions,
     },
   });
 
   registerPlugin({
     pluginType: 'Panel',
-    kind: EmptyChartKind,
+    kind: 'EmptyChart',
     plugin: {
       PanelComponent: EmptyChart,
+      OptionsEditorComponent: EmptyChartOptionsEditor,
+      createInitialOptions: createInitialEmptyChartOptions,
     },
   });
 };

--- a/ui/panels-plugin/src/plugins/empty-chart/EmptyChart.tsx
+++ b/ui/panels-plugin/src/plugins/empty-chart/EmptyChart.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,14 +12,10 @@
 // limitations under the License.
 
 import { Box } from '@mui/material';
-import { JsonObject } from '@perses-dev/core';
 import { PanelProps } from '@perses-dev/plugin-system';
-
-export const EmptyChartKind = 'EmptyChart' as const;
+import { EmptyChartOptions } from './empty-chart-model';
 
 export type EmptyChartProps = PanelProps<EmptyChartOptions>;
-
-type EmptyChartOptions = JsonObject;
 
 export function EmptyChart(props: EmptyChartProps) {
   return <Box sx={{ overflow: 'hidden' }}>{props.definition.kind}</Box>;

--- a/ui/panels-plugin/src/plugins/empty-chart/EmptyChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/empty-chart/EmptyChartOptionsEditor.tsx
@@ -11,8 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Box } from '@mui/material';
+import { EmptyChartOptions } from './empty-chart-model';
+
+export type EmptyChartOptionsEditorProps = OptionsEditorProps<EmptyChartOptions>;
+
+export function EmptyChartOptionsEditor(props: EmptyChartOptionsEditorProps) {
+  const { value } = props;
+  return <Box>{JSON.stringify(value)}</Box>;
+}

--- a/ui/panels-plugin/src/plugins/empty-chart/empty-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/empty-chart/empty-chart-model.ts
@@ -11,8 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+import { JsonObject } from '@perses-dev/core';
+
+export type EmptyChartOptions = JsonObject;
+
+export function createInitialEmptyChartOptions(): EmptyChartOptions {
+  return {};
+}

--- a/ui/panels-plugin/src/plugins/empty-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/empty-chart/index.ts
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+export * from './empty-chart-model';
+export * from './EmptyChartOptionsEditor';
+export * from './EmptyChart';

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditor.tsx
@@ -11,8 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Box } from '@mui/material';
+import { GaugeChartOptions } from './gauge-chart-model';
+
+export type GaugeChartOptionsEditorProps = OptionsEditorProps<GaugeChartOptions>;
+
+export function GaugeChartOptionsEditor(props: GaugeChartOptionsEditorProps) {
+  const { value } = props;
+  return <Box>{JSON.stringify(value)}</Box>;
+}

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,26 +12,16 @@
 // limitations under the License.
 
 import { GaugeSeriesOption } from 'echarts';
-import { JsonObject } from '@perses-dev/core';
-import { GraphQueryDefinition, useGraphQuery, PanelProps } from '@perses-dev/plugin-system';
-import { GaugeChart, GaugeChartData, UnitOptions } from '@perses-dev/components';
+import { useGraphQuery, PanelProps } from '@perses-dev/plugin-system';
+import { GaugeChart, GaugeChartData } from '@perses-dev/components';
 import { Skeleton } from '@mui/material';
 import { useMemo } from 'react';
-import { convertThresholds, defaultThresholdInput, ThresholdOptions } from '../../model/thresholds';
-import { CalculationsMap, CalculationType } from '../../model/calculations';
+import { convertThresholds, defaultThresholdInput } from '../../model/thresholds';
+import { CalculationsMap } from '../../model/calculations';
 import { useSuggestedStepMs } from '../../model/time';
-
-export const GaugeChartKind = 'GaugeChart' as const;
+import { GaugeChartOptions } from './gauge-chart-model';
 
 export type GaugeChartPanelProps = PanelProps<GaugeChartOptions>;
-
-interface GaugeChartOptions extends JsonObject {
-  query: GraphQueryDefinition;
-  calculation: CalculationType;
-  unit?: UnitOptions;
-  thresholds?: ThresholdOptions;
-  max?: number;
-}
 
 export function GaugeChartPanel(props: GaugeChartPanelProps) {
   const {

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -1,0 +1,43 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import { GraphQueryDefinition } from '@perses-dev/plugin-system';
+import { UnitOptions } from '@perses-dev/components';
+import { ThresholdOptions } from '../../model/thresholds';
+import { CalculationType } from '../../model/calculations';
+
+/**
+ * The Options object type supported by the GaugeChart panel plugin.
+ */
+export interface GaugeChartOptions extends JsonObject {
+  query: GraphQueryDefinition;
+  calculation: CalculationType;
+  unit?: UnitOptions;
+  thresholds?: ThresholdOptions;
+  max?: number;
+}
+
+/**
+ * Creates the initial/empty options for a GaugeChart panel.
+ */
+export function createInitialGaugeChartOptions(): GaugeChartOptions {
+  return {
+    // TODO: How do you represent an initially empty/unset graph query?
+    query: {
+      kind: '',
+      options: {},
+    },
+    calculation: 'First',
+  };
+}

--- a/ui/panels-plugin/src/plugins/gauge-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/index.ts
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+export * from './gauge-chart-model';
+export * from './GaugeChartPanel';
+export * from './GaugeChartOptionsEditor';

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartOptionsEditor.tsx
@@ -11,8 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Box } from '@mui/material';
+import { LineChartOptions } from './line-chart-model';
+
+export type LineChartOptionsEditorProps = OptionsEditorProps<LineChartOptions>;
+
+export function LineChartOptionsEditor(props: LineChartOptionsEditorProps) {
+  const { value } = props;
+  return <Box>{JSON.stringify(value)}</Box>;
+}

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartPanel.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,24 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { JsonObject } from '@perses-dev/core';
-import { UnitOptions } from '@perses-dev/components';
-import { GraphQueryDefinition, PanelProps } from '@perses-dev/plugin-system';
+import { PanelProps } from '@perses-dev/plugin-system';
 import { useSuggestedStepMs } from '../../model/time';
-import { ThresholdOptions } from '../../model/thresholds';
 import GraphQueryRunner from './GraphQueryRunner';
+import { LineChartOptions } from './line-chart-model';
 import { LineChartContainer } from './LineChartContainer';
 
-export const LineChartKind = 'LineChart' as const;
-
 export type LineChartProps = PanelProps<LineChartOptions>;
-
-interface LineChartOptions extends JsonObject {
-  queries: GraphQueryDefinition[];
-  show_legend?: boolean;
-  unit?: UnitOptions;
-  thresholds?: ThresholdOptions;
-}
 
 export function LineChartPanel(props: LineChartProps) {
   const {

--- a/ui/panels-plugin/src/plugins/line-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/index.ts
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+export * from './line-chart-model';
+export * from './LineChartOptionsEditor';
+export * from './LineChartPanel';

--- a/ui/panels-plugin/src/plugins/line-chart/line-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/line-chart-model.ts
@@ -1,0 +1,36 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import { UnitOptions } from '@perses-dev/components';
+import { GraphQueryDefinition } from '@perses-dev/plugin-system';
+import { ThresholdOptions } from '../../model/thresholds';
+
+/**
+ * The Options object supported by the LineChartPanel plugin.
+ */
+export interface LineChartOptions extends JsonObject {
+  queries: GraphQueryDefinition[];
+  show_legend?: boolean;
+  unit?: UnitOptions;
+  thresholds?: ThresholdOptions;
+}
+
+/**
+ * Creates an initial/empty options object for the LineChartPanel.
+ */
+export function createInitialLineChartOptions(): LineChartOptions {
+  return {
+    queries: [],
+  };
+}

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditor.tsx
@@ -11,8 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Box } from '@mui/material';
+import { StatChartOptions } from './stat-chart-model';
+
+export type StatChartOptionsEditorProps = OptionsEditorProps<StatChartOptions>;
+
+export function StatChartOptionsEditor(props: StatChartOptionsEditorProps) {
+  const { value } = props;
+  return <Box>{JSON.stringify(value)}</Box>;
+}

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,33 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { JsonObject } from '@perses-dev/core';
-import { StatChart, StatChartData, UnitOptions, useChartsTheme, PersesChartsTheme } from '@perses-dev/components';
+import { StatChart, StatChartData, useChartsTheme, PersesChartsTheme } from '@perses-dev/components';
 import { Box, Skeleton } from '@mui/material';
 import { LineSeriesOption } from 'echarts/charts';
 import { useMemo } from 'react';
-import { GraphQueryDefinition, GraphData, useGraphQuery, PanelProps } from '@perses-dev/plugin-system';
-import { ThresholdOptions } from '../../model/thresholds';
+import { GraphData, useGraphQuery, PanelProps } from '@perses-dev/plugin-system';
 import { CalculationsMap, CalculationType } from '../../model/calculations';
 import { useSuggestedStepMs } from '../../model/time';
-
-export const StatChartKind = 'StatChart' as const;
+import { SparklineOptions, StatChartOptions } from './stat-chart-model';
 
 export type StatChartPanelProps = PanelProps<StatChartOptions>;
-
-export interface SparklineOptions extends JsonObject {
-  color?: string;
-  width?: number;
-}
-
-interface StatChartOptions extends JsonObject {
-  name: string;
-  query: GraphQueryDefinition;
-  calculation: CalculationType;
-  unit: UnitOptions;
-  thresholds?: ThresholdOptions;
-  sparkline?: SparklineOptions;
-}
 
 export function StatChartPanel(props: StatChartPanelProps) {
   const {

--- a/ui/panels-plugin/src/plugins/stat-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/index.ts
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
-export * from './panels';
-export * from './plugins';
-export * from './variables';
-export * from './visual-editing';
+export * from './stat-chart-model';
+export * from './StatChartOptionsEditor';
+export * from './StatChartPanel';

--- a/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
@@ -1,0 +1,46 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import { GraphQueryDefinition } from '@perses-dev/plugin-system';
+import { UnitOptions } from '@perses-dev/components';
+import { ThresholdOptions } from '../../model/thresholds';
+import { CalculationType } from '../../model/calculations';
+
+export interface SparklineOptions extends JsonObject {
+  color?: string;
+  width?: number;
+}
+
+export interface StatChartOptions extends JsonObject {
+  name: string;
+  query: GraphQueryDefinition;
+  calculation: CalculationType;
+  unit: UnitOptions;
+  thresholds?: ThresholdOptions;
+  sparkline?: SparklineOptions;
+}
+
+export function createInitialStatChartOptions(): StatChartOptions {
+  return {
+    name: '',
+    query: {
+      kind: '',
+      options: {},
+    },
+    calculation: 'First',
+    unit: {
+      kind: 'Decimal',
+    },
+  };
+}

--- a/ui/plugin-system/src/model/panels.tsx
+++ b/ui/plugin-system/src/model/panels.tsx
@@ -36,13 +36,20 @@ export interface PanelProps<Options extends JsonObject> {
 }
 
 /**
- * Renders a PanelComponent from a panel plugin at runtime.
+ * Hook for using a panel plugin at runtime.
  */
-export const PanelComponent: PanelPlugin['PanelComponent'] = (props) => {
-  const plugin = usePlugin('Panel', props.definition.kind);
-  if (plugin === undefined) {
-    return null;
+export function usePanelPlugin(kind: string): PanelPlugin<JsonObject> {
+  const plugin = usePlugin('Panel', kind);
+  if (plugin !== undefined) {
+    return plugin;
   }
-  const { PanelComponent: PluginComponent } = plugin;
-  return <PluginComponent {...props} />;
+
+  // Return a default/placeholder plugin while loading happens
+  return defaultPanelPlugin;
+}
+
+const defaultPanelPlugin: PanelPlugin<JsonObject> = {
+  PanelComponent: () => null,
+  OptionsEditorComponent: () => null,
+  createInitialOptions: () => ({}),
 };

--- a/ui/plugin-system/src/model/panels.tsx
+++ b/ui/plugin-system/src/model/panels.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,12 +13,15 @@
 
 import { JsonObject, PanelDefinition } from '@perses-dev/core';
 import { usePlugin } from '../components/PluginLoadingBoundary';
+import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
 
 /**
  * Plugin the provides custom visualizations inside of a Panel.
  */
 export interface PanelPlugin<Options extends JsonObject = JsonObject> {
   PanelComponent: React.ComponentType<PanelProps<Options>>;
+  OptionsEditorComponent: OptionsEditor<Options>;
+  createInitialOptions: InitialOptionsCallback<Options>;
 }
 
 /**

--- a/ui/plugin-system/src/model/visual-editing.ts
+++ b/ui/plugin-system/src/model/visual-editing.ts
@@ -1,0 +1,35 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import React from 'react';
+
+/**
+ * A component for visual editing of a plugin's options.
+ */
+export type OptionsEditor<Options extends JsonObject = JsonObject> = React.ComponentType<OptionsEditorProps<Options>>;
+
+/**
+ * Common props passed to options editor components.
+ */
+export interface OptionsEditorProps<Options extends JsonObject = JsonObject> {
+  // TODO: These are temporary and may not actually make sense, so replace
+  // with whatever makes sense as visual editing evolves
+  value: Options;
+  onChange: (next: Options) => void;
+}
+
+/**
+ * Callback for creating initial/empty options for a plugin.
+ */
+export type InitialOptionsCallback<Options extends JsonObject> = () => Options;


### PR DESCRIPTION
This extends panel plugins to add placeholders for what I _think_ are going to be the APIs needed for visual editing. Basically, it extends the definition of a `PanelPlugin` to add:

- `createInitialOptions`: a callback to create the initial/empty options object for a panel
- `PanelOptionsEditor`: a React component for visually editing the Options object

I went ahead and put some "stub" implementations in for our existing panel plugins. Since this was already a decent-sized PR, I didn't try integrating this with the visual editing functionality that's there yet. I'll try and do that in a follow-up PR shortly.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>