### PR TITLE
create initial panel preview component

### DIFF
--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -12,10 +12,11 @@
 // limitations under the License.
 
 import { FormEventHandler, useState } from 'react';
-import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps } from '@mui/material';
+import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps, Box } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { useLayouts } from '../../context';
 import { PanelEditorValues } from '../../context/DashboardProvider/panel-editing';
+import { Panel, PanelProps } from '../Panel';
 import { usePanelSpecState } from './panel-editor-model';
 import { PanelTypeSelect } from './PanelTypeSelect';
 import { PanelSpecEditor } from './PanelSpecEditor';
@@ -49,6 +50,24 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
     e.preventDefault();
     const values: PanelEditorValues = { name, description, groupIndex, kind, spec };
     onSubmit(values);
+  };
+
+  const panelPreviewProps: PanelProps = {
+    definition: {
+      kind: 'Panel',
+      spec: {
+        display: {
+          name,
+          description,
+        },
+        plugin: {
+          kind,
+          spec,
+        },
+      },
+    },
+    groupIndex,
+    itemIndex: 0, // TODO: what should itemIndex be?
   };
 
   return (
@@ -96,6 +115,12 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
           </FormControl>
         </Grid>
         <Grid item xs={12}>
+          {kind !== '' && (
+            <Box height={300}>
+              {/* TODO: break out into separate preview component */}
+              <Panel {...panelPreviewProps} />
+            </Box>
+          )}
           <ErrorBoundary FallbackComponent={ErrorAlert}>
             {/* Wait until we have some proper initial spec values before rendering the editor */}
             {spec !== undefined && <PanelSpecEditor panelPluginKind={kind} value={spec} onChange={onSpecChange} />}
@@ -103,7 +128,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
         </Grid>
       </Grid>
     </form>
-  );
+);
 }
 
 /**

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -16,10 +16,10 @@ import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { useLayouts } from '../../context';
 import { PanelEditorValues } from '../../context/DashboardProvider/panel-editing';
-import { Panel, PanelProps } from '../Panel';
 import { usePanelSpecState } from './panel-editor-model';
 import { PanelTypeSelect } from './PanelTypeSelect';
 import { PanelSpecEditor } from './PanelSpecEditor';
+import { PanelPreview } from './PanelPreview';
 
 export interface PanelEditorFormProps {
   initialValues: PanelEditorValues;
@@ -50,24 +50,6 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
     e.preventDefault();
     const values: PanelEditorValues = { name, description, groupIndex, kind, spec };
     onSubmit(values);
-  };
-
-  const panelPreviewProps: PanelProps = {
-    definition: {
-      kind: 'Panel',
-      spec: {
-        display: {
-          name,
-          description,
-        },
-        plugin: {
-          kind,
-          spec,
-        },
-      },
-    },
-    groupIndex,
-    itemIndex: 0, // TODO: what should itemIndex be?
   };
 
   return (
@@ -116,10 +98,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
         </Grid>
         <Grid item xs={12}>
           {kind !== '' && (
-            <Box height={300}>
-              {/* TODO: break out into separate preview component */}
-              <Panel {...panelPreviewProps} />
-            </Box>
+            <PanelPreview kind={kind} name={name} description={description} spec={spec} groupIndex={groupIndex} />
           )}
           <ErrorBoundary FallbackComponent={ErrorAlert}>
             {/* Wait until we have some proper initial spec values before rendering the editor */}

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -97,10 +97,10 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
           </FormControl>
         </Grid>
         <Grid item xs={12}>
-          {kind !== '' && (
-            <PanelPreview kind={kind} name={name} description={description} spec={spec} groupIndex={groupIndex} />
-          )}
           <ErrorBoundary FallbackComponent={ErrorAlert}>
