### PR TITLE
add Array checks after template variable changes

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -45,14 +45,15 @@ export function TemplateVariableList() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {variableDefinitions.map((v) => (
-                  <TableRow key={v.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
-                    <TableCell component="th" scope="row" sx={{ fontWeight: 'bold' }}>
-                      {v.name}
-                    </TableCell>
-                    <TableCell align="right">{v.kind}</TableCell>
-                  </TableRow>
-                ))}
+                {Array.isArray(variableDefinitions) &&
+                  variableDefinitions.map((v) => (
+                    <TableRow key={v.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                      <TableCell component="th" scope="row" sx={{ fontWeight: 'bold' }}>
+                        {v.name}
+                      </TableCell>
+                      <TableCell align="right">{v.kind}</TableCell>
+                    </TableRow>
+                  ))}
               </TableBody>
             </Table>
           </TableContainer>
@@ -61,11 +62,11 @@ export function TemplateVariableList() {
       </Drawer>
       <Box display={'flex'} justifyContent="space-between">
         <Stack direction={'row'} spacing={2}>
-          {variableDefinitions.map((v) => (
-            <Box key={v.name}>
-              <TemplateVariable key={v.name} name={v.name} />
-            </Box>
-          ))}
+          {Array.isArray(variableDefinitions) && variableDefinitions.map((v) => (
+              <Box key={v.name}>
+                <TemplateVariable key={v.name} name={v.name} />
+              </Box>
+            ))}
           {isEditMode && <Button onClick={() => setIsEditing(true)}>Modify Variables</Button>}
         </Stack>
       </Box>

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -62,7 +62,8 @@ export function TemplateVariableList() {
       </Drawer>
       <Box display={'flex'} justifyContent="space-between">
         <Stack direction={'row'} spacing={2}>
-          {Array.isArray(variableDefinitions) && variableDefinitions.map((v) => (
+          {Array.isArray(variableDefinitions) &&
+            variableDefinitions.map((v) => (
               <Box key={v.name}>
                 <TemplateVariable key={v.name} name={v.name} />
               </Box>

--- a/ui/dashboards/src/context/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider.tsx
@@ -260,8 +260,10 @@ function hydrateTemplateVariableState(definition: VariableDefinition) {
 
 function hydrateTemplateVariableStates(definitions: VariableDefinition[]): VariableStateMap {
   const state: VariableStateMap = {};
-  definitions.forEach((v) => {
-    state[v.name] = hydrateTemplateVariableState(v);
-  });
+  if (Array.isArray(definitions)) {
+    definitions.forEach((v) => {
+      state[v.name] = hydrateTemplateVariableState(v);
+    });
+  }
   return state;
 }


### PR DESCRIPTION
- Add Array checks before calling forEach and map so existing dashboards don't break
- Prevents `definitions.forEach is not a function` and similar .map error
- see related PR #561 