### PR TITLE
Update styles for markdown panel links

### DIFF
--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -32,24 +32,28 @@ function createMarkdownPanelStyles(theme: Theme) {
     // Styles for <code>
     '& code': { fontSize: '0.85em' },
     '& :not(pre) code': {
-      padding: '.2em .4em',
+      padding: '0.2em 0.4em',
       backgroundColor: theme.palette.grey[100],
-      borderRadius: `${theme.shape.borderRadius}px`,
+      borderRadius: '4px',
     },
     '& pre': {
-      padding: theme.spacing(2),
+      padding: '1.2em',
       backgroundColor: theme.palette.grey[100],
-      borderRadius: `${theme.shape.borderRadius}px`,
+      borderRadius: '4px',
     },
     // Styles for <table>
     '& table, & th, & td': {
-      padding: theme.spacing(1),
+      padding: '0.6em',
       border: `1px solid ${theme.palette.grey[300]}`,
       borderCollapse: 'collapse',
     },
     // Styles for <li>
     '& li + li': {
       marginTop: '0.25em',
+    },
+    // Styles for <a>
+    '& a': {
+      color: theme.palette.primary.main,
     },
   };
 }


### PR DESCRIPTION
Showed some screenshots to Mohit, he reminded me to check dark mode, which made me see that the links looked weird.

## Changes
* For links, get the color from `theme`
* For code blocks, the border-radius is fixed instead of coming from `theme.borderRadius` 
  * Even if people are theme-ing their buttons/containers to have a certain border-radius, I don't think this should apply to the code formatting
* For code blocks + tables, the padding depends on font-size instead of `theme.spacing()`
  * theme.spacing() can defined be in terms of `px`, I think the padding for this formatting should be set to always scale with the font-size

## Screenshots
<img width="788" alt="Screen Shot 2022-09-22 at 3 10 28 PM" src="https://user-images.githubusercontent.com/2584129/191860970-a4053fff-85da-4f16-be3f-7aee82614ddd.png">
<img width="753" alt="Screen Shot 2022-09-22 at 3 10 40 PM" src="https://user-images.githubusercontent.com/2584129/191860972-0c842783-1e3f-4910-af7d-103a8ae33510.png">

Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>