### PR TITLE
Simplify plugin module format, use metadata to drive plugin loading

### DIFF
--- a/ui/app/src/model/bundled-plugins.ts
+++ b/ui/app/src/model/bundled-plugins.ts
@@ -14,11 +14,11 @@
 // Eagerly load the metadata for the bundled plugins, but lazy-load the plugins
 import prometheusResource from '@perses-dev/prometheus-plugin/plugin.json';
 import panelsResource from '@perses-dev/panels-plugin/plugin.json';
-import { PluginRegistryProps, PluginModuleResource, PluginModule } from '@perses-dev/plugin-system';
+import { PluginRegistryProps, PluginModuleResource } from '@perses-dev/plugin-system';
 import { useCallback } from 'react';
 
 interface BundledPlugin {
-  importPluginModule: () => Promise<PluginModule>;
+  importPluginModule: () => Promise<unknown>;
 }
 
 /**

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { JsonObject } from '@perses-dev/core';
-import { PluginRegistrationConfig, PluginRegistry } from '@perses-dev/plugin-system';
+import { PanelPlugin, PluginRegistry } from '@perses-dev/plugin-system';
 import 'intersection-observer';
 import { screen } from '@testing-library/react';
 import { renderWithContext, mockPluginRegistryProps } from '../../test';
@@ -20,18 +20,14 @@ import testDashboard from '../../test/testDashboard';
 import { DashboardProvider, DashboardStoreProps } from '../../context';
 import { Panel, PanelProps } from './Panel';
 
-const FAKE_PANEL_PLUGIN: PluginRegistrationConfig<JsonObject> = {
-  pluginType: 'Panel',
-  kind: 'FakePanel',
-  plugin: {
-    PanelComponent: () => {
-      return <div role="figure">FakePanel chart</div>;
-    },
-    OptionsEditorComponent: () => {
-      return <div>Edit options here</div>;
-    },
-    createInitialOptions: () => ({}),
+const FAKE_PANEL_PLUGIN: PanelPlugin<JsonObject> = {
+  PanelComponent: () => {
+    return <div role="figure">FakePanel chart</div>;
   },
+  OptionsEditorComponent: () => {
+    return <div>Edit options here</div>;
+  },
+  createInitialOptions: () => ({}),
 };
 
 describe('Panel', () => {
@@ -59,7 +55,7 @@ describe('Panel', () => {
   // Helper to render the panel with some context set
   const renderPanel = (initialState: DashboardStoreProps) => {
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
-    addMockPlugin(FAKE_PANEL_PLUGIN);
+    addMockPlugin('Panel', 'FakePanel', FAKE_PANEL_PLUGIN);
 
     renderWithContext(
       <DashboardProvider initialState={initialState}>

--- a/ui/dashboards/src/components/VariableList/VariableList.test.tsx
+++ b/ui/dashboards/src/components/VariableList/VariableList.test.tsx
@@ -14,7 +14,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { JsonObject, VariableDefinition } from '@perses-dev/core';
-import { PluginRegistrationConfig, PluginRegistry } from '@perses-dev/plugin-system';
+import { PluginRegistry, VariablePlugin } from '@perses-dev/plugin-system';
 import { mockPluginRegistryProps, renderWithContext } from '../../test';
 import { TemplateVariablesProvider } from '../../context';
 import { VariableList } from './VariableList';
@@ -36,25 +36,19 @@ describe('VariableList', () => {
     },
   };
 
-  const options: any = {
-    data: ['node', 'all'],
-    isLoading: false,
-    error: undefined,
-  };
-
-  const FAKE_PANEL_PLUGIN: PluginRegistrationConfig<JsonObject> = {
-    pluginType: 'Variable',
-    kind: 'PrometheusLabelValues',
-    plugin: {
-      useVariableOptions: () => {
-        return options;
-      },
+  const FAKE_VARIABLE_PLUGIN: VariablePlugin<JsonObject> = {
+    useVariableOptions: () => {
+      return {
+        data: ['node', 'all'],
+        loading: false,
+        error: undefined,
+      };
     },
   };
 
   const renderVariableOptionsDrawer = () => {
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
-    addMockPlugin(FAKE_PANEL_PLUGIN);
+    addMockPlugin('Variable', 'PrometheusLabelValues', FAKE_VARIABLE_PLUGIN);
     renderWithContext(
       <PluginRegistry {...pluginRegistryProps}>
         <TemplateVariablesProvider variableDefinitions={variables}>

--- a/ui/dashboards/src/components/VariableList/VariableList.test.tsx
+++ b/ui/dashboards/src/components/VariableList/VariableList.test.tsx
@@ -36,17 +36,20 @@ describe('VariableList', () => {
     },
   };
 
+  // Make sure fake data stays consistent so don't get a render loop
+  const data = ['node', 'all'];
+
   const FAKE_VARIABLE_PLUGIN: VariablePlugin<JsonObject> = {
     useVariableOptions: () => {
       return {
-        data: ['node', 'all'],
+        data,
         loading: false,
         error: undefined,
       };
     },
   };
 
-  const renderVariableOptionsDrawer = () => {
+  const renderVariableList = () => {
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
     addMockPlugin('Variable', 'PrometheusLabelValues', FAKE_VARIABLE_PLUGIN);
     renderWithContext(
@@ -59,26 +62,26 @@ describe('VariableList', () => {
   };
 
   it('should display Variables as the title', async () => {
-    renderVariableOptionsDrawer();
+    renderVariableList();
     const title = await screen.findByText('Variables');
     expect(title).toBeInTheDocument();
   });
 
   describe('VariableAutocomplete', () => {
     it('should display correct variable', async () => {
-      renderVariableOptionsDrawer();
+      renderVariableList();
       const jobInput = await screen.findByLabelText('Job');
       expect(jobInput).toBeInTheDocument();
     });
 
     it('should display correct default value', async () => {
-      renderVariableOptionsDrawer();
+      renderVariableList();
       const jobValue = await screen.findByDisplayValue('node');
       expect(jobValue).toBeInTheDocument();
     });
 
     it('should display correct options', async () => {
-      renderVariableOptionsDrawer();
+      renderVariableList();
       const openButton = await screen.findByRole('button', { name: 'Open' });
       userEvent.click(openButton);
       const option1 = await screen.findByText('all');

--- a/ui/dashboards/src/test/plugin-registry.ts
+++ b/ui/dashboards/src/test/plugin-registry.ts
@@ -10,13 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import {
-  PluginModule,
-  PluginRegistryProps,
-  PluginModuleResource,
-  PluginSetupFunction,
-  RegisterPlugin,
-} from '@perses-dev/plugin-system';
+import { JsonObject } from '@perses-dev/core';
+import { PluginRegistryProps, PluginModuleResource, PluginRegistrationConfig } from '@perses-dev/plugin-system';
 
 /**
  * Helper for mocking `PluginRegistry` data during tests. Returns props that can be spread on the `PluginRegistry`
@@ -34,9 +29,10 @@ export function mockPluginRegistryProps() {
     },
   };
 
+  const mockPluginModule: Record<string, PluginRegistrationConfig<JsonObject>> = {};
+
   // Allow adding mock plugins in tests
-  const mockSetupFunctions: PluginSetupFunction[] = [];
-  const addMockPlugin: RegisterPlugin = (config) => {
+  const addMockPlugin = (config: PluginRegistrationConfig<JsonObject>) => {
     mockPluginResource.spec.plugins.push({
       pluginType: config.pluginType,
       kind: config.kind,
@@ -45,18 +41,7 @@ export function mockPluginRegistryProps() {
       },
     });
 
-    mockSetupFunctions.push((registerPlugin) => {
-      registerPlugin(config);
-    });
-  };
-
-  // Our mock plugin module just calls all the setup functions that were added
-  const mockPluginModule: PluginModule = {
-    setup(registerPlugin) {
-      for (const setup of mockSetupFunctions) {
-        setup(registerPlugin);
-      }
-    },
+    mockPluginModule[config.kind] = config;
   };
 
   const pluginRegistryProps: Omit<PluginRegistryProps, 'children'> = {

--- a/ui/dashboards/src/test/plugin-registry.ts
+++ b/ui/dashboards/src/test/plugin-registry.ts
@@ -11,7 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { JsonObject } from '@perses-dev/core';
-import { PluginRegistryProps, PluginModuleResource, PluginRegistrationConfig } from '@perses-dev/plugin-system';
+import {
+  PluginRegistryProps,
+  PluginModuleResource,
+  PluginImplementation,
+  PluginType,
+  Plugin,
+} from '@perses-dev/plugin-system';
 
 /**
  * Helper for mocking `PluginRegistry` data during tests. Returns props that can be spread on the `PluginRegistry`
@@ -29,19 +35,24 @@ export function mockPluginRegistryProps() {
     },
   };
 
-  const mockPluginModule: Record<string, PluginRegistrationConfig<JsonObject>> = {};
+  const mockPluginModule: Record<string, Plugin<JsonObject>> = {};
 
   // Allow adding mock plugins in tests
-  const addMockPlugin = (config: PluginRegistrationConfig<JsonObject>) => {
+  const addMockPlugin = <T extends PluginType>(
+    pluginType: T,
+    kind: string,
+    plugin: PluginImplementation<T, JsonObject>
+  ) => {
     mockPluginResource.spec.plugins.push({
-      pluginType: config.pluginType,
-      kind: config.kind,
+      pluginType,
+      kind,
       display: {
-        name: `Fake Plugin ${mockPluginResource.spec.plugins.length + 1}`,
+        name: `Fake ${pluginType} Plugin for ${kind}`,
       },
     });
 
-    mockPluginModule[config.kind] = config;
+    // "Export" on the module under the same name as the kind the plugin handles
+    mockPluginModule[kind] = plugin;
   };
 
   const pluginRegistryProps: Omit<PluginRegistryProps, 'children'> = {

--- a/ui/panels-plugin/plugin.json
+++ b/ui/panels-plugin/plugin.json
@@ -36,6 +36,14 @@
           "name": "Empty Chart",
           "description": ""
         }
+      },
+      {
+        "pluginType": "Panel",
+        "kind": "Markdown",
+        "display": {
+          "name": "Markdown",
+          "description": ""
+        }
       }
     ]
   }

--- a/ui/panels-plugin/src/index.ts
+++ b/ui/panels-plugin/src/index.ts
@@ -11,50 +11,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PluginSetupFunction } from '@perses-dev/plugin-system';
-import { createInitialEmptyChartOptions, EmptyChart, EmptyChartOptionsEditor } from './plugins/empty-chart';
+import {
+  createInitialEmptyChartOptions,
+  EmptyChart as EmptyChartPanel,
+  EmptyChartOptionsEditor,
+} from './plugins/empty-chart';
 import { createInitialGaugeChartOptions, GaugeChartPanel, GaugeChartOptionsEditor } from './plugins/gauge-chart';
 import { LineChartPanel, LineChartOptionsEditor, createInitialLineChartOptions } from './plugins/line-chart';
 import { createInitialStatChartOptions, StatChartOptionsEditor, StatChartPanel } from './plugins/stat-chart';
 
-export const setup: PluginSetupFunction = (registerPlugin) => {
-  registerPlugin({
-    pluginType: 'Panel',
-    kind: 'LineChart',
-    plugin: {
-      PanelComponent: LineChartPanel,
-      OptionsEditorComponent: LineChartOptionsEditor,
-      createInitialOptions: createInitialLineChartOptions,
-    },
-  });
+export const LineChart = {
+  pluginType: 'Panel',
+  kind: 'LineChart',
+  plugin: {
+    PanelComponent: LineChartPanel,
+    OptionsEditorComponent: LineChartOptionsEditor,
+    createInitialOptions: createInitialLineChartOptions,
+  },
+};
 
-  registerPlugin({
-    pluginType: 'Panel',
-    kind: 'GaugeChart',
-    plugin: {
-      PanelComponent: GaugeChartPanel,
-      OptionsEditorComponent: GaugeChartOptionsEditor,
-      createInitialOptions: createInitialGaugeChartOptions,
-    },
-  });
+export const GaugeChart = {
+  pluginType: 'Panel',
+  kind: 'GaugeChart',
+  plugin: {
+    PanelComponent: GaugeChartPanel,
+    OptionsEditorComponent: GaugeChartOptionsEditor,
+    createInitialOptions: createInitialGaugeChartOptions,
+  },
+};
 
-  registerPlugin({
-    pluginType: 'Panel',
-    kind: 'StatChart',
-    plugin: {
-      PanelComponent: StatChartPanel,
-      OptionsEditorComponent: StatChartOptionsEditor,
-      createInitialOptions: createInitialStatChartOptions,
-    },
-  });
+export const StatChart = {
+  pluginType: 'Panel',
+  kind: 'StatChart',
+  plugin: {
+    PanelComponent: StatChartPanel,
+    OptionsEditorComponent: StatChartOptionsEditor,
+    createInitialOptions: createInitialStatChartOptions,
+  },
+};
 
-  registerPlugin({
-    pluginType: 'Panel',
-    kind: 'EmptyChart',
-    plugin: {
-      PanelComponent: EmptyChart,
-      OptionsEditorComponent: EmptyChartOptionsEditor,
-      createInitialOptions: createInitialEmptyChartOptions,
-    },
-  });
+export const EmptyChart = {
+  pluginType: 'Panel',
+  kind: 'EmptyChart',
+  plugin: {
+    PanelComponent: EmptyChartPanel,
+    OptionsEditorComponent: EmptyChartOptionsEditor,
+    createInitialOptions: createInitialEmptyChartOptions,
+  },
 };

--- a/ui/panels-plugin/src/plugins/empty-chart/EmptyChart.ts
+++ b/ui/panels-plugin/src/plugins/empty-chart/EmptyChart.ts
@@ -11,10 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { EmptyChart } from './plugins/empty-chart';
-import { GaugeChart } from './plugins/gauge-chart';
-import { LineChart } from './plugins/line-chart';
-import { StatChart } from './plugins/stat-chart';
+import { PanelPlugin } from '@perses-dev/plugin-system';
+import { createInitialEmptyChartOptions, EmptyChartOptions } from './empty-chart-model';
+import { EmptyChartOptionsEditor } from './EmptyChartOptionsEditor';
+import { EmptyChartPanel } from './EmptyChartPanel';
 
-// Just export the plugins under the same name as the kinds they handle from the plugin.json
-export { LineChart, GaugeChart, EmptyChart, StatChart };
+/**
+ * The core EmptyChart panel plugin for Perses.
+ */
+export const EmptyChart: PanelPlugin<EmptyChartOptions> = {
+  PanelComponent: EmptyChartPanel,
+  OptionsEditorComponent: EmptyChartOptionsEditor,
+  createInitialOptions: createInitialEmptyChartOptions,
+};

