### PR TITLE
add static panel options for TimeSeriesChart

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -12,12 +12,38 @@
 // limitations under the License.
 
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
-import { Box } from '@mui/material';
+import { Stack, Box } from '@mui/material';
 import { TimeSeriesChartOptions } from './time-series-chart-model';
+import { TimeSeriesChartPanel, TimeSeriesChartProps } from './TimeSeriesChartPanel';
 
 export type TimeSeriesChartOptionsEditorProps = OptionsEditorProps<TimeSeriesChartOptions>;
 
 export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditorProps) {
   const { value } = props;
-  return <Box>{JSON.stringify(value)}</Box>;
+
+  const panelPreviewProps: TimeSeriesChartProps = {
+    definition: {
+      kind: 'Panel',
+      spec: {
+        display: { name: 'Single Query' },
+        plugin: {
+          kind: 'TimeSeriesChart',
+          spec: {
+            ...value,
+          },
+        },
+      },
+    },
+    contentDimensions: { width: 500, height: 250 },
+  };
+
+  return (
+    <>
+      <TimeSeriesChartPanel {...panelPreviewProps} />
+      <Stack spacing={1}>
+        <Box>{JSON.stringify(value)}</Box>
+        {/* TODO: add form controls to edit panel options */}
+      </Stack>
+    </>
+  );
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -25,7 +25,8 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
     definition: {
       kind: 'Panel',
       spec: {
-        display: { name: 'Single Query' },
+        // TODO: how to exlude display (display.name is required but gets overriden)
+        display: { name: 'Temp Name' },
         plugin: {
           kind: 'TimeSeriesChart',
           spec: {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -17,9 +17,9 @@ import TimeSeriesQueryRunner from './TimeSeriesQueryRunner';
 import { TimeSeriesChartOptions } from './time-series-chart-model';
 import { TimeSeriesChartContainer } from './TimeSeriesChartContainer';
 
-export type LineChartProps = PanelProps<TimeSeriesChartOptions>;
+export type TimeSeriesChartProps = PanelProps<TimeSeriesChartOptions>;
 
-export function TimeSeriesChartPanel(props: LineChartProps) {
+export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   const {
     definition: {
       spec: {

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -30,6 +30,23 @@ export interface TimeSeriesChartOptions {
  */
 export function createInitialTimeSeriesChartOptions(): TimeSeriesChartOptions {
   return {
-    queries: [],
+    queries: [
+      {
+        kind: 'TimeSeriesQuery',
+        spec: {
+          plugin: {
+            kind: 'PrometheusTimeSeriesQuery',
+            spec: {
+              query: 'up',
+            },
+          },
+        },
+      },
+    ],
+    // TODO: configurable legend, change from show_legend to legend.show
+    show_legend: true,
+    unit: {
+      kind: 'Decimal',
+    },
   };
 }


### PR DESCRIPTION
## Overview

Add hard-coded options to TimeSeriesChart panel as first step in chart options editing. Static panel can now be previewed in edit drawer and added to dashboards, but _nothing is editable yet_ (adding form controls is next).

## Screenshots:

![hard-coded_panel_edit_ex](https://user-images.githubusercontent.com/9369625/193826038-e4f404a5-ea87-4867-a2e6-bfd9b4bf2225.png)

![hard-coded_panel_dash_ex](https://user-images.githubusercontent.com/9369625/193826035-8de3f717-9906-43e0-b0ab-7048d3143634.png)



