### PR TITLE
[WIP] sync time range refactor

### DIFF
--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -25,6 +25,7 @@ const demoDashboard: DashboardResource = {
   spec: {
     datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
     duration: '30m',
+    // variables: [],
     variables: [
       {
         kind: 'ListVariable',
@@ -204,7 +205,7 @@ const demoDashboard: DashboardResource = {
           },
         },
       },
-      doubleQueries: {
+      doubleQueriesAlt: {
         kind: 'Panel',
         spec: {
           display: { name: 'Thresholds Example', description: 'Description text' },
@@ -223,6 +224,61 @@ const demoDashboard: DashboardResource = {
                     },
                   },
                 },
+                // {
+                //   kind: 'TimeSeriesQuery',
+                //   spec: {
+                //     plugin: {
+                //       kind: 'PrometheusTimeSeriesQuery',
+                //       spec: {
+                //         query: 'node_load1{instance=~"$instance",job="node"}',
+                //       },
+                //     },
+                //   },
+                // },
+              ],
+              show_legend: false,
+              unit: {
+                kind: 'PercentDecimal',
+                decimal_places: 1,
+              },
+              thresholds: {
+                // default_color: '#000', // optional
+                steps: [
+                  {
+                    value: 0.4,
+                    name: 'Alert: Warning condition example',
+                    // color: '#FFFFFF',
+                  },
+                  {
+                    value: 0.75,
+                    name: 'Alert: Critical condition example',
+                    // color: '#0000FF', // blue
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      doubleQueries: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'Thresholds Example', description: 'Description text' },
+          plugin: {
+            kind: 'TimeSeriesChart',
+            spec: {
+              queries: [
+                // {
+                //   kind: 'TimeSeriesQuery',
+                //   spec: {
+                //     plugin: {
+                //       kind: 'PrometheusTimeSeriesQuery',
+                //       spec: {
+                //         query: 'node_load15{instance=~"$instance",job="node"}',
+                //       },
+                //     },
+                //   },
+                // },
                 {
                   kind: 'TimeSeriesQuery',
                   spec: {
@@ -607,13 +663,14 @@ const demoDashboard: DashboardResource = {
             },
           },
           items: [
-            {
-              x: 0,
-              y: 0,
-              width: 12,
-              height: 6,
-              content: { $ref: '#/spec/panels/cpu' },
-            },
+            // {
+            //   x: 0,
+            //   y: 0,
+            //   width: 12,
+            //   height: 6,
+            //   // content: { $ref: '#/spec/panels/cpu' },
+            //   content: { $ref: '#/spec/panels/doubleQueriesAlt' },
+            // },
             {
               x: 12,
               y: 0,

--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -25,47 +25,47 @@ const demoDashboard: DashboardResource = {
   spec: {
     datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
     duration: '30m',
-    // variables: [],
-    variables: [
-      {
-        kind: 'ListVariable',
-        spec: {
-          name: 'job',
-          plugin: {
-            kind: 'PrometheusLabelValuesVariable',
-            spec: {
-              label_name: 'job',
-            },
-          },
-        },
-      },
-      {
-        kind: 'ListVariable',
-        spec: {
-          name: 'instance',
-          allowAllValue: true,
-          plugin: {
-            kind: 'PrometheusLabelValuesVariable',
-            spec: {
-              label_name: 'instance',
-              matchers: ['up{job="$job"}'],
-            },
-          },
-        },
-      },
-      {
-        kind: 'ListVariable',
-        spec: {
-          name: 'interval',
-          plugin: {
-            kind: 'StaticListVariable',
-            spec: {
-              values: ['1m', '5m'],
-            },
-          },
-        },
-      },
-    ],
+    variables: [],
+    // variables: [
+    //   {
+    //     kind: 'ListVariable',
+    //     spec: {
+    //       name: 'job',
+    //       plugin: {
+    //         kind: 'PrometheusLabelValuesVariable',
+    //         spec: {
+    //           label_name: 'job',
+    //         },
+    //       },
+    //     },
+    //   },
+    //   {
+    //     kind: 'ListVariable',
+    //     spec: {
+    //       name: 'instance',
+    //       allowAllValue: true,
+    //       plugin: {
+    //         kind: 'PrometheusLabelValuesVariable',
+    //         spec: {
+    //           label_name: 'instance',
+    //           matchers: ['up{job="$job"}'],
+    //         },
+    //       },
+    //     },
+    //   },
+    //   {
+    //     kind: 'ListVariable',
+    //     spec: {
+    //       name: 'interval',
+    //       plugin: {
+    //         kind: 'StaticListVariable',
+    //         spec: {
+    //           values: ['1m', '5m'],
+    //         },
+    //       },
+    //     },
+    //   },
+    // ],
     panels: {
       seriesTest: {
         kind: 'Panel',
@@ -659,7 +659,7 @@ const demoDashboard: DashboardResource = {
           display: {
             title: 'Row 2',
             collapse: {
-              open: true,
+              open: false,
             },
           },
           items: [

--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -25,47 +25,47 @@ const demoDashboard: DashboardResource = {
   spec: {
     datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
     duration: '30m',
-    variables: [],
-    // variables: [
-    //   {
-    //     kind: 'ListVariable',
-    //     spec: {
-    //       name: 'job',
-    //       plugin: {
-    //         kind: 'PrometheusLabelValuesVariable',
-    //         spec: {
-    //           label_name: 'job',
-    //         },
-    //       },
-    //     },
-    //   },
-    //   {
-    //     kind: 'ListVariable',
-    //     spec: {
-    //       name: 'instance',
-    //       allowAllValue: true,
-    //       plugin: {
-    //         kind: 'PrometheusLabelValuesVariable',
-    //         spec: {
-    //           label_name: 'instance',
-    //           matchers: ['up{job="$job"}'],
-    //         },
-    //       },
-    //     },
-    //   },
-    //   {
-    //     kind: 'ListVariable',
-    //     spec: {
-    //       name: 'interval',
-    //       plugin: {
-    //         kind: 'StaticListVariable',
-    //         spec: {
-    //           values: ['1m', '5m'],
-    //         },
-    //       },
-    //     },
-    //   },
-    // ],
+    // variables: [],
+    variables: [
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'job',
+          plugin: {
+            kind: 'PrometheusLabelValuesVariable',
+            spec: {
+              label_name: 'job',
+            },
+          },
+        },
+      },
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'instance',
+          allowAllValue: true,
+          plugin: {
+            kind: 'PrometheusLabelValuesVariable',
+            spec: {
+              label_name: 'instance',
+              matchers: ['up{job="$job"}'],
+            },
+          },
+        },
+      },
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'interval',
+          plugin: {
+            kind: 'StaticListVariable',
+            spec: {
+              values: ['1m', '5m'],
+            },
+          },
+        },
+      },
+    ],
     panels: {
       seriesTest: {
         kind: 'Panel',
@@ -659,18 +659,18 @@ const demoDashboard: DashboardResource = {
           display: {
             title: 'Row 2',
             collapse: {
-              open: false,
+              open: true,
             },
           },
           items: [
-            // {
-            //   x: 0,
-            //   y: 0,
-            //   width: 12,
-            //   height: 6,
-            //   // content: { $ref: '#/spec/panels/cpu' },
-            //   content: { $ref: '#/spec/panels/doubleQueriesAlt' },
-            // },
+            {
+              x: 0,
+              y: 0,
+              width: 12,
+              height: 6,
+              // content: { $ref: '#/spec/panels/cpu' },
+              content: { $ref: '#/spec/panels/doubleQueriesAlt' },
+            },
             {
               x: 12,
               y: 0,

--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -24,13 +24,13 @@ const demoDashboard: DashboardResource = {
   },
   spec: {
     datasource: { kind: 'Prometheus', name: 'PrometheusDemo', global: true },
-    duration: '30m',
-    // variables: [],
+    duration: '5m',
     variables: [
       {
         kind: 'ListVariable',
         spec: {
           name: 'job',
+          defaultValue: 'node',
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
             spec: {
@@ -205,7 +205,36 @@ const demoDashboard: DashboardResource = {
           },
         },
       },
-      doubleQueriesAlt: {
+      testNodeQuery: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'Test Query', description: 'Description text' },
+          plugin: {
+            kind: 'TimeSeriesChart',
+            spec: {
+              queries: [
+                {
+                  kind: 'TimeSeriesQuery',
+                  spec: {
+                    plugin: {
+                      kind: 'PrometheusTimeSeriesQuery',
+                      spec: {
+                        query: 'node_load15{instance=~"$instance",job="node"}',
+                      },
+                    },
+                  },
+                },
+              ],
+              show_legend: false,
+              unit: {
+                kind: 'PercentDecimal',
+                decimal_places: 1,
+              },
+            },
+          },
+        },
+      },
+      doubleQueries: {
         kind: 'Panel',
         spec: {
           display: { name: 'Thresholds Example', description: 'Description text' },
@@ -224,61 +253,6 @@ const demoDashboard: DashboardResource = {
                     },
                   },
                 },
-                // {
-                //   kind: 'TimeSeriesQuery',
-                //   spec: {
-                //     plugin: {
-                //       kind: 'PrometheusTimeSeriesQuery',
-                //       spec: {
-                //         query: 'node_load1{instance=~"$instance",job="node"}',
-                //       },
-                //     },
-                //   },
-                // },
-              ],
-              show_legend: false,
-              unit: {
-                kind: 'PercentDecimal',
-                decimal_places: 1,
-              },
-              thresholds: {
-                // default_color: '#000', // optional
-                steps: [
-                  {
-                    value: 0.4,
-                    name: 'Alert: Warning condition example',
-                    // color: '#FFFFFF',
-                  },
-                  {
-                    value: 0.75,
-                    name: 'Alert: Critical condition example',
-                    // color: '#0000FF', // blue
-                  },
-                ],
-              },
-            },
-          },
-        },
-      },
-      doubleQueries: {
-        kind: 'Panel',
-        spec: {
-          display: { name: 'Thresholds Example', description: 'Description text' },
-          plugin: {
-            kind: 'TimeSeriesChart',
-            spec: {
-              queries: [
-                // {
-                //   kind: 'TimeSeriesQuery',
-                //   spec: {
-                //     plugin: {
-                //       kind: 'PrometheusTimeSeriesQuery',
-                //       spec: {
-                //         query: 'node_load15{instance=~"$instance",job="node"}',
-                //       },
-                //     },
-                //   },
-                // },
                 {
                   kind: 'TimeSeriesQuery',
                   spec: {
@@ -669,7 +643,7 @@ const demoDashboard: DashboardResource = {
               width: 12,
               height: 6,
               // content: { $ref: '#/spec/panels/cpu' },
-              content: { $ref: '#/spec/panels/doubleQueriesAlt' },
+              content: { $ref: '#/spec/panels/testNodeQuery' },
             },
             {
               x: 12,

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -35,7 +35,7 @@ const ECHARTS_THEME_OVERRIDES = {};
 function App() {
   const { getInstalledPlugins, importPluginModule } = useBundledPlugins();
 
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const muiTheme = useTheme();
   const chartsTheme: PersesChartsTheme = useMemo(() => {
@@ -62,7 +62,7 @@ function App() {
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <ChartsThemeProvider themeName="perses" chartsTheme={chartsTheme}>
             <PluginRegistry getInstalledPlugins={getInstalledPlugins} importPluginModule={importPluginModule}>
-              <QueryStringProvider queryString={searchParams}>
+              <QueryStringProvider queryString={searchParams} setQueryString={setSearchParams}>
                 <ErrorBoundary FallbackComponent={ErrorAlert}>
                   {/* temp fix to ensure dashboard refreshes when URL changes since setQueryString not reloading as expected  */}
                   <ViewDashboard />

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import userEvent from '@testing-library/user-event';
-import { getDefaultTimeRange } from '@perses-dev/core';
 import { screen } from '@testing-library/react';
 import { renderWithContext } from '../../test';
 import testDashboard from '../../test/testDashboard';
@@ -30,11 +29,10 @@ describe('TimeRangeControls', () => {
 
   const renderTimeRangeControls = () => {
     const queryString = new URLSearchParams();
-    const defaultTimeRange = getDefaultTimeRange(initialState.dashboardSpec.duration, queryString);
     renderWithContext(
       <QueryStringProvider queryString={queryString}>
         <DashboardProvider initialState={initialState}>
-          <TimeRangeProvider initialTimeRange={defaultTimeRange}>
+          <TimeRangeProvider initialTimeRange={{ pastDuration: initialState.dashboardSpec.duration }}>
             <TimeRangeControls />
           </TimeRangeProvider>
         </DashboardProvider>

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -21,7 +21,6 @@ import {
   TimeRangeValue,
   isRelativeTimeRange,
   toAbsoluteTimeRange,
-  // getDefaultTimeRange,
 } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { useDashboard, useSyncTimeRangeParams, useInitialTimeRange } from '../../context';

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -42,10 +42,10 @@ export const TIME_OPTIONS: TimeOption[] = [
 export function TimeRangeControls() {
   const { timeRange, setTimeRange } = useTimeRange();
   const { dashboard } = useDashboard();
-  const { defaultTimeRange } = useInitialTimeRange(dashboard.duration);
+  const { initialTimeRange } = useInitialTimeRange(dashboard.duration);
 
   // selected form value can be relative or absolute, timeRange from plugin-system is only absolute
-  const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRangeValue>(defaultTimeRange);
+  const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRangeValue>(initialTimeRange);
 
   // ensure URL params match selected time range
   useSyncTimeRangeParams(selectedTimeRange);

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -47,16 +47,19 @@ export function TimeRangeControls() {
   // selected form value can be relative or absolute, timeRange from plugin-system is only absolute
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRangeValue>(defaultTimeRange);
 
+  // ensure URL params match selected time range
   useSyncTimeRangeParams(selectedTimeRange);
 
   const [showCustomDateSelector, setShowCustomDateSelector] = useState(false);
   const anchorEl = useRef();
 
-  // updates selectedTimeRange when zoom event has fired
+  // TODO: better approach to update selectedTimeRange on zoom
   useEffect(() => {
     const convertedTimeRange = isRelativeTimeRange(selectedTimeRange)
       ? toAbsoluteTimeRange(selectedTimeRange)
       : selectedTimeRange;
+    // determines whether timeRange has changed since last call to setSelectedTimeRange
+    // which means zoom event has been triggered
     if (timeRange.start > convertedTimeRange.start) {
       setSelectedTimeRange(timeRange);
     }

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -54,10 +54,10 @@ export function TimeRangeControls() {
 
   // updates selectedTimeRange when zoom event has fired
   useEffect(() => {
-    const prevTimeRange = isRelativeTimeRange(selectedTimeRange)
+    const convertedTimeRange = isRelativeTimeRange(selectedTimeRange)
       ? toAbsoluteTimeRange(selectedTimeRange)
       : selectedTimeRange;
-    if (timeRange.start > prevTimeRange.start) {
+    if (timeRange.start > convertedTimeRange.start) {
       setSelectedTimeRange(timeRange);
     }
   }, [timeRange, selectedTimeRange]);

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -22,7 +22,7 @@ import {
   getDefaultTimeRange,
 } from '@perses-dev/core';
 import { useTimeRange, useQueryString } from '@perses-dev/plugin-system';
-import { useDashboard } from '../../context';
+import { useDashboard, useSyncTimeRangeParams } from '../../context';
 
 // TODO: add time shortcut if one does not match duration
 export const TIME_OPTIONS: TimeOption[] = [
@@ -46,6 +46,8 @@ export function TimeRangeControls() {
 
   // selected form value can be relative or absolute, timeRange from plugin-system is only absolute
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRangeValue>(defaultTimeRange);
+
+  useSyncTimeRangeParams(selectedTimeRange);
 
   const [showCustomDateSelector, setShowCustomDateSelector] = useState(false);
   const anchorEl = useRef();

--- a/ui/dashboards/src/context/TimeRangeProvider.tsx
+++ b/ui/dashboards/src/context/TimeRangeProvider.tsx
@@ -31,6 +31,9 @@ export interface TimeRangeProviderProps {
   onTimeRangeChange?: (e: TimeRangeValue) => void;
 }
 
+/**
+ * Gets the initial time range taking into account URL params and dashboard JSON duration
+ */
 export function useInitialTimeRange(dashboardDuration: DurationString) {
   const { queryString } = useQueryString();
   const startParam = queryString.get('start');
@@ -50,11 +53,14 @@ export function useInitialTimeRange(dashboardDuration: DurationString) {
   return { defaultTimeRange };
 }
 
+/**
+ * Set initial start and end URL params and update when selected time range changes
+ */
 export function useSyncTimeRangeParams(selectedTimeRange: TimeRangeValue) {
   const { queryString, setQueryString } = useQueryString();
   const { dashboard } = useDashboard();
   const dashboardDuration = dashboard.duration;
-  const lastParamSync = useRef<{ [k: string]: string }>();
+  const lastParamSync = useRef<{ [param: string]: string }>();
 
   useEffect(() => {
     if (setQueryString) {

--- a/ui/dashboards/src/context/TimeRangeProvider.tsx
+++ b/ui/dashboards/src/context/TimeRangeProvider.tsx
@@ -39,18 +39,18 @@ export function useInitialTimeRange(dashboardDuration: DurationString) {
   const startParam = queryString.get('start');
   const endParam = queryString.get('end');
 
-  let defaultTimeRange: TimeRangeValue = { pastDuration: dashboardDuration };
+  let initialTimeRange: TimeRangeValue = { pastDuration: dashboardDuration };
   if (startParam === null) {
-    return { defaultTimeRange };
+    return { initialTimeRange };
   }
 
   if (isDurationString(startParam.toString())) {
-    defaultTimeRange = { pastDuration: startParam } as RelativeTimeRange;
+    initialTimeRange = { pastDuration: startParam } as RelativeTimeRange;
   } else {
-    defaultTimeRange = { start: new Date(Number(startParam)), end: new Date(Number(endParam)) };
+    initialTimeRange = { start: new Date(Number(startParam)), end: new Date(Number(endParam)) };
   }
 
-  return { defaultTimeRange };
+  return { initialTimeRange };
 }
 
 /**

--- a/ui/dashboards/src/context/TimeRangeProvider.tsx
+++ b/ui/dashboards/src/context/TimeRangeProvider.tsx
@@ -23,6 +23,7 @@ import {
   DurationString,
 } from '@perses-dev/core';
 import { TimeRange, TimeRangeContext, useQueryString, useTimeRange } from '@perses-dev/plugin-system';
+import { useDashboard } from './DashboardProvider';
 
 export interface TimeRangeProviderProps {
   initialTimeRange: TimeRangeValue;
@@ -31,22 +32,23 @@ export interface TimeRangeProviderProps {
 }
 
 export function useInitialTimeRange(dashboardDuration: DurationString) {
-  const { queryString, setQueryString } = useQueryString();
+  // const { queryString, setQueryString } = useQueryString();
+  const { queryString } = useQueryString();
 
   const startParam = queryString.get('start');
   // const endParam = queryString.get('end');
 
   let defaultTimeRange: TimeRangeValue = { pastDuration: dashboardDuration };
 
-  useEffect(() => {
-    if (startParam === null) {
-      if (setQueryString) {
-        queryString.set('start', dashboardDuration);
-        queryString.delete('end');
-        setQueryString(queryString);
-      }
-    }
-  }, [startParam, dashboardDuration, queryString, setQueryString]);
+  // useEffect(() => {
+  //   if (startParam === null) {
+  //     if (setQueryString) {
+  //       queryString.set('start', dashboardDuration);
+  //       queryString.delete('end');
+  //       setQueryString(queryString);
+  //     }
+  //   }
+  // }, [startParam, dashboardDuration, queryString, setQueryString]);
 
   if (startParam === null) {
     return { defaultTimeRange };
@@ -59,40 +61,46 @@ export function useInitialTimeRange(dashboardDuration: DurationString) {
   return { defaultTimeRange };
 }
 
-export function useSyncTimeRangeParams() {
+export function useSyncTimeRangeParams(selectedTimeRange: TimeRangeValue) {
   const { queryString, setQueryString } = useQueryString();
+  const { dashboard } = useDashboard();
   const { timeRange } = useTimeRange();
   const lastParamSync = useRef<{ [k: string]: string }>();
 
-  useEffect(() => {
-    // TODO (sjcobb): how to tell whether resolved timeRange was originally relative?
-    // if (isRelativeTimeRange(value)) {
-    //   if (setQueryString) {
-    //     queryString.set('start', value.pastDuration);
-    //     // end not required for relative time but may have been set by AbsoluteTimePicker or zoom
-    //     queryString.delete('end');
-    //     setQueryString(queryString);
-    //   } else {
-    //     setActiveTimeRange(toAbsoluteTimeRange(value));
-    //   }
-    //   return;
-    // }
+  const dashboardDuration = dashboard.duration;
+  const startParam = queryString.get('start');
+  // const endParam = queryString.get('end');
+  // const startParamString = startParam?.toString() ?? '';
 
+  useEffect(() => {
     if (setQueryString) {
-      // Absolute URL example) ?start=1663707045000&end=1663713330000
-      // currently set from ViewDashboard initial queryString, AbsoluteTimePicker, or LineChart panel onDataZoom
-      const startUnixMs = getUnixTime(timeRange.start) * 1000;
-      const endUnixMs = getUnixTime(timeRange.end) * 1000;
-      queryString.set('start', startUnixMs.toString());
-      queryString.set('end', endUnixMs.toString());
-      setQueryString(queryString); // TODO (sjcobb); only re-set start query param when it changes
-      lastParamSync.current = Object.fromEntries([...queryString]);
+      if (startParam === null) {
+        // queryString.set('start', dashboardDuration);
+        // queryString.delete('end');
+        // setQueryString(queryString);
+      } else {
+        if (isRelativeTimeRange(selectedTimeRange)) {
+          queryString.set('start', selectedTimeRange.pastDuration);
+          // end not required for relative time but may have been set by AbsoluteTimePicker or zoom
+          queryString.delete('end');
+          setQueryString(queryString);
+        } else {
+          // Absolute URL example) ?start=1663707045000&end=1663713330000
+          // currently set from ViewDashboard initial queryString, AbsoluteTimePicker, or LineChart panel onDataZoom
+          const startUnixMs = getUnixTime(timeRange.start) * 1000;
+          const endUnixMs = getUnixTime(timeRange.end) * 1000;
+          queryString.set('start', startUnixMs.toString());
+          queryString.set('end', endUnixMs.toString());
+          setQueryString(queryString); // TODO (sjcobb); only re-set start query param when it changes
+          lastParamSync.current = Object.fromEntries([...queryString]);
+        }
+      }
     }
 
     // return () => {
     //   // TODO (sjcobb): cleanup
     // };
-  }, [timeRange, queryString, setQueryString]);
+  }, [timeRange, selectedTimeRange, dashboardDuration, startParam, queryString, setQueryString]);
 }
 
 /**

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -17,7 +17,7 @@ import { DashboardResource } from '@perses-dev/core';
 import { PanelDrawer, Dashboard } from '../../components';
 import PanelGroupDialog from '../../components/PanelGroupDialog/PanelGroupDialog';
 import { DashboardToolbar } from '../../components/DashboardToolbar';
-import { useDashboard, useDashboardApp, useSyncTimeRangeParams } from '../../context';
+import { useDashboard, useDashboardApp } from '../../context';
 
 export interface DashboardAppProps {
   dashboardResource: DashboardResource;
@@ -27,8 +27,6 @@ export const DashboardApp = (props: DashboardAppProps) => {
   const { dashboardResource } = props;
   const { dashboard } = useDashboard();
   const { panelGroupDialog } = useDashboardApp();
-
-  useSyncTimeRangeParams();
 
   return (
     <Box

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -17,7 +17,7 @@ import { DashboardResource } from '@perses-dev/core';
 import { PanelDrawer, Dashboard } from '../../components';
 import PanelGroupDialog from '../../components/PanelGroupDialog/PanelGroupDialog';
 import { DashboardToolbar } from '../../components/DashboardToolbar';
-import { useDashboard, useDashboardApp } from '../../context';
+import { useDashboard, useDashboardApp, useSyncTimeRangeParams } from '../../context';
 
 export interface DashboardAppProps {
   dashboardResource: DashboardResource;
@@ -27,6 +27,9 @@ export const DashboardApp = (props: DashboardAppProps) => {
   const { dashboardResource } = props;
   const { dashboard } = useDashboard();
   const { panelGroupDialog } = useDashboardApp();
+
+  useSyncTimeRangeParams();
+
   return (
     <Box
       sx={{

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -39,12 +39,12 @@ export function ViewDashboard(props: ViewDashboardProps) {
   const { dashboardResource, datasourceApi, sx, ...others } = props;
   const { spec } = dashboardResource;
   const dashboardDuration = spec.duration ?? '1h';
-  const { defaultTimeRange } = useInitialTimeRange(dashboardDuration);
+  const { initialTimeRange } = useInitialTimeRange(dashboardDuration);
 
   return (
     <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>
       <DashboardProvider initialState={{ dashboardSpec: spec }}>
-        <TimeRangeProvider initialTimeRange={defaultTimeRange}>
+        <TimeRangeProvider initialTimeRange={initialTimeRange}>
           <TemplateVariableProvider initialVariableDefinitions={spec.variables}>
             <Box
               sx={combineSx(

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -19,6 +19,7 @@ import { DashboardResource } from '@perses-dev/core';
 import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import {
   TimeRangeProvider,
+  useInitialTimeRange,
   TemplateVariableProvider,
   DashboardProvider,
   DatasourceStoreProviderProps,
@@ -37,24 +38,8 @@ export interface ViewDashboardProps extends Omit<BoxProps, 'children'> {
 export function ViewDashboard(props: ViewDashboardProps) {
   const { dashboardResource, datasourceApi, sx, ...others } = props;
   const { spec } = dashboardResource;
-
-  const defaultTimeRange = { pastDuration: spec.duration };
-
-  // TODO (sjcobb); create useInitialTimeRange hook to use in addition to useSyncTimeRangeParams
-  // const { queryString, setQueryString } = useQueryString();
-  // const dashboardDuration = spec.duration ?? '1h';
-  // const defaultTimeRange = getDefaultTimeRange(dashboardDuration, queryString);
-
-  // // TODO: add reusable sync query string or no-op util
-  // useEffect(() => {
-  //   const currentParams = Object.fromEntries([...queryString]);
-  //   // if app does not provide query string implementation, setTimeRange is used instead
-  //   if (!currentParams.start && setQueryString) {
-  //     // default to duration in dashboard definition if start param is not already set
-  //     queryString.set('start', dashboardDuration);
-  //     setQueryString(queryString);
-  //   }
-  // }, [dashboardDuration, queryString, setQueryString]);
+  const dashboardDuration = spec.duration ?? '1h';
+  const { defaultTimeRange } = useInitialTimeRange(dashboardDuration);
 
   return (
     <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -11,10 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useEffect } from 'react';
+// import { useEffect } from 'react';
 import { Box, BoxProps } from '@mui/material';
-import { DashboardResource, getDefaultTimeRange } from '@perses-dev/core';
-import { useQueryString } from '@perses-dev/plugin-system';
+import { DashboardResource } from '@perses-dev/core';
+// import { DashboardResource, getDefaultTimeRange } from '@perses-dev/core';
+// import { useQueryString } from '@perses-dev/plugin-system';
 import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import {
   TimeRangeProvider,
@@ -37,20 +38,23 @@ export function ViewDashboard(props: ViewDashboardProps) {
   const { dashboardResource, datasourceApi, sx, ...others } = props;
   const { spec } = dashboardResource;
 
-  const { queryString, setQueryString } = useQueryString();
-  const dashboardDuration = spec.duration ?? '1h';
-  const defaultTimeRange = getDefaultTimeRange(dashboardDuration, queryString);
+  const defaultTimeRange = { pastDuration: spec.duration };
 
-  // TODO: add reusable sync query string or no-op util
-  useEffect(() => {
-    const currentParams = Object.fromEntries([...queryString]);
-    // if app does not provide query string implementation, setTimeRange is used instead
-    if (!currentParams.start && setQueryString) {
-      // default to duration in dashboard definition if start param is not already set
-      queryString.set('start', dashboardDuration);
-      setQueryString(queryString);
-    }
-  }, [dashboardDuration, queryString, setQueryString]);
+  // TODO (sjcobb); create useInitialTimeRange hook to use in addition to useSyncTimeRangeParams
+  // const { queryString, setQueryString } = useQueryString();
+  // const dashboardDuration = spec.duration ?? '1h';
+  // const defaultTimeRange = getDefaultTimeRange(dashboardDuration, queryString);
+
+  // // TODO: add reusable sync query string or no-op util
+  // useEffect(() => {
+  //   const currentParams = Object.fromEntries([...queryString]);
+  //   // if app does not provide query string implementation, setTimeRange is used instead
+  //   if (!currentParams.start && setQueryString) {
+  //     // default to duration in dashboard definition if start param is not already set
+  //     queryString.set('start', dashboardDuration);
+  //     setQueryString(queryString);
+  //   }
+  // }, [dashboardDuration, queryString, setQueryString]);
 
   return (
     <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -11,11 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// import { useEffect } from 'react';
 import { Box, BoxProps } from '@mui/material';
 import { DashboardResource } from '@perses-dev/core';
-// import { DashboardResource, getDefaultTimeRange } from '@perses-dev/core';
-// import { useQueryString } from '@perses-dev/plugin-system';
 import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import {
   TimeRangeProvider,

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartContainer.tsx
@@ -38,6 +38,7 @@ export interface TimeSeriesChartContainerProps {
  */
 export function TimeSeriesChartContainer(props: TimeSeriesChartContainerProps) {
   const { width, height, show_legend, thresholds } = props;
+
   const queries = useRunningGraphQueries();
 
   const { setTimeRange } = useTimeRange();

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartContainer.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartContainer.tsx
@@ -38,7 +38,6 @@ export interface TimeSeriesChartContainerProps {
  */
 export function TimeSeriesChartContainer(props: TimeSeriesChartContainerProps) {
   const { width, height, show_legend, thresholds } = props;
-
   const queries = useRunningGraphQueries();
 
   const { setTimeRange } = useTimeRange();


### PR DESCRIPTION
Refactor setQueryString approach, instead of calling directly in TimeRangeProvider's setTimeRange, create hook that sync start and end params. Call in TimeRangeControls since sync hook needs to know whether time range is relative or absolute (current useTimeRange from plugin-system only returns resolved absolute time).

ViewDashboard is also updated to call new useInitialTimeRange hook.