### PR TITLE
Shan/var chaining

### DIFF
--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -42,11 +42,12 @@ const demoDashboard: DashboardResource = {
         kind: 'ListVariable',
         spec: {
           name: 'instance',
+          allowAllValue: true,
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
             spec: {
               label_name: 'instance',
-              matchers: ['up{job="node"}'],
+              matchers: ['up{job="$job"}'],
             },
           },
         },
@@ -132,7 +133,7 @@ const demoDashboard: DashboardResource = {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
-                          '1 - node_filesystem_free_bytes{job="node",instance="$instance",fstype!="rootfs",mountpoint!~"/(run|var).*",mountpoint!=""} / node_filesystem_size_bytes{job="node",instance="$instance"}',
+                          '1 - node_filesystem_free_bytes{job="node",instance=~"$instance",fstype!="rootfs",mountpoint!~"/(run|var).*",mountpoint!=""} / node_filesystem_size_bytes{job="node",instance=~"$instance"}',
                       },
                     },
                   },
@@ -158,7 +159,7 @@ const demoDashboard: DashboardResource = {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
-                          'node_memory_MemTotal_bytes{job="node",instance="$instance"} - node_memory_MemFree_bytes{job="node",instance="$instance"} - node_memory_Buffers_bytes{job="node",instance="$instance"} - node_memory_Cached_bytes{job="node",instance="$instance"}',
+                          'node_memory_MemTotal_bytes{job="node",instance=~"$instance"} - node_memory_MemFree_bytes{job="node",instance=~"$instance"} - node_memory_Buffers_bytes{job="node",instance=~"$instance"} - node_memory_Cached_bytes{job="node",instance=~"$instance"}',
                       },
                     },
                   },
@@ -169,7 +170,7 @@ const demoDashboard: DashboardResource = {
                     plugin: {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
-                        query: 'node_memory_Buffers_bytes{job="node",instance="$instance"}',
+                        query: 'node_memory_Buffers_bytes{job="node",instance=~"$instance"}',
                       },
                     },
                   },
@@ -180,7 +181,7 @@ const demoDashboard: DashboardResource = {
                     plugin: {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
-                        query: 'node_memory_Cached_bytes{job="node",instance="$instance"}',
+                        query: 'node_memory_Cached_bytes{job="node",instance=~"$instance"}',
                       },
                     },
                   },
@@ -191,7 +192,7 @@ const demoDashboard: DashboardResource = {
                     plugin: {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
-                        query: 'node_memory_MemFree_bytes{job="node",instance="$instance"}',
+                        query: 'node_memory_MemFree_bytes{job="node",instance=~"$instance"}',
                       },
                     },
                   },
@@ -217,7 +218,7 @@ const demoDashboard: DashboardResource = {
                     plugin: {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
-                        query: 'node_load15{instance="$instance",job="node"}',
+                        query: 'node_load15{instance=~"$instance",job="node"}',
                       },
                     },
                   },
@@ -228,7 +229,7 @@ const demoDashboard: DashboardResource = {
                     plugin: {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
-                        query: 'node_load1{instance="$instance",job="node"}',
+                        query: 'node_load1{instance=~"$instance",job="node"}',
                       },
                     },
                   },
@@ -273,7 +274,7 @@ const demoDashboard: DashboardResource = {
                       kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
-                          'avg without (cpu)(rate(node_cpu_seconds_total{job="node",instance="$instance",mode!="idle"}[$interval]))',
+                          'avg without (cpu)(rate(node_cpu_seconds_total{job="node",instance=~"$instance",mode!="idle"}[$interval]))',
                       },
                     },
                   },
@@ -305,7 +306,7 @@ const demoDashboard: DashboardResource = {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
-                        'node_time_seconds{job="node",instance="$instance"} - node_boot_time_seconds{job="node",instance="$instance"}',
+                        'node_time_seconds{job="node",instance=~"$instance"} - node_boot_time_seconds{job="node",instance=~"$instance"}',
                     },
                   },
                 },
@@ -337,7 +338,7 @@ const demoDashboard: DashboardResource = {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
-                        '100 - ((node_memory_MemAvailable_bytes{job="node",instance="$instance"} * 100) / node_memory_MemTotal_bytes{job="node",instance="$instance"})',
+                        '100 - ((node_memory_MemAvailable_bytes{job="node",instance=~"$instance"} * 100) / node_memory_MemTotal_bytes{job="node",instance=~"$instance"})',
                     },
                   },
                 },