--- a/ui/panels-plugin/src/plugins/empty-chart/EmptyChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/empty-chart/EmptyChartPanel.tsx
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { EmptyChart } from './plugins/empty-chart';
-import { GaugeChart } from './plugins/gauge-chart';
-import { LineChart } from './plugins/line-chart';
-import { StatChart } from './plugins/stat-chart';
+import { Box } from '@mui/material';
+import { PanelProps } from '@perses-dev/plugin-system';
+import { EmptyChartOptions } from './empty-chart-model';
 
-// Just export the plugins under the same name as the kinds they handle from the plugin.json
-export { LineChart, GaugeChart, EmptyChart, StatChart };
+export type EmptyChartPanelProps = PanelProps<EmptyChartOptions>;
+
+export function EmptyChartPanel(props: EmptyChartPanelProps) {
+  return <Box sx={{ overflow: 'hidden' }}>{props.definition.kind}</Box>;
+}

--- a/ui/panels-plugin/src/plugins/empty-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/empty-chart/index.ts
@@ -11,6 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './empty-chart-model';
-export * from './EmptyChartOptionsEditor';
 export * from './EmptyChart';

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChart.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChart.ts
@@ -11,10 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { EmptyChart } from './plugins/empty-chart';
-import { GaugeChart } from './plugins/gauge-chart';
-import { LineChart } from './plugins/line-chart';
-import { StatChart } from './plugins/stat-chart';
+import { PanelPlugin } from '@perses-dev/plugin-system';
+import { createInitialGaugeChartOptions, GaugeChartOptions } from './gauge-chart-model';
+import { GaugeChartOptionsEditor } from './GaugeChartOptionsEditor';
+import { GaugeChartPanel } from './GaugeChartPanel';
 
