### PR TITLE
Upgrade to react-query v4, clean-up test logs

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -23,6 +23,7 @@
     "@perses-dev/panels-plugin": "^0.8.1",
     "@perses-dev/plugin-system": "^0.8.1",
     "@perses-dev/prometheus-plugin": "^0.8.1",
+    "@tanstack/react-query": "^4.7.1",
     "immer": "^9.0.15",
     "lodash-es": "^4.17.21",
     "mdi-material-ui": "^7.4.0",
@@ -30,7 +31,6 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-error-boundary": "^3.1.4",
-    "react-query": "^3.39.2",
     "react-router-dom": "^6.3.0",
     "use-immer": "^0.7.0",
     "use-resize-observer": "^9.0.0"

--- a/ui/app/src/model/health-client.ts
+++ b/ui/app/src/model/health-client.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { fetchJson } from '@perses-dev/core';
-import { useQuery, UseQueryOptions } from 'react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import buildURL from './url-builder';
 
 const resource = 'health';
@@ -30,7 +30,7 @@ type HealthOptions = Omit<UseQueryOptions<HealthModel, Error>, 'queryKey' | 'que
  */
 export function useHealth(options?: HealthOptions) {
   return useQuery<HealthModel, Error>(
-    resource,
+    [resource],
     () => {
       const url = buildURL({ resource });
       return fetchJson<HealthModel>(url);

--- a/ui/app/src/model/project-client.ts
+++ b/ui/app/src/model/project-client.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { fetchJson, Metadata } from '@perses-dev/core';
-import { useQuery, UseQueryOptions } from 'react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import buildURL from './url-builder';
 
 const resource = 'projects';
@@ -29,7 +29,7 @@ type ProjectListOptions = Omit<UseQueryOptions<ProjectModel[], Error>, 'queryKey
  */
 export function useProjectQuery(options?: ProjectListOptions) {
   return useQuery<ProjectModel[], Error>(
-    resource,
+    [resource],
     () => {
       const url = buildURL({ resource });
       return fetchJson<ProjectModel[]>(url);

--- a/ui/app/src/render-app.tsx
+++ b/ui/app/src/render-app.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { CssBaseline } from '@mui/material';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Router from './Router';
 import { SnackbarProvider } from './context/SnackbarProvider';
 import { DarkModeContextProvider } from './context/DarkMode';

--- a/ui/components/src/test/render.tsx
+++ b/ui/components/src/test/render.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { render, RenderOptions } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false } } });
 

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -28,7 +28,7 @@ import PanelDrawer from './PanelDrawer';
 describe('Panel Drawer', () => {
   const renderPanelDrawer = () => {
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
-    addMockPlugin('Panel', 'FakePanel', FAKE_PANEL_PLUGIN);
+    addMockPlugin('Panel', 'LineChart', FAKE_PANEL_PLUGIN);
 
     const { store, DashboardProviderSpy } = createDashboardProviderSpy();
 

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
@@ -25,10 +25,11 @@ import {
   Typography,
 } from '@mui/material';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { OptionsEditorProps, useListPluginMetadata, usePlugin } from '@perses-dev/plugin-system';
+import { OptionsEditorProps, usePlugin } from '@perses-dev/plugin-system';
 import { ChangeEvent, FormEvent, useState, useEffect, useMemo } from 'react';
 import { useDashboardApp, useLayouts, usePanels } from '../../context';
 import { removeWhiteSpacesAndSpecialCharacters } from '../../utils/functions';
+import { PanelTypeSelect } from './PanelTypeSelect';
 
 interface PanelDrawerHeaderProps {
   onClose: () => void;
@@ -65,7 +66,6 @@ const PanelDrawer = () => {
   const options = kindToOptions[kind];
 
   // TODO: What should we show if either of these error out?
-  const { data: pluginMetadata } = useListPluginMetadata('Panel');
   const { data: plugin } = usePlugin('Panel', kind, {
     enabled: kind !== '',
     onSuccess: (plugin) => {
@@ -202,13 +202,13 @@ const PanelDrawer = () => {
           <Grid item xs={4}>
             <FormControl>
               <InputLabel id="panel-type-label">Panel Type</InputLabel>
-              <Select required labelId="panel-type-label" label="Panel Type" value={kind} onChange={handleKindChange}>
-                {pluginMetadata?.map((metadata) => (
-                  <MenuItem key={metadata.kind} value={metadata.kind}>
-                    {metadata.display.name}
-                  </MenuItem>
-                ))}
-              </Select>
+              <PanelTypeSelect
+                required
+                labelId="panel-type-label"
+                label="Panel Type"
+                value={kind}
+                onChange={handleKindChange}
+              />
             </FormControl>
           </Grid>
           <Grid item xs={12}>

--- a/ui/dashboards/src/components/PanelDrawer/PanelTypeSelect.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelTypeSelect.tsx
@@ -1,0 +1,41 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Select, SelectProps, MenuItem } from '@mui/material';
+import { useListPluginMetadata } from '@perses-dev/plugin-system';
+
+export type PanelTypeSelectProps = Omit<SelectProps<string>, 'children'>;
+
+/**
+ * Displays a MUI Select input for selecing a Panel type. Queries the plugin system to get the list of all panel types.
+ */
+export function PanelTypeSelect(props: PanelTypeSelectProps) {
+  let { value, ...others } = props;
+  const { data, isLoading } = useListPluginMetadata('Panel');
+
+  // Pass an empty value while options are still loading so MUI doesn't complain about us using an "out of range" value
+  if (value !== '' && isLoading) {
+    value = '';
+  }
+
+  // TODO: Does this need a loading indicator of some kind?
+  return (
+    <Select {...others} value={value}>
+      {data?.map((metadata) => (
+        <MenuItem key={metadata.kind} value={metadata.kind}>
+          {metadata.display.name}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}

--- a/ui/dashboards/src/components/PanelDrawer/PanelTypeSelect.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelTypeSelect.tsx
@@ -20,13 +20,11 @@ export type PanelTypeSelectProps = Omit<SelectProps<string>, 'children'>;
  * Displays a MUI Select input for selecing a Panel type. Queries the plugin system to get the list of all panel types.
  */
 export function PanelTypeSelect(props: PanelTypeSelectProps) {
-  let { value, ...others } = props;
+  const { value: propValue, ...others } = props;
   const { data, isLoading } = useListPluginMetadata('Panel');
 
   // Pass an empty value while options are still loading so MUI doesn't complain about us using an "out of range" value
-  if (value !== '' && isLoading) {
-    value = '';
-  }
+  const value = propValue !== '' && isLoading ? '' : propValue;
 
   // TODO: Does this need a loading indicator of some kind?
   return (

--- a/ui/dashboards/src/test/render.tsx
+++ b/ui/dashboards/src/test/render.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { render, RenderOptions } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 /**
  * Test helper to render a React component with some common app-level providers wrapped around it.

--- a/ui/dashboards/src/test/render.tsx
+++ b/ui/dashboards/src/test/render.tsx
@@ -14,11 +14,11 @@
 import { render, RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false } } });
-
 /**
  * Test helper to render a React component with some common app-level providers wrapped around it.
  */
 export function renderWithContext(ui: React.ReactElement, options?: Omit<RenderOptions, 'queries'>) {
+  // Create a new QueryClient for each test to avoid caching issues
+  const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } } });
   return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>, options);
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -64,6 +64,7 @@
         "@perses-dev/panels-plugin": "^0.8.1",
         "@perses-dev/plugin-system": "^0.8.1",
         "@perses-dev/prometheus-plugin": "^0.8.1",
+        "@tanstack/react-query": "^4.7.1",
         "immer": "^9.0.15",
         "lodash-es": "^4.17.21",
         "mdi-material-ui": "^7.4.0",
@@ -71,7 +72,6 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-error-boundary": "^3.1.4",
-        "react-query": "^3.39.2",
         "react-router-dom": "^6.3.0",
         "use-immer": "^0.7.0",
         "use-resize-observer": "^9.0.0"
@@ -3894,6 +3894,41 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.7.1.tgz",
+      "integrity": "sha512-BzFI4KdiklxfUUgNiO6E4XsSwaX5NscuIhP7aqWbS8Hqik1KohfvO+SXpftSZHOyzm0+XpycRsip/QEs3Hx3AA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.7.1.tgz",
+      "integrity": "sha512-/3PBXuvdlvUbSv5eqgkda4VAN14t+rpDop9LnZmEmIMW8ARrbW7Rt6PYTya33JGaeo6XoztRzEH8TaY5S+neNQ==",
+      "dependencies": {
+        "@tanstack/query-core": "4.7.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.16.0.tgz",
@@ -5362,21 +5397,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "engines": {
-        "node": ">=0.6"
-      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -5466,6 +5494,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5481,21 +5510,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -5867,7 +5881,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concurrently": {
       "version": "7.4.0",
@@ -6402,7 +6417,8 @@
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -8272,7 +8288,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -8398,6 +8415,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8923,6 +8941,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8931,7 +8950,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -9997,11 +10017,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10359,15 +10374,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "node_modules/mathjs": {
       "version": "10.6.4",
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.6.4.tgz",
@@ -10469,11 +10475,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -10535,6 +10536,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10573,14 +10575,6 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
-      }
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dependencies": {
-        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -10830,11 +10824,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
-    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -10866,6 +10855,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -11062,6 +11052,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11605,31 +11596,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/react-query": {
-      "version": "3.39.2",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.2.tgz",
-      "integrity": "sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-resizable": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.4.tgz",
@@ -11846,11 +11812,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
-    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -11973,6 +11934,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -13369,15 +13331,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -13992,7 +13945,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -14170,9 +14124,9 @@
         "use-immer": "^0.7.0"
       },
       "peerDependencies": {
+        "@tanstack/react-query": "^4.7.1",
         "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0",
-        "react-query": "^3.34.16"
+        "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "prometheus-plugin": {
@@ -14188,8 +14142,7 @@
         "date-fns": "^2.28.0"
       },
       "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0",
-        "react-query": "^3.34.16"
+        "react": "^17.0.2 || ^18.0.0"
       }
     },
     "prometheus-plugin/node_modules/@prometheus-io/lezer-promql": {
@@ -16323,6 +16276,7 @@
         "@perses-dev/plugin-system": "^0.8.1",
         "@perses-dev/prometheus-plugin": "^0.8.1",
         "@svgr/webpack": "^6.3.0",
+        "@tanstack/react-query": "^4.7.1",
         "@types/loadable__component": "^5.13.4",
         "@types/webpack-bundle-analyzer": "^4.4.1",
         "css-loader": "^6.7.1",
@@ -16337,7 +16291,6 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-error-boundary": "^3.1.4",
-        "react-query": "^3.39.2",
         "react-router-dom": "^6.3.0",
         "style-loader": "^3.3.1",
         "ts-loader": "^9.3.1",
@@ -16817,6 +16770,20 @@
       "integrity": "sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==",
       "dev": true,
       "optional": true
+    },
+    "@tanstack/query-core": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.7.1.tgz",
+      "integrity": "sha512-BzFI4KdiklxfUUgNiO6E4XsSwaX5NscuIhP7aqWbS8Hqik1KohfvO+SXpftSZHOyzm0+XpycRsip/QEs3Hx3AA=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.7.1.tgz",
+      "integrity": "sha512-/3PBXuvdlvUbSv5eqgkda4VAN14t+rpDop9LnZmEmIMW8ARrbW7Rt6PYTya33JGaeo6XoztRzEH8TaY5S+neNQ==",
+      "requires": {
+        "@tanstack/query-core": "4.7.1",
+        "use-sync-external-store": "^1.2.0"
+      }
     },
     "@testing-library/dom": {
       "version": "8.16.0",
@@ -18023,18 +17990,14 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
-    },
-    "big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -18113,6 +18076,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -18125,21 +18089,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "browser-process-hrtime": {
@@ -18418,7 +18367,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "concurrently": {
       "version": "7.4.0",
@@ -18803,7 +18753,8 @@
     "detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true
     },
     "diff": {
       "version": "4.0.2",
@@ -20145,7 +20096,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -20231,6 +20183,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -20617,6 +20570,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -20625,7 +20579,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -21421,11 +21376,6 @@
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
       "dev": true
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -21710,15 +21660,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
       "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
     },
-    "match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "mathjs": {
       "version": "10.6.4",
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.6.4.tgz",
@@ -21796,11 +21737,6 @@
         "picomatch": "^2.3.1"
       }
     },
-    "microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -21844,6 +21780,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -21873,14 +21810,6 @@
       "requires": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
-      }
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "requires": {
-        "big-integer": "^1.6.16"
       }
     },
     "nanoid": {
@@ -22059,11 +21988,6 @@
         "es-abstract": "^1.19.1"
       }
     },
-    "oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
-    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -22089,6 +22013,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -22243,7 +22168,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -22628,16 +22554,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "react-query": {
-      "version": "3.39.2",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.2.tgz",
-      "integrity": "sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      }
-    },
     "react-resizable": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.4.tgz",
@@ -22803,11 +22719,6 @@
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "dev": true
     },
-    "remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
-    },
     "renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -22899,6 +22810,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -23945,15 +23857,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
-    "unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -24387,7 +24290,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -32,9 +32,9 @@
     "use-immer": "^0.7.0"
   },
   "peerDependencies": {
+    "@tanstack/react-query": "^4.7.1",
     "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0",
-    "react-query": "^3.34.16"
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "files": [
     "dist"

--- a/ui/plugin-system/src/runtime/graph-queries.ts
+++ b/ui/plugin-system/src/runtime/graph-queries.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { TimeSeriesQueryContext } from '../model';
 import { useLegacyDatasources } from './datasources-old';
 import { useTemplateVariableValues } from './template-variables';

--- a/ui/plugin-system/src/runtime/plugins.ts
+++ b/ui/plugin-system/src/runtime/plugins.ts
@@ -11,14 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useQuery, UseQueryOptions } from 'react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { usePluginRegistry } from '../components/PluginRegistry';
 import { PluginImplementation, PluginMetadata, PluginType } from '../model';
-import { getTypeAndKindKey } from '../utils/cache-keys';
 
 // Allows consumers to pass useQuery options from react-query when loading a plugin
 type UsePluginOptions<T extends PluginType> = Omit<
-  UseQueryOptions<PluginImplementation<T>, unknown, PluginImplementation<T>, string>,
+  UseQueryOptions<PluginImplementation<T>, unknown, PluginImplementation<T>, [string, string]>,
   'queryKey' | 'queryFn'
 >;
 
@@ -27,13 +26,12 @@ type UsePluginOptions<T extends PluginType> = Omit<
  */
 export function usePlugin<T extends PluginType>(pluginType: T, kind: string, options?: UsePluginOptions<T>) {
   const { getPlugin } = usePluginRegistry();
-  const queryKey = getTypeAndKindKey(pluginType, kind);
-  return useQuery(queryKey, () => getPlugin(pluginType, kind), options);
+  return useQuery([pluginType, kind], () => getPlugin(pluginType, kind), options);
 }
 
 // Allow consumers to pass useQuery options from react-query when listing metadata
 type UseListPluginMetadataOptions = Omit<
-  UseQueryOptions<PluginMetadata[], unknown, PluginMetadata[], string>,
+  UseQueryOptions<PluginMetadata[], unknown, PluginMetadata[], [string]>,
   'queryKey' | 'queryFn'
 >;
 
@@ -42,6 +40,5 @@ type UseListPluginMetadataOptions = Omit<
  */
 export function useListPluginMetadata(pluginType: PluginType, options?: UseListPluginMetadataOptions) {
   const { listPluginMetadata } = usePluginRegistry();
-  const queryKey: string = pluginType;
-  return useQuery(queryKey, () => listPluginMetadata(pluginType), options);
+  return useQuery([pluginType], () => listPluginMetadata(pluginType), options);
 }

--- a/ui/plugin-system/src/test/render.tsx
+++ b/ui/plugin-system/src/test/render.tsx
@@ -14,12 +14,11 @@
 import { render, RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-// Don't retry in tests
-const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } } });
-
 /**
  * Test helper to render a React component with some common app-level providers wrapped around it.
  */
 export function renderWithContext(ui: React.ReactElement, options?: Omit<RenderOptions, 'queries'>) {
+  // Create a new QueryClient for each test to avoid caching issues
+  const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } } });
   return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>, options);
 }