@@ -364,7 +365,7 @@ const demoDashboard: DashboardResource = {
                   plugin: {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
-                      query: 'node_memory_MemTotal_bytes{job="node",instance="$instance"}',
+                      query: 'node_memory_MemTotal_bytes{job="node",instance=~"$instance"}',
                     },
                   },
                 },
@@ -395,7 +396,7 @@ const demoDashboard: DashboardResource = {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
-                        'avg(node_load15{job="node",instance="$instance"}) /  count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu)) * 100',
+                        'avg(node_load15{job="node",instance=~"$instance"}) /  count(count(node_cpu_seconds_total{job="node",instance=~"$instance"}) by (cpu)) * 100',
                     },
                   },
                 },
@@ -431,7 +432,7 @@ const demoDashboard: DashboardResource = {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
-                        '(((count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance="$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))',
+                        '(((count(count(node_cpu_seconds_total{job="node",instance=~"$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance=~"$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance=~"$instance"}) by (cpu))',
                     },
                   },
                 },
@@ -461,7 +462,7 @@ const demoDashboard: DashboardResource = {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
-                        '(((count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance="$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance="$instance"}) by (cpu))',
+                        '(((count(count(node_cpu_seconds_total{job="node",instance=~"$instance"}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode="idle",job="node",instance=~"$instance"}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job="node",instance=~"$instance"}) by (cpu))',
                     },
                   },
                 },
@@ -498,7 +499,7 @@ const demoDashboard: DashboardResource = {
                   plugin: {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
-                      query: 'node_load15{instance="$instance",job="node"}',
+                      query: 'node_load15{instance=~"$instance",job="node"}',
                     },
                   },
                 },
@@ -541,7 +542,7 @@ const demoDashboard: DashboardResource = {
                     kind: 'PrometheusTimeSeriesQuery',
                     spec: {
                       query:
-                        'node_time_seconds{job="node",instance="$instance"} - node_boot_time_seconds{job="node",instance="$instance"}',
+                        'node_time_seconds{job="node",instance=~"$instance"} - node_boot_time_seconds{job="node",instance=~"$instance"}',
                     },
                   },
                 },

