### PR TITLE
refactor the code of the cmd remove and fix the unit tests that failed randomly

### DIFF
--- a/internal/cli/cmd/remove/remove.go
+++ b/internal/cli/cmd/remove/remove.go
@@ -16,6 +16,7 @@ package remove
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/config"
@@ -30,8 +31,10 @@ import (
 )
 
 // keyCombination is a struct that contains a combination of the project name and the name of the resource.
-// These two information are used to delete an unique resource.
+// These two information are used to delete a unique resource.
+// kind is used to instantiate the correct client.
 type keyCombination struct {
+	kind    modelV1.Kind
 	project string
 	name    string
 }
@@ -43,42 +46,36 @@ type option struct {
 	writer    io.Writer
 	kind      modelV1.Kind
 	all       bool
-	names     map[modelV1.Kind][]keyCombination
+	names     []keyCombination
 	apiClient api.ClientInterface
 }
 
 func (o *option) Complete(args []string) error {
-	o.names = make(map[modelV1.Kind][]keyCombination)
+	if len(o.Project) == 0 {
+		o.Project = config.Global.Project
+	}
 	if len(o.File) == 0 {
 		// Then the user need to specify the resource type and the name of the resource to delete
 		if len(args) == 0 {
 			return fmt.Errorf(resource.FormatMessage())
 		}
-
 		var err error
 		o.kind, err = resource.GetKind(args[0])
 		if err != nil {
 			return err
 		}
-
-		if !o.all && len(args) <= 1 {
+		if !o.all && len(args) < 2 {
 			return fmt.Errorf("you have to specify the resource name you would like to delete")
 		}
-
-		for _, name := range args[1:] {
-			o.names[o.kind] = append(o.names[o.kind], keyCombination{
-				name:    name,
-				project: o.Project,
-			})
-		}
 	}
-	// Then, if no particular project has been specified through a flag, let's grab the one defined in the CLI config.
-	if len(o.Project) == 0 {
-		o.Project = config.Global.Project
+	// Set the API Client to used
+	apiClient, err := config.Global.GetAPIClient()
+	if err != nil {
+		return err
 	}
-	var err error
-	o.apiClient, err = config.Global.GetAPIClient()
-	return err
+	o.apiClient = apiClient
+	// Complete the list of resources to bind
+	return o.completeNames(args)
 }
 
 func (o *option) Validate() error {
@@ -86,6 +83,30 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
+	sort.Slice(o.names, func(i, j int) bool {
+		return o.names[i].kind <= o.names[j].kind &&
+			o.names[i].name <= o.names[j].name &&
+			o.names[i].project <= o.names[j].project
+	})
+	for _, key := range o.names {
+		kind := key.kind
+		name := key.name
+		project := key.project
+		svc, svcErr := service.New(kind, project, o.apiClient)
+		if svcErr != nil {
+			return svcErr
+		}
+		if err := svc.DeleteResource(name); err != nil {
+			return err
+		}
+		if outputError := resource.HandleSuccessMessage(o.writer, kind, project, fmt.Sprintf("object %q %q has been deleted", kind, name)); outputError != nil {
+			return outputError
+		}
+	}
+	return nil
+}
+
+func (o *option) completeNames(args []string) error {
 	if len(o.File) > 0 {
 		if err := o.setNamesFromFile(); err != nil {
 			return err
@@ -94,24 +115,20 @@ func (o *option) Execute() error {
 		if err := o.setNamesFromAll(); err != nil {
 			return err
 		}
-	}
-	for kind, keys := range o.names {
-		for _, key := range keys {
-			name := key.name
-			project := key.project
-			svc, svcErr := service.New(kind, project, o.apiClient)
-			if svcErr != nil {
-				return svcErr
-			}
-			if err := svc.DeleteResource(name); err != nil {
-				return err
-			}
-			if outputError := resource.HandleSuccessMessage(o.writer, kind, project, fmt.Sprintf("object %q %q has been deleted", kind, name)); outputError != nil {
-				return outputError
-			}
-		}
+	} else {
+		o.setNamesFromArgs(args)
 	}
 	return nil
+}
+
+func (o *option) setNamesFromArgs(args []string) {
+	for _, name := range args[1:] {
+		o.names = append(o.names, keyCombination{
+			kind:    o.kind,
+			name:    name,
+			project: o.Project,
+		})
+	}
 }
 
 func (o *option) setNamesFromAll() error {
@@ -140,7 +157,8 @@ func (o *option) setNames(entities []modelAPI.Entity) {
 	for _, entity := range entities {
 		kind := modelV1.Kind(entity.GetKind())
 		metadata := entity.GetMetadata()
-		o.names[kind] = append(o.names[kind], keyCombination{
+		o.names = append(o.names, keyCombination{
+			kind:    kind,
 			name:    metadata.GetName(),
 			project: resource.GetProject(metadata, o.Project),
 		})

--- a/internal/cli/cmd/remove/remove_test.go
+++ b/internal/cli/cmd/remove/remove_test.go
@@ -46,9 +46,9 @@ func TestDeleteCMD(t *testing.T) {
 			Args:            []string{"project", "--all"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: `object "Project" "perses" has been deleted
-object "Project" "Amadeus" has been deleted
+			ExpectedMessage: `object "Project" "Amadeus" has been deleted
 object "Project" "Chronosphere" has been deleted
+object "Project" "perses" has been deleted
 `,
 		},
 		{
@@ -79,8 +79,8 @@ object "Project" "Chronosphere" has been deleted
 			Args:            []string{"-f", "../../test/sample_resources/multiple_resources.json", "--project", "perses"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: `object "Folder" "ff15" has been deleted in the project "perses"
-object "Folder" "aoe4" has been deleted in the project "game"
+			ExpectedMessage: `object "Folder" "aoe4" has been deleted in the project "game"
+object "Folder" "ff15" has been deleted in the project "perses"
 object "Project" "perses" has been deleted
 `,
 		},


### PR DESCRIPTION
This PR should fix the unit tests that failed randomly like in https://github.com/perses/perses/actions/runs/3101521684/jobs/5022971774

The tests failed because the order is not guarantee with a map. Moving to an array and sort it will definitely guarantee the order.

I took the opportunity to refactor a bit the command. I find it a bit clearer like that.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>