### PR TITLE
use GOHOSTARCH and GOHOSTOS for code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ GO                    ?= go
 CUE                   ?= cue
 GOCI                  ?= golangci-lint
 GOFMT                 ?= $(GO)fmt
-GOARCH                ?= amd64
+GOOS                  ?= $(shell $(GO) env GOOS)
+GOARCH                ?= $(shell $(GO) env GOARCH)
+GOHOSTOS              ?= $(shell $(GO) env GOHOSTOS)
+GOHOSTARCH            ?= $(shell $(GO) env GOHOSTARCH)
 COMMIT                := $(shell git rev-parse HEAD)
 DATE                  := $(shell date +%Y-%m-%d)
 BRANCH                := $(shell git rev-parse --abbrev-ref HEAD)
@@ -117,7 +120,7 @@ build: build-ui build-api build-cli
 .PHONY: build-api
 build-api: generate
 	@echo ">> build the perses api"
-	CGO_ENABLED=0 GOARCH=${GOARCH} $(GO) build -ldflags "${LDFLAGS}" -o ./bin/perses ./cmd/perses
+	CGO_ENABLED=0 GOARCH=${GOARCH} GOOS=${GOOS} $(GO) build -ldflags "${LDFLAGS}" -o ./bin/perses ./cmd/perses
 
 .PHONY: build-ui
 build-ui:
@@ -126,11 +129,11 @@ build-ui:
 .PHONY: build-cli
 build-cli:
 	@echo ">> build the perses cli"
-	CGO_ENABLED=0 GOARCH=${GOARCH} $(GO) build -ldflags "${LDFLAGS}" -o ./bin/percli ./cmd/percli
+	CGO_ENABLED=0 GOARCH=${GOARCH} GOOS=${GOOS} $(GO) build -ldflags "${LDFLAGS}" -o ./bin/percli ./cmd/percli
 
 .PHONY: generate
 generate: assets-compress
-	$(GO) generate ./internal/api
+	GOARCH=${GOHOSTARCH} GOOS=${GOHOSTOS} $(GO) generate ./internal/api
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
After trying to use promu to improve our CI, when you are cross-building the binary, the code generation should use the host arch and host os and shouldn't depend on the cross build variable.

This PR is fixing that, so the code generation doesn't depend on the cross build variable.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>