-// Just export the plugins under the same name as the kinds they handle from the plugin.json
-export { LineChart, GaugeChart, EmptyChart, StatChart };
+/**
+ * The core GaugeChart panel plugin for Perses.
+ */
+export const GaugeChart: PanelPlugin<GaugeChartOptions> = {
+  PanelComponent: GaugeChartPanel,
+  OptionsEditorComponent: GaugeChartOptionsEditor,
+  createInitialOptions: createInitialGaugeChartOptions,
+};

--- a/ui/panels-plugin/src/plugins/gauge-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/index.ts
@@ -11,6 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './gauge-chart-model';
-export * from './GaugeChartPanel';
-export * from './GaugeChartOptionsEditor';
+export * from './GaugeChart';

--- a/ui/panels-plugin/src/plugins/line-chart/LineChart.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChart.ts
@@ -11,12 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from '@mui/material';
-import { PanelProps } from '@perses-dev/plugin-system';
-import { EmptyChartOptions } from './empty-chart-model';
+import { PanelPlugin } from '@perses-dev/plugin-system';
+import { createInitialLineChartOptions, LineChartOptions } from './line-chart-model';
+import { LineChartOptionsEditor } from './LineChartOptionsEditor';
+import { LineChartPanel } from './LineChartPanel';
 
