### PR TITLE
Add an UnknownSpec type for framework code at runtime

### DIFF
--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Definition } from './definitions';
+import { Definition, UnknownSpec } from './definitions';
 import { Metadata, ProjectMetadata } from './resource';
 
 /**
@@ -32,7 +32,7 @@ export interface Datasource {
   spec: DatasourceSpec;
 }
 
-export interface DatasourceSpec<PluginSpec = unknown> {
+export interface DatasourceSpec<PluginSpec = UnknownSpec> {
   display?: {
     name: string;
     description?: string;

--- a/ui/core/src/model/definitions.ts
+++ b/ui/core/src/model/definitions.ts
@@ -18,3 +18,9 @@ export interface Definition<Spec> {
   kind: string;
   spec: Spec;
 }
+
+/**
+ * Type to represent specs at runtime in framework code where we don't know the spec's real type, probably because it's
+ * part of a plugin.
+ */
+export type UnknownSpec = Record<string, unknown>;

--- a/ui/core/src/model/panels.ts
+++ b/ui/core/src/model/panels.ts
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Definition } from './definitions';
+import { Definition, UnknownSpec } from './definitions';
 
-export interface PanelDefinition<PluginSpec = unknown> extends Definition<PanelSpec<PluginSpec>> {
+export interface PanelDefinition<PluginSpec = UnknownSpec> extends Definition<PanelSpec<PluginSpec>> {
   kind: 'Panel';
 }
 

--- a/ui/core/src/model/time-series-queries.ts
+++ b/ui/core/src/model/time-series-queries.ts
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Definition } from './definitions';
+import { Definition, UnknownSpec } from './definitions';
 
-export interface TimeSeriesQueryDefinition<PluginSpec = unknown> extends Definition<TimeSeriesQuerySpec<PluginSpec>> {
+export interface TimeSeriesQueryDefinition<PluginSpec = UnknownSpec>
+  extends Definition<TimeSeriesQuerySpec<PluginSpec>> {
   kind: 'TimeSeriesQuery';
 }
 

--- a/ui/core/src/model/variables.ts
+++ b/ui/core/src/model/variables.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Definition } from './definitions';
+import { Definition, UnknownSpec } from './definitions';
 
 export type VariableName = string;
 
@@ -34,7 +34,7 @@ export interface TextVariableSpec extends VariableSpec {
   value: string;
 }
 
