### PR TITLE
remove unused panel name in StatChartPanel

### DIFF
--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -71,12 +71,7 @@ const useChartData = (data: TimeSeriesData | undefined, calculation: Calculation
     const calculate = CalculationsMap[calculation];
     const calculatedValue = seriesData !== undefined ? calculate(Array.from(seriesData.values)) : undefined;
 
-    return {
-      calculatedValue,
-      seriesData,
-      // TODO: How is this name used in StatChart? Do we really need it? Should it be a chart spec option?
-      name: 'StatChart',
-    };
+    return { calculatedValue, seriesData };
   }, [data, calculation]);
 };
 


### PR DESCRIPTION
Follow up to discussion in #599, name can be removed completely now. Before it was an optional prop to show the name above the calculated value-- I since refactored StatChart in #462 but forgot to remove it from StatChartPanel