### PR TITLE
bugfix redundant no data message in StatChart

### DIFF
--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -56,7 +56,7 @@ export function StatChart(props: StatChartProps) {
   const { width, height, data, unit, sparkline } = props;
   const chartsTheme = useChartsTheme();
 
-  const formattedValue = data.calculatedValue === undefined ? 'No data' : formatValue(data.calculatedValue, unit);
+  const formattedValue = data.calculatedValue === undefined ? '' : formatValue(data.calculatedValue, unit);
 
   const option: EChartsCoreOption = useMemo(() => {
     if (data.seriesData === undefined) return chartsTheme.noDataOption;


### PR DESCRIPTION
Remove second 'No data' message, instead only use noDataOption (will be easier to keep consistent with other charts)

### Before 
![stat_no_data_bug_before](https://user-images.githubusercontent.com/9369625/194102438-9b008066-9a06-4fbd-a86a-f01842a513b1.png)

### After 
![stat_no_data_bug_after](https://user-images.githubusercontent.com/9369625/194102444-71ff93ca-035a-42ac-89f7-14afd2842fbb.png)
