### PR TITLE
Add client concept to Datasource plugins

### DIFF
--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -25,26 +25,30 @@ export function useDatasourceApi(): DatasourceStoreProviderProps['datasourceApi'
 
       // Just resolve a default PrometheusDatasource right now
       if (selector.kind === 'PrometheusDatasource' && selector.name === undefined) {
+        const name = 'PrometheusDemo';
         return {
-          kind: 'GlobalDatasource',
-          metadata: {
-            name: 'PrometheusDemo',
-            created_at: '',
-            updated_at: '',
-            version: 0,
-          },
-          spec: {
-            default: true,
-            display: {
-              name: 'Prometheus Demo',
+          resource: {
+            kind: 'GlobalDatasource',
+            metadata: {
+              name,
+              created_at: '',
+              updated_at: '',
+              version: 0,
             },
-            plugin: {
-              kind: 'PrometheusDatasource',
-              spec: {
-                direct_url: 'https://prometheus.demo.do.prometheus.io',
+            spec: {
+              default: true,
+              display: {
+                name: 'Prometheus Demo',
+              },
+              plugin: {
+                kind: 'PrometheusDatasource',
+                spec: {
+                  direct_url: 'https://prometheus.demo.do.prometheus.io',
+                },
               },
             },
           },
+          proxyUrl: `/proxy/globaldatasources/${encodeURIComponent(name)}`,
         };
       }
       return undefined;

--- a/ui/dashboards/src/context/DatasourceStoreProvider.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   DashboardResource,
   DashboardSpec,
@@ -21,7 +21,7 @@ import {
   GlobalDatasource,
   useEvent,
 } from '@perses-dev/core';
-import { DatasourceStoreContext, DatasourceStore } from '@perses-dev/plugin-system';
+import { DatasourceStoreContext, DatasourceStore, usePluginRegistry } from '@perses-dev/plugin-system';
 
 export interface DatasourceStoreProviderProps {
   dashboardResource: DashboardResource;
@@ -41,35 +41,57 @@ export interface DatasourceApi {
 export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
   const { dashboardResource, datasourceApi, children } = props;
 
-  const getDatasource = useEvent(async (selector: DatasourceSelector): Promise<DatasourceSpec> => {
+  const { getPlugin } = usePluginRegistry();
+
+  const findDatasource = useEvent(async (selector: DatasourceSelector) => {
     // Try to find it in dashboard spec
     const { datasources } = dashboardResource.spec;
     const dashboardDatasource = findDashboardDatasource(datasources, selector);
     if (dashboardDatasource !== undefined) {
-      return dashboardDatasource;
+      return { spec: dashboardDatasource, proxyUrl: undefined };
     }
 
     // Try to find it at the project level as a Datasource resource
     const { project } = dashboardResource.metadata;
     const datasource = await datasourceApi.getDatasource(project, selector);
     if (datasource !== undefined) {
-      return datasource.spec;
+      return { spec: datasource.spec, proxyUrl: '' };
     }
 
     // Try to find it at the global level as a GlobalDatasource resource
     const globalDatasource = await datasourceApi.getGlobalDatasource(selector);
     if (globalDatasource !== undefined) {
-      return globalDatasource.spec;
+      return { spec: globalDatasource.spec, proxyUrl: '' };
     }
 
     throw new Error(`No datasource found for kind '${selector.kind}' and name '${selector.name}'`);
   });
 
+  // Gets a datasource spec for a given selector
+  const getDatasource = useCallback(
+    async (selector: DatasourceSelector): Promise<DatasourceSpec> => {
+      const { spec } = await findDatasource(selector);
+      return spec;
+    },
+    [findDatasource]
+  );
+
+  // Given a Datasource selector, finds the spec for it and then uses its corresponding plugin the create a client
+  const getDatasourceClient = useCallback(
+    async function getClient<Client>(selector: DatasourceSelector): Promise<Client> {
+      const { kind } = selector;
+      const [{ spec, proxyUrl }, plugin] = await Promise.all([findDatasource(selector), getPlugin('Datasource', kind)]);
+      return plugin.createClient(spec.plugin.spec, { proxyUrl }) as Client;
+    },
+    [findDatasource, getPlugin]
+  );
+
   const ctxValue: DatasourceStore = useMemo(
     () => ({
       getDatasource,
+      getDatasourceClient,
     }),
-    [getDatasource]
+    [getDatasource, getDatasourceClient]
   );
 
   return <DatasourceStoreContext.Provider value={ctxValue}>{children}</DatasourceStoreContext.Provider>;

--- a/ui/dashboards/src/context/DatasourceStoreProvider.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.tsx
@@ -31,8 +31,14 @@ export interface DatasourceStoreProviderProps {
 
 // The external API for fetching datasource resources
 export interface DatasourceApi {
-  getDatasource: (project: string, selector: DatasourceSelector) => Promise<Datasource | undefined>;
-  getGlobalDatasource: (selector: DatasourceSelector) => Promise<GlobalDatasource | undefined>;
+  getDatasource: (
+    project: string,
+    selector: DatasourceSelector
+  ) => Promise<{ resource: Datasource; proxyUrl: string } | undefined>;
+
+  getGlobalDatasource: (
+    selector: DatasourceSelector
+  ) => Promise<{ resource: GlobalDatasource; proxyUrl: string } | undefined>;
 }
 
 /**
@@ -55,13 +61,13 @@ export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
     const { project } = dashboardResource.metadata;
     const datasource = await datasourceApi.getDatasource(project, selector);
     if (datasource !== undefined) {
-      return { spec: datasource.spec, proxyUrl: '' };
+      return { spec: datasource.resource.spec, proxyUrl: datasource.proxyUrl };
     }
 
     // Try to find it at the global level as a GlobalDatasource resource
     const globalDatasource = await datasourceApi.getGlobalDatasource(selector);
     if (globalDatasource !== undefined) {
-      return { spec: globalDatasource.spec, proxyUrl: '' };
+      return { spec: globalDatasource.resource.spec, proxyUrl: globalDatasource.proxyUrl };
     }
 
     throw new Error(`No datasource found for kind '${selector.kind}' and name '${selector.name}'`);

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -15,7 +15,13 @@ import { DatasourceSelector, DatasourceSpec } from '@perses-dev/core';
 import { createContext, useContext } from 'react';
 
 export interface DatasourceStore {
+  // TODO: Do we even need this method?
   getDatasource(selector: DatasourceSelector): Promise<DatasourceSpec>;
+
+  /**
+   * Given a DatasourceSelector, gets a `Client` object from the corresponding Datasource plugin.
+   */
+  getDatasourceClient<Client>(selector: DatasourceSelector): Promise<Client>;
 }
 
 export const DatasourceStoreContext = createContext<DatasourceStore | undefined>(undefined);

--- a/ui/prometheus-plugin/src/model/index.ts
+++ b/ui/prometheus-plugin/src/model/index.ts
@@ -11,17 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
-
-/**
- * Plugin that defines options for an external system that Perses talks to for data.
- */
-export interface DatasourcePlugin<Spec = unknown, Client = unknown> {
-  createClient: (spec: Spec, options: DatasourceClientOptions) => Client;
-  OptionsEditorComponent: OptionsEditor<Spec>;
-  createInitialOptions: InitialOptionsCallback<Spec>;
-}
-
-export interface DatasourceClientOptions {
-  proxyUrl?: string;
-}
+export * from './api-types';
+export * from './parse-sample-values';
+export * from './prometheus-client';
+export * from './prometheus-selectors';
+export * from './templating';
+export * from './time';
+export * from './utils';

--- a/ui/prometheus-plugin/src/model/prometheus-client.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-client.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DatasourceSelector, fetchJson } from '@perses-dev/core';
+import { fetchJson } from '@perses-dev/core';
 import {
   InstantQueryRequestParameters,
   InstantQueryResponse,
@@ -23,17 +23,15 @@ import {
   RangeQueryResponse,
 } from './api-types';
 
+export interface PrometheusClient {
+  instantQuery(params: InstantQueryRequestParameters): Promise<InstantQueryResponse>;
+  rangeQuery(params: RangeQueryRequestParameters): Promise<RangeQueryResponse>;
+  labelNames(params: LabelNamesRequestParameters): Promise<LabelNamesResponse>;
+  labelValues(params: LabelValuesRequestParameters): Promise<LabelValuesResponse>;
+}
+
 export interface QueryOptions {
-  datasource: PrometheusDatasourceSpec;
-}
-
-export interface PrometheusDatasourceSpec {
-  // TODO: Make optional for proxy scenario
-  direct_url: string;
-}
-
-export interface PrometheusDatasourceSelector extends DatasourceSelector {
-  kind: 'PrometheusDatasource';
+  datasourceUrl: string;
 }
 
 /**
@@ -67,11 +65,9 @@ export function labelValues(params: LabelValuesRequestParameters, queryOptions: 
 }
 
 function fetchWithGet<T extends RequestParams<T>, TResponse>(apiURI: string, params: T, queryOptions: QueryOptions) {
-  const {
-    datasource: { direct_url: datasourceURL },
-  } = queryOptions;
+  const { datasourceUrl } = queryOptions;
 
-  let url = `${datasourceURL}${apiURI}`;
+  let url = `${datasourceUrl}${apiURI}`;
   const urlParams = createSearchParams(params).toString();
   if (urlParams !== '') {
     url += `?${urlParams}`;
@@ -80,11 +76,9 @@ function fetchWithGet<T extends RequestParams<T>, TResponse>(apiURI: string, par
 }
 
 function fetchWithPost<T extends RequestParams<T>, TResponse>(apiURI: string, params: T, queryOptions: QueryOptions) {
-  const {
-    datasource: { direct_url: datasourceURL },
-  } = queryOptions;
+  const { datasourceUrl } = queryOptions;
 
-  const url = `${datasourceURL}${apiURI}`;
+  const url = `${datasourceUrl}${apiURI}`;
   const init = {
     method: 'POST',
     headers: {

--- a/ui/prometheus-plugin/src/model/prometheus-selectors.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-selectors.ts
@@ -11,17 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
+import { DatasourceSelector } from '@perses-dev/core';
 
 /**
- * Plugin that defines options for an external system that Perses talks to for data.
+ * DatasourceSelector for Prom Datasources.
  */
-export interface DatasourcePlugin<Spec = unknown, Client = unknown> {
-  createClient: (spec: Spec, options: DatasourceClientOptions) => Client;
-  OptionsEditorComponent: OptionsEditor<Spec>;
-  createInitialOptions: InitialOptionsCallback<Spec>;
+export interface PrometheusDatasourceSelector extends DatasourceSelector {
+  kind: 'PrometheusDatasource';
 }
 
-export interface DatasourceClientOptions {
-  proxyUrl?: string;
-}
+/**
+ * A default selector that asks for the default Prom Datasource.
+ */
+export const DEFAULT_PROM: PrometheusDatasourceSelector = { kind: 'PrometheusDatasource' };

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
@@ -26,7 +26,10 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
   const { proxyUrl } = options;
 
   // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
-  const datasourceUrl = direct_url ?? proxyUrl ?? window.location.origin;
+  const datasourceUrl = direct_url ?? proxyUrl;
+  if (datasourceUrl === undefined) {
+    throw new Error('No URL specified for Prometheus client. You can use direct_url in the spec to configure it.');
+  }
 
   // Could think about this becoming a class, although it definitely doesn't have to be
   return {

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
@@ -12,9 +12,34 @@
 // limitations under the License.
 
 import { DatasourcePlugin } from '@perses-dev/plugin-system';
-import { PrometheusDatasourceSpec } from '../model/prometheus-client';
+import { instantQuery, rangeQuery, labelNames, labelValues, PrometheusClient } from '../model';
 
-export const PrometheusDatasource: DatasourcePlugin<PrometheusDatasourceSpec> = {
+export interface PrometheusDatasourceSpec {
+  // TODO: Make optional for proxy scenario
+  direct_url?: string;
+}
+
+/**
+ * Creates a PrometheusClient for a specific datasource spec.
+ */
+const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>['createClient'] = (spec, options) => {
+  const { direct_url } = spec;
+  const { proxyUrl } = options;
+
+  // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
+  const datasourceUrl = direct_url ?? proxyUrl ?? window.location.origin;
+
+  // TODO: Could think about this maybe becoming a class, although it definitely doesn't have to be
+  return {
+    instantQuery: (params) => instantQuery(params, { datasourceUrl }),
+    rangeQuery: (params) => rangeQuery(params, { datasourceUrl }),
+    labelNames: (params) => labelNames(params, { datasourceUrl }),
+    labelValues: (params) => labelValues(params, { datasourceUrl }),
+  };
+};
+
+export const PrometheusDatasource: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient> = {
+  createClient,
   OptionsEditorComponent: () => null,
   createInitialOptions: () => ({ direct_url: '' }),
 };

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
@@ -15,7 +15,6 @@ import { DatasourcePlugin } from '@perses-dev/plugin-system';
 import { instantQuery, rangeQuery, labelNames, labelValues, PrometheusClient } from '../model';
 
 export interface PrometheusDatasourceSpec {
-  // TODO: Make optional for proxy scenario
   direct_url?: string;
 }
 
@@ -29,7 +28,7 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
   // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
   const datasourceUrl = direct_url ?? proxyUrl ?? window.location.origin;
 
-  // TODO: Could think about this maybe becoming a class, although it definitely doesn't have to be
+  // Could think about this becoming a class, although it definitely doesn't have to be
   return {
     instantQuery: (params) => instantQuery(params, { datasourceUrl }),
     rangeQuery: (params) => rangeQuery(params, { datasourceUrl }),


### PR DESCRIPTION
This adds a `createClient` property to Datasource plugins. What is a client you might ask? Well, right now, it's whatever kind of object a plugin wants it to be, just so long as it takes a datasource spec and turns it into something useful. In our Prometheus plugin, we have a `PrometheusClient` object which just has methods for communicating with a Prometheus API.  Other future Datasource plugins might have their own client objects, perhaps using some well-known Javascript library for communicating with a server.

There might come a time when we decide a Datasource's client needs to implement some kind of common functionality (maybe like a health check?) but we'll see how it evolves. This also gives some flexibility to people embedding to, for example, use their own Prometheus client with additional headers injected in requests, etc.