+            {kind && (
+              <PanelPreview kind={kind} name={name} description={description} spec={spec} groupIndex={groupIndex} />
+            )}
             {/* Wait until we have some proper initial spec values before rendering the editor */}
             {spec !== undefined && <PanelSpecEditor panelPluginKind={kind} value={spec} onChange={onSpecChange} />}
           </ErrorBoundary>

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -98,7 +98,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
         </Grid>
         <Grid item xs={12}>
           <ErrorBoundary FallbackComponent={ErrorAlert}>
-            {kind && (
+            {spec !== undefined && kind && (
               <PanelPreview kind={kind} name={name} description={description} spec={spec} groupIndex={groupIndex} />
             )}
             {/* Wait until we have some proper initial spec values before rendering the editor */}

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { FormEventHandler, useState } from 'react';
-import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps, Box } from '@mui/material';
+import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { useLayouts } from '../../context';
 import { PanelEditorValues } from '../../context/DashboardProvider/panel-editing';
@@ -107,7 +107,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
         </Grid>
       </Grid>
     </form>
-);
+  );
 }
 
 /**

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -1,0 +1,44 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box } from '@mui/material';
+import { PanelEditorValues } from '../../context/DashboardProvider/panel-editing';
+import { Panel, PanelProps } from '../Panel';
+
+export function PanelPreview(props: PanelEditorValues) {
+  const { name, description, kind, spec, groupIndex } = props;
+
+  const panelPreviewProps: PanelProps = {
+    definition: {
+      kind: 'Panel',
+      spec: {
+        display: {
+          name,
+          description,
+        },
+        plugin: {
+          kind,
+          spec,
+        },
+      },
+    },
+    groupIndex,
+    itemIndex: 0, // TODO: what should itemIndex be?
+  };
+
+  return (
+    <Box height={300}>
+      <Panel {...panelPreviewProps} />
+    </Box>
+  );
+}

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -15,10 +15,8 @@ import { Box } from '@mui/material';
 import { PanelEditorValues } from '../../context/DashboardProvider/panel-editing';
 import { Panel, PanelProps } from '../Panel';
 
-export function PanelPreview(props: PanelEditorValues) {
-  const { name, description, kind, spec, groupIndex } = props;
-
-  const panelPreviewProps: PanelProps = {
+export function PanelPreview({ name, description, kind, spec, groupIndex }: PanelEditorValues) {
+  const previewValues: PanelProps = {
     definition: {
       kind: 'Panel',
       spec: {
@@ -38,7 +36,7 @@ export function PanelPreview(props: PanelEditorValues) {
 
   return (
     <Box height={300}>
-      <Panel {...panelPreviewProps} />
+      <Panel {...previewValues} />
     </Box>
   );
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -14,27 +14,15 @@
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 import { Stack, Box } from '@mui/material';
 import { TimeSeriesChartOptions } from './time-series-chart-model';
-import { TimeSeriesChartPanel, TimeSeriesChartProps } from './TimeSeriesChartPanel';
-
 export type TimeSeriesChartOptionsEditorProps = OptionsEditorProps<TimeSeriesChartOptions>;
 
 export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditorProps) {
   const { value } = props;
 
-  const panelPreviewProps: TimeSeriesChartProps = {
-    spec: {
-      ...value,
-    },
-    contentDimensions: { width: 500, height: 250 },
-  };
-
   return (
-    <>
-      <TimeSeriesChartPanel {...panelPreviewProps} />
-      <Stack spacing={1}>
-        <Box>{JSON.stringify(value)}</Box>
-        {/* TODO: add form controls to edit panel options */}
-      </Stack>
-    </>
+    <Stack spacing={1}>
+      <Box>{JSON.stringify(value)}</Box>
+      {/* TODO: add form controls to edit panel options */}
+    </Stack>
   );
 }


### PR DESCRIPTION
Follow up to #596 
- move preview out of TimeSeriesChartOptionsEditor
- add PanelPreview.tsx component
- currently it is pulled into PanelEditorForm above PanelSpecEditor
  - _I tried a few places and this seemed to work the best but open to other ideas!_
- static height was needed since by default you could only see the panel header

### TODO
- [ ] show preview component without edit action icons in panel header