### PR TITLE
Use snake_case in spec definitions

### DIFF
--- a/ui/app/sample-data/demoDashboard.ts
+++ b/ui/app/sample-data/demoDashboard.ts
@@ -42,7 +42,7 @@ const demoDashboard: DashboardResource = {
         kind: 'ListVariable',
         spec: {
           name: 'instance',
-          allowAllValue: true,
+          allow_all_value: true,
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
             spec: {

--- a/ui/app/sample-data/templateVariableDemo.ts
+++ b/ui/app/sample-data/templateVariableDemo.ts
@@ -30,7 +30,7 @@ const demoDashboard: DashboardResource = {
         kind: 'ListVariable',
         spec: {
           name: 'job',
-          allowAllValue: true,
+          allow_all_value: true,
           defaultValue: 'prometheus',
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
@@ -44,8 +44,8 @@ const demoDashboard: DashboardResource = {
         kind: 'ListVariable',
         spec: {
           name: 'handler',
-          allowMultiple: true,
-          allowAllValue: true,
+          allow_multiple: true,
+          allow_all_value: true,
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
             spec: {
@@ -59,7 +59,7 @@ const demoDashboard: DashboardResource = {
         kind: 'ListVariable',
         spec: {
           name: 'code',
-          allowAllValue: true,
+          allow_all_value: true,
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
             spec: {
@@ -86,7 +86,7 @@ const demoDashboard: DashboardResource = {
         kind: 'ListVariable',
         spec: {
           name: 'labelNames',
-          allowMultiple: true,
+          allow_multiple: true,
           plugin: {
             kind: 'PrometheusLabelNamesVariable',
             spec: {},

--- a/ui/core/src/model/variables.ts
+++ b/ui/core/src/model/variables.ts
@@ -23,7 +23,7 @@ interface VariableSpec {
     label?: string;
     hidden?: boolean;
   };
-  defaultValue?: VariableValue;
+  default_value?: VariableValue;
 }
 
 export interface TextVariableDefinition extends Definition<TextVariableSpec> {
@@ -39,9 +39,9 @@ export interface ListVariableDefinition<PluginSpec = unknown> extends Definition
 }
 
 export interface ListVariableSpec<PluginSpec> extends VariableSpec {
-  allowMultiple?: boolean;
-  allowAllValue?: boolean;
-  customAllValue?: string;
+  allow_multiple?: boolean;
+  allow_all_value?: boolean;
+  custom_all_value?: string;
   plugin: Definition<PluginSpec>;
 }
 

--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -65,8 +65,8 @@ function ListVariable({ name }: TemplateVariableProps) {
   }
 
   const variables = useTemplateVariableValues(dependsOnVariables);
-  const allowMultiple = definition?.spec.allowMultiple === true;
-  const allowAllValue = definition?.spec.allowAllValue === true;
+  const allowMultiple = definition?.spec.allow_multiple === true;
+  const allowAllValue = definition?.spec.allow_all_value === true;
 
   let waitToLoad = false;
   if (dependsOnVariables) {
@@ -127,7 +127,7 @@ function ListVariable({ name }: TemplateVariableProps) {
     }
 
     // If there is a value but it's not in the options, select the first value or set to null
-    if (value && !valueIsInOptions && !definition.spec.defaultValue) {
+    if (value && !valueIsInOptions && !definition.spec.default_value) {
       setVariableValue(name, firstOption?.value || null);
     }
   }, [finalOptions, setVariableValue, value, name, allowMultiple]);

--- a/ui/dashboards/src/context/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider.tsx
@@ -196,7 +196,7 @@ export function TemplateVariableProvider({
 function hydrateTemplateVariableState(definition: VariableDefinition) {
   const v = definition;
   const varState: VariableState = {
-    value: v.spec.defaultValue ?? null,
+    value: v.spec.default_value ?? null,
     loading: false,
   };
   switch (v.kind) {
@@ -208,7 +208,7 @@ function hydrateTemplateVariableState(definition: VariableDefinition) {
       if (varState.options.length > 0 && !varState.value) {
         const firstOptionValue = varState.options[0]?.value ?? null;
         if (firstOptionValue !== null) {
-          varState.value = v.spec.allowMultiple ? [firstOptionValue] : firstOptionValue;
+          varState.value = v.spec.allow_multiple ? [firstOptionValue] : firstOptionValue;
         }
       }
       break;


### PR DESCRIPTION
Renaming:
- `defaultValue` -> `default_value`
- `allowMultiple` -> `allow_multiple`
- `allowAllValue` -> `allow_all_value`

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>