### PR TITLE
Create the skeleton of the Markdown panel

### DIFF
--- a/ui/app/sample-data/benchmarkDashboard.ts
+++ b/ui/app/sample-data/benchmarkDashboard.ts
@@ -71,6 +71,16 @@ const benchmarkDashboard: DashboardResource = {
       } as AnyVariableDefinition,
     },
     panels: {
+      markdownEx: {
+        kind: 'Markdown',
+        display: {
+          name: 'Dashboard Team Overview',
+          description: 'This is a markdown panel',
+        },
+        options: {
+          text: "## Dashboard Team!\nOn this page, you'll find charts used by the dashboard team.\n\n```\n{ look: 'at this code' }```\n\n1. One\n2. Two\n3. Three\n\n[check the internet again](https://www.google.com)\n| Dashboard | Link |\n| :----------- | :----------- |\n| Dashboard 1 | [link](www.google.com) |\n| Dashboard 2 | [link](www.google.com) | ",
+        },
+      },
       seriesTest: {
         kind: 'LineChart',
         display: { name: '1500+ Series', description: 'This is a line chart' },
@@ -434,16 +444,14 @@ const benchmarkDashboard: DashboardResource = {
               y: 0,
               width: 12,
               height: 6,
-              content: { $ref: '#/spec/panels/legendEx' },
-              // content: { $ref: '#/spec/panels/seriesTestAlt' },
-              // content: { $ref: '#/spec/panels/seriesTest' },
+              content: { $ref: '#/spec/panels/markdownEx' },
             },
             {
               x: 12,
               y: 0,
               width: 12,
               height: 6,
-              content: { $ref: '#/spec/panels/basicEx' },
+              content: { $ref: '#/spec/panels/legendEx' },
             },
             {
               x: 0,

--- a/ui/panels-plugin/src/index.ts
+++ b/ui/panels-plugin/src/index.ts
@@ -14,7 +14,8 @@
 import { PluginSetupFunction } from '@perses-dev/plugin-system';
 import { createInitialEmptyChartOptions, EmptyChart, EmptyChartOptionsEditor } from './plugins/empty-chart';
 import { createInitialGaugeChartOptions, GaugeChartPanel, GaugeChartOptionsEditor } from './plugins/gauge-chart';
-import { LineChartPanel, LineChartOptionsEditor, createInitialLineChartOptions } from './plugins/line-chart';
+import { createInitialLineChartOptions, LineChartPanel, LineChartOptionsEditor } from './plugins/line-chart';
+import { createInitialMarkdownPanelOptions, MarkdownPanel, MarkdownPanelOptionsEditor } from './plugins/markdown';
 import { createInitialStatChartOptions, StatChartOptionsEditor, StatChartPanel } from './plugins/stat-chart';
 
 export const setup: PluginSetupFunction = (registerPlugin) => {
@@ -55,6 +56,16 @@ export const setup: PluginSetupFunction = (registerPlugin) => {
       PanelComponent: EmptyChart,
       OptionsEditorComponent: EmptyChartOptionsEditor,
       createInitialOptions: createInitialEmptyChartOptions,
+    },
+  });
+
+  registerPlugin({
+    pluginType: 'Panel',
+    kind: 'Markdown',
+    plugin: {
+      PanelComponent: MarkdownPanel,
+      OptionsEditorComponent: MarkdownPanelOptionsEditor,
+      createInitialOptions: createInitialMarkdownPanelOptions,
     },
   });
 };

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -1,0 +1,28 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box } from '@mui/material';
+import { PanelProps } from '@perses-dev/plugin-system';
+import { MarkdownPanelOptions } from './markdown-panel-model';
+
+export type MarkdownPanelProps = PanelProps<MarkdownPanelOptions>;
+
+export function MarkdownPanel(props: MarkdownPanelProps) {
+  const {
+    definition: {
+      options: { text },
+    },
+  } = props;
+
+  return <Box sx={{ height: '100%', overflowY: 'auto' }}>{text}</Box>;
+}

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanelOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanelOptionsEditor.tsx
@@ -1,0 +1,23 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Box } from '@mui/material';
+import { MarkdownPanelOptions } from './markdown-panel-model';
+
+export type MarkdownPanelOptionsEditorProps = OptionsEditorProps<MarkdownPanelOptions>;
+
+export function MarkdownPanelOptionsEditor(props: MarkdownPanelOptionsEditorProps) {
+  const { value } = props;
+  return <Box>{JSON.stringify(value)}</Box>;
+}

--- a/ui/panels-plugin/src/plugins/markdown/index.ts
+++ b/ui/panels-plugin/src/plugins/markdown/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './markdown-panel-model';
+export * from './MarkdownPanel';
+export * from './MarkdownPanelOptionsEditor';

--- a/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
+++ b/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
@@ -1,0 +1,22 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JsonObject } from '@perses-dev/core';
+
+export interface MarkdownPanelOptions extends JsonObject {
+  text: string;
+}
+
+export function createInitialMarkdownPanelOptions(): MarkdownPanelOptions {
+  return { text: '' };
+}


### PR DESCRIPTION
Adds a component, but it's doesn't do anything yet:

<img width="793" alt="Screen Shot 2022-09-14 at 7 53 43 AM" src="https://user-images.githubusercontent.com/2584129/190189338-bc8a3a5d-8836-407a-b912-3e7f539c2b7e.png">
