### PR TITLE
Add optional datasource selector to spec for Prom variables and time series queries

### DIFF
--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -41,7 +41,7 @@ export function useDatasourceApi(): DatasourceStoreProviderProps['datasourceApi'
             plugin: {
               kind: 'PrometheusDatasource',
               spec: {
-                url: 'https://prometheus.demo.do.prometheus.io',
+                direct_url: 'https://prometheus.demo.do.prometheus.io',
               },
             },
           },

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -11,17 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AbsoluteTimeRange, TimeSeriesQueryDefinition, UnixTimeMs } from '@perses-dev/core';
+import { AbsoluteTimeRange, UnixTimeMs } from '@perses-dev/core';
 import { DatasourceStore, VariableStateMap } from '../runtime';
 
 /**
  * A plugin for running graph queries.
  */
 export interface TimeSeriesQueryPlugin<Spec = unknown> {
-  getTimeSeriesData: (
-    definition: TimeSeriesQueryDefinition<Spec>,
-    ctx: TimeSeriesQueryContext
-  ) => Promise<TimeSeriesData>;
+  getTimeSeriesData: (spec: Spec, ctx: TimeSeriesQueryContext) => Promise<TimeSeriesData>;
 }
 
 /**

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -50,7 +50,7 @@ export const useTimeSeriesQueryData = (definition: TimeSeriesQueryDefinition, op
         throw new Error('Expected plugin to be loaded');
       }
       const [definition, context] = queryKey;
-      return plugin.getTimeSeriesData(definition, context);
+      return plugin.getTimeSeriesData(definition.spec.plugin.spec, context);
     },
     { enabled: plugin !== undefined }
   );

--- a/ui/prometheus-plugin/plugin.json
+++ b/ui/prometheus-plugin/plugin.json
@@ -36,6 +36,14 @@
           "name": "Prometheus Range Query",
           "description": ""
         }
+      },
+      {
+        "pluginType": "Datasource",
+        "kind": "PrometheusDatasource",
+        "display": {
+          "name": "Prometheus Datasource",
+          "description": ""
+        }
       }
     ]
   }

--- a/ui/prometheus-plugin/src/model/prometheus-client.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-client.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { fetchJson } from '@perses-dev/core';
+import { DatasourceSelector, fetchJson } from '@perses-dev/core';
 import {
   InstantQueryRequestParameters,
   InstantQueryResponse,
@@ -28,7 +28,12 @@ export interface QueryOptions {
 }
 
 export interface PrometheusDatasourceSpec {
-  url: string;
+  // TODO: Make optional for proxy scenario
+  direct_url: string;
+}
+
+export interface PrometheusDatasourceSelector extends DatasourceSelector {
+  kind: 'PrometheusDatasource';
 }
 
 /**
@@ -63,7 +68,7 @@ export function labelValues(params: LabelValuesRequestParameters, queryOptions: 
 
 function fetchWithGet<T extends RequestParams<T>, TResponse>(apiURI: string, params: T, queryOptions: QueryOptions) {
   const {
-    datasource: { url: datasourceURL },
+    datasource: { direct_url: datasourceURL },
   } = queryOptions;
 
   let url = `${datasourceURL}${apiURI}`;
@@ -76,7 +81,7 @@ function fetchWithGet<T extends RequestParams<T>, TResponse>(apiURI: string, par
 
 function fetchWithPost<T extends RequestParams<T>, TResponse>(apiURI: string, params: T, queryOptions: QueryOptions) {
   const {
-    datasource: { url: datasourceURL },
+    datasource: { direct_url: datasourceURL },
   } = queryOptions;
 
   const url = `${datasourceURL}${apiURI}`;

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
@@ -16,5 +16,5 @@ import { PrometheusDatasourceSpec } from '../model/prometheus-client';
 
 export const PrometheusDatasource: DatasourcePlugin<PrometheusDatasourceSpec> = {
   OptionsEditorComponent: () => null,
-  createInitialOptions: () => ({ url: '' }),
+  createInitialOptions: () => ({ direct_url: '' }),
 };

--- a/ui/prometheus-plugin/src/plugins/time-series-query.ts
+++ b/ui/prometheus-plugin/src/plugins/time-series-query.ts
@@ -21,19 +21,17 @@ import { TemplateString } from '../model/templating';
 import { getDurationStringSeconds, getPrometheusTimeRange, getRangeStep } from '../model/time';
 import { replaceTemplateVariables } from '../model/utils';
 
-interface PrometheusTimeSeriesQueryOptions {
+interface PrometheusTimeSeriesQuerySpec {
   query: TemplateString;
   min_step?: DurationString;
   resolution?: number;
 }
 
-const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>['getTimeSeriesData'] = async (
-  definition,
+const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
+  spec,
   context
 ) => {
-  const pluginSpec = definition.spec.plugin.spec;
-
-  const minStep = getDurationStringSeconds(pluginSpec.min_step);
+  const minStep = getDurationStringSeconds(spec.min_step);
   const timeRange = getPrometheusTimeRange(context.timeRange);
   const step = getRangeStep(timeRange, minStep, undefined, context.suggestedStepMs);
 
@@ -47,7 +45,7 @@ const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>
   end = alignedEnd;
 
   // Replace template variable placeholders in PromQL query
-  let query = pluginSpec.query.replace('$__rate_interval', `15s`);
+  let query = spec.query.replace('$__rate_interval', `15s`);
   query = replaceTemplateVariables(query, context.variableState);
 
   // Get the datasource (TODO: Use selector from JSON instead of hardcoded one)
@@ -98,6 +96,6 @@ const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions>
 /**
  * The core Prometheus TimeSeriesQuery plugin for Perses.
  */
-export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryOptions> = {
+export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec> = {
   getTimeSeriesData,
 };


### PR DESCRIPTION
This just adds an optional datasource selector to both the Prometheus variable and time series query specs. I also switched up the time series query plugins to just take the spec object and not the entire definition when fetching time series data.