### PR TITLE
add clean as dep of build in turbo.json

### DIFF
--- a/ui/turbo.json
+++ b/ui/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     // The build task depends on all its upstream dependencies build tasks being run first
     "build": {
-      "dependsOn": ["^build", "clean"],
+      "dependsOn": ["clean", "^build"],
       "outputs": ["dist/**"]
     },
     "clean": {

--- a/ui/turbo.json
+++ b/ui/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     // The build task depends on all its upstream dependencies build tasks being run first
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "clean"],
       "outputs": ["dist/**"]
     },
     "clean": {


### PR DESCRIPTION
Add `npm run clean` as dependency of build in turbo.json to hopefully help with errors after switching branches caused by:
- Old build output is still around
- You pull latest code
- You run npm run start which runs a new build and moves files, but leaves old build output intact so some files from the old build are still around

See turbo docs here: https://turborepo.org/docs/core-concepts/running-tasks