### PR TITLE
Swap sed and npm version calls when bumping version

### DIFF
--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -72,12 +72,13 @@ function bumpVersion() {
   if [[ "${version}" == v* ]]; then
     version="${version:1}"
   fi
-  # increase the version on all packages
-  npm version "${version}" --workspaces
   # upgrade the @perses-dev/* dependencies on all packages
   for workspace in ${workspaces}; do
     sed -E -i "" "s|(\"@perses-dev/.+\": )\".+\"|\1\"\^${version}\"|" "${workspace}"/package.json
   done
+
+  # increase the version on all packages
+  npm version "${version}" --workspaces
 }
 
 if [[ "$1" == "--copy" ]]; then


### PR DESCRIPTION
This just swaps the order of the `sed` and `npm version` calls when bumping the UI package versions so that when `npm version` runs, the dependencies are already updated and don't try to resolve package dependencies against the old verison. (This was causing peer dependency conflicts in the latest attempt at a release because we upgraded the React peer dependency.)

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>