### PR TITLE
Allow listing datasources for a given datasource plugin kind

### DIFF
--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -51,7 +51,7 @@ export function useDatasourceApi(): DatasourceStoreProviderProps['datasourceApi'
 function getProxyUrl(datasource: Datasource | GlobalDatasource) {
   let url = `/proxy`;
   if (datasource.kind === 'Datasource') {
-    url += `/project/${encodeURIComponent(datasource.metadata.project)}`;
+    url += `/projects/${encodeURIComponent(datasource.metadata.project)}`;
   }
   url += `/${datasource.kind.toLowerCase()}s/${encodeURIComponent(datasource.metadata.name)}`;
   return url;

--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Datasource, GlobalDatasource } from '@perses-dev/core';
 import { DatasourceStoreProviderProps } from '@perses-dev/dashboards';
 
 export function useDatasourceApi(): DatasourceStoreProviderProps['datasourceApi'] {
@@ -24,34 +25,57 @@ export function useDatasourceApi(): DatasourceStoreProviderProps['datasourceApi'
       // TODO: Convert selector to appropriate request params and fetchJson to get it from backend
 
       // Just resolve a default PrometheusDatasource right now
-      if (selector.kind === 'PrometheusDatasource' && selector.name === undefined) {
-        const name = 'PrometheusDemo';
+      if (selector.kind === tempDatasource.spec.plugin.kind && selector.name === undefined) {
         return {
-          resource: {
-            kind: 'GlobalDatasource',
-            metadata: {
-              name,
-              created_at: '',
-              updated_at: '',
-              version: 0,
-            },
-            spec: {
-              default: true,
-              display: {
-                name: 'Prometheus Demo',
-              },
-              plugin: {
-                kind: 'PrometheusDatasource',
-                spec: {
-                  direct_url: 'https://prometheus.demo.do.prometheus.io',
-                },
-              },
-            },
-          },
-          proxyUrl: `/proxy/globaldatasources/${encodeURIComponent(name)}`,
+          resource: tempDatasource,
+          proxyUrl: getProxyUrl(tempDatasource),
         };
       }
       return undefined;
     },
+
+    listDatasources: async (/*project, pluginKind*/) => {
+      return [];
+    },
+
+    listGlobalDatasources: async (pluginKind) => {
+      if (pluginKind === tempDatasource.spec.plugin.kind) {
+        return [tempDatasource];
+      }
+      return [];
+    },
   };
 }
+
+// Helper function for getting a proxy URL from a datasource or global datasource
+function getProxyUrl(datasource: Datasource | GlobalDatasource) {
+  let url = `/proxy`;
+  if (datasource.kind === 'Datasource') {
+    url += `/project/${encodeURIComponent(datasource.metadata.project)}`;
+  }
+  url += `/${datasource.kind.toLowerCase()}s/${encodeURIComponent(datasource.metadata.name)}`;
+  return url;
+}
+
+// Just a temporary datasource while we're working on connecting to a real backend API
+const tempDatasource: GlobalDatasource = {
+  kind: 'GlobalDatasource',
+  metadata: {
+    name: 'PrometheusDemo',
+    created_at: '',
+    updated_at: '',
+    version: 0,
+  },
+  spec: {
+    default: true,
+    display: {
+      name: 'Prometheus Demo',
+    },
+    plugin: {
+      kind: 'PrometheusDatasource',
+      spec: {
+        direct_url: 'https://prometheus.demo.do.prometheus.io',
+      },
+    },
+  },
+};

--- a/ui/dashboards/src/context/DatasourceStoreProvider.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.tsx
@@ -101,17 +101,17 @@ export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
     [findDatasource, getPlugin]
   );
 
-  const listDatasourceMetadata = useEvent(async (pluginKind: string): Promise<DatasourceMetadata[]> => {
+  const listDatasourceMetadata = useEvent(async (datasourcePluginKind: string): Promise<DatasourceMetadata[]> => {
     const [pluginMetadata, datasources, globalDatasources] = await Promise.all([
       listPluginMetadata('Datasource'),
-      datasourceApi.listDatasources(project, pluginKind),
-      datasourceApi.listGlobalDatasources(pluginKind),
+      datasourceApi.listDatasources(project, datasourcePluginKind),
+      datasourceApi.listGlobalDatasources(datasourcePluginKind),
     ]);
 
     // Find the metadata for the plugin type they asked for so we can use it for the name of the default datasource
-    const datasourcePluginMetadata = pluginMetadata.find((metadata) => metadata.kind === pluginKind);
+    const datasourcePluginMetadata = pluginMetadata.find((metadata) => metadata.kind === datasourcePluginKind);
     if (datasourcePluginMetadata === undefined) {
-      throw new Error(`Could not find a Datasource plugin with kind '${pluginKind}'`);
+      throw new Error(`Could not find a Datasource plugin with kind '${datasourcePluginKind}'`);
     }
 
     // Get helper for de-duping results properly
@@ -121,7 +121,7 @@ export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
     if (dashboardResource.spec.datasources !== undefined) {
       for (const selectorName in dashboardResource.spec.datasources) {
         const spec = dashboardResource.spec.datasources[selectorName];
-        if (spec === undefined || spec.plugin.kind !== pluginKind) continue;
+        if (spec === undefined || spec.plugin.kind !== datasourcePluginKind) continue;
         addResult(spec, selectorName);
       }
     }

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { DatasourceSelector, DatasourceSpec } from '@perses-dev/core';
+import { useQuery } from '@tanstack/react-query';
 import { createContext, useContext } from 'react';
 
 export interface DatasourceStore {
@@ -26,7 +27,7 @@ export interface DatasourceStore {
   /**
    * Gets a list of datasource metadata for a plugin kind.
    */
-  listDatasourceMetadata(pluginKind: string): Promise<DatasourceMetadata[]>;
+  listDatasourceMetadata(datasourcePluginKind: string): Promise<DatasourceMetadata[]>;
 }
 
 export interface DatasourceMetadata {
@@ -42,4 +43,13 @@ export function useDatasourceStore() {
     throw new Error('No DatasourceStoreContext found. Did you forget a Provider?');
   }
   return ctx;
+}
+
+/**
+ * Lists all available Datasource instances for a given datasource plugin kind. Returns a list with the name of that
+ * instance, as well as its DatasourceSelector for referencing it.
+ */
+export function useListDatasources(datasourcePluginKind: string) {
+  const { listDatasourceMetadata } = useDatasourceStore();
+  return useQuery(['listDatasourceMetadata', datasourcePluginKind], () => listDatasourceMetadata(datasourcePluginKind));
 }

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -22,6 +22,16 @@ export interface DatasourceStore {
    * Given a DatasourceSelector, gets a `Client` object from the corresponding Datasource plugin.
    */
   getDatasourceClient<Client>(selector: DatasourceSelector): Promise<Client>;
+
+  /**
+   * Gets a list of datasource metadata for a plugin kind.
+   */
+  listDatasourceMetadata(pluginKind: string): Promise<DatasourceMetadata[]>;
+}
+
+export interface DatasourceMetadata {
+  name: string;
+  selector: DatasourceSelector;
 }
 
 export const DatasourceStoreContext = createContext<DatasourceStore | undefined>(undefined);


### PR DESCRIPTION
This adds functionality to the `DatasourceStoreProvider` to enable us to list all the datasources of a specific plugin kind (i.e. "give me all the `PrometheusDatasource` instances available"). This is so that while visually editing a time series query or variable definition, we can present the user with a list of datasources to select from. I added a hook to the plugin runtime called `useListDatasources` that should hopefully be helpful when someone is ready to build that UI.