### PR TITLE
reinstall cmd to wipe all dist and node_modules folders

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -33,6 +33,12 @@ developing:
 - [NPM](https://npmjs.com/) v7 or higher: a version of `npm` that supports workspaces (use
   `npm --version` to check your version locally)
 
+### Debugging Build Errors
+
+Occasionally after switching branches or installing new dependencies, your environment may start throwing build errors, to fix try clearing all dist folders by running `npm run clean` in the ui folder before rerunning `npm start`. 
+
+If this does not work, try also deleting all node_modules folders (`rm -rf **/node_modules && npm install`). To do this as well as clean dist folders, use: `npm run reinstall`
+
 ## Running Scripts
 
 You can use the `-w ${WORKSPACE_NAME}` flag of `npm run` to run scripts inside

--- a/ui/README.md
+++ b/ui/README.md
@@ -37,7 +37,7 @@ developing:
 
 Occasionally, after switching branches or installing new dependencies, your environment may start throwing build errors. To fix, try clearing all dist folders by running `npm run clean` in the ui folder (before rerunning `npm start`).
 
-If this does not work, try also deleting all node_modules folders (`rm -rf **/node_modules && npm install`). To do this as well as clean dist folders for each package, use: `npm run reinstall`
+If this does not work, `npm run reinstall` can be used to remove all `node_modules` folders and clear the `dist` folders.
 
 ## Running Scripts
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -35,9 +35,9 @@ developing:
 
 ### Debugging Build Errors
 
-Occasionally after switching branches or installing new dependencies, your environment may start throwing build errors, to fix try clearing all dist folders by running `npm run clean` in the ui folder before rerunning `npm start`. 
+Occasionally, after switching branches or installing new dependencies, your environment may start throwing build errors. To fix, try clearing all dist folders by running `npm run clean` in the ui folder (before rerunning `npm start`).
 
-If this does not work, try also deleting all node_modules folders (`rm -rf **/node_modules && npm install`). To do this as well as clean dist folders, use: `npm run reinstall`
+If this does not work, try also deleting all node_modules folders (`rm -rf **/node_modules && npm install`). To do this as well as clean dist folders for each package, use: `npm run reinstall`
 
 ## Running Scripts
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,8 @@
     "lint": "npm run lint --workspaces",
     "lint:fix": "npm run lint:fix --workspaces",
     "start": "npm run start -w app",
-    "clean": "rimraf .build-cache && npm run clean --workspaces"
+    "clean": "rimraf .build-cache && npm run clean --workspaces",
+    "reinstall": "npm run clean && rm -rf **/node_modules && npm install"
   },
   "workspaces": [
     "app",


### PR DESCRIPTION
This PR adds a new npm script, `npm run reinstall` that wipes all dist and node_modules folders for each perses-dev package. A section in the ui/README is also added describing when to use this command.