-export type EmptyChartProps = PanelProps<EmptyChartOptions>;
-
-export function EmptyChart(props: EmptyChartProps) {
-  return <Box sx={{ overflow: 'hidden' }}>{props.definition.kind}</Box>;
-}
+/**
+ * The core LineChart panel plugin for Perses.
+ */
+export const LineChart: PanelPlugin<LineChartOptions> = {
+  PanelComponent: LineChartPanel,
+  OptionsEditorComponent: LineChartOptionsEditor,
+  createInitialOptions: createInitialLineChartOptions,
+};

--- a/ui/panels-plugin/src/plugins/line-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/index.ts
@@ -11,6 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './line-chart-model';
-export * from './LineChartOptionsEditor';
-export * from './LineChartPanel';
+export * from './LineChart';

--- a/ui/panels-plugin/src/plugins/markdown/Markdown.ts
+++ b/ui/panels-plugin/src/plugins/markdown/Markdown.ts
@@ -11,11 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { EmptyChart } from './plugins/empty-chart';
-import { GaugeChart } from './plugins/gauge-chart';
-import { LineChart } from './plugins/line-chart';
-import { Markdown } from './plugins/markdown';
-import { StatChart } from './plugins/stat-chart';
+import { PanelPlugin } from '@perses-dev/plugin-system';
+import { createInitialMarkdownPanelOptions, MarkdownPanelOptions } from './markdown-panel-model';
+import { MarkdownPanel } from './MarkdownPanel';
+import { MarkdownPanelOptionsEditor } from './MarkdownPanelOptionsEditor';
 
-// Just export the plugins under the same name as the kinds they handle from the plugin.json
-export { LineChart, GaugeChart, EmptyChart, StatChart, Markdown };
+/**
+ * The core Markdown panel plugin in Perses.
+ */
+export const Markdown: PanelPlugin<MarkdownPanelOptions> = {
+  PanelComponent: MarkdownPanel,
+  OptionsEditorComponent: MarkdownPanelOptionsEditor,
+  createInitialOptions: createInitialMarkdownPanelOptions,
+};

