### PR TITLE
Add markdown parser and HTML sanitizer to markdown panel

### DIFF
--- a/ui/app/sample-data/benchmarkDashboard.ts
+++ b/ui/app/sample-data/benchmarkDashboard.ts
@@ -78,7 +78,7 @@ const benchmarkDashboard: DashboardResource = {
           description: 'This is a markdown panel',
         },
         options: {
-          text: "## Dashboard Team!\nOn this page, you'll find charts used by the dashboard team.\n\n```\n{ look: 'at this code' }```\n\n1. One\n2. Two\n3. Three\n\n[check the internet again](https://www.google.com)\n| Dashboard | Link |\n| :----------- | :----------- |\n| Dashboard 1 | [link](www.google.com) |\n| Dashboard 2 | [link](www.google.com) | ",
+          text: "## Dashboard Team!\nOn this page, you'll find charts used by the dashboard team.\n\n```\n{ look: 'at this code' }\n```\n\n1. One\n2. Two\n3. Three\n\n[check the internet again](https://www.google.com)\n| Dashboard | Link |\n| :----------- | :----------- |\n| Dashboard 1 | [link](www.google.com) |\n| Dashboard 2 | [link](www.google.com) | \n\n<script>alert('xss');</script>\n> Will this <a \n> href='javascript:alert()'>block-quote attack work?</a>\n\n<h1>Will this header be here?</h1><a href='www.google.com'>Will this regular link be here?</a> <a href='javascript:alert('xss')>Will this javascript link be here?</a>\n\n",
         },
       },
       seriesTest: {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3668,6 +3668,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-EXzDatIb5EspL2eb/xPGmaC8pePcTHrkDCONjeisusLFrVfl38Pjea/R0YJGu3k9ZQadSvMqW0WXPI2hEo2Ajg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
@@ -3811,6 +3820,12 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/marked": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.7.tgz",
+      "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -3947,6 +3962,12 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "dev": true
     },
     "node_modules/@types/webpack-bundle-analyzer": {
       "version": "4.4.1",
@@ -6030,6 +6051,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
+      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -9389,6 +9415,17 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/match-sorter": {
@@ -13049,9 +13086,15 @@
         "@perses-dev/core": "^0.6.0",
         "@perses-dev/plugin-system": "^0.6.0",
         "date-fns": "^2.28.0",
+        "dompurify": "^2.4.0",
         "echarts": "^5.3.3",
         "lodash-es": "^4.17.21",
+        "marked": "^4.1.0",
         "mathjs": "^10.6.4"
+      },
+      "devDependencies": {
+        "@types/dompurify": "^2.3.4",
+        "@types/marked": "^4.0.7"
       },
       "peerDependencies": {
         "@mui/material": "^5.5.1",
@@ -15262,9 +15305,13 @@
         "@perses-dev/components": "^0.6.0",
         "@perses-dev/core": "^0.6.0",
         "@perses-dev/plugin-system": "^0.6.0",
+        "@types/dompurify": "^2.3.4",
+        "@types/marked": "^4.0.7",
         "date-fns": "^2.28.0",
+        "dompurify": "^2.4.0",
         "echarts": "^5.3.3",
         "lodash-es": "^4.17.21",
+        "marked": "^4.1.0",
         "mathjs": "^10.6.4"
       }
     },
@@ -15649,6 +15696,15 @@
         "@types/node": "*"
       }
     },
+    "@types/dompurify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-EXzDatIb5EspL2eb/xPGmaC8pePcTHrkDCONjeisusLFrVfl38Pjea/R0YJGu3k9ZQadSvMqW0WXPI2hEo2Ajg==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
@@ -15792,6 +15848,12 @@
         "@types/lodash": "*"
       }
     },
+    "@types/marked": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.7.tgz",
+      "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -15928,6 +15990,12 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "dev": true
     },
     "@types/webpack-bundle-analyzer": {
       "version": "4.4.1",
@@ -17502,6 +17570,11 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
+    },
+    "dompurify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
+      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -20056,6 +20129,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "marked": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
     },
     "match-sorter": {
       "version": "6.3.1",

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -28,8 +28,10 @@
     "@perses-dev/core": "^0.6.0",
     "@perses-dev/plugin-system": "^0.6.0",
     "date-fns": "^2.28.0",
+    "dompurify": "^2.4.0",
     "echarts": "^5.3.3",
     "lodash-es": "^4.17.21",
+    "marked": "^4.1.0",
     "mathjs": "^10.6.4"
   },
   "peerDependencies": {
@@ -40,5 +42,9 @@
   "files": [
     "dist",
     "plugin.json"
-  ]
+  ],
+  "devDependencies": {
+    "@types/dompurify": "^2.3.4",
+    "@types/marked": "^4.0.7"
+  }
 }

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -11,11 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as DOMPurify from 'dompurify';
+import { marked } from 'marked';
 import { Box } from '@mui/material';
 import { PanelProps } from '@perses-dev/plugin-system';
 import { MarkdownPanelOptions } from './markdown-panel-model';
 
 export type MarkdownPanelProps = PanelProps<MarkdownPanelOptions>;
+
+// Overall, this panel does:
+// 1. text --> html (with support for original markdown and GFM)
+// 2. sanitize the html to prevent XSS attacks
 
 export function MarkdownPanel(props: MarkdownPanelProps) {
   const {
@@ -24,5 +30,8 @@ export function MarkdownPanel(props: MarkdownPanelProps) {
     },
   } = props;
 
-  return <Box sx={{ height: '100%', overflowY: 'auto' }}>{text}</Box>;
+  const html = marked.parse(text, { gfm: true });
+  const sanitizedHTML = DOMPurify.sanitize(html);
+
+  return <Box sx={{ height: '100%', overflowY: 'auto' }} dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />;
 }


### PR DESCRIPTION
Not a lot of code, but a lot of thought 🤔 

I tried a number of the major markdown parsing libraries in Javascript. I started off trying the libraries that Luke had surfaced, then tried some others. 

Main requirements are: 
- make sure to sanitize the HTML (i.e. convert text to HTML, _then_ sanitize) 
- make sure we can support Github Flavored Markdown (GFM adds support for tables and code-blocks and is also what most developers will be used to)
- lastly, general checks like "is this library well-maintained?" and "is this library a reasonable size?"

The best options came out as:
* `react-markdown`, wrapper for chaining a bunch of plugins in the `remark` ecosystem
* `micromark`, the markdown parser in the `remark` ecosystem
* `marked`, popular markdown parser that's been around for awhile

Ultimately, went with `marked` because it seems as good as `micromark` in terms of parsing markdown, and the sanitization step is more explicit. 