-export interface ListVariableDefinition<PluginSpec = unknown> extends Definition<ListVariableSpec<PluginSpec>> {
+export interface ListVariableDefinition<PluginSpec = UnknownSpec> extends Definition<ListVariableSpec<PluginSpec>> {
   kind: 'ListVariable';
 }
 

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -13,8 +13,9 @@
 
 import { usePlugin, PanelProps } from '@perses-dev/plugin-system';
 import { Skeleton } from '@mui/material';
+import { UnknownSpec } from '@perses-dev/core';
 
-export interface PanelContentProps extends PanelProps<unknown> {
+export interface PanelContentProps extends PanelProps<UnknownSpec> {
   panelPluginKind: string;
 }
 

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -47,6 +47,9 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
 
   const handleSubmit: FormEventHandler = (e) => {
     e.preventDefault();
+    if (spec === undefined) {
+      throw new Error('Cannot submit without a plugin spec');
+    }
     const values: PanelEditorValues = { name, description, groupIndex, kind, spec };
     onSubmit(values);
   };

--- a/ui/dashboards/src/components/PanelDrawer/PanelSpecEditor.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelSpecEditor.tsx
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { UnknownSpec } from '@perses-dev/core';
 import { OptionsEditorProps, usePlugin } from '@perses-dev/plugin-system';
 
-export interface PanelSpecEditorProps extends OptionsEditorProps<unknown> {
+export interface PanelSpecEditorProps extends OptionsEditorProps<UnknownSpec> {
   panelPluginKind: string;
 }
 

--- a/ui/dashboards/src/components/PanelDrawer/panel-editor-model.ts
+++ b/ui/dashboards/src/components/PanelDrawer/panel-editor-model.ts
@@ -14,14 +14,15 @@
 import { useMemo } from 'react';
 import { usePlugin } from '@perses-dev/plugin-system';
 import { useImmer } from 'use-immer';
+import { UnknownSpec } from '@perses-dev/core';
 
 /**
  * Manages panel plugin spec state. The spec will be undefined while a plugin is being loaded.
  */
-export function usePanelSpecState(panelPluginKind: string, initialState: unknown) {
+export function usePanelSpecState(panelPluginKind: string, initialState: UnknownSpec) {
   // Keeping track of spec values by kind allows users to switch between panel types and come back with their old
   // values intact from before the switch
-  const [specByKind, setSpecByKind] = useImmer<Record<string, unknown>>({ [panelPluginKind]: initialState });
+  const [specByKind, setSpecByKind] = useImmer<Record<string, UnknownSpec>>({ [panelPluginKind]: initialState });
   const { data: plugin } = usePlugin('Panel', panelPluginKind, { enabled: panelPluginKind !== '' });
   const pluginInitialSpec = useMemo(() => plugin?.createInitialOptions(), [plugin]);
 
@@ -30,7 +31,7 @@ export function usePanelSpecState(panelPluginKind: string, initialState: unknown
 
   // TODO: Do we want to expose more of a immer style API to plugin authors for managing their state, rather than the
   // current "onChange" API?
-  const onSpecChange = (next: unknown) => {
+  const onSpecChange = (next: UnknownSpec) => {
     setSpecByKind((draft) => {
       draft[panelPluginKind] = next;
     });

--- a/ui/dashboards/src/context/DashboardProvider/panel-editing-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editing-slice.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PanelDefinition } from '@perses-dev/core';
+import { PanelDefinition, UnknownSpec } from '@perses-dev/core';
 import { StateCreator } from 'zustand';
 import { removeWhiteSpacesAndSpecialCharacters } from '../../utils/functions';
 import { Middleware } from './common';
@@ -65,7 +65,7 @@ export interface PanelEditorValues {
   description: string;
   groupIndex: number;
   kind: string;
-  spec: unknown;
+  spec: UnknownSpec;
 }
 
 /**

--- a/ui/plugin-system/src/model/datasource.ts
+++ b/ui/plugin-system/src/model/datasource.ts
@@ -11,12 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { UnknownSpec } from '@perses-dev/core';
 import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
 
 /**
  * Plugin that defines options for an external system that Perses talks to for data.
  */
-export interface DatasourcePlugin<Spec = unknown, Client = unknown> {
+export interface DatasourcePlugin<Spec = UnknownSpec, Client = unknown> {
   createClient: (spec: Spec, options: DatasourceClientOptions) => Client;
   OptionsEditorComponent: OptionsEditor<Spec>;
   createInitialOptions: InitialOptionsCallback<Spec>;

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -11,12 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { UnknownSpec } from '@perses-dev/core';
 import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
 
 /**
  * Plugin the provides custom visualizations inside of a Panel.
  */
-export interface PanelPlugin<Spec = unknown> {
+export interface PanelPlugin<Spec = UnknownSpec> {
   PanelComponent: React.ComponentType<PanelProps<Spec>>;
   OptionsEditorComponent: OptionsEditor<Spec>;
   createInitialOptions: InitialOptionsCallback<Spec>;

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AbsoluteTimeRange, UnixTimeMs } from '@perses-dev/core';
+import { AbsoluteTimeRange, UnixTimeMs, UnknownSpec } from '@perses-dev/core';
 import { DatasourceStore, VariableStateMap } from '../runtime';
 
 /**
  * A plugin for running graph queries.
  */
-export interface TimeSeriesQueryPlugin<Spec = unknown> {
+export interface TimeSeriesQueryPlugin<Spec = UnknownSpec> {
   getTimeSeriesData: (spec: Spec, ctx: TimeSeriesQueryContext) => Promise<TimeSeriesData>;
 }
 

--- a/ui/plugin-system/src/model/variables.ts
+++ b/ui/plugin-system/src/model/variables.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { UnknownSpec } from '@perses-dev/core';
 import { VariableStateMap } from '../runtime';
 import { DatasourceStore } from '../runtime';
 
@@ -24,7 +25,7 @@ export interface GetVariableOptionsContext {
 /**
  * Plugin for handling custom VariableDefinitions.
  */
-export interface VariablePlugin<Spec = unknown> {
+export interface VariablePlugin<Spec = UnknownSpec> {
   getVariableOptions: GetVariableOptions<Spec>;
 
   /** Returns a list of variables name this variable depends on. Used to optimize fetching */


### PR DESCRIPTION
This is a follow-up to something I noticed in #604 and adds an `UnknownSpec` type we can use at runtime, rather than using `unknown` from Typescript. Why? Because this lets us distinguish between "some unknown object" and something like `undefined` (i.e. "I don't have an object yet"). This is sometimes useful when, for example, a plugin is loading and hasn't created a spec yet and we need to tell the difference.