--- a/ui/panels-plugin/src/plugins/markdown/index.ts
+++ b/ui/panels-plugin/src/plugins/markdown/index.ts
@@ -11,6 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './markdown-panel-model';
-export * from './MarkdownPanel';
-export * from './MarkdownPanelOptionsEditor';
+export * from './Markdown';

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChart.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChart.ts
@@ -11,10 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { EmptyChart } from './plugins/empty-chart';
-import { GaugeChart } from './plugins/gauge-chart';
-import { LineChart } from './plugins/line-chart';
-import { StatChart } from './plugins/stat-chart';
+import { PanelPlugin } from '@perses-dev/plugin-system';
+import { createInitialStatChartOptions, StatChartOptions } from './stat-chart-model';
+import { StatChartOptionsEditor } from './StatChartOptionsEditor';
+import { StatChartPanel } from './StatChartPanel';
 
-// Just export the plugins under the same name as the kinds they handle from the plugin.json
-export { LineChart, GaugeChart, EmptyChart, StatChart };
+/**
+ * The core StatChart panel plugin for Perses.
+ */
+export const StatChart: PanelPlugin<StatChartOptions> = {
+  PanelComponent: StatChartPanel,
+  OptionsEditorComponent: StatChartOptionsEditor,
+  createInitialOptions: createInitialStatChartOptions,
+};

--- a/ui/panels-plugin/src/plugins/stat-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/index.ts
@@ -11,6 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './stat-chart-model';
-export * from './StatChartOptionsEditor';
-export * from './StatChartPanel';
+export * from './StatChart';

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -46,7 +46,7 @@ export function PluginRegistry(props: PluginRegistryProps) {
 
       // Load and register the resource
       const pluginModule = await importPluginModule(resource);
-      register(pluginModule);
+      register(resource, pluginModule);
     },
     [plugins, loadablePlugins, importPluginModule, register]
   );

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -13,13 +13,13 @@
 
 import { createContext, useContext, useMemo, useCallback } from 'react';
 import { useQuery } from 'react-query';
-import { PluginModule, PluginModuleResource, PluginType } from '../../model';
+import { PluginModuleResource, PluginType } from '../../model';
 import { LoadedPluginsByTypeAndKind, useRegistryState } from './registry-state';
 
 export interface PluginRegistryProps {
   children?: React.ReactNode;
   getInstalledPlugins: () => Promise<PluginModuleResource[]>;
-  importPluginModule: (resource: PluginModuleResource) => Promise<PluginModule>;
+  importPluginModule: (resource: PluginModuleResource) => Promise<unknown>;
 }
 
 /**

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -68,12 +68,11 @@ type SupportedPlugins<Options extends JsonObject> = {
 };
 
 /**
- * The definition handled for a given plugin type.
+ * Union type of all available plugin implementations.
  */
-export type PluginDefinition<
-  Type extends PluginType,
-  Options extends JsonObject
-> = SupportedPlugins<Options>[Type]['Def'];
+export type Plugin<Options extends JsonObject> = {
+  [Type in PluginType]: PluginImplementation<Type, Options>;
+}[PluginType];
 
 /**
  * The implementation for a given plugin type.
@@ -82,20 +81,3 @@ export type PluginImplementation<
   Type extends PluginType,
   Options extends JsonObject
 > = SupportedPlugins<Options>[Type]['Impl'];
-
-/**
- * Configuration (including the plugin implementation) that's expected when
- * registering a plugin with Perses.
- */
-export type PluginRegistrationConfig<Options extends JsonObject> = {
-  [Type in PluginType]: PluginConfig<Type, Options>;
-}[PluginType];
-
-/**
- * Configuration expected for a particular plugin type.
- */
-export type PluginConfig<Type extends PluginType, Options extends JsonObject> = {
-  pluginType: Type;
-  kind: string;
-  plugin: PluginImplementation<Type, Options>;
-};

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -42,24 +42,6 @@ export interface PluginMetadata {
 }
 
 /**
- * A JavaScript module with Perses plugins.
- */
-export interface PluginModule {
-  setup: PluginSetupFunction;
-}
-
-/**
- * When a PluginModule is loaded, this function is called to allow the module
- * to register plugins with Perses.
- */
-export type PluginSetupFunction = (registerPlugin: RegisterPlugin) => void;
-
-/**
- * Callback function that registers a plugin with Perses.
- */
-export type RegisterPlugin = <Options extends JsonObject>(config: PluginRegistrationConfig<Options>) => void;
-
-/**
  * All supported plugin type values as an array for use at runtime.
  */
 export const ALL_PLUGIN_TYPES = ['Variable', 'Panel', 'GraphQuery'] as const;

--- a/ui/prometheus-plugin/src/index.ts
+++ b/ui/prometheus-plugin/src/index.ts
@@ -11,39 +11,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PluginSetupFunction } from '@perses-dev/plugin-system';
-import { PrometheusGraphQueryKind, usePrometheusGraphQuery } from './plugins/graph-query';
-import { IntervalKind, useIntervalValues } from './plugins/interval-variable';
-import { PrometheusLabelNamesKind, usePrometheusLabelNames } from './plugins/label-names-variable';
-import { PrometheusLabelValuesKind, usePrometheusLabelValues } from './plugins/label-values-variable';
+import { usePrometheusGraphQuery } from './plugins/graph-query';
+import { useIntervalValues } from './plugins/interval-variable';
+import { usePrometheusLabelNames } from './plugins/label-names-variable';
+import { usePrometheusLabelValues } from './plugins/label-values-variable';
 
