### PR TITLE
Move more complicated panel editing logic into dashboard state store

### DIFF
--- a/ui/core/src/utils/panel-refs.ts
+++ b/ui/core/src/utils/panel-refs.ts
@@ -23,7 +23,7 @@ export function resolvePanelRef(spec: DashboardSpec, panelRef: PanelRef) {
   if (panelDefinition === undefined) {
     throw new Error(`Could not resolve panels reference ${panelRef.$ref}`);
   }
-  return { panelDefinition, panelsKey };
+  return panelDefinition;
 }
 
 /**

--- a/ui/dashboards/src/components/Dashboard.tsx
+++ b/ui/dashboards/src/components/Dashboard.tsx
@@ -29,13 +29,13 @@ export function Dashboard(props: DashboardProps) {
   return (
     <Box {...others}>
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        {spec.layouts.map((layout, idx) => (
+        {spec.layouts.map((layout, groupIndex) => (
           <GridLayout
-            key={`${JSON.stringify(spec.layouts)} ${idx}`} // reset grid layout states when spec.layout changes
-            groupIndex={idx}
+            key={`${JSON.stringify(spec.layouts)} ${groupIndex}`} // reset grid layout states when spec.layout changes
+            groupIndex={groupIndex}
             definition={layout}
-            renderGridItemContent={(definition, groupIndex) => (
-              <GridItemContent content={definition.content} spec={spec} groupIndex={groupIndex} />
+            renderGridItemContent={(definition, itemIndex) => (
+              <GridItemContent content={definition.content} spec={spec} groupIndex={groupIndex} itemIndex={itemIndex} />
             )}
           />
         ))}

--- a/ui/dashboards/src/components/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar.tsx
@@ -16,7 +16,7 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import AddPanelGroupIcon from 'mdi-material-ui/PlusBoxOutline';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
-import { useDashboardApp, useEditMode } from '../context';
+import { useDashboardApp, useEditMode, usePanels } from '../context';
 import { TemplateVariableList, TimeRangeControls } from '../components';
 
 export interface DashboardToolbarProps {
@@ -27,7 +27,8 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   const { dashboardName } = props;
 
   const { isEditMode, setEditMode } = useEditMode();
-  const { openPanelDrawer, openPanelGroupDialog } = useDashboardApp();
+  const { openPanelGroupDialog } = useDashboardApp();
+  const { addPanel } = usePanels();
 
   const onEditButtonClick = () => {
     setEditMode(true);
@@ -66,7 +67,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               <Button startIcon={<AddPanelGroupIcon />} onClick={() => openPanelGroupDialog()}>
                 Add Panel Group
               </Button>
-              <Button startIcon={<AddPanelIcon />} onClick={() => openPanelDrawer({ groupIndex: 0 })}>
+              <Button startIcon={<AddPanelIcon />} onClick={() => addPanel(0)}>
                 Add Panel
               </Button>
               <TimeRangeControls />

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -19,16 +19,17 @@ export interface GridItemContentProps {
   spec: DashboardSpec;
   content: GridItemDefinition['content'];
   groupIndex: number;
+  itemIndex: number;
 }
 
 /**
  * Resolves the reference to panel content in a GridItemDefinition and renders the panel.
  */
 export function GridItemContent(props: GridItemContentProps) {
-  const { content, spec, groupIndex } = props;
+  const { content, spec, groupIndex, itemIndex } = props;
   try {
-    const { panelDefinition, panelsKey } = resolvePanelRef(spec, content);
-    return <Panel definition={panelDefinition} groupIndex={groupIndex} panelKey={panelsKey} />;
+    const panelDefinition = resolvePanelRef(spec, content);
+    return <Panel definition={panelDefinition} groupIndex={groupIndex} itemIndex={itemIndex} />;
   } catch (err) {
     return <ErrorAlert error={err as Error} />;
   }

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -23,7 +23,7 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
 export interface GridLayoutProps extends BoxProps {
   groupIndex: number;
   definition: GridDefinition;
-  renderGridItemContent: (definition: GridItemDefinition, groupIndex: number) => React.ReactNode;
+  renderGridItemContent: (definition: GridItemDefinition, itemIndex: number) => React.ReactNode;
 }
 
 /**
@@ -48,7 +48,7 @@ export function GridLayout(props: GridLayoutProps) {
 
     gridItems.push(
       <div key={idx} data-grid={{ x, y, w, h }}>
-        {renderGridItemContent(item, groupIndex)}
+        {renderGridItemContent(item, idx)}
       </div>
     );
   });

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -43,12 +43,12 @@ export function GridLayout(props: GridLayoutProps) {
 
   const gridItems: React.ReactNode[] = [];
 
-  spec.items.forEach((item, idx) => {
+  spec.items.forEach((item, itemIndex) => {
     const { x, y, width: w, height: h } = item;
 
     gridItems.push(
-      <div key={idx} data-grid={{ x, y, w, h }}>
-        {renderGridItemContent(item, idx)}
+      <div key={itemIndex} data-grid={{ x, y, w, h }}>
+        {renderGridItemContent(item, itemIndex)}
       </div>
     );
   });

--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -17,7 +17,7 @@ import CollapsedIcon from 'mdi-material-ui/ChevronDown';
 import AddIcon from 'mdi-material-ui/Plus';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
 import { useState } from 'react';
-import { useDashboardApp, useEditMode } from '../../context';
+import { useDashboardApp, useEditMode, usePanels } from '../../context';
 
 export interface GridTitleProps {
   groupIndex: number;
@@ -36,7 +36,8 @@ export function GridTitle(props: GridTitleProps) {
   const { groupIndex, title, collapse } = props;
 
   const [isHovered, setIsHovered] = useState(false);
-  const { openPanelDrawer, openPanelGroupDialog } = useDashboardApp();
+  const { openPanelGroupDialog } = useDashboardApp();
+  const { addPanel } = usePanels();
   const { isEditMode } = useEditMode();
 
   const text = (
@@ -65,7 +66,7 @@ export function GridTitle(props: GridTitleProps) {
           {text}
           {isEditMode && isHovered && (
             <Stack direction="row" sx={{ marginLeft: 'auto' }}>
-              <IconButton onClick={() => openPanelDrawer({ groupIndex })}>
+              <IconButton onClick={() => addPanel(groupIndex)}>
                 <AddIcon />
               </IconButton>
               <IconButton onClick={() => openPanelGroupDialog(groupIndex)}>

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -36,7 +36,7 @@ describe('Panel', () => {
         },
       },
       groupIndex: 0,
-      panelKey: 'panelRef',
+      itemIndex: 0,
     };
   };
 

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -30,20 +30,20 @@ import {
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import DragIcon from 'mdi-material-ui/DragVertical';
-import { useDashboardApp, useEditMode } from '../../context';
+import { usePanels, useEditMode } from '../../context';
 import { PanelContent } from './PanelContent';
 
 export interface PanelProps extends CardProps {
   definition: PanelDefinition;
   groupIndex: number;
-  panelKey: string;
+  itemIndex: number;
 }
 
 /**
  * Renders a PanelDefinition's content inside of a Card.
  */
 export function Panel(props: PanelProps) {
-  const { definition, groupIndex, panelKey, ...others } = props;
+  const { definition, groupIndex, itemIndex, ...others } = props;
 
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null);
   const [isHovered, setIsHovered] = useState(false);
@@ -66,10 +66,10 @@ export function Panel(props: PanelProps) {
 
   const { isEditMode } = useEditMode();
 
-  const { openPanelDrawer } = useDashboardApp();
+  const { editPanel } = usePanels();
 
   const handleEditButtonClick = () => {
-    openPanelDrawer({ groupIndex, panelKey });
+    editPanel({ groupIndex, itemIndex });
   };
 
   return (

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -28,7 +28,7 @@ import { PanelDrawer } from './PanelDrawer';
 describe('Panel Drawer', () => {
   const renderPanelDrawer = () => {
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
-    addMockPlugin('Panel', 'LineChart', FAKE_PANEL_PLUGIN);
+    addMockPlugin('Panel', 'TimeSeriesChart', FAKE_PANEL_PLUGIN);
 
     const { store, DashboardProviderSpy } = createDashboardProviderSpy();
 
@@ -66,7 +66,7 @@ describe('Panel Drawer', () => {
       NewPanel: {
         kind: 'Panel',
         spec: {
-          display: { name: 'New Panel', description: '' },
+          display: { name: 'New Panel' },
           plugin: {
             kind: '',
             spec: {},
@@ -92,7 +92,7 @@ describe('Panel Drawer', () => {
       cpu: {
         kind: 'Panel',
         spec: {
-          display: { name: 'cpu usage', description: '' },
+          display: { name: 'cpu usage' },
           plugin: {
             kind: 'TimeSeriesChart',
             spec: {},

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -53,7 +53,7 @@ describe('Panel Drawer', () => {
     const storeApi = renderPanelDrawer();
 
     // Open the drawer for a new panel (i.e. no panel key)
-    act(() => storeApi.getState().openPanelDrawer({ groupIndex: 0 }));
+    act(() => storeApi.getState().addPanel(0));
 
     const nameInput = await screen.findByLabelText(/Panel Name/);
     userEvent.type(nameInput, 'New Panel');
@@ -80,7 +80,7 @@ describe('Panel Drawer', () => {
     const storeApi = renderPanelDrawer();
 
     // Open the drawer for an existing panel
-    act(() => storeApi.getState().openPanelDrawer({ groupIndex: 0, panelKey: 'cpu' }));
+    act(() => storeApi.getState().editPanel({ groupIndex: 0, itemIndex: 0 }));
 
     const nameInput = await screen.findByLabelText(/Panel Name/);
     userEvent.clear(nameInput);

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
@@ -77,7 +77,7 @@ export const PanelDrawer = () => {
             <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
               {/* Using the 'form' attribute lets us have a submit button like this outside the form element */}
               <Button type="submit" variant="contained" form={panelEditorFormId}>
-                {panelEditor.mode === 'Add' ? 'Add Panel' : 'Apply'}
+                {panelEditor.mode === 'Add' ? 'Add' : 'Apply'}
               </Button>
               <Button variant="outlined" onClick={handleClose}>
                 Cancel

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
@@ -14,7 +14,6 @@
 import { useState } from 'react';
 import { Stack, Box, Button, Typography } from '@mui/material';
 import { Drawer } from '@perses-dev/components';
-import { PanelDefinition } from '@perses-dev/core';
 import { usePanels } from '../../context';
 import { PanelEditorForm, panelEditorFormId, PanelEditorFormProps } from './PanelEditorForm';
 
@@ -42,20 +41,7 @@ export const PanelDrawer = () => {
     if (panelEditor === undefined) {
       throw new Error('Cannot apply changes');
     }
-    const newDefinition: PanelDefinition = {
-      kind: 'Panel',
-      spec: {
-        display: {
-          name: values.name,
-          description: values.description !== '' ? values.description : undefined,
-        },
-        plugin: {
-          kind: values.kind,
-          spec: values.spec,
-        },
-      },
-    };
-    panelEditor.applyChanges(newDefinition, values.group);
+    panelEditor.applyChanges(values);
     handleClose();
   };
 
@@ -84,11 +70,7 @@ export const PanelDrawer = () => {
               </Button>
             </Stack>
           </Box>
-          <PanelEditorForm
-            onSubmit={handleSubmit}
-            initialGroup={panelEditor.initialGroup}
-            initialDefinition={panelEditor.initialDefinition}
-          />
+          <PanelEditorForm onSubmit={handleSubmit} initialValues={panelEditor.initialValues} />
         </>
       )}
     </Drawer>

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -15,25 +15,27 @@ import { FormEventHandler, useState } from 'react';
 import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { useLayouts } from '../../context';
+import { PanelEditorState } from '../../context/DashboardProvider/panel-editing';
 import { PanelEditorFormValues, usePanelSpecState } from './panel-editor-model';
 import { PanelTypeSelect } from './PanelTypeSelect';
 import { PanelSpecEditor } from './PanelSpecEditor';
 
 export interface PanelEditorFormProps {
-  initialValues: PanelEditorFormValues;
+  initialDefinition: PanelEditorState['initialDefinition'];
+  initialGroup: PanelEditorState['initialGroup'];
   onSubmit: (values: PanelEditorFormValues) => void;
 }
 
 export function PanelEditorForm(props: PanelEditorFormProps) {
-  const { initialValues, onSubmit } = props;
+  const { initialDefinition, initialGroup, onSubmit } = props;
 
   const { layouts } = useLayouts();
 
-  const [name, setName] = useState(initialValues.name);
-  const [description, setDescription] = useState(initialValues.description);
-  const [group, setGroup] = useState(initialValues.group);
-  const [kind, setKind] = useState(initialValues.kind);
-  const { spec, onSpecChange } = usePanelSpecState(kind, initialValues.spec);
+  const [name, setName] = useState(initialDefinition.spec.display.name);
+  const [description, setDescription] = useState(initialDefinition.spec.display.name ?? '');
+  const [group, setGroup] = useState(initialGroup);
+  const [kind, setKind] = useState(initialDefinition.spec.plugin.kind);
+  const { spec, onSpecChange } = usePanelSpecState(kind, initialDefinition.spec.plugin.spec);
 
   // Ignore string values (which would be an "empty" value from the Select) since we don't allow them to unset it
   const handleGroupChange: SelectProps<number>['onChange'] = (e) => {

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -15,27 +15,26 @@ import { FormEventHandler, useState } from 'react';
 import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { useLayouts } from '../../context';
-import { PanelEditorState } from '../../context/DashboardProvider/panel-editing';
-import { PanelEditorFormValues, usePanelSpecState } from './panel-editor-model';
+import { PanelEditorValues } from '../../context/DashboardProvider/panel-editing';
+import { usePanelSpecState } from './panel-editor-model';
 import { PanelTypeSelect } from './PanelTypeSelect';
 import { PanelSpecEditor } from './PanelSpecEditor';
 
 export interface PanelEditorFormProps {
-  initialDefinition: PanelEditorState['initialDefinition'];
-  initialGroup: PanelEditorState['initialGroup'];
-  onSubmit: (values: PanelEditorFormValues) => void;
+  initialValues: PanelEditorValues;
+  onSubmit: (values: PanelEditorValues) => void;
 }
 
 export function PanelEditorForm(props: PanelEditorFormProps) {
-  const { initialDefinition, initialGroup, onSubmit } = props;
+  const { initialValues, onSubmit } = props;
 
   const { layouts } = useLayouts();
 
-  const [name, setName] = useState(initialDefinition.spec.display.name);
-  const [description, setDescription] = useState(initialDefinition.spec.display.description ?? '');
-  const [group, setGroup] = useState(initialGroup);
-  const [kind, setKind] = useState(initialDefinition.spec.plugin.kind);
-  const { spec, onSpecChange } = usePanelSpecState(kind, initialDefinition.spec.plugin.spec);
+  const [name, setName] = useState(initialValues.name);
+  const [description, setDescription] = useState(initialValues.description);
+  const [groupIndex, setGroupIndex] = useState(initialValues.groupIndex);
+  const [kind, setKind] = useState(initialValues.kind);
+  const { spec, onSpecChange } = usePanelSpecState(kind, initialValues.spec);
 
   // Ignore string values (which would be an "empty" value from the Select) since we don't allow them to unset it
   const handleGroupChange: SelectProps<number>['onChange'] = (e) => {
@@ -43,12 +42,12 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
     if (typeof value === 'string') {
       return;
     }
-    setGroup(value);
+    setGroupIndex(value);
   };
 
   const handleSubmit: FormEventHandler = (e) => {
     e.preventDefault();
-    const values: PanelEditorFormValues = { name, description, group, kind, spec };
+    const values: PanelEditorValues = { name, description, groupIndex, kind, spec };
     onSubmit(values);
   };
 
@@ -67,7 +66,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
         <Grid item xs={4}>
           <FormControl>
             <InputLabel id="select-group">Group</InputLabel>
-            <Select required labelId="select-group" label="Group" value={group ?? 0} onChange={handleGroupChange}>
+            <Select required labelId="select-group" label="Group" value={groupIndex ?? 0} onChange={handleGroupChange}>
               {layouts.map((layout, index) => (
                 <MenuItem key={index} value={index}>
                   {layout.spec.display?.title ?? `Group ${index + 1}`}

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -32,7 +32,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
   const { layouts } = useLayouts();
 
   const [name, setName] = useState(initialDefinition.spec.display.name);
-  const [description, setDescription] = useState(initialDefinition.spec.display.name ?? '');
+  const [description, setDescription] = useState(initialDefinition.spec.display.description ?? '');
   const [group, setGroup] = useState(initialGroup);
   const [kind, setKind] = useState(initialDefinition.spec.plugin.kind);
   const { spec, onSpecChange } = usePanelSpecState(kind, initialDefinition.spec.plugin.spec);

--- a/ui/dashboards/src/components/PanelDrawer/panel-editor-model.ts
+++ b/ui/dashboards/src/components/PanelDrawer/panel-editor-model.ts
@@ -14,8 +14,6 @@
 import { useMemo } from 'react';
 import { usePlugin } from '@perses-dev/plugin-system';
 import { useImmer } from 'use-immer';
-import { useDashboardApp, usePanels } from '../../context';
-import { removeWhiteSpacesAndSpecialCharacters } from '../../utils/functions';
 
 export interface PanelEditorFormValues {
   name: string;
@@ -23,102 +21,6 @@ export interface PanelEditorFormValues {
   group: number;
   kind: string;
   spec: unknown;
-}
-
-// Props that vary based on whether the PanelDrawer is in add or edit mode
-interface PanelDrawerModel {
-  drawerTitle: string;
-  submitButtonText: string;
-  initialValues: PanelEditorFormValues;
-  applyChanges: (values: PanelEditorFormValues) => void;
-}
-
-/**
- * Returns props that are different depending on whether the PanelDrawer has been opened in add or edit mode. If the
- * drawer isn't open at all, returns undefined.
- */
-export function usePanelDrawerModel(): PanelDrawerModel | undefined {
-  const { panelDrawer } = useDashboardApp();
-  const { panels, updatePanel } = usePanels();
-
-  // If we're closed, no model to return
-  if (panelDrawer === undefined) {
-    return undefined;
-  }
-
-  // If we don't have a panel key, we're adding a new panel
-  const { panelKey, groupIndex } = panelDrawer;
-  if (panelKey === undefined) {
-    return {
-      drawerTitle: 'Add Panel',
-      submitButtonText: 'Add',
-      initialValues: {
-        name: '',
-        description: '',
-        group: groupIndex ?? 0,
-        kind: '',
-        spec: {},
-      },
-      applyChanges: (values) => {
-        const { name, description, group, kind, spec } = values;
-        const panelKey = removeWhiteSpacesAndSpecialCharacters(name);
-        updatePanel(
-          panelKey,
-          {
-            kind: 'Panel',
-            spec: {
-              display: { name, description },
-              plugin: {
-                kind,
-                spec,
-              },
-            },
-          },
-          group
-        );
-      },
-    };
-  }
-
-  // Otherwise we have a panel key, so we're trying to edit an existing panel
-  const existingPanel = panels[panelKey];
-
-  // TODO: Can we better express this via the type system on the dashboard store to avoid these states?
-  if (existingPanel === undefined) {
-    throw new Error(`Cannot find existing panel '${panelKey}' to edit`);
-  }
-  if (groupIndex === undefined) {
-    throw new Error(`Cannot edit existing panel '${panelKey}' without its group index`);
-  }
-
-  return {
-    drawerTitle: 'Edit Panel',
-    submitButtonText: 'Apply',
-    initialValues: {
-      name: existingPanel.spec.display.name,
-      description: existingPanel.spec.display.description ?? '',
-      group: groupIndex,
-      kind: existingPanel.spec.plugin.kind,
-      spec: existingPanel.spec.plugin.spec, // TODO: Should we clone to be safe?
-    },
-    applyChanges: (values) => {
-      const { name, description, group, kind, spec } = values;
-      updatePanel(panelKey, {
-        kind: 'Panel',
-        spec: {
-          display: { name, description },
-          plugin: {
-            kind,
-            spec,
-          },
-        },
-      });
-
-      if (group !== groupIndex) {
-        // TO DO: need to move panel if panel group changes
-      }
-    },
-  };
 }
 
 /**

--- a/ui/dashboards/src/components/PanelDrawer/panel-editor-model.ts
+++ b/ui/dashboards/src/components/PanelDrawer/panel-editor-model.ts
@@ -15,14 +15,6 @@ import { useMemo } from 'react';
 import { usePlugin } from '@perses-dev/plugin-system';
 import { useImmer } from 'use-immer';
 
-export interface PanelEditorFormValues {
-  name: string;
-  description: string;
-  group: number;
-  kind: string;
-  spec: unknown;
-}
-
 /**
  * Manages panel plugin spec state. The spec will be undefined while a plugin is being loaded.
  */

--- a/ui/dashboards/src/context/DashboardProvider/DashboardAppSlice.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardAppSlice.tsx
@@ -15,35 +15,17 @@ import { StateCreator } from 'zustand';
 import { Middleware } from './common';
 import { useDashboardStore } from './DashboardProvider';
 
-interface PanelDrawer {
-  groupIndex?: number;
-  panelKey?: string;
-}
 interface PanelGroupDialog {
   groupIndex?: number;
 }
 
 export interface DashboardAppSlice {
-  panelDrawer?: PanelDrawer;
-  openPanelDrawer: (panelDrawer: PanelDrawer) => void;
-  closePanelDrawer: () => void;
   panelGroupDialog?: PanelGroupDialog;
   openPanelGroupDialog: (groupIndex?: number) => void;
   closePanelGroupDialog: () => void;
 }
 
 export const createDashboardAppSlice: StateCreator<DashboardAppSlice, Middleware, [], DashboardAppSlice> = (set) => ({
-  openPanelDrawer: ({ groupIndex, panelKey }: PanelDrawer) =>
-    set((state) => {
-      state.panelDrawer = {
-        groupIndex,
-        panelKey,
-      };
-    }),
-  closePanelDrawer: () =>
-    set((state) => {
-      state.panelDrawer = undefined;
-    }),
   openPanelGroupDialog: (groupIndex?: number) =>
     set((state) => {
       state.panelGroupDialog = { groupIndex };
@@ -55,21 +37,9 @@ export const createDashboardAppSlice: StateCreator<DashboardAppSlice, Middleware
 });
 
 export function useDashboardApp() {
-  return useDashboardStore(
-    ({
-      panelDrawer,
-      openPanelDrawer,
-      closePanelDrawer,
-      panelGroupDialog,
-      openPanelGroupDialog,
-      closePanelGroupDialog,
-    }) => ({
-      panelDrawer,
-      openPanelDrawer,
-      closePanelDrawer,
-      panelGroupDialog,
-      openPanelGroupDialog,
-      closePanelGroupDialog,
-    })
-  );
+  return useDashboardStore(({ panelGroupDialog, openPanelGroupDialog, closePanelGroupDialog }) => ({
+    panelGroupDialog,
+    openPanelGroupDialog,
+    closePanelGroupDialog,
+  }));
 }

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -18,7 +18,7 @@ import { immer } from 'zustand/middleware/immer';
 import shallow from 'zustand/shallow';
 import { createContext, useContext } from 'react';
 import produce from 'immer';
-import { DashboardSpec, PanelDefinition } from '@perses-dev/core';
+import { DashboardSpec } from '@perses-dev/core';
 import { DashboardAppSlice, createDashboardAppSlice } from './DashboardAppSlice';
 import { createLayoutEditorSlice, LayoutEditorSlice } from './layout-editing';
 import { createPanelEditorSlice, PanelEditorSlice } from './panel-editing';

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -21,11 +21,11 @@ import produce from 'immer';
 import { DashboardSpec, PanelDefinition } from '@perses-dev/core';
 import { DashboardAppSlice, createDashboardAppSlice } from './DashboardAppSlice';
 import { createLayoutEditorSlice, LayoutEditorSlice } from './layout-editing';
+import { createPanelEditorSlice, PanelEditorSlice } from './panel-editing';
 
-export interface DashboardStoreState extends DashboardAppSlice, LayoutEditorSlice {
+export interface DashboardStoreState extends DashboardAppSlice, LayoutEditorSlice, PanelEditorSlice {
   dashboard: DashboardSpec;
   panels: Record<string, PanelDefinition>;
-  updatePanel: (name: string, panel: PanelDefinition, groupIndex?: number) => void;
   isEditMode: boolean;
   setEditMode: (isEditMode: boolean) => void;
 }
@@ -37,10 +37,6 @@ export interface DashboardStoreProps {
 export interface DashboardProviderProps {
   initialState: DashboardStoreProps;
   children?: React.ReactNode;
-}
-
-export function usePanels() {
-  return useDashboardStore(({ panels, updatePanel }) => ({ panels, updatePanel }));
 }
 
 export function useEditMode() {
@@ -80,23 +76,12 @@ export function DashboardProvider(props: DashboardProviderProps) {
   const dashboardStore = createStore<DashboardStoreState>()(
     immer(
       devtools((...args) => {
-        const [set, get] = args;
+        const [set] = args;
         return {
           ...createDashboardAppSlice(...args),
           ...createLayoutEditorSlice(layouts)(...args),
-          panels,
+          ...createPanelEditorSlice(panels)(...args),
           dashboard: dashboardSpec,
-          // TODO: Move this logic into a PanelEditor slice
-          updatePanel: (name: string, panel: PanelDefinition, groupIndex = 0) => {
-            const { addPanelToGroup, panels } = get();
-            // add new panel to layouts if panels[name] is undefined
-            if (panels[name] === undefined) {
-              addPanelToGroup(name, groupIndex);
-            }
-            set((state) => {
-              state.panels[name] = panel;
-            });
-          },
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
         };

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -25,7 +25,6 @@ import { createPanelEditorSlice, PanelEditorSlice } from './panel-editing';
 
 export interface DashboardStoreState extends DashboardAppSlice, LayoutEditorSlice, PanelEditorSlice {
   dashboard: DashboardSpec;
-  panels: Record<string, PanelDefinition>;
   isEditMode: boolean;
   setEditMode: (isEditMode: boolean) => void;
 }

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -21,3 +21,12 @@ export function useLayouts() {
     updatePanelGroup,
   }));
 }
+
+export function usePanels() {
+  return useDashboardStore(({ panels, panelEditor, addPanel, editPanel }) => ({
+    panels,
+    panelEditor,
+    addPanel,
+    editPanel,
+  }));
+}

--- a/ui/dashboards/src/context/DashboardProvider/layout-editing.ts
+++ b/ui/dashboards/src/context/DashboardProvider/layout-editing.ts
@@ -98,7 +98,7 @@ export function createLayoutEditorSlice(
 
       set((state) => {
         // Remove the item from its current group
-        state.layouts[groupIndex]?.spec.items.splice(itemIndex);
+        state.layouts[groupIndex]?.spec.items.splice(itemIndex, 1);
 
         // Add a new item to the new group
         state.layouts[newGroupIndex]?.spec.items.push({

--- a/ui/dashboards/src/context/DashboardProvider/panel-editing.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editing.ts
@@ -1,0 +1,155 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PanelDefinition } from '@perses-dev/core';
+import { StateCreator } from 'zustand';
+import { removeWhiteSpacesAndSpecialCharacters } from '../../utils/functions';
+import { Middleware } from './common';
+import { LayoutEditorSlice, LayoutItem } from './layout-editing';
+
+export interface PanelEditorSlice {
+  panels: Record<string, PanelDefinition>;
+  /**
+   * State for the panel editor when its open, otherwise undefined when it's closed.
+   */
+  panelEditor?: PanelEditorState;
+
+  /**
+   * Edit an existing panel by providing its layout coordinates.
+   */
+  editPanel: (item: LayoutItem) => void;
+
+  /**
+   * Add a new Panel to a panel group.
+   */
+  addPanel: (initialGroup: number) => void;
+}
+
+export interface PanelEditorState {
+  /**
+   * Whether we're adding a new panel, or editing an existing panel.
+   */
+  mode: 'Add' | 'Edit';
+
+  /**
+   * The intial PanelGroup that the panel being added/edited is in.
+   */
+  initialGroup: number;
+
+  /**
+   * The initial values for the PanelDefinition being added/edited.
+   */
+  initialDefinition: PanelDefinition;
+
+  /**
+   * Applies changes, but doesn't close the editor.
+   */
+  applyChanges: (next: PanelDefinition, group: number) => void;
+
+  /**
+   * Close the editor.
+   */
+  close: () => void;
+}
+
+/**
+ * Curried function for creating the PanelEditorSlice.
+ */
+export function createPanelEditorSlice(
+  panels: PanelEditorSlice['panels']
+): StateCreator<PanelEditorSlice & LayoutEditorSlice, Middleware, [], PanelEditorSlice> {
+  // Return the state creator function for Zustand that uses the panels provided as intitial state
+  return (set, get) => ({
+    panels,
+
+    panelEditor: undefined,
+
+    editPanel(item) {
+      const { panels, getPanelKey } = get();
+
+      // Ask the layout store for the panel key at that location
+      const panelKey = getPanelKey(item);
+
+      // Find the panel to edit
+      const panelToEdit = panels[panelKey];
+      if (panelToEdit === undefined) {
+        throw new Error(`Cannot find Panel with key '${panelKey}'`);
+      }
+
+      const editorState: PanelEditorState = {
+        mode: 'Edit',
+        initialGroup: item.groupIndex,
+        initialDefinition: panelToEdit,
+        applyChanges: (next, group) => {
+          set((state) => {
+            state.panels[panelKey] = next;
+          });
+
+          // Move the panel to another group if it changed
+          if (group !== item.groupIndex) {
+            get().movePanelToGroup(item, group);
+          }
+        },
+        close: () => {
+          set((state) => {
+            state.panelEditor = undefined;
+          });
+        },
+      };
+
+      // Open the editor with the new state
+      set((state) => {
+        state.panelEditor = editorState;
+      });
+    },
+
+    addPanel(initialGroup) {
+      const editorState: PanelEditorState = {
+        mode: 'Add',
+        initialGroup,
+        initialDefinition: {
+          kind: 'Panel',
+          spec: {
+            display: {
+              name: '',
+              description: undefined,
+            },
+            // TODO: If we knew what plugins were available (and how to create the initial spec), we might be able to
+            // set a smarter default here?
+            plugin: {
+              kind: '',
+              spec: {},
+            },
+          },
+        },
+        applyChanges: (next, group) => {
+          const panelKey = removeWhiteSpacesAndSpecialCharacters(next.spec.display.name);
+          set((state) => {
+            state.panels[panelKey] = next;
+          });
+          get().addPanelToGroup(panelKey, group);
+        },
+        close: () => {
+          set((state) => {
+            state.panelEditor = undefined;
+          });
+        },
+      };
+
+      // Open the editor with the new state
+      set((state) => {
+        state.panelEditor = editorState;
+      });
+    },
+  });
+}


### PR DESCRIPTION
This builds on #590 (so look at that PR first) and moves the more complicated panel editing logic into a `PanelEditingSlice` into the store. The initial editor state is now in the store, making sure you can't (for example) edit a panel that doesn't exist. It also adds support for editing a panel and having it move between groups. This is what that looks like:


https://user-images.githubusercontent.com/428023/193431778-e9201073-c1b7-42ec-a7af-3b8ae1d2c75a.mov

