### PR TITLE
Rename GraphQuery to TimeSeriesQuery

### DIFF
--- a/ui/app/sample-data/benchmarkDashboard.ts
+++ b/ui/app/sample-data/benchmarkDashboard.ts
@@ -83,10 +83,10 @@ const benchmarkDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'rate(caddy_http_request_duration_seconds_bucket[$interval])',
                         // query: 'caddy_http_request_duration_seconds_bucket',
@@ -109,10 +109,10 @@ const benchmarkDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'rate(caddy_http_response_duration_seconds_sum[$interval])',
                         // query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[$interval]))',
@@ -138,10 +138,10 @@ const benchmarkDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           '1 - node_filesystem_free_bytes{job="node",instance="$instance",fstype!="rootfs",mountpoint!~"/(run|var).*",mountpoint!=""} / node_filesystem_size_bytes{job="node",instance="$instance"}',
@@ -167,10 +167,10 @@ const benchmarkDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'node_memory_MemTotal_bytes{job="node",instance="$instance"} - node_memory_MemFree_bytes{job="node",instance="$instance"} - node_memory_Buffers_bytes{job="node",instance="$instance"} - node_memory_Cached_bytes{job="node",instance="$instance"}',
@@ -179,10 +179,10 @@ const benchmarkDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
                       },
@@ -190,10 +190,10 @@ const benchmarkDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_Cached_bytes{job="node",instance="$instance"}',
                       },
@@ -201,10 +201,10 @@ const benchmarkDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_MemFree_bytes{job="node",instance="$instance"}',
                       },
@@ -227,10 +227,10 @@ const benchmarkDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_load15{instance="$instance",job="node"}',
                       },
@@ -238,10 +238,10 @@ const benchmarkDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_load1{instance="$instance",job="node"}',
                       },
@@ -282,10 +282,10 @@ const benchmarkDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'avg without (cpu)(rate(node_cpu_seconds_total{job="node",instance="$instance",mode!="idle"}[$interval]))',
@@ -314,10 +314,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         'node_time_seconds{job="node",instance="$instance"} - node_boot_time_seconds{job="node",instance="$instance"}',
@@ -346,10 +346,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         '100 - ((node_memory_MemAvailable_bytes{job="node",instance="$instance"} * 100) / node_memory_MemTotal_bytes{job="node",instance="$instance"})',
@@ -374,10 +374,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query: 'node_memory_MemTotal_bytes{job="node",instance="$instance"}',
                     },