-export const setup: PluginSetupFunction = (registerPlugin) => {
-  registerPlugin({
-    pluginType: 'Variable',
-    kind: PrometheusLabelNamesKind,
-    plugin: {
-      useVariableOptions: usePrometheusLabelNames,
-    },
-  });
-  registerPlugin({
-    pluginType: 'Variable',
-    kind: PrometheusLabelValuesKind,
-    plugin: {
-      useVariableOptions: usePrometheusLabelValues,
-    },
-  });
-  registerPlugin({
-    pluginType: 'Variable',
-    kind: IntervalKind,
-    plugin: {
-      useVariableOptions: useIntervalValues,
-    },
-  });
-  registerPlugin({
-    pluginType: 'GraphQuery',
-    kind: PrometheusGraphQueryKind,
-    plugin: {
-      useGraphQuery: usePrometheusGraphQuery,
-    },
-  });
+export const PrometheusLabelNames = {
+  pluginType: 'Variable',
+  kind: 'PrometheusLabelNames',
+  plugin: {
+    useVariableOptions: usePrometheusLabelNames,
+  },
+};
+
+export const PrometheusLabelValues = {
+  pluginType: 'Variable',
+  kind: 'PrometheusLabelValues',
+  plugin: {
+    useVariableOptions: usePrometheusLabelValues,
+  },
+};
+
+export const Interval = {
+  pluginType: 'Variable',
+  kind: 'Interval',
+  plugin: {
+    useVariableOptions: useIntervalValues,
+  },
+};
+
+export const PrometheusGraphQuery = {
+  pluginType: 'GraphQuery',
+  kind: 'PrometheusGraphQuery',
+  plugin: {
+    useGraphQuery: usePrometheusGraphQuery,
+  },
 };

--- a/ui/prometheus-plugin/src/index.ts
+++ b/ui/prometheus-plugin/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,39 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { usePrometheusGraphQuery } from './plugins/graph-query';
-import { useIntervalValues } from './plugins/interval-variable';
-import { usePrometheusLabelNames } from './plugins/label-names-variable';
-import { usePrometheusLabelValues } from './plugins/label-values-variable';
+import { PrometheusGraphQuery } from './plugins/graph-query';
+import { Interval } from './plugins/interval-variable';
+import { PrometheusLabelNames } from './plugins/label-names-variable';
+import { PrometheusLabelValues } from './plugins/label-values-variable';
 
-export const PrometheusLabelNames = {
-  pluginType: 'Variable',
-  kind: 'PrometheusLabelNames',
-  plugin: {
-    useVariableOptions: usePrometheusLabelNames,
-  },
-};
-
-export const PrometheusLabelValues = {
-  pluginType: 'Variable',
-  kind: 'PrometheusLabelValues',
-  plugin: {
-    useVariableOptions: usePrometheusLabelValues,
-  },
-};
-
-export const Interval = {
-  pluginType: 'Variable',
-  kind: 'Interval',
-  plugin: {
-    useVariableOptions: useIntervalValues,
-  },
-};
-
-export const PrometheusGraphQuery = {
-  pluginType: 'GraphQuery',
-  kind: 'PrometheusGraphQuery',
-  plugin: {
-    useGraphQuery: usePrometheusGraphQuery,
-  },
-};
+// Export plugins under the same name as the kinds they handle from the plugin.json
+export { PrometheusGraphQuery, Interval, PrometheusLabelNames, PrometheusLabelValues };

--- a/ui/prometheus-plugin/src/plugins/graph-query.ts
+++ b/ui/prometheus-plugin/src/plugins/graph-query.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,6 +15,7 @@ import { DurationString, JsonObject, useMemoized } from '@perses-dev/core';
 import {
   GraphData,
   GraphQueryDefinition,
+  GraphQueryPlugin,
   UseGraphQueryHook,
   UseGraphQueryHookOptions,
 } from '@perses-dev/plugin-system';
@@ -26,18 +27,16 @@ import { useRangeQuery } from '../model/prometheus-client';
 import { TemplateString, useReplaceTemplateString } from '../model/templating';
 import { getDurationStringSeconds, useDashboardPrometheusTimeRange, usePanelRangeStep } from '../model/time';
 
-type PrometheusGraphQuery = GraphQueryDefinition<GraphQueryOptions>;
-
-interface GraphQueryOptions extends JsonObject {
+interface PrometheusGraphQueryOptions extends JsonObject {
   query: TemplateString;
   min_step?: DurationString;
   resolution?: number;
 }
 
-export function usePrometheusGraphQuery(
-  definition: PrometheusGraphQuery,
+function usePrometheusGraphQuery(
+  definition: GraphQueryDefinition<PrometheusGraphQueryOptions>,
   hookOptions?: UseGraphQueryHookOptions
-): ReturnType<UseGraphQueryHook<GraphQueryOptions>> {
+): ReturnType<UseGraphQueryHook<PrometheusGraphQueryOptions>> {
   const minStep = getDurationStringSeconds(definition.options.min_step);
   const timeRange = useDashboardPrometheusTimeRange();
   const step = usePanelRangeStep(timeRange, minStep, undefined, hookOptions?.suggestedStepMs);
@@ -106,3 +105,10 @@ export function usePrometheusGraphQuery(
 
   return { data, loading, error: error ?? undefined };
 }
+
+/**
+ * The core Prometheus GraphQuery plugin for Perses.
+ */
+export const PrometheusGraphQuery: GraphQueryPlugin<PrometheusGraphQueryOptions> = {
+  useGraphQuery: usePrometheusGraphQuery,
+};

--- a/ui/prometheus-plugin/src/plugins/graph-query.ts
+++ b/ui/prometheus-plugin/src/plugins/graph-query.ts
@@ -26,8 +26,6 @@ import { useRangeQuery } from '../model/prometheus-client';
 import { TemplateString, useReplaceTemplateString } from '../model/templating';
 import { getDurationStringSeconds, useDashboardPrometheusTimeRange, usePanelRangeStep } from '../model/time';
 
-export const PrometheusGraphQueryKind = 'PrometheusGraphQuery' as const;
-
 type PrometheusGraphQuery = GraphQueryDefinition<GraphQueryOptions>;
 
 interface GraphQueryOptions extends JsonObject {

--- a/ui/prometheus-plugin/src/plugins/interval-variable.ts
+++ b/ui/prometheus-plugin/src/plugins/interval-variable.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,9 +12,7 @@
 // limitations under the License.
 
 import { JsonObject, DurationString, VariableDefinition } from '@perses-dev/core';
-import { UseVariableOptionsHook } from '@perses-dev/plugin-system';
-
-type IntervalVariable = VariableDefinition<IntervalOptions>;
+import { UseVariableOptionsHook, VariablePlugin } from '@perses-dev/plugin-system';
 
 interface IntervalOptions extends JsonObject {
   values: DurationString[];
@@ -28,10 +26,19 @@ interface IntervalOptions extends JsonObject {
  * Variable plugin for getting a list of variable options from a predefined
  * list of duration values.
  */
-export function useIntervalValues(definition: IntervalVariable): ReturnType<UseVariableOptionsHook<IntervalOptions>> {
+function useIntervalValues(
+  definition: VariableDefinition<IntervalOptions>
+): ReturnType<UseVariableOptionsHook<IntervalOptions>> {
   // TODO: What about auto?
   const {
     options: { values },
   } = definition;
   return { loading: false, error: undefined, data: values };
 }
+
+/**
+ * The core Interval variable plugin for Perses.
+ */
+export const Interval: VariablePlugin<IntervalOptions> = {
+  useVariableOptions: useIntervalValues,
+};

--- a/ui/prometheus-plugin/src/plugins/interval-variable.ts
+++ b/ui/prometheus-plugin/src/plugins/interval-variable.ts
@@ -14,8 +14,6 @@
 import { JsonObject, DurationString, VariableDefinition } from '@perses-dev/core';
 import { UseVariableOptionsHook } from '@perses-dev/plugin-system';
 
-export const IntervalKind = 'Inverval' as const;
-
 type IntervalVariable = VariableDefinition<IntervalOptions>;
 
 interface IntervalOptions extends JsonObject {

--- a/ui/prometheus-plugin/src/plugins/label-names-variable.ts
+++ b/ui/prometheus-plugin/src/plugins/label-names-variable.ts
@@ -18,8 +18,6 @@ import { useDashboardPrometheusTimeRange } from '../model/time';
 import { LabelNamesRequestParameters } from '../model/api-types';
 import { useLabelNames } from '../model/prometheus-client';
 
-export const PrometheusLabelNamesKind = 'PrometheusLabelNames' as const;
-
 type PrometheusLabelNames = VariableDefinition<LabelNamesOptions>;
 
 interface LabelNamesOptions extends JsonObject {

--- a/ui/prometheus-plugin/src/plugins/label-names-variable.ts
+++ b/ui/prometheus-plugin/src/plugins/label-names-variable.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,24 +12,22 @@
 // limitations under the License.
 
 import { JsonObject, VariableDefinition } from '@perses-dev/core';
-import { UseVariableOptionsHook } from '@perses-dev/plugin-system';
+import { UseVariableOptionsHook, VariablePlugin } from '@perses-dev/plugin-system';
 import { TemplateString, useReplaceTemplateStrings } from '../model/templating';
 import { useDashboardPrometheusTimeRange } from '../model/time';
 import { LabelNamesRequestParameters } from '../model/api-types';
 import { useLabelNames } from '../model/prometheus-client';
 
-type PrometheusLabelNames = VariableDefinition<LabelNamesOptions>;
-
-interface LabelNamesOptions extends JsonObject {
+interface PrometheusLabelNamesOptions extends JsonObject {
   match: TemplateString[];
 }
 
 /**
  * Get variable option values by running a Prometheus label names query.
  */
-export function usePrometheusLabelNames(
-  definition: PrometheusLabelNames
-): ReturnType<UseVariableOptionsHook<LabelNamesOptions>> {
+function usePrometheusLabelNames(
+  definition: VariableDefinition<PrometheusLabelNamesOptions>
+): ReturnType<UseVariableOptionsHook<PrometheusLabelNamesOptions>> {
   const { start, end } = useDashboardPrometheusTimeRange();
   const { result: match, needsVariableValuesFor } = useReplaceTemplateStrings(definition.options.match);
 
@@ -55,3 +53,10 @@ export function usePrometheusLabelNames(
     error: error ?? undefined,
   };
 }
+
+/**
+ * The core Prometheus Label Names variable plugin for Perses.
+ */
+export const PrometheusLabelNames: VariablePlugin<PrometheusLabelNamesOptions> = {
+  useVariableOptions: usePrometheusLabelNames,
+};

--- a/ui/prometheus-plugin/src/plugins/label-values-variable.ts
+++ b/ui/prometheus-plugin/src/plugins/label-values-variable.ts
@@ -18,8 +18,6 @@ import { useDashboardPrometheusTimeRange } from '../model/time';
 import { TemplateString, useReplaceTemplateStrings } from '../model/templating';
 import { useLabelValues } from '../model/prometheus-client';
 
-export const PrometheusLabelValuesKind = 'PrometheusLabelValues' as const;
-
 type PrometheusLabelValues = VariableDefinition<LabelValuesOptions>;
 
 interface LabelValuesOptions extends JsonObject {

--- a/ui/prometheus-plugin/src/plugins/label-values-variable.ts
+++ b/ui/prometheus-plugin/src/plugins/label-values-variable.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2022 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,15 +12,13 @@
 // limitations under the License.
 
 import { JsonObject, useMemoized, VariableDefinition } from '@perses-dev/core';
-import { UseVariableOptionsHook } from '@perses-dev/plugin-system';
+import { UseVariableOptionsHook, VariablePlugin } from '@perses-dev/plugin-system';
 import { LabelValuesRequestParameters } from '../model/api-types';
 import { useDashboardPrometheusTimeRange } from '../model/time';
 import { TemplateString, useReplaceTemplateStrings } from '../model/templating';
 import { useLabelValues } from '../model/prometheus-client';
 
-type PrometheusLabelValues = VariableDefinition<LabelValuesOptions>;
-
-interface LabelValuesOptions extends JsonObject {
+interface PrometheusLabelValuesOptions extends JsonObject {
   label_name: string;
   match?: TemplateString[];
 }
@@ -28,9 +26,9 @@ interface LabelValuesOptions extends JsonObject {
 /**
  * Get variable option values by running a Prometheus label values query.
  */
-export function usePrometheusLabelValues(
-  definition: PrometheusLabelValues
-): ReturnType<UseVariableOptionsHook<LabelValuesOptions>> {
+function usePrometheusLabelValues(
+  definition: VariableDefinition<PrometheusLabelValuesOptions>
+): ReturnType<UseVariableOptionsHook<PrometheusLabelValuesOptions>> {
   const { start, end } = useDashboardPrometheusTimeRange();
   const { result: match, needsVariableValuesFor } = useReplaceTemplateStrings(definition.options.match);
 
@@ -57,3 +55,10 @@ export function usePrometheusLabelValues(
     error: error ?? undefined,
   };
 }
+
+/**
+ * The core Prometheus Label Values variable plugin in Perses.
+ */
+export const PrometheusLabelValues: VariablePlugin<PrometheusLabelValuesOptions> = {
+  useVariableOptions: usePrometheusLabelValues,
+};


### PR DESCRIPTION
My ultimate goal is to simplify the plugin loading code a bunch, but the first step in doing that is to simplify the module format used in plugins. Before this PR, the format for plugin modules was to export a `setup` function, that then used a `register` callback in that function to register plugins. There were a few downsides to that:

1. It was more complicated than it needed to be. There was nothing stopping someone from registering plugins that weren't in the metadata.
2. We were duplicating information in those register calls (like the plugin type and kind that a plugin handles) that was already in the plugin metadata.
3. We weren't doing any sort of validation that the plugin metadata was correct (i.e. all the plugins the metadata said were in the module, were actually in the module we imported).

This updates the plugin module format so that plugins are now just named exports that correspond to the `kind` they handle. The import process for a module is now driven by the plugin metadata, only looking for named exports from that module's metadata. I think this is a lot simpler and should allow for some further simplification of the plugin loading code.

One other side-effect of this change is it forced me to treat plugin modules being imported as `unknown`, which is actually probably more representative of what's happening at runtime (i.e. we have no idea what we're going to get inside the dynamically imported JS module). I think in the future we could add some runtime validation for the various plugin types to try and make sure that the imported code is at least on the surface, what we expect for that kind of plugin.