### PR TITLE
Basic integration of options editor for panel plugins

### DIFF
--- a/ui/dashboards/src/components/AddPanel/PanelOptionsEditor.tsx
+++ b/ui/dashboards/src/components/AddPanel/PanelOptionsEditor.tsx
@@ -1,0 +1,38 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import { usePanelPlugin } from '@perses-dev/plugin-system';
+import { useEffect } from 'react';
+
+export interface PanelOptionsEditorProps {
+  kind: string;
+  value: JsonObject;
+  onChange: (next: JsonObject) => void;
+}
+
+export function PanelOptionsEditor(props: PanelOptionsEditorProps) {
+  const { kind, value, onChange } = props;
+  const { OptionsEditorComponent, createInitialOptions } = usePanelPlugin(kind);
+
+  // When the kind changes, re-init options
+  useEffect(() => {
+    onChange(createInitialOptions());
+
+    // TODO: See if we can switch up plugin loading so this happens as part of selecting the plugin kind so we don't
+    // need this effect at all
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [kind]);
+
+  return <OptionsEditorComponent value={value} onChange={onChange} />;
+}

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -14,7 +14,7 @@
 import { useState, useMemo } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import { useInView } from 'react-intersection-observer';
-import { PluginBoundary, PanelComponent } from '@perses-dev/plugin-system';
+import { PluginBoundary } from '@perses-dev/plugin-system';
 import { ErrorAlert, InfoTooltip, TooltipPlacement } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
 import {
@@ -33,6 +33,7 @@ import PencilIcon from 'mdi-material-ui/Pencil';
 import MenuIcon from 'mdi-material-ui/DotsVertical';
 import DragIcon from 'mdi-material-ui/Drag';
 import { useEditMode } from '../../context';
+import { PanelContent } from './PanelContent';
 
 export interface PanelProps extends CardProps {
   definition: PanelDefinition;
@@ -152,7 +153,7 @@ export function Panel(props: PanelProps) {
         ref={setContentElement}
       >
         <PluginBoundary loadingFallback="Loading..." ErrorFallbackComponent={ErrorAlert}>
-          {inView === true && <PanelComponent definition={definition} contentDimensions={contentDimensions} />}
+          {inView === true && <PanelContent definition={definition} contentDimensions={contentDimensions} />}
         </PluginBoundary>
       </CardContent>
     </Card>

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -1,0 +1,27 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+import { usePanelPlugin, PanelProps } from '@perses-dev/plugin-system';
+
+export type PanelContentProps = PanelProps<JsonObject>;
+
+/**
+ * A small wrapper component that renders the appropriate PanelComponent from a Panel plugin based on the panel
+ * definition's kind. Used so that a PluginLoadingBoundary can be wrapped around this for fallback UI while
+ * the plugin is loading.
+ */
+export function PanelContent(props: PanelContentProps) {
+  const { PanelComponent } = usePanelPlugin(props.definition.kind);
+  return <PanelComponent {...props} />;
+}

--- a/ui/dashboards/src/components/Panel/index.ts
+++ b/ui/dashboards/src/components/Panel/index.ts
@@ -11,9 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './Dashboard';
-export * from './GridLayout';
 export * from './Panel';
-export * from './TimeRangeControls';
-export * from './VariableAutocomplete';
-export * from './VariableList';

--- a/ui/plugin-system/src/model/panels.tsx
+++ b/ui/plugin-system/src/model/panels.tsx
@@ -36,13 +36,20 @@ export interface PanelProps<Options extends JsonObject> {
 }
 
 /**
- * Renders a PanelComponent from a panel plugin at runtime.
+ * Hook for using a panel plugin at runtime.
  */
-export const PanelComponent: PanelPlugin['PanelComponent'] = (props) => {
-  const plugin = usePlugin('Panel', props.definition.kind);
-  if (plugin === undefined) {
-    return null;
+export function usePanelPlugin(kind: string): PanelPlugin<JsonObject> {
+  const plugin = usePlugin('Panel', kind);
+  if (plugin !== undefined) {
+    return plugin;
   }
-  const { PanelComponent: PluginComponent } = plugin;
-  return <PluginComponent {...props} />;
+
+  // Return a default/placeholder plugin while loading happens
+  return defaultPanelPlugin;
+}
+
+const defaultPanelPlugin: PanelPlugin<JsonObject> = {
+  PanelComponent: () => null,
+  OptionsEditorComponent: () => null,
+  createInitialOptions: () => ({}),
 };


### PR DESCRIPTION
This shows off basic integration of the new Panel plugin APIs in #528 with the existing panel editing UI. Obviously this isn't at all what the final version will look like, but just wanted to show the new APIs being used. I've opened this PR against the other one (i.e. I want to merge it into the branch for #528) and then I'll commit all the changes together there.

Here's a quick look at it in action:





https://user-images.githubusercontent.com/428023/189772752-5f1f4cfd-77fd-41e4-986e-b892305e55a7.mov


Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>