@@ -404,10 +404,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         'avg(node_load15{job="node",instance="$instance"}) /  count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu)) * 100',
@@ -440,10 +440,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         '(((count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance="$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))',
@@ -470,10 +470,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'GaugeChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         '(((count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance="$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))',
@@ -508,10 +508,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'GaugeChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query: 'node_load15{instance="$instance",job="node"}',
                     },
@@ -550,10 +550,10 @@ const benchmarkDashboard: DashboardResource = {
             kind: 'GaugeChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         'node_time_seconds{job="node",instance="$instance"} - node_boot_time_seconds{job="node",instance="$instance"}',

--- a/ui/app/sample-data/convert/convert-panels.ts
+++ b/ui/app/sample-data/convert/convert-panels.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GraphQueryDefinition, PanelDefinition, DashboardSpec } from '@perses-dev/core';
+import { TimeSeriesQueryDefinition, PanelDefinition, DashboardSpec } from '@perses-dev/core';
 import { camelCase } from 'lodash-es';
 import {
   GrafanaGaugePanel,
@@ -161,15 +161,15 @@ function convertSingleStatPanel(statPanel: GrafanaSingleStatPanel): PanelDefinit
   return convertedPanel;
 }
 
-function convertQueryTarget(target?: PromQueryTarget): GraphQueryDefinition {
+function convertQueryTarget(target?: PromQueryTarget): TimeSeriesQueryDefinition {
   const query = target?.expr ?? '';
   const min_step = target?.step === undefined ? undefined : `${target.step}s`;
 
   return {
-    kind: 'GraphQuery',
+    kind: 'TimeSeriesQuery',
     spec: {
       plugin: {
-        kind: 'PrometheusGraphQuery',
+        kind: 'PrometheusTimeSeriesQuery',
         spec: {
           query,
           min_step,

--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -74,10 +74,10 @@ const demoDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'rate(caddy_http_request_duration_seconds_bucket[$interval])',
                         // query: 'caddy_http_request_duration_seconds_bucket',
@@ -100,10 +100,10 @@ const demoDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'rate(caddy_http_response_duration_seconds_sum[$interval])',
                         // query: 'histogram_quantile(0.9, rate(caddy_http_request_duration_seconds_bucket[$interval]))',
@@ -126,10 +126,10 @@ const demoDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           '1 - node_filesystem_free_bytes{job="node",instance="$instance",fstype!="rootfs",mountpoint!~"/(run|var).*",mountpoint!=""} / node_filesystem_size_bytes{job="node",instance="$instance"}',
@@ -152,10 +152,10 @@ const demoDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'node_memory_MemTotal_bytes{job="node",instance="$instance"} - node_memory_MemFree_bytes{job="node",instance="$instance"} - node_memory_Buffers_bytes{job="node",instance="$instance"} - node_memory_Cached_bytes{job="node",instance="$instance"}',
@@ -164,10 +164,10 @@ const demoDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
                       },
@@ -175,10 +175,10 @@ const demoDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_Cached_bytes{job="node",instance="$instance"}',
                       },
@@ -186,10 +186,10 @@ const demoDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_MemFree_bytes{job="node",instance="$instance"}',
                       },
@@ -212,10 +212,10 @@ const demoDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_load15{instance="$instance",job="node"}',
                       },
@@ -223,10 +223,10 @@ const demoDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_load1{instance="$instance",job="node"}',
                       },
@@ -267,10 +267,10 @@ const demoDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'avg without (cpu)(rate(node_cpu_seconds_total{job="node",instance="$instance",mode!="idle"}[$interval]))',
@@ -299,10 +299,10 @@ const demoDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         'node_time_seconds{job="node",instance="$instance"} - node_boot_time_seconds{job="node",instance="$instance"}',
@@ -331,10 +331,10 @@ const demoDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         '100 - ((node_memory_MemAvailable_bytes{job="node",instance="$instance"} * 100) / node_memory_MemTotal_bytes{job="node",instance="$instance"})',
@@ -359,10 +359,10 @@ const demoDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query: 'node_memory_MemTotal_bytes{job="node",instance="$instance"}',
                     },
@@ -389,10 +389,10 @@ const demoDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         'avg(node_load15{job="node",instance="$instance"}) /  count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu)) * 100',
@@ -425,10 +425,10 @@ const demoDashboard: DashboardResource = {
             kind: 'StatChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         '(((count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance="$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))',
@@ -455,10 +455,10 @@ const demoDashboard: DashboardResource = {
             kind: 'GaugeChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         '(((count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance="$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))',
@@ -493,10 +493,10 @@ const demoDashboard: DashboardResource = {
             kind: 'GaugeChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query: 'node_load15{instance="$instance",job="node"}',
                     },
@@ -535,10 +535,10 @@ const demoDashboard: DashboardResource = {
             kind: 'GaugeChart',
             spec: {
               query: {
-                kind: 'GraphQuery',
+                kind: 'TimeSeriesQuery',
                 spec: {
                   plugin: {
-                    kind: 'PrometheusGraphQuery',
+                    kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
                         'node_time_seconds{job="node",instance="$instance"} - node_boot_time_seconds{job="node",instance="$instance"}',

--- a/ui/core/src/model/index.ts
+++ b/ui/core/src/model/index.ts
@@ -13,9 +13,9 @@
 
 export * from './dashboard';
 export * from './definitions';
-export * from './graph-queries';
 export * from './layout';
 export * from './panels';
 export * from './resource';
 export * from './time';
+export * from './time-series-queries';
 export * from './variables';

--- a/ui/core/src/model/time-series-queries.ts
+++ b/ui/core/src/model/time-series-queries.ts
@@ -13,10 +13,10 @@
 
 import { Definition } from './definitions';
 
-export interface GraphQueryDefinition<PluginSpec = unknown> extends Definition<GraphQuerySpec<PluginSpec>> {
-  kind: 'GraphQuery';
+export interface TimeSeriesQueryDefinition<PluginSpec = unknown> extends Definition<TimeSeriesQuerySpec<PluginSpec>> {
+  kind: 'TimeSeriesQuery';
 }
 
-export interface GraphQuerySpec<PluginSpec> {
+export interface TimeSeriesQuerySpec<PluginSpec> {
   plugin: Definition<PluginSpec>;
 }

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -35,14 +35,10 @@ export function mockPluginRegistryProps() {
     },
   };
 
-  const mockPluginModule: Record<string, Plugin<unknown>> = {};
+  const mockPluginModule: Record<string, Plugin> = {};
 
   // Allow adding mock plugins in tests
-  const addMockPlugin = <T extends PluginType>(
-    pluginType: T,
-    kind: string,
-    plugin: PluginImplementation<T, unknown>
-  ) => {
+  const addMockPlugin = <T extends PluginType>(pluginType: T, kind: string, plugin: PluginImplementation<T>) => {
     mockPluginResource.spec.plugins.push({
       pluginType,
       kind,

--- a/ui/dashboards/src/test/testDashboard.ts
+++ b/ui/dashboards/src/test/testDashboard.ts
@@ -58,10 +58,10 @@ const testDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'avg without (cpu)(rate(node_cpu_seconds_total{job="node",instance="$instance",mode!="idle"}[$interval]))',
@@ -84,10 +84,10 @@ const testDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'node_memory_MemTotal_bytes{job="node",instance="$instance"} - node_memory_MemFree_bytes{job="node",instance="$instance"} - node_memory_Buffers_bytes{job="node",instance="$instance"} - node_memory_Cached_bytes{job="node",instance="$instance"}',
@@ -96,10 +96,10 @@ const testDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
                       },
@@ -107,10 +107,10 @@ const testDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_Cached_bytes{job="node",instance="$instance"}',
                       },
@@ -118,10 +118,10 @@ const testDashboard: DashboardResource = {
                   },
                 },
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query: 'node_memory_MemFree_bytes{job="node",instance="$instance"}',
                       },
@@ -143,10 +143,10 @@ const testDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'rate(node_disk_io_time_seconds_total{job="node",instance="$instance",device!~"^(md\\\\d+$|dm-)"}[$interval])',
@@ -169,10 +169,10 @@ const testDashboard: DashboardResource = {
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           '1 - node_filesystem_free_bytes{job="node",instance="$instance",fstype!="rootfs",mountpoint!~"/(run|var).*",mountpoint!=""} / node_filesystem_size_bytes{job="node",instance="$instance"}',

--- a/ui/panels-plugin/src/model/calculations.ts
+++ b/ui/panels-plugin/src/model/calculations.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GraphSeriesValueTuple } from '@perses-dev/plugin-system';
+import { TimeSeriesValueTuple } from '@perses-dev/plugin-system';
 import { findLast, meanBy, sumBy } from 'lodash-es';
 
 export const CalculationsMap = {
@@ -24,33 +24,33 @@ export const CalculationsMap = {
 
 export type CalculationType = keyof typeof CalculationsMap;
 
-function first(values: GraphSeriesValueTuple[]): number | undefined {
+function first(values: TimeSeriesValueTuple[]): number | undefined {
   const tuple = values[0];
   return tuple === undefined ? undefined : getValue(tuple);
 }
 
-function last(values: GraphSeriesValueTuple[]): number | undefined {
+function last(values: TimeSeriesValueTuple[]): number | undefined {
   if (values.length <= 0) return undefined;
 
   const tuple = values[values.length - 1];
   return tuple === undefined ? undefined : getValue(tuple);
 }
 
-function lastNumber(values: GraphSeriesValueTuple[]): number | undefined {
+function lastNumber(values: TimeSeriesValueTuple[]): number | undefined {
   const tuple = findLast(values, (tuple) => isNaN(getValue(tuple)) === false);
   return tuple === undefined ? undefined : getValue(tuple);
 }
 
-function mean(values: GraphSeriesValueTuple[]): number | undefined {
+function mean(values: TimeSeriesValueTuple[]): number | undefined {
   if (values.length <= 0) return undefined;
   return meanBy(values, getValue);
 }
 
-function sum(values: GraphSeriesValueTuple[]): number | undefined {
+function sum(values: TimeSeriesValueTuple[]): number | undefined {
   if (values.length <= 0) return undefined;
   return sumBy(values, getValue);
 }
 
-function getValue(valueTuple: GraphSeriesValueTuple) {
+function getValue(valueTuple: TimeSeriesValueTuple) {
   return valueTuple[1];
 }

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { GaugeSeriesOption } from 'echarts';
-import { useGraphQueryData, PanelProps } from '@perses-dev/plugin-system';
+import { useTimeSeriesQueryData, PanelProps } from '@perses-dev/plugin-system';
 import { GaugeChart, GaugeChartData } from '@perses-dev/components';
 import { Skeleton } from '@mui/material';
 import { useMemo } from 'react';
@@ -38,7 +38,7 @@ export function GaugeChartPanel(props: GaugeChartPanelProps) {
   const thresholds = pluginSpec.thresholds ?? defaultThresholdInput;
 
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);
-  const { data, loading, error } = useGraphQueryData(query, { suggestedStepMs });
+  const { data, loading, error } = useTimeSeriesQueryData(query, { suggestedStepMs });
 
   const chartData: GaugeChartData = useMemo(() => {
     if (data === undefined) return undefined;

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GraphQueryDefinition } from '@perses-dev/core';
+import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
 import { ThresholdOptions } from '../../model/thresholds';
 import { CalculationType } from '../../model/calculations';
@@ -20,7 +20,7 @@ import { CalculationType } from '../../model/calculations';
  * The Options object type supported by the GaugeChart panel plugin.
  */
 export interface GaugeChartOptions {
-  query: GraphQueryDefinition;
+  query: TimeSeriesQueryDefinition;
   calculation: CalculationType;
   unit?: UnitOptions;
   thresholds?: ThresholdOptions;
@@ -34,7 +34,7 @@ export function createInitialGaugeChartOptions(): GaugeChartOptions {
   return {
     // TODO: How do you represent an initially empty/unset graph query?
     query: {
-      kind: 'GraphQuery',
+      kind: 'TimeSeriesQuery',
       spec: {
         plugin: {
           kind: '',

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartContainer.tsx
@@ -17,7 +17,7 @@ import { Box, Skeleton } from '@mui/material';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { LineChart, EChartsDataFormat, UnitOptions, ZoomEventData } from '@perses-dev/components';
 import { StepOptions, ThresholdOptions, ThresholdColors, ThresholdColorsPalette } from '../../model/thresholds';
-import { useRunningGraphQueries } from './GraphQueryRunner';
+import { useRunningGraphQueries } from './TimeSeriesQueryRunner';
 import { getLineSeries, getCommonTimeScale, getYValues, getXValues } from './utils/data-transform';
 
 export const EMPTY_GRAPH_DATA = {

--- a/ui/panels-plugin/src/plugins/line-chart/LineChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/line-chart/LineChartPanel.tsx
@@ -13,7 +13,7 @@
 
 import { PanelProps } from '@perses-dev/plugin-system';
 import { useSuggestedStepMs } from '../../model/time';
-import GraphQueryRunner from './GraphQueryRunner';
+import TimeSeriesQueryRunner from './TimeSeriesQueryRunner';
 import { LineChartOptions } from './line-chart-model';
 import { LineChartContainer } from './LineChartContainer';
 
@@ -34,7 +34,7 @@ export function LineChartPanel(props: LineChartProps) {
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);
 
   return (
-    <GraphQueryRunner queries={queries} suggestedStepMs={suggestedStepMs}>
+    <TimeSeriesQueryRunner queries={queries} suggestedStepMs={suggestedStepMs}>
       {contentDimensions !== undefined && (
         <LineChartContainer
           width={contentDimensions.width}
@@ -44,6 +44,6 @@ export function LineChartPanel(props: LineChartProps) {
           thresholds={thresholds}
         />
       )}
-    </GraphQueryRunner>
+    </TimeSeriesQueryRunner>
   );
 }

--- a/ui/panels-plugin/src/plugins/line-chart/line-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/line-chart-model.ts
@@ -12,14 +12,14 @@
 // limitations under the License.
 
 import { UnitOptions } from '@perses-dev/components';
-import { GraphQueryDefinition } from '@perses-dev/core';
+import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { ThresholdOptions } from '../../model/thresholds';
 
 /**
  * The Options object supported by the LineChartPanel plugin.
  */
 export interface LineChartOptions {
-  queries: GraphQueryDefinition[];
+  queries: TimeSeriesQueryDefinition[];
   show_legend?: boolean;
   unit?: UnitOptions;
   thresholds?: ThresholdOptions;

--- a/ui/panels-plugin/src/plugins/line-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/utils/data-transform.ts
@@ -13,7 +13,7 @@
 
 import { AbsoluteTimeRange } from '@perses-dev/core';
 import { EChartsTimeSeries } from '@perses-dev/components';
-import { GraphSeries } from '@perses-dev/plugin-system';
+import { TimeSeries } from '@perses-dev/plugin-system';
 import { gcd } from 'mathjs';
 import { QueryState } from '../TimeSeriesQueryRunner';
 import { getRandomColor } from '../utils/palette-gen';
@@ -93,7 +93,7 @@ export function getXValues(timeScale: TimeScale): number[] {
  * y axis of a graph, filling in any timestamps that are missing from the time
  * series data with `null` values.
  */
-export function getYValues(series: GraphSeries, timeScale: TimeScale): Array<number | null> {
+export function getYValues(series: TimeSeries, timeScale: TimeScale): Array<number | null> {
   let timestamp = timeScale.startMs;
 
   const yValues: Array<number | null> = [];

--- a/ui/panels-plugin/src/plugins/line-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/line-chart/utils/data-transform.ts
@@ -15,7 +15,7 @@ import { AbsoluteTimeRange } from '@perses-dev/core';
 import { EChartsTimeSeries } from '@perses-dev/components';
 import { GraphSeries } from '@perses-dev/plugin-system';
 import { gcd } from 'mathjs';
-import { QueryState } from '../GraphQueryRunner';
+import { QueryState } from '../TimeSeriesQueryRunner';
 import { getRandomColor } from '../utils/palette-gen';
 import { StepOptions } from '../../../model/thresholds';
 

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -15,7 +15,7 @@ import { StatChart, StatChartData, useChartsTheme, PersesChartsTheme } from '@pe
 import { Box, Skeleton } from '@mui/material';
 import { LineSeriesOption } from 'echarts/charts';
 import { useMemo } from 'react';
-import { GraphData, useTimeSeriesQueryData, PanelProps } from '@perses-dev/plugin-system';
+import { TimeSeriesData, useTimeSeriesQueryData, PanelProps } from '@perses-dev/plugin-system';
 import { CalculationsMap, CalculationType } from '../../model/calculations';
 import { useSuggestedStepMs } from '../../model/time';
 import { SparklineOptions, StatChartOptions } from './stat-chart-model';
@@ -66,7 +66,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
   );
 }
 
-const useChartData = (data: GraphData | undefined, calculation: CalculationType, name: string): StatChartData => {
+const useChartData = (data: TimeSeriesData | undefined, calculation: CalculationType, name: string): StatChartData => {
   return useMemo(() => {
     const loadingData = {
       calculatedValue: undefined,

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -15,7 +15,7 @@ import { StatChart, StatChartData, useChartsTheme, PersesChartsTheme } from '@pe
 import { Box, Skeleton } from '@mui/material';
 import { LineSeriesOption } from 'echarts/charts';
 import { useMemo } from 'react';
-import { GraphData, useGraphQueryData, PanelProps } from '@perses-dev/plugin-system';
+import { GraphData, useTimeSeriesQueryData, PanelProps } from '@perses-dev/plugin-system';
 import { CalculationsMap, CalculationType } from '../../model/calculations';
 import { useSuggestedStepMs } from '../../model/time';
 import { SparklineOptions, StatChartOptions } from './stat-chart-model';
@@ -35,7 +35,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
     contentDimensions,
   } = props;
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);
-  const { data, loading, error } = useGraphQueryData(query, { suggestedStepMs });
+  const { data, loading, error } = useTimeSeriesQueryData(query, { suggestedStepMs });
   const chartData = useChartData(data, calculation, name);
   const chartsTheme = useChartsTheme();
 

--- a/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GraphQueryDefinition } from '@perses-dev/core';
+import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
 import { ThresholdOptions } from '../../model/thresholds';
 import { CalculationType } from '../../model/calculations';
@@ -23,7 +23,7 @@ export interface SparklineOptions {
 
 export interface StatChartOptions {
   name: string;
-  query: GraphQueryDefinition;
+  query: TimeSeriesQueryDefinition;
   calculation: CalculationType;
   unit: UnitOptions;
   thresholds?: ThresholdOptions;
@@ -34,7 +34,7 @@ export function createInitialStatChartOptions(): StatChartOptions {
   return {
     name: '',
     query: {
-      kind: 'GraphQuery',
+      kind: 'TimeSeriesQuery',
       spec: {
         plugin: {
           kind: '',

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.test.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.test.tsx
@@ -33,7 +33,7 @@ describe('PluginRegistry', () => {
 
   it('errors when plugin is not installed', async () => {
     // This plugin is not in the test metadata at all
-    renderPluginRegistry(<PluginConsumer pluginType="GraphQuery" kind="NotInstalled" />);
+    renderPluginRegistry(<PluginConsumer pluginType="TimeSeriesQuery" kind="NotInstalled" />);
 
     const error = await screen.findByText(/error:/i);
     expect(error).toBeInTheDocument();
@@ -60,8 +60,8 @@ describe('PluginRegistry', () => {
   });
 
   it('lists metadata for plugin types with no plugins available', async () => {
-    // There are no GraphQuery plugins in any of the test modules
-    renderPluginRegistry(<MetadataConsumer pluginType="GraphQuery" />);
+    // There are no TimeSeriesQuery plugins in any of the test modules
+    renderPluginRegistry(<MetadataConsumer pluginType="TimeSeriesQuery" />);
 
     const table = await screen.findByRole('table');
     expect(table).toBeInTheDocument();

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -51,7 +51,7 @@ export function PluginRegistry(props: PluginRegistryProps) {
   });
 
   const getPlugin = useCallback(
-    async <T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T, unknown>> => {
+    async <T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>> => {
       // Get the indexes of the installed plugins
       const pluginIndexes = await getPluginIndexes();
 
@@ -63,7 +63,7 @@ export function PluginRegistry(props: PluginRegistryProps) {
       }
 
       // Treat the plugin module as a bunch of named exports that have plugins
-      const pluginModule = (await loadPluginModule(resource)) as Record<string, Plugin<unknown>>;
+      const pluginModule = (await loadPluginModule(resource)) as Record<string, Plugin>;
 
       // We currently assume that plugin modules will have named exports that match the kinds they handle
       const plugin = pluginModule[kind];
@@ -73,7 +73,7 @@ export function PluginRegistry(props: PluginRegistryProps) {
         );
       }
 
-      return plugin;
+      return plugin as PluginImplementation<T>;
     },
     [getPluginIndexes, loadPluginModule]
   );

--- a/ui/plugin-system/src/components/PluginRegistry/plugin-registry-model.ts
+++ b/ui/plugin-system/src/components/PluginRegistry/plugin-registry-model.ts
@@ -15,7 +15,7 @@ import { createContext, useContext } from 'react';
 import { PluginImplementation, PluginMetadata, PluginType } from '../../model';
 
 export interface PluginRegistryContextType {
-  getPlugin<T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T, unknown>>;
+  getPlugin<T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>>;
   listPluginMetadata(pluginType: PluginType): Promise<PluginMetadata[]>;
 }
 

--- a/ui/plugin-system/src/model/index.ts
+++ b/ui/plugin-system/src/model/index.ts
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph-queries';
 export * from './panels';
 export * from './plugins';
+export * from './time-series-queries';
 export * from './variables';
 export * from './visual-editing';

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ResourceMetadata, ListVariableDefinition, PanelDefinition, GraphQueryDefinition } from '@perses-dev/core';
+import { ResourceMetadata } from '@perses-dev/core';
 import { GraphQueryPlugin } from './graph-queries';
 import { PanelPlugin } from './panels';
 import { VariablePlugin } from './variables';
@@ -52,29 +52,20 @@ export const ALL_PLUGIN_TYPES = ['Variable', 'Panel', 'GraphQuery'] as const;
 export type PluginType = typeof ALL_PLUGIN_TYPES[number];
 
 // Map of plugin type -> config and implementation type
-type SupportedPlugins<Spec> = {
-  Variable: {
-    Def: ListVariableDefinition<Spec>;
-    Impl: VariablePlugin<Spec>;
-  };
-  Panel: {
-    Def: PanelDefinition<Spec>;
-    Impl: PanelPlugin<Spec>;
-  };
-  GraphQuery: {
-    Def: GraphQueryDefinition<Spec>;
-    Impl: GraphQueryPlugin<Spec>;
-  };
-};
+interface SupportedPlugins {
+  Variable: VariablePlugin;
+  Panel: PanelPlugin;
+  GraphQuery: GraphQueryPlugin;
+}
 
 /**
  * Union type of all available plugin implementations.
  */
-export type Plugin<Spec> = {
-  [Type in PluginType]: PluginImplementation<Type, Spec>;
+export type Plugin = {
+  [Type in PluginType]: PluginImplementation<Type>;
 }[PluginType];
 
 /**
  * The implementation for a given plugin type.
  */
-export type PluginImplementation<Type extends PluginType, Spec> = SupportedPlugins<Spec>[Type]['Impl'];
+export type PluginImplementation<Type extends PluginType> = SupportedPlugins[Type];

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -42,17 +42,14 @@ export interface PluginMetadata {
 }
 
 /**
- * All supported plugin type values as an array for use at runtime.
- */
-export const ALL_PLUGIN_TYPES = ['Variable', 'Panel', 'GraphQuery'] as const;
-
-/**
  * All supported plugin types.
  */
-export type PluginType = typeof ALL_PLUGIN_TYPES[number];
+export type PluginType = keyof SupportedPlugins;
 
-// Map of plugin type -> config and implementation type
-interface SupportedPlugins {
+/**
+ * Map of plugin type key/string -> implementation type
+ */
+export interface SupportedPlugins {
   Variable: VariablePlugin;
   Panel: PanelPlugin;
   GraphQuery: GraphQueryPlugin;

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { ResourceMetadata } from '@perses-dev/core';
-import { GraphQueryPlugin } from './graph-queries';
+import { TimeSeriesQueryPlugin } from './time-series-queries';
 import { PanelPlugin } from './panels';
 import { VariablePlugin } from './variables';
 
@@ -52,7 +52,7 @@ export type PluginType = keyof SupportedPlugins;
 export interface SupportedPlugins {
   Variable: VariablePlugin;
   Panel: PanelPlugin;
-  GraphQuery: GraphQueryPlugin;
+  TimeSeriesQuery: TimeSeriesQueryPlugin;
 }
 
 /**

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -18,7 +18,10 @@ import { LegacyDatasources, VariableStateMap } from '../runtime';
  * A plugin for running graph queries.
  */
 export interface TimeSeriesQueryPlugin<Spec = unknown> {
-  getGraphData: (definition: TimeSeriesQueryDefinition<Spec>, ctx: TimeSeriesQueryContext) => Promise<GraphData>;
+  getTimeSeriesData: (
+    definition: TimeSeriesQueryDefinition<Spec>,
+    ctx: TimeSeriesQueryContext
+  ) => Promise<TimeSeriesData>;
 }
 
 /**
@@ -31,15 +34,15 @@ export interface TimeSeriesQueryContext {
   datasources: LegacyDatasources;
 }
 
-export interface GraphData {
+export interface TimeSeriesData {
   timeRange: AbsoluteTimeRange;
   stepMs: number;
-  series: Iterable<GraphSeries>;
+  series: Iterable<TimeSeries>;
 }
 
-export interface GraphSeries {
+export interface TimeSeries {
   name: string;
-  values: Iterable<GraphSeriesValueTuple>;
+  values: Iterable<TimeSeriesValueTuple>;
 }
 
-export type GraphSeriesValueTuple = [timestamp: UnixTimeMs, value: number];
+export type TimeSeriesValueTuple = [timestamp: UnixTimeMs, value: number];

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -11,20 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AbsoluteTimeRange, GraphQueryDefinition, UnixTimeMs } from '@perses-dev/core';
+import { AbsoluteTimeRange, TimeSeriesQueryDefinition, UnixTimeMs } from '@perses-dev/core';
 import { LegacyDatasources, VariableStateMap } from '../runtime';
 
 /**
  * A plugin for running graph queries.
  */
-export interface GraphQueryPlugin<Spec = unknown> {
-  getGraphData: (definition: GraphQueryDefinition<Spec>, ctx: GraphQueryContext) => Promise<GraphData>;
+export interface TimeSeriesQueryPlugin<Spec = unknown> {
+  getGraphData: (definition: TimeSeriesQueryDefinition<Spec>, ctx: TimeSeriesQueryContext) => Promise<GraphData>;
 }
 
 /**
- * Context available to GraphQuery plugins at runtime.
+ * Context available to TimeSeriesQuery plugins at runtime.
  */
-export interface GraphQueryContext {
+export interface TimeSeriesQueryContext {
   suggestedStepMs?: number;
   timeRange: AbsoluteTimeRange;
   variableState: VariableStateMap;

--- a/ui/plugin-system/src/runtime/graph-queries.ts
+++ b/ui/plugin-system/src/runtime/graph-queries.ts
@@ -50,7 +50,7 @@ export const useTimeSeriesQueryData = (definition: TimeSeriesQueryDefinition, op
         throw new Error('Expected plugin to be loaded');
       }
       const [definition, context] = queryKey;
-      return plugin.getGraphData(definition, context);
+      return plugin.getTimeSeriesData(definition, context);
     },
     { enabled: plugin !== undefined }
   );

--- a/ui/plugin-system/src/runtime/graph-queries.ts
+++ b/ui/plugin-system/src/runtime/graph-queries.ts
@@ -11,30 +11,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GraphQueryDefinition } from '@perses-dev/core';
+import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { useQuery } from 'react-query';
-import { GraphQueryContext } from '../model';
+import { TimeSeriesQueryContext } from '../model';
 import { useLegacyDatasources } from './datasources-old';
 import { useTemplateVariableValues } from './template-variables';
 import { useTimeRange } from './time-range';
 import { usePlugin } from './plugins';
 
-type UseGraphQueryOptions = {
+type UseTimeSeriesQueryOptions = {
   suggestedStepMs?: number;
 };
 
 /**
  * Runs a Graph Query using a plugin and returns the results.
  */
-export const useGraphQueryData = (definition: GraphQueryDefinition, options?: UseGraphQueryOptions) => {
-  const { data: plugin } = usePlugin('GraphQuery', definition.spec.plugin.kind);
+export const useTimeSeriesQueryData = (definition: TimeSeriesQueryDefinition, options?: UseTimeSeriesQueryOptions) => {
+  const { data: plugin } = usePlugin('TimeSeriesQuery', definition.spec.plugin.kind);
 
   // Build the context object from data available at runtime
   const { timeRange } = useTimeRange();
   const variableState = useTemplateVariableValues();
   const datasources = useLegacyDatasources();
 
-  const context: GraphQueryContext = {
+  const context: TimeSeriesQueryContext = {
     suggestedStepMs: options?.suggestedStepMs,
     timeRange,
     variableState,

--- a/ui/plugin-system/src/runtime/plugins.ts
+++ b/ui/plugin-system/src/runtime/plugins.ts
@@ -18,7 +18,7 @@ import { getTypeAndKindKey } from '../utils/cache-keys';
 
 // Allows consumers to pass useQuery options from react-query when loading a plugin
 type UsePluginOptions<T extends PluginType> = Omit<
-  UseQueryOptions<PluginImplementation<T, unknown>, unknown, PluginImplementation<T, unknown>, string>,
+  UseQueryOptions<PluginImplementation<T>, unknown, PluginImplementation<T>, string>,
   'queryKey' | 'queryFn'
 >;
 

--- a/ui/prometheus-plugin/plugin.json
+++ b/ui/prometheus-plugin/plugin.json
@@ -30,8 +30,8 @@
         }
       },
       {
-        "pluginType": "GraphQuery",
-        "kind": "PrometheusGraphQuery",
+        "pluginType": "TimeSeriesQuery",
+        "kind": "PrometheusTimeSeriesQuery",
         "display": {
           "name": "Prometheus Range Query",
           "description": ""

--- a/ui/prometheus-plugin/src/index.ts
+++ b/ui/prometheus-plugin/src/index.ts
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PrometheusGraphQuery } from './plugins/graph-query';
+import { PrometheusTimeSeriesQuery } from './plugins/graph-query';
 // @TODO: Move this to a more generic location;
 import { StaticListVariable } from './plugins/variable';
 import { PrometheusLabelNamesVariable, PrometheusLabelValuesVariable } from './plugins/prometheus-variables';
 
 // Export plugins under the same name as the kinds they handle from the plugin.json
-export { PrometheusGraphQuery, StaticListVariable, PrometheusLabelNamesVariable, PrometheusLabelValuesVariable };
+export { PrometheusTimeSeriesQuery, StaticListVariable, PrometheusLabelNamesVariable, PrometheusLabelValuesVariable };

--- a/ui/prometheus-plugin/src/index.ts
+++ b/ui/prometheus-plugin/src/index.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PrometheusTimeSeriesQuery } from './plugins/graph-query';
+import { PrometheusTimeSeriesQuery } from './plugins/time-series-query';
 // @TODO: Move this to a more generic location;
 import { StaticListVariable } from './plugins/variable';
 import { PrometheusLabelNamesVariable, PrometheusLabelValuesVariable } from './plugins/prometheus-variables';

--- a/ui/prometheus-plugin/src/plugins/graph-query.ts
+++ b/ui/prometheus-plugin/src/plugins/graph-query.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { DurationString } from '@perses-dev/core';
-import { GraphData, GraphQueryPlugin } from '@perses-dev/plugin-system';
+import { GraphData, TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
 import { fromUnixTime } from 'date-fns';
 import { RangeQueryRequestParameters } from '../model/api-types';
 import { parseValueTuple } from '../model/parse-sample-values';
@@ -21,13 +21,16 @@ import { TemplateString } from '../model/templating';
 import { getDurationStringSeconds, getPrometheusTimeRange, getRangeStep } from '../model/time';
 import { replaceTemplateVariables } from '../model/utils';
 
-interface PrometheusGraphQueryOptions {
+interface PrometheusTimeSeriesQueryOptions {
   query: TemplateString;
   min_step?: DurationString;
   resolution?: number;
 }
 
-const getGraphData: GraphQueryPlugin<PrometheusGraphQueryOptions>['getGraphData'] = async (definition, context) => {
+const getGraphData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>['getGraphData'] = async (
+  definition,
+  context
+) => {
   const pluginSpec = definition.spec.plugin.spec;
 
   const minStep = getDurationStringSeconds(pluginSpec.min_step);
@@ -87,8 +90,8 @@ const getGraphData: GraphQueryPlugin<PrometheusGraphQueryOptions>['getGraphData'
 };
 
 /**
- * The core Prometheus GraphQuery plugin for Perses.
+ * The core Prometheus TimeSeriesQuery plugin for Perses.
  */
-export const PrometheusGraphQuery: GraphQueryPlugin<PrometheusGraphQueryOptions> = {
+export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions> = {
   getGraphData,
 };

--- a/ui/prometheus-plugin/src/plugins/time-series-query.ts
+++ b/ui/prometheus-plugin/src/plugins/time-series-query.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { DurationString } from '@perses-dev/core';
-import { GraphData, TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
+import { TimeSeriesData, TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
 import { fromUnixTime } from 'date-fns';
 import { RangeQueryRequestParameters } from '../model/api-types';
 import { parseValueTuple } from '../model/parse-sample-values';
@@ -27,7 +27,7 @@ interface PrometheusTimeSeriesQueryOptions {
   resolution?: number;
 }
 
-const getGraphData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>['getGraphData'] = async (
+const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>['getTimeSeriesData'] = async (
   definition,
   context
 ) => {
@@ -63,7 +63,7 @@ const getGraphData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>['get
   const result = response.data?.result ?? [];
 
   // Transform response
-  const chartData: GraphData = {
+  const chartData: TimeSeriesData = {
     // Return the time range and step we actually used for the query
     timeRange: { start: fromUnixTime(start), end: fromUnixTime(end) },
     stepMs: step * 1000,
@@ -93,5 +93,5 @@ const getGraphData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>['get
  * The core Prometheus TimeSeriesQuery plugin for Perses.
  */
 export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions> = {
-  getGraphData,
+  getTimeSeriesData,
 };


### PR DESCRIPTION
As discussed in chat, this renames the very generic `GraphQuery` to the more descriptive `TimeSeriesQuery` which better reflects the output format. I tried to also rename all the related types, but I may have missed a few which we can clean-up as we find them. There are [a few lines of refactoring](https://github.com/perses/perses/pull/573/commits/8b08c2461ce9be760188df7239a07796928fbc16) in here to plugin-related types that just simplified a few of the generics that aren't helpful at runtime, but most of this is just renames.