--- a/ui/app/sample-data/templateVariableDemo.ts
+++ b/ui/app/sample-data/templateVariableDemo.ts
@@ -100,14 +100,14 @@ const demoDashboard: DashboardResource = {
         spec: {
           display: { name: 'Prom HTTP Requests', description: 'This is a line chart' },
           plugin: {
-            kind: 'LineChart',
+            kind: 'TimeSeriesChart',
             spec: {
               queries: [
                 {
-                  kind: 'GraphQuery',
+                  kind: 'TimeSeriesQuery',
                   spec: {
                     plugin: {
-                      kind: 'PrometheusGraphQuery',
+                      kind: 'PrometheusTimeSeriesQuery',
                       spec: {
                         query:
                           'irate(prometheus_http_requests_total{job=~"$job", handler=~"$handler", code=~"$code"}[$interval])',

--- a/ui/app/sample-data/templateVariableDemo.ts
+++ b/ui/app/sample-data/templateVariableDemo.ts
@@ -1,0 +1,150 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DashboardResource } from '@perses-dev/core';
+
+const demoDashboard: DashboardResource = {
+  kind: 'Dashboard',
+  metadata: {
+    name: 'Template Variable Demo',
+    project: 'perses',
+    created_at: '2021-11-09',
+    updated_at: '2021-11-09',
+    version: 0,
+  },
+  spec: {
+    datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
+    duration: '30m',
+    variables: [
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'job',
+          allowAllValue: true,
+          defaultValue: 'prometheus',
+          plugin: {
+            kind: 'PrometheusLabelValuesVariable',
+            spec: {
+              label_name: 'job',
+            },
+          },
+        },
+      },
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'handler',
+          allowMultiple: true,
+          allowAllValue: true,
+          plugin: {
+            kind: 'PrometheusLabelValuesVariable',
+            spec: {
+              label_name: 'handler',
+              matchers: ['prometheus_http_requests_total{job=~"$job"}'],
+            },
+          },
+        },
+      },
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'code',
+          allowAllValue: true,
+          plugin: {
+            kind: 'PrometheusLabelValuesVariable',
+            spec: {
+              label_name: 'code',
+              matchers: ['prometheus_http_requests_total{job=~"$job", handler=~"$handler"}'],
+            },
+          },
+        },
+      },
+
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'interval',
+          plugin: {
+            kind: 'StaticListVariable',
+            spec: {
+              values: ['1m', '5m', '10m'],
+            },
+          },
+        },
+      },
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'labelNames',
+          allowMultiple: true,
+          plugin: {
+            kind: 'PrometheusLabelNamesVariable',
+            spec: {},
+          },
+        },
+      },
+    ],
+    panels: {
+      demoPanel: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'Prom HTTP Requests', description: 'This is a line chart' },
+          plugin: {
+            kind: 'LineChart',
+            spec: {
+              queries: [
+                {
+                  kind: 'GraphQuery',
+                  spec: {
+                    plugin: {
+                      kind: 'PrometheusGraphQuery',
+                      spec: {
+                        query:
+                          'irate(prometheus_http_requests_total{job=~"$job", handler=~"$handler", code=~"$code"}[$interval])',
+                      },
+                    },
+                  },
+                },
+              ],
+              unit: { kind: 'Bytes' },
+            },
+          },
+        },
+      },
+    },
+    layouts: [
+      {
+        kind: 'Grid',
+        spec: {
+          display: {
+            title: 'Sample Row',
+            collapse: {
+              open: true,
+            },
+          },
+          items: [
+            {
+              x: 0,
+              y: 0,
+              width: 24,
+              height: 6,
+              content: { $ref: '#/spec/panels/demoPanel' },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+export default demoDashboard;

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useMemo } from 'react';
-import { useSearchParams, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { Box, useTheme } from '@mui/material';
 import {
   ChartsThemeProvider,
@@ -36,10 +36,7 @@ const ECHARTS_THEME_OVERRIDES = {};
 function App() {
   const { getInstalledPlugins, importPluginModule } = useBundledPlugins();
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // TODO: remove temporary location.key reload hack when routing setup properly
-  const location = useLocation();
+  const [searchParams] = useSearchParams();
 
   const muiTheme = useTheme();
   const chartsTheme: PersesChartsTheme = useMemo(() => {
@@ -67,10 +64,10 @@ function App() {
           <ChartsThemeProvider themeName="perses" chartsTheme={chartsTheme}>
             <PluginRegistry getInstalledPlugins={getInstalledPlugins} importPluginModule={importPluginModule}>
               <LegacyDataSourceRegistry>
-                <QueryStringProvider queryString={searchParams} setQueryString={setSearchParams}>
+                <QueryStringProvider queryString={searchParams}>
                   <ErrorBoundary FallbackComponent={ErrorAlert}>
                     {/* temp fix to ensure dashboard refreshes when URL changes since setQueryString not reloading as expected  */}
-                    <ViewDashboard key={location.key} />
+                    <ViewDashboard />
                   </ErrorBoundary>
                 </QueryStringProvider>
               </LegacyDataSourceRegistry>

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -46,7 +46,8 @@
   "peerDependencies": {
     "@mui/material": "^5.6.0",
     "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react-dom": "^17.0.2 || ^18.0.0",
+    "react-query": "^3.34.16"
   },
   "files": [
     "dist"

--- a/ui/plugin-system/src/model/variables.ts
+++ b/ui/plugin-system/src/model/variables.ts
@@ -12,12 +12,13 @@
 // limitations under the License.
 
 import { ListVariableDefinition } from '@perses-dev/core';
-import { LegacyDatasources } from '../runtime';
+import { LegacyDatasources, VariableStateMap } from '../runtime';
 
 export type VariableOption = { label: string; value: string };
 
 export interface GetVariableOptionsContext {
   datasources: LegacyDatasources;
+  variables: VariableStateMap;
 }
 
 /**
@@ -25,6 +26,9 @@ export interface GetVariableOptionsContext {
  */
 export interface VariablePlugin<Spec = unknown> {
   getVariableOptions: GetVariableOptions<Spec>;
+
+  /** Returns a list of variables name this variable depends on. Used to optimize fetching */
+  dependsOn?: (definition: ListVariableDefinition<Spec>) => string[];
 }
 
 /**

--- a/ui/plugin-system/src/runtime/template-variables.ts
+++ b/ui/plugin-system/src/runtime/template-variables.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import { VariableName, VariableValue } from '@perses-dev/core';
 import { VariableOption } from '../model';
 
@@ -43,17 +43,20 @@ function useTemplateVariableContext() {
 export function useTemplateVariableValues(names?: string[]) {
   const { state } = useTemplateVariableContext();
 
+  const values = useMemo(() => {
+    const values: VariableStateMap = {};
+    names?.forEach((name) => {
+      const s = state[name];
+      if (s) {
+        values[name] = s;
+      }
+    });
+    return values;
+  }, [state, names]);
+
   if (names === undefined) {
     return state;
   }
-
-  const values: VariableStateMap = {};
-  names.forEach((name) => {
-    const s = state[name];
-    if (s) {
-      values[name] = s;
-    }
-  });
 
   return values;
 }

--- a/ui/prometheus-plugin/src/model/utils.test.ts
+++ b/ui/prometheus-plugin/src/model/utils.test.ts
@@ -11,7 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { parseTemplateVariables, replaceTemplateVariable, replaceTemplateVariables } from './utils';
+import {
+  parseTemplateVariables,
+  replaceTemplateVariable,
+  replaceTemplateVariables,
+  replaceTemplateVariablesInObject,
+} from './utils';
 
 describe('parseTemplateVariables()', () => {
   const tests = [
@@ -86,6 +91,41 @@ describe('replaceTemplateVariables()', () => {
   tests.forEach(({ text, state, expected }) => {
     it(`replaces ${text} ${JSON.stringify(state)}`, () => {
       expect(replaceTemplateVariables(text, state)).toEqual(expected);
+    });
+  });
+});
+
+describe('replaceTemplateVariablesInObject()', () => {
+  const tests = [
+    {
+      obj: {
+        hello: '$var1',
+      },
+      state: {
+        var1: { value: 'world', loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: {
+        hello: 'world',
+      },
+    },
+    {
+      obj: {
+        query: ['$var1', 'foo', '$var2'],
+      },
+      state: {
+        var1: { value: 'world', loading: false },
+        var2: { value: 'world2', loading: false },
+      },
+      expected: {
+        query: ['world', 'foo', 'world2'],
+      },
+    },
+  ];
+
+  tests.forEach(({ obj, state, expected }) => {
+    it(`replaces ${JSON.stringify(obj)} ${JSON.stringify(state)}`, () => {
+      expect(replaceTemplateVariablesInObject(obj, state)).toEqual(expected);
     });
   });
 });

--- a/ui/prometheus-plugin/src/model/utils.ts
+++ b/ui/prometheus-plugin/src/model/utils.ts
@@ -62,3 +62,12 @@ export const parseTemplateVariables = (text: string) => {
   // return unique matches
   return Array.from(new Set(matches));
 };
+
+export function replaceTemplateVariablesInObject(obj: object, variables: VariableStateMap) {
+  // TODO: This is a simple way of interpolating. Technically, this will interpolate property names as well
+  // but this shouldn't happen since no properties should have a $ in them. If this is the case,
+  // we should modify this function to only interpolate allowed values.
+  const str = JSON.stringify(obj);
+  const interpolatedStr = replaceTemplateVariables(str, variables);
+  return JSON.parse(interpolatedStr);
+}

--- a/ui/prometheus-plugin/src/plugins/variable.ts
+++ b/ui/prometheus-plugin/src/plugins/variable.ts
@@ -31,4 +31,5 @@ export const StaticListVariable: VariablePlugin<StaticListVariableOptions> = {
       data: values,
     };
   },
+  dependsOn: () => [],
 };


### PR DESCRIPTION
Video demo: https://www.loom.com/share/82d034251f8c4d628cfdc23b6cf8dce9

This includes the following:
- PromQL variables now support variable chaining. Meaning you can use another variable's value in a variable definition.
For example, lets assume you had a variable called `job`, you can use that in your definition. The `handler` variable will update whenever the `job` variable value changes.
```ts
spec: {
   label_name: 'handler',
   matchers: ['prometheus_http_requests_total{job=~"$job"}'],
},
````
- Moves variable options loading to react-query
- Modifies the plugin spec to include a new property called `dependsOn` which allows the plugin to return a list of variables a variable depends on. This optimizes loading of variables and also gives the ability to let the "framework" which variables a variable depends on to build features like a dependency graph in the future. We could potentially use this paradigm for TimeSeriesQuery plugin as well.

 

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>