### PR TITLE
Pass spec only to panel plugins, rather than definition

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -160,7 +160,13 @@ export function Panel(props: PanelProps) {
         ref={setContentElement}
       >
         <ErrorBoundary FallbackComponent={ErrorAlert}>
-          {inView === true && <PanelContent definition={definition} contentDimensions={contentDimensions} />}
+          {inView === true && (
+            <PanelContent
+              panelPluginKind={definition.spec.plugin.kind}
+              spec={definition.spec.plugin.spec}
+              contentDimensions={contentDimensions}
+            />
+          )}
         </ErrorBoundary>
       </CardContent>
     </Card>

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -14,21 +14,16 @@
 import { usePlugin, PanelProps } from '@perses-dev/plugin-system';
 import { Skeleton } from '@mui/material';
 
-export type PanelContentProps = PanelProps<unknown>;
+export interface PanelContentProps extends PanelProps<unknown> {
+  panelPluginKind: string;
+}
 
 /**
  * A small wrapper component that renders the appropriate PanelComponent from a Panel plugin based on the panel
  * definition's kind. Used so that an ErrorBoundary can be wrapped around this.
  */
 export function PanelContent(props: PanelContentProps) {
-  const {
-    definition: {
-      spec: {
-        plugin: { kind: panelPluginKind },
-      },
-    },
-    contentDimensions,
-  } = props;
+  const { panelPluginKind, contentDimensions, ...others } = props;
   const { data: plugin, isLoading } = usePlugin('Panel', panelPluginKind, { useErrorBoundary: true });
   const PanelComponent = plugin?.PanelComponent;
 
@@ -40,5 +35,5 @@ export function PanelContent(props: PanelContentProps) {
     throw new Error(`Missing PanelComponent from panel plugin for kind '${panelPluginKind}'`);
   }
 
-  return <PanelComponent {...props} />;
+  return <PanelComponent {...others} contentDimensions={contentDimensions} />;
 }

--- a/ui/panels-plugin/src/plugins/empty-chart/EmptyChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/empty-chart/EmptyChartPanel.tsx
@@ -17,6 +17,6 @@ import { EmptyChartOptions } from './empty-chart-model';
 
 export type EmptyChartPanelProps = PanelProps<EmptyChartOptions>;
 
-export function EmptyChartPanel(props: EmptyChartPanelProps) {
-  return <Box sx={{ overflow: 'hidden' }}>{props.definition.kind}</Box>;
+export function EmptyChartPanel() {
+  return <Box sx={{ overflow: 'hidden' }}>EmptyChart</Box>;
 }

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -24,14 +24,7 @@ import { GaugeChartOptions } from './gauge-chart-model';
 export type GaugeChartPanelProps = PanelProps<GaugeChartOptions>;
 
 export function GaugeChartPanel(props: GaugeChartPanelProps) {
-  const {
-    definition: {
-      spec: {
-        plugin: { spec: pluginSpec },
-      },
-    },
-    contentDimensions,
-  } = props;
+  const { spec: pluginSpec, contentDimensions } = props;
   const { query, calculation, max } = pluginSpec;
 
   const unit = pluginSpec.unit ?? { kind: 'PercentDecimal', decimal_places: 1 };

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -70,13 +70,7 @@ function sanitizeHTML(html: string): string {
 
 export function MarkdownPanel(props: MarkdownPanelProps) {
   const {
-    definition: {
-      spec: {
-        plugin: {
-          spec: { text },
-        },
-      },
-    },
+    spec: { text },
   } = props;
 
   const html = useMemo(() => convertTextToHTML(text), [text]);

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -24,19 +24,12 @@ export type StatChartPanelProps = PanelProps<StatChartOptions>;
 
 export function StatChartPanel(props: StatChartPanelProps) {
   const {
-    definition: {
-      spec: {
-        display: { name },
-        plugin: {
-          spec: { query, calculation, unit, sparkline },
-        },
-      },
-    },
+    spec: { query, calculation, unit, sparkline },
     contentDimensions,
   } = props;
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);
   const { data, loading, error } = useTimeSeriesQueryData(query, { suggestedStepMs });
-  const chartData = useChartData(data, calculation, name);
+  const chartData = useChartData(data, calculation);
   const chartsTheme = useChartsTheme();
 
   if (error) throw error;
@@ -66,7 +59,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
   );
 }
 
-const useChartData = (data: TimeSeriesData | undefined, calculation: CalculationType, name: string): StatChartData => {
+const useChartData = (data: TimeSeriesData | undefined, calculation: CalculationType): StatChartData => {
   return useMemo(() => {
     const loadingData = {
       calculatedValue: undefined,
@@ -81,9 +74,10 @@ const useChartData = (data: TimeSeriesData | undefined, calculation: Calculation
     return {
       calculatedValue,
       seriesData,
-      name,
+      // TODO: How is this name used in StatChart? Do we really need it? Should it be a chart spec option?
+      name: 'StatChart',
     };
-  }, [data, calculation, name]);
+  }, [data, calculation]);
 };
 
 export function convertSparkline(

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -22,18 +22,8 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
   const { value } = props;
 
   const panelPreviewProps: TimeSeriesChartProps = {
-    definition: {
-      kind: 'Panel',
-      spec: {
-        // TODO: how to exlude display (display.name is required but gets overriden)
-        display: { name: 'Temp Name' },
-        plugin: {
-          kind: 'TimeSeriesChart',
-          spec: {
-            ...value,
-          },
-        },
-      },
+    spec: {
+      ...value,
     },
     contentDimensions: { width: 500, height: 250 },
   };

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -21,13 +21,7 @@ export type TimeSeriesChartProps = PanelProps<TimeSeriesChartOptions>;
 
 export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   const {
-    definition: {
-      spec: {
-        plugin: {
-          spec: { queries, show_legend, thresholds, unit },
-        },
-      },
-    },
+    spec: { queries, show_legend, thresholds, unit },
     contentDimensions,
   } = props;
 

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PanelDefinition } from '@perses-dev/core';
 import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
 
 /**
@@ -27,7 +26,7 @@ export interface PanelPlugin<Spec = unknown> {
  * The props provided by Perses to a panel plugin's PanelComponent.
  */
 export interface PanelProps<Spec> {
-  definition: PanelDefinition<Spec>;
+  spec: Spec;
   contentDimensions?: {
     width: number;
     height: number;


### PR DESCRIPTION
This just simplifies Panel plugins to only take the plugin's `spec` as props, rather than the entire `PanelDefinition` object. This is consistent with what we've already done in variable and time series query plugins where we've found that the plugin code doesn't really care about the stuff in the full-blown definition at this point. It should also make building panel previews for visual editing a little easier. (See some of the discussion in #596)

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>