### PR TITLE
Add eslint:recommended, enable pretty output from Typescript

### DIFF
--- a/ui/.eslintrc.base.js
+++ b/ui/.eslintrc.base.js
@@ -14,6 +14,7 @@
 // Base eslint configuration for typescript projects
 module.exports = {
   extends: [
+    'eslint:recommended',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',

--- a/ui/app/src/utils/browser-storage.ts
+++ b/ui/app/src/utils/browser-storage.ts
@@ -34,7 +34,9 @@ function useStorage<T>(storage: Storage, key: string, initialValue: T) {
       if (json !== null) {
         return JSON.parse(json);
       }
-    } catch {}
+    } catch {
+      // No-op
+    }
 
     // Either the value isn't in storage yet or JSON parsing failed, so
     // set to the initial value in both places

--- a/ui/components/src/model/units.ts
+++ b/ui/components/src/model/units.ts
@@ -84,9 +84,10 @@ function formatTime(value: number, unitOptions: TimeUnitOptions): string {
     case 'Years':
       duration.years = value;
       break;
-    default:
+    default: {
       const exhaustive: never = unitOptions.kind;
       throw new Error(`Unknown time unit type ${exhaustive}`);
+    }
   }
 
   // Find the largest whole time unit we can display the value in and use it

--- a/ui/dashboards/src/context/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider.tsx
@@ -194,6 +194,7 @@ function hydrateTemplateVariableState(definition: VariableDefinition) {
           varState.value = v.spec.allowMultiple ? [firstOptionValue] : firstOptionValue;
         }
       }
+      break;
     default:
       break;
   }

--- a/ui/prometheus-plugin/src/model/parse-sample-values.ts
+++ b/ui/prometheus-plugin/src/model/parse-sample-values.ts
@@ -40,8 +40,10 @@ export function parseSampleValue(sampleValue: ValueTuple[1]): number {
   switch (sampleValue) {
     case '+Inf':
       value = Number.POSITIVE_INFINITY;
+      break;
     case '-Inf':
       value = Number.NEGATIVE_INFINITY;
+      break;
     default:
       value = parseFloat(sampleValue);
   }

--- a/ui/prometheus-plugin/src/model/utils.ts
+++ b/ui/prometheus-plugin/src/model/utils.ts
@@ -40,6 +40,8 @@ export function replaceTemplateVariable(text: string, varName: string, templateV
   return text.replaceAll(variableTemplate, replaceString);
 }
 
+// TODO: Fix this lint eror
+// eslint-disable-next-line no-useless-escape
 const TEMPLATE_VARIABLE_REGEX = /\$(\w+)|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/gm;
 
 /**

--- a/ui/tsconfig.base.json
+++ b/ui/tsconfig.base.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "pretty": true
   },
   // For builds that use ts-node to compile the configs (e.g. webpack, jest)
   "ts-node": {


### PR DESCRIPTION
This just makes two minor tweaks to our dev tool configs:

1. Turns on `eslint:recommended` which was somehow missing (definitely my fault 😂 )
2. Set `pretty: true` in `tsconfig` so that the Typescript compiler outputs colors for compile errors, making that more obvious in our log output

