### PR TITLE
Use external file for plugin module resources, add metadata for individual plugins

### DIFF
--- a/ui/app/src/model/bundled-plugins.ts
+++ b/ui/app/src/model/bundled-plugins.ts
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 // Eagerly load the metadata for the bundled plugins, but lazy-load the plugins
-import prometheusPackage from '@perses-dev/prometheus-plugin/package.json';
-import panelsPackage from '@perses-dev/panels-plugin/package.json';
-import { PluginRegistryProps, PluginResource, PluginModule } from '@perses-dev/plugin-system';
+import prometheusResource from '@perses-dev/prometheus-plugin/plugin.json';
+import panelsResource from '@perses-dev/panels-plugin/plugin.json';
+import { PluginRegistryProps, PluginModuleResource, PluginModule } from '@perses-dev/plugin-system';
 import { useCallback } from 'react';
 
 interface BundledPlugin {
@@ -24,11 +24,11 @@ interface BundledPlugin {
 /**
  * Plugins that are bundled with the app via code-splitting.
  */
-const BUNDLED_PLUGINS = new Map<PluginResource, BundledPlugin>();
-BUNDLED_PLUGINS.set(prometheusPackage.perses as PluginResource, {
+const BUNDLED_PLUGINS = new Map<PluginModuleResource, BundledPlugin>();
+BUNDLED_PLUGINS.set(prometheusResource as PluginModuleResource, {
   importPluginModule: () => import('@perses-dev/prometheus-plugin'),
 });
-BUNDLED_PLUGINS.set(panelsPackage.perses as PluginResource, {
+BUNDLED_PLUGINS.set(panelsResource as PluginModuleResource, {
   importPluginModule: () => import('@perses-dev/panels-plugin'),
 });
 

--- a/ui/dashboards/src/test/plugin-registry.ts
+++ b/ui/dashboards/src/test/plugin-registry.ts
@@ -13,7 +13,7 @@
 import {
   PluginModule,
   PluginRegistryProps,
-  PluginResource,
+  PluginModuleResource,
   PluginSetupFunction,
   RegisterPlugin,
 } from '@perses-dev/plugin-system';
@@ -24,20 +24,27 @@ import {
  * to add mock plugins before rendering components that use them.
  */
 export function mockPluginRegistryProps() {
-  const mockPluginResource: PluginResource = {
-    kind: 'Plugin',
+  const mockPluginResource: PluginModuleResource = {
+    kind: 'PluginModule',
     metadata: {
-      name: 'Fake Plugin for Tests',
+      name: 'Fake Plugin Module for Tests',
     },
     spec: {
-      supported_kinds: {},
+      plugins: [],
     },
   };
 
   // Allow adding mock plugins in tests
   const mockSetupFunctions: PluginSetupFunction[] = [];
   const addMockPlugin: RegisterPlugin = (config) => {
-    mockPluginResource.spec.supported_kinds[config.kind] = config.pluginType;
+    mockPluginResource.spec.plugins.push({
+      pluginType: config.pluginType,
+      kind: config.kind,
+      display: {
+        name: `Fake Plugin ${mockPluginResource.spec.plugins.length + 1}`,
+      },
+    });
+
     mockSetupFunctions.push((registerPlugin) => {
       registerPlugin(config);
     });

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -37,22 +37,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
-  "perses": {
-    "kind": "Plugin",
-    "metadata": {
-      "name": "Core Panels"
-    },
-    "spec": {
-      "supported_kinds": {
-        "LineChart": "Panel",
-        "GaugeChart": "Panel",
-        "StatChart": "Panel",
-        "EmptyChart": "Panel"
-      },
-      "plugin_module_path": "./dist/index.js"
-    }
-  },
   "files": [
-    "dist"
+    "dist",
+    "plugin.json"
   ]
 }

--- a/ui/panels-plugin/plugin.json
+++ b/ui/panels-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "kind": "PluginModule",
+  "metadata": {
+    "name": "Core Panels"
+  },
+  "spec": {
+    "plugins": [
+      {
+        "pluginType": "Panel",
+        "kind": "LineChart",
+        "display": {
+          "name": "Line Chart",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "Panel",
+        "kind": "GaugeChart",
+        "display": {
+          "name": "Gauge Chart",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "Panel",
+        "kind": "StatChart",
+        "display": {
+          "name": "Stat Chart",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "Panel",
+        "kind": "EmptyChart",
+        "display": {
+          "name": "Empty Chart",
+          "description": ""
+        }
+      }
+    ]
+  }
+}

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -13,13 +13,13 @@
 
 import { createContext, useContext, useMemo, useCallback } from 'react';
 import { useQuery } from 'react-query';
-import { PluginModule, PluginResource, PluginType } from '../../model';
+import { PluginModule, PluginModuleResource, PluginType } from '../../model';
 import { LoadedPluginsByTypeAndKind, useRegistryState } from './registry-state';
 
 export interface PluginRegistryProps {
   children?: React.ReactNode;
-  getInstalledPlugins: () => Promise<PluginResource[]>;
-  importPluginModule: (resource: PluginResource) => Promise<PluginModule>;
+  getInstalledPlugins: () => Promise<PluginModuleResource[]>;
+  importPluginModule: (resource: PluginModuleResource) => Promise<PluginModule>;
 }
 
 /**

--- a/ui/plugin-system/src/components/PluginRegistry/registry-state.ts
+++ b/ui/plugin-system/src/components/PluginRegistry/registry-state.ts
@@ -17,7 +17,7 @@ import { JsonObject } from '@perses-dev/core';
 import {
   PluginRegistrationConfig,
   PluginModule,
-  PluginResource,
+  PluginModuleResource,
   RegisterPlugin,
   PluginType,
   ALL_PLUGIN_TYPES,
@@ -29,7 +29,7 @@ import {
 
 // Given a PluginType and Kind, return the associated Plugin that can be loaded
 export type PluginResourcesByTypeAndKind = {
-  [K in PluginType]: Record<string, PluginResource>;
+  [K in PluginType]: Record<string, PluginModuleResource>;
 };
 
 // Once a plugin is registered, it's stored by plugin type and kind
@@ -41,7 +41,7 @@ export type LoadedPluginsByTypeAndKind = {
  * Hook for setting up plugin registry state. Returns the state, plus a function
  * for registering plugins with that state.
  */
-export function useRegistryState(installedPlugins?: PluginResource[]) {
+export function useRegistryState(installedPlugins?: PluginModuleResource[]) {
   // Go through all installed plugins and bundled plugins and build an index of
   // those resources by type and kind
   const loadablePlugins = useMemo(() => {
@@ -53,11 +53,9 @@ export function useRegistryState(installedPlugins?: PluginResource[]) {
     // If no plugins installed or waiting on that data, nothing else to do
     if (installedPlugins === undefined) return loadableProps;
 
-    const addToLoadable = (resource: PluginResource) => {
-      const supportedKinds = resource.spec.supported_kinds;
-      for (const kind in supportedKinds) {
-        const pluginType = supportedKinds[kind];
-        if (pluginType === undefined) continue;
+    for (const resource of installedPlugins) {
+      for (const plugin of resource.spec.plugins) {
+        const { pluginType, kind } = plugin;
 
         const map = loadableProps[pluginType];
         if (map[kind] !== undefined) {
@@ -66,10 +64,6 @@ export function useRegistryState(installedPlugins?: PluginResource[]) {
         }
         map[kind] = resource;
       }
-    };
-
-    for (const resource of installedPlugins) {
-      addToLoadable(resource);
     }
 
     return loadableProps;

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -16,14 +16,29 @@ import { GraphQueryDefinition, GraphQueryPlugin } from './graph-queries';
 import { PanelPlugin } from './panels';
 import { VariablePlugin } from './variables';
 
-export interface PluginResource {
-  kind: 'Plugin';
+/**
+ * Information about a module/package that contains plugins.
+ */
+export interface PluginModuleResource {
+  kind: 'PluginModule';
   metadata: ResourceMetadata;
   spec: PluginSpec;
 }
 
 export interface PluginSpec {
-  supported_kinds: Record<string, PluginType>;
+  plugins: PluginMetadata[];
+}
+
+/**
+ * Metadata about an individual plugin that's part of a PluginModule.
+ */
+export interface PluginMetadata {
+  pluginType: PluginType;
+  kind: string;
+  display: {
+    name: string;
+    description?: string;
+  };
 }
 
 /**

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -34,22 +34,8 @@
     "react": "^17.0.2",
     "react-query": "^3.34.16"
   },
-  "perses": {
-    "kind": "Plugin",
-    "metadata": {
-      "name": "Prometheus"
-    },
-    "spec": {
-      "supported_kinds": {
-        "PrometheusLabelNames": "Variable",
-        "PrometheusLabelValues": "Variable",
-        "Interval": "Variable",
-        "PrometheusGraphQuery": "GraphQuery"
-      },
-      "plugin_module_path": "./dist/index.js"
-    }
-  },
   "files": [
-    "dist"
+    "dist",
+    "plugin.json"
   ]
 }

--- a/ui/prometheus-plugin/plugin.json
+++ b/ui/prometheus-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "kind": "PluginModule",
+  "metadata": {
+    "name": "Prometheus"
+  },
+  "spec": {
+    "plugins": [
+      {
+        "pluginType": "Variable",
+        "kind": "PrometheusLabelNames",
+        "display": {
+          "name": "Prometheus Label Names",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "Variable",
+        "kind": "PrometheusLabelValues",
+        "display": {
+          "name": "Prometheus Label Values",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "Variable",
+        "kind": "Interval",
+        "display": {
+          "name": "Time Duration",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "GraphQuery",
+        "kind": "PrometheusGraphQuery",
+        "display": {
+          "name": "Prometheus Range Query",
+          "description": ""
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Up until now, we've kept some very basic metadata about plugin modules (i.e. packages) in the `package.json` for each package under the `perses` key. This PR does three things to that:

1. Removes that metadata from `package.json` and into its own `plugin.json` file in each package (which will be distributed along with the package when it's published).
2. Changes the format of plugin module metadata so that individual plugins inside the module can have their own metadata. This is so that we can (eventually) show that metadata in the UI to the user (e.g. when selecting a panel type, we should be able to display a list of friendly names for each panel plugin).
3. Updates the `PluginRegistry` to work with the new format.

At some point in the near future, I'll be adding some APIs to the plugin system to allow our code to "introspect" or query that metadata to, for example, get the metadata for all plugins of a certain plugin type.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>