### PR TITLE
make row display.title and display.collapse optional 

### DIFF
--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -25,6 +25,7 @@ const demoDashboard: DashboardResource = {
   spec: {
     datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
     duration: '30m',
+    // variables: {},
     variables: [
       {
         name: 'job',
@@ -397,7 +398,7 @@ const demoDashboard: DashboardResource = {
           display: {
             title: 'Row 1',
             collapse: {
-              open: false,
+              open: true,
             },
           },
           items: [
@@ -423,12 +424,12 @@ const demoDashboard: DashboardResource = {
       {
         kind: 'Grid',
         spec: {
-          display: {
-            title: 'Row 2',
-            collapse: {
-              open: true,
-            },
-          },
+          // display: {
+          //   title: 'Row 2',
+          //   collapse: {
+          //     open: true,
+          //   },
+          // },
           items: [
             {
               x: 0,

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -37,7 +37,15 @@ export function GridLayout(props: GridLayoutProps) {
     ...others
   } = props;
 
-  const [isOpen, setIsOpen] = useState(!!spec.display?.collapse?.open);
+  // allow display to be optional, default to open state
+  const rowDisplay = spec.display ?? {
+    title: '',
+    collapse: {
+      open: true,
+    },
+  };
+
+  const [isOpen, setIsOpen] = useState(rowDisplay.collapse?.open ?? true);
 
   const { isEditMode } = useEditMode();
 
@@ -57,17 +65,15 @@ export function GridLayout(props: GridLayoutProps) {
     <>
       <GlobalStyles styles={styles} />
       <Box {...others} component="section" sx={{ '& + &': { marginTop: (theme) => theme.spacing(1) } }}>
-        {spec.display !== undefined && (
-          <GridTitle
-            groupIndex={groupIndex}
-            title={spec.display.title}
-            collapse={
-              spec.display.collapse === undefined
-                ? undefined
-                : { isOpen, onToggleOpen: () => setIsOpen((current) => !current) }
-            }
-          />
-        )}
+        <GridTitle
+          groupIndex={groupIndex}
+          title={rowDisplay.title}
+          collapse={
+            rowDisplay.collapse === undefined
+              ? undefined
+              : { isOpen, onToggleOpen: () => setIsOpen((current) => !current) }
+          }
+        />
         <Collapse in={isOpen} unmountOnExit>
           <ResponsiveGridLayout
             className="layout"


### PR DESCRIPTION
- Allow panels to still render if spec.display (inside layouts array) is not populated. 
- This PR defaults rows to open with an empty title
- see related PR #560 