### PR TITLE
Use dashboard store in view mode also

### DIFF
--- a/ui/dashboards/src/components/Dashboard.tsx
+++ b/ui/dashboards/src/components/Dashboard.tsx
@@ -13,30 +13,25 @@
 
 import { Box, BoxProps } from '@mui/material';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
-import { DashboardSpec } from '@perses-dev/core';
-import { GridLayout, GridItemContent } from './GridLayout';
+import { useLayouts } from '../context';
+import { GridLayout } from './GridLayout';
 
-export interface DashboardProps extends BoxProps {
-  spec: DashboardSpec;
-}
+export type DashboardProps = BoxProps;
 
 /**
  * Renders a Dashboard for the provided Dashboard spec.
  */
 export function Dashboard(props: DashboardProps) {
-  const { spec, ...others } = props;
-
+  const { layouts } = useLayouts();
   return (
-    <Box {...others}>
+    <Box {...props}>
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        {spec.layouts.map((layout, groupIndex) => (
+        {layouts.map((layout, groupIndex) => (
           <GridLayout
-            key={`${JSON.stringify(spec.layouts)} ${groupIndex}`} // reset grid layout states when spec.layout changes
+            // TODO: Better data structure with actual keys for grids?
+            key={groupIndex}
             groupIndex={groupIndex}
             definition={layout}
-            renderGridItemContent={(definition, itemIndex) => (
-              <GridItemContent content={definition.content} spec={spec} groupIndex={groupIndex} itemIndex={itemIndex} />
-            )}
           />
         ))}
       </ErrorBoundary>

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -11,26 +11,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ErrorAlert } from '@perses-dev/components';
-import { DashboardSpec, GridItemDefinition, resolvePanelRef } from '@perses-dev/core';
+import { getPanelKeyFromRef, GridItemDefinition } from '@perses-dev/core';
+import { usePanels } from '../../context';
 import { Panel } from '../Panel/Panel';
 
 export interface GridItemContentProps {
-  spec: DashboardSpec;
-  content: GridItemDefinition['content'];
   groupIndex: number;
   itemIndex: number;
+  content: GridItemDefinition['content'];
 }
 
 /**
  * Resolves the reference to panel content in a GridItemDefinition and renders the panel.
  */
 export function GridItemContent(props: GridItemContentProps) {
-  const { content, spec, groupIndex, itemIndex } = props;
-  try {
-    const panelDefinition = resolvePanelRef(spec, content);
-    return <Panel definition={panelDefinition} groupIndex={groupIndex} itemIndex={itemIndex} />;
-  } catch (err) {
-    return <ErrorAlert error={err as Error} />;
+  const { content, groupIndex, itemIndex } = props;
+
+  // Find the panel referenced in content in the store
+  const { panels } = usePanels();
+  const panelKey = getPanelKeyFromRef(content);
+  const panelDefinition = panels[panelKey];
+  if (panelDefinition === undefined) {
+    throw new Error(`Panel with key '${panelKey}' was not found`);
   }
+  return <Panel definition={panelDefinition} groupIndex={groupIndex} itemIndex={itemIndex} />;
 }

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -13,17 +13,18 @@
 import { useState } from 'react';
 import { Responsive, WidthProvider } from 'react-grid-layout';
 import { Box, BoxProps, Collapse, GlobalStyles } from '@mui/material';
-import { GridDefinition, GridItemDefinition } from '@perses-dev/core';
+import { GridDefinition } from '@perses-dev/core';
+import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { styles } from '../../css/styles';
 import { useEditMode } from '../../context';
 import { GridTitle } from './GridTitle';
+import { GridItemContent } from './GridItemContent';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
 export interface GridLayoutProps extends BoxProps {
   groupIndex: number;
   definition: GridDefinition;
-  renderGridItemContent: (definition: GridItemDefinition, itemIndex: number) => React.ReactNode;
 }
 
 /**
@@ -33,25 +34,11 @@ export function GridLayout(props: GridLayoutProps) {
   const {
     groupIndex,
     definition: { spec },
-    renderGridItemContent,
     ...others
   } = props;
 
   const [isOpen, setIsOpen] = useState(spec.display?.collapse?.open ?? true);
-
   const { isEditMode } = useEditMode();
-
-  const gridItems: React.ReactNode[] = [];
-
-  spec.items.forEach((item, itemIndex) => {
-    const { x, y, width: w, height: h } = item;
-
-    gridItems.push(
-      <div key={itemIndex} data-grid={{ x, y, w, h }}>
-        {renderGridItemContent(item, itemIndex)}
-      </div>
-    );
-  });
 
   return (
     <>
@@ -79,7 +66,13 @@ export function GridLayout(props: GridLayoutProps) {
             isDraggable={isEditMode}
             isResizable={isEditMode}
           >
-            {gridItems}
+            {spec.items.map(({ x, y, width, height, content }, itemIndex) => (
+              <div key={itemIndex} data-grid={{ x, y, w: width, h: height }}>
+                <ErrorBoundary FallbackComponent={ErrorAlert}>
+                  <GridItemContent groupIndex={groupIndex} itemIndex={itemIndex} content={content} />
+                </ErrorBoundary>
+              </div>
+            ))}
           </ResponsiveGridLayout>
         </Collapse>
       </Box>

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -22,7 +22,7 @@ import {
   getDefaultTimeRange,
 } from '@perses-dev/core';
 import { useTimeRange, useQueryString } from '@perses-dev/plugin-system';
-import { useDashboard } from '../../context';
+import { useDefaultTimeRange } from '../../context';
 
 // TODO: add time shortcut if one does not match duration
 export const TIME_OPTIONS: TimeOption[] = [
@@ -39,10 +39,10 @@ export const TIME_OPTIONS: TimeOption[] = [
 
 export function TimeRangeControls() {
   const { timeRange, setTimeRange } = useTimeRange();
-  const { dashboard } = useDashboard();
+  const dashboardDefaultTimeRange = useDefaultTimeRange();
   const { queryString } = useQueryString();
 
-  const defaultTimeRange = getDefaultTimeRange(dashboard.duration, queryString);
+  const defaultTimeRange = getDefaultTimeRange(dashboardDefaultTimeRange, queryString);
 
   // selected form value can be relative or absolute, timeRange from plugin-system is only absolute
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRangeValue>(defaultTimeRange);

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -17,7 +17,6 @@ import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import shallow from 'zustand/shallow';
 import { createContext, useContext } from 'react';
-import produce from 'immer';
 import { DashboardSpec, DurationString } from '@perses-dev/core';
 import { DashboardAppSlice, createDashboardAppSlice } from './DashboardAppSlice';
 import { createLayoutSlice, LayoutSlice } from './layout-slice';

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -18,13 +18,13 @@ import { immer } from 'zustand/middleware/immer';
 import shallow from 'zustand/shallow';
 import { createContext, useContext } from 'react';
 import produce from 'immer';
-import { DashboardSpec } from '@perses-dev/core';
+import { DashboardSpec, DurationString } from '@perses-dev/core';
 import { DashboardAppSlice, createDashboardAppSlice } from './DashboardAppSlice';
 import { createLayoutSlice, LayoutSlice } from './layout-slice';
 import { createPanelEditorSlice, PanelEditorSlice } from './panel-editing';
 
 export interface DashboardStoreState extends DashboardAppSlice, LayoutSlice, PanelEditorSlice {
-  dashboard: DashboardSpec;
+  defaultTimeRange: DurationString;
   isEditMode: boolean;
   setEditMode: (isEditMode: boolean) => void;
 }
@@ -33,6 +33,7 @@ export interface DashboardStoreProps {
   dashboardSpec: DashboardSpec;
   isEditMode?: boolean;
 }
+
 export interface DashboardProviderProps {
   initialState: DashboardStoreProps;
   children?: React.ReactNode;
@@ -40,18 +41,6 @@ export interface DashboardProviderProps {
 
 export function useEditMode() {
   return useDashboardStore(({ isEditMode, setEditMode }) => ({ isEditMode, setEditMode }));
-}
-
-export function useDashboard() {
-  const selectDashboardSpec = (state: DashboardStoreState) => {
-    return produce(state.dashboard, (draftState) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      draftState.panels = state.panels as any;
-      draftState.layouts = state.layouts;
-    });
-  };
-  const dashboard = useDashboardStore(selectDashboardSpec);
-  return { dashboard };
 }
 
 export const DashboardContext = createContext<StoreApi<DashboardStoreState> | undefined>(undefined);
@@ -80,7 +69,7 @@ export function DashboardProvider(props: DashboardProviderProps) {
           ...createDashboardAppSlice(...args),
           ...createLayoutSlice(layouts)(...args),
           ...createPanelEditorSlice(panels)(...args),
-          dashboard: dashboardSpec,
+          defaultTimeRange: dashboardSpec.duration,
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
         };

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -30,3 +30,7 @@ export function usePanels() {
     editPanel,
   }));
 }
+
+export function useDefaultTimeRange() {
+  return useDashboardStore((state) => state.defaultTimeRange);
+}

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -17,7 +17,7 @@ import { DashboardResource } from '@perses-dev/core';
 import { PanelDrawer, Dashboard } from '../../components';
 import PanelGroupDialog from '../../components/PanelGroupDialog/PanelGroupDialog';
 import { DashboardToolbar } from '../../components/DashboardToolbar';
-import { useDashboard, useDashboardApp } from '../../context';
+import { useDashboardApp } from '../../context';
 
 export interface DashboardAppProps {
   dashboardResource: DashboardResource;
@@ -25,7 +25,6 @@ export interface DashboardAppProps {
 
 export const DashboardApp = (props: DashboardAppProps) => {
   const { dashboardResource } = props;
-  const { dashboard } = useDashboard();
   const { panelGroupDialog } = useDashboardApp();
   return (
     <Box
@@ -41,7 +40,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
       <DashboardToolbar dashboardName={dashboardResource.metadata.name} />
       <Box sx={{ padding: (theme) => theme.spacing(2) }}>
         <ErrorBoundary FallbackComponent={ErrorAlert}>
-          <Dashboard spec={dashboard} />
+          <Dashboard />
         </ErrorBoundary>
         <PanelDrawer />
         {panelGroupDialog && <PanelGroupDialog />}


### PR DESCRIPTION
This just removes the `useDashboard` hook and some of the weird state flow where I screwed up and told Eunice we should be passing the dashboard spec around everywhere. 😂  Instead, it just uses the `layouts` and `panels` state already in the store for both view and edit modes. I haven't tried to do anything "smart" yet (like more granular selectors to help with re-rendering), just simplified the mess I made so we can start doing that.