--- a/ui/plugin-system/src/test/render.tsx
+++ b/ui/plugin-system/src/test/render.tsx
@@ -12,13 +12,24 @@
 // limitations under the License.
 
 import { render, RenderOptions } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const testLogger = {
+  log: console.log,
+  warn: console.warn,
+  error: () => {
+    // Don't log network errors in tests to the console
+  },
+};
 
 /**
  * Test helper to render a React component with some common app-level providers wrapped around it.
  */
 export function renderWithContext(ui: React.ReactElement, options?: Omit<RenderOptions, 'queries'>) {
   // Create a new QueryClient for each test to avoid caching issues
-  const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } } });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } },
+    logger: testLogger,
+  });
   return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>, options);
 }

--- a/ui/plugin-system/src/test/setup-tests.ts
+++ b/ui/plugin-system/src/test/setup-tests.ts
@@ -11,15 +11,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { setLogger } from 'react-query';
-
 // Add testing library assertions
 import '@testing-library/jest-dom/extend-expect';
-
-setLogger({
-  log: console.log,
-  warn: console.warn,
-  error: () => {
-    // Don't log network errors to the console during tests
-  },
-});

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -35,8 +35,7 @@
     "date-fns": "^2.28.0"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0",
-    "react-query": "^3.34.16"
+    "react": "^17.0.2 || ^18.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This updates our `react-query` dependency to the latest major version (v4) which helps clean-up our Jest test logs in the dashboards package where we were getting some console error messages related to that package. I also cleaned up one other warning that was getting logged by MUI due to the panel types being loaded dynamically.