### PR TITLE
Add PluginSpecEditor to support a query input for TimeSeriesChart

### DIFF
--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -14,11 +14,11 @@
 import { FormEventHandler, useState } from 'react';
 import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, SelectProps } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { PluginSpecEditor } from '@perses-dev/plugin-system';
 import { useLayouts } from '../../context';
 import { PanelEditorValues } from '../../context/DashboardProvider/panel-editing-slice';
 import { usePanelSpecState } from './panel-editor-model';
 import { PanelTypeSelect } from './PanelTypeSelect';
-import { PanelSpecEditor } from './PanelSpecEditor';
 import { PanelPreview } from './PanelPreview';
 
 export interface PanelEditorFormProps {
@@ -105,7 +105,9 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
               <PanelPreview kind={kind} name={name} description={description} spec={spec} groupIndex={groupIndex} />
             )}
             {/* Wait until we have some proper initial spec values before rendering the editor */}
-            {spec !== undefined && <PanelSpecEditor panelPluginKind={kind} value={spec} onChange={onSpecChange} />}
+            {spec !== undefined && (
+              <PluginSpecEditor pluginType="Panel" pluginKind={kind} value={spec} onChange={onSpecChange} />
+            )}
           </ErrorBoundary>
         </Grid>
       </Grid>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14100,6 +14100,7 @@
         "date-fns": "^2.28.0",
         "dompurify": "^2.4.0",
         "echarts": "^5.3.3",
+        "immer": "^9.0.15",
         "lodash-es": "^4.17.21",
         "marked": "^4.1.0",
         "mathjs": "^10.6.4"
@@ -14140,7 +14141,8 @@
         "@perses-dev/core": "^0.9.0",
         "@perses-dev/plugin-system": "^0.9.0",
         "@prometheus-io/lezer-promql": "^0.37.0",
-        "date-fns": "^2.28.0"
+        "date-fns": "^2.28.0",
+        "immer": "^9.0.15"
       },
       "peerDependencies": {
         "react": "^17.0.2 || ^18.0.0"
@@ -16355,6 +16357,7 @@
         "date-fns": "^2.28.0",
         "dompurify": "^2.4.0",
         "echarts": "^5.3.3",
+        "immer": "^9.0.15",
         "lodash-es": "^4.17.21",
         "marked": "^4.1.0",
         "mathjs": "^10.6.4"
@@ -16377,7 +16380,8 @@
         "@perses-dev/core": "^0.9.0",
         "@perses-dev/plugin-system": "^0.9.0",
         "@prometheus-io/lezer-promql": "^0.37.0",
-        "date-fns": "^2.28.0"
+        "date-fns": "^2.28.0",
+        "immer": "^9.0.15"
       },
       "dependencies": {
         "@prometheus-io/lezer-promql": {

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -33,6 +33,7 @@
     "date-fns": "^2.28.0",
     "dompurify": "^2.4.0",
     "echarts": "^5.3.3",
+    "immer": "^9.0.15",
     "lodash-es": "^4.17.21",
     "marked": "^4.1.0",
     "mathjs": "^10.6.4"

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -13,6 +13,7 @@
 
 import produce from 'immer';
 import { Stack, Typography } from '@mui/material';
+import { UnknownSpec } from '@perses-dev/core';
 import { PluginSpecEditor, OptionsEditorProps } from '@perses-dev/plugin-system';
 import { TimeSeriesChartOptions } from './time-series-chart-model';
 
@@ -22,10 +23,10 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
   const { onChange, value } = props;
   const { queries } = value;
 
-  const handleQueryPluginSpecChange = (index: number, pluginSpec: unknown) => {
+  const handleQueryPluginSpecChange = (index: number, pluginSpec: UnknownSpec) => {
     onChange(
       produce(value, (draft: TimeSeriesChartOptions) => {
-        if (draft.queries[index]?.spec?.plugin?.spec) {
+        if (draft.queries.length && draft.queries[index]?.spec?.plugin?.spec) {
           draft.queries[index].spec.plugin.spec = pluginSpec;
         }
       })
@@ -43,7 +44,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
               pluginType="TimeSeriesQuery"
               pluginKind={plugin.kind}
               value={plugin.spec}
-              onChange={(next: unknown) => handleQueryPluginSpecChange(i, next)}
+              onChange={(next: UnknownSpec) => handleQueryPluginSpecChange(i, next)}
             />
           )}
         </>

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -26,7 +26,10 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
   const handleQueryPluginSpecChange = (index: number, pluginSpec: UnknownSpec) => {
     onChange(
       produce(value, (draft: TimeSeriesChartOptions) => {
-        draft.queries[index].spec.plugin.spec = pluginSpec;
+        const timeSeriesQuery = draft.queries[index];
+        if (timeSeriesQuery) {
+          timeSeriesQuery.spec.plugin.spec = pluginSpec;
+        }
       })
     );
   };

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -26,9 +26,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
   const handleQueryPluginSpecChange = (index: number, pluginSpec: UnknownSpec) => {
     onChange(
       produce(value, (draft: TimeSeriesChartOptions) => {
-        if (draft.queries.length && draft.queries[index]?.spec?.plugin?.spec) {
-          draft.queries[index].spec.plugin.spec = pluginSpec;
-        }
+        draft.queries[index].spec.plugin.spec = pluginSpec;
       })
     );
   };

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -11,18 +11,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { OptionsEditorProps } from '@perses-dev/plugin-system';
-import { Stack, Box } from '@mui/material';
+import produce from 'immer';
+import { Stack, Typography } from '@mui/material';
+import { PluginSpecEditor, OptionsEditorProps } from '@perses-dev/plugin-system';
 import { TimeSeriesChartOptions } from './time-series-chart-model';
+
 export type TimeSeriesChartOptionsEditorProps = OptionsEditorProps<TimeSeriesChartOptions>;
 
 export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditorProps) {
-  const { value } = props;
+  const { onChange, value } = props;
+  const { queries } = value;
+
+  const handleQueryPluginSpecChange = (index: number, pluginSpec: unknown) => {
+    onChange(
+      produce(value, (draft: TimeSeriesChartOptions) => {
+        if (draft.queries[index]?.spec?.plugin?.spec) {
+          draft.queries[index].spec.plugin.spec = pluginSpec;
+        }
+      })
+    );
+  };
 
   return (
     <Stack spacing={1}>
-      <Box>{JSON.stringify(value)}</Box>
-      {/* TODO: add form controls to edit panel options */}
+      {/* TODO: Deal with user deleting all queries */}
+      {queries.map(({ spec: { plugin } }, i) => (
+        <>
+          <Typography variant="overline">Query {i + 1}</Typography>
+          {plugin && (
+            <PluginSpecEditor
+              pluginType="TimeSeriesQuery"
+              pluginKind={plugin.kind}
+              value={plugin.spec}
+              onChange={(next: unknown) => handleQueryPluginSpecChange(i, next)}
+            />
+          )}
+        </>
+      ))}
     </Stack>
   );
 }

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -13,12 +13,15 @@
 
 import { AbsoluteTimeRange, UnixTimeMs, UnknownSpec } from '@perses-dev/core';
 import { DatasourceStore, VariableStateMap } from '../runtime';
+import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
 
 /**
- * A plugin for running graph queries.
+ * A plugin for running time series queries.
  */
 export interface TimeSeriesQueryPlugin<Spec = UnknownSpec> {
   getTimeSeriesData: (spec: Spec, ctx: TimeSeriesQueryContext) => Promise<TimeSeriesData>;
+  OptionsEditorComponent: OptionsEditor<Spec>;
+  createInitialOptions: InitialOptionsCallback<Spec>;
 }
 
 /**

--- a/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
+++ b/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import { UnknownSpec } from '@perses-dev/core';
-import { OptionsEditorProps, usePlugin } from '@perses-dev/plugin-system';
+import { OptionsEditorProps } from '../model/visual-editing';
+import { usePlugin } from './plugins';
 
 export interface PluginSpecEditorProps extends OptionsEditorProps<UnknownSpec> {
   pluginType: 'Panel' | 'TimeSeriesQuery';

--- a/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
+++ b/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
@@ -14,15 +14,16 @@
 import { UnknownSpec } from '@perses-dev/core';
 import { OptionsEditorProps, usePlugin } from '@perses-dev/plugin-system';
 
-export interface PanelSpecEditorProps extends OptionsEditorProps<UnknownSpec> {
-  panelPluginKind: string;
+export interface PluginSpecEditorProps extends OptionsEditorProps<UnknownSpec> {
+  pluginType: 'Panel' | 'TimeSeriesQuery';
+  pluginKind: string;
 }
 
-export function PanelSpecEditor(props: PanelSpecEditorProps) {
-  const { panelPluginKind, ...others } = props;
-  const { data: plugin, isLoading } = usePlugin('Panel', panelPluginKind, {
+export function PluginSpecEditor(props: PluginSpecEditorProps) {
+  const { pluginType, pluginKind, ...others } = props;
+  const { data: plugin, isLoading } = usePlugin(pluginType, pluginKind, {
     useErrorBoundary: true,
-    enabled: panelPluginKind !== '',
+    enabled: pluginKind !== '',
   });
 
   // TODO: Proper loading indicator
@@ -31,7 +32,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
   }
 
   if (plugin === undefined) {
-    throw new Error(`Missing OptionsEditorComponent for Panel plugin with kind '${panelPluginKind}'`);
+    throw new Error(`Missing OptionsEditorComponent for ${pluginType} plugin with kind '${pluginKind}'`);
   }
 
   const { OptionsEditorComponent } = plugin;

--- a/ui/plugin-system/src/runtime/index.ts
+++ b/ui/plugin-system/src/runtime/index.ts
@@ -12,8 +12,9 @@
 // limitations under the License.
 
 export * from './datasources';
-export * from './time-series-queries';
 export * from './plugins';
+export * from './PluginSpecEditor';
 export * from './query-string';
 export * from './template-variables';
 export * from './time-range';
+export * from './time-series-queries';

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -32,7 +32,8 @@
     "@perses-dev/core": "^0.9.0",
     "@perses-dev/plugin-system": "^0.9.0",
     "@prometheus-io/lezer-promql": "^0.37.0",
-    "date-fns": "^2.28.0"
+    "date-fns": "^2.28.0",
+    "immer": "^9.0.15"
   },
   "peerDependencies": {
     "react": "^17.0.2 || ^18.0.0"

--- a/ui/prometheus-plugin/src/plugins/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/PrometheusTimeSeriesQueryEditor.tsx
@@ -1,0 +1,35 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ChangeEvent } from 'react';
+import produce from 'immer';
+import { TextField } from '@mui/material';
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { PrometheusTimeSeriesQuerySpec } from './time-series-query';
+
+export type PrometheusTimeSeriesQueryEditorProps = OptionsEditorProps<PrometheusTimeSeriesQuerySpec>;
+
+export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQueryEditorProps) {
+  const { onChange, value } = props;
+  const { query } = value;
+
+  const handleQueryChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(
+      produce(value, (draft: PrometheusTimeSeriesQuerySpec) => {
+        draft.query = e.target.value;
+      })
+    );
+  };
+
+  return <TextField label="Query" value={query} onChange={handleQueryChange} />;
+}

--- a/ui/prometheus-plugin/src/plugins/time-series-query.ts
+++ b/ui/prometheus-plugin/src/plugins/time-series-query.ts
@@ -25,8 +25,9 @@ import {
   replaceTemplateVariables,
   DEFAULT_PROM,
 } from '../model';
+import { PrometheusTimeSeriesQueryEditor } from './PrometheusTimeSeriesQueryEditor';
 
-interface PrometheusTimeSeriesQuerySpec {
+export interface PrometheusTimeSeriesQuerySpec {
   query: TemplateString;
   min_step?: DurationString;
   resolution?: number;
@@ -100,4 +101,8 @@ const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec>['g
  */
 export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec> = {
   getTimeSeriesData,
+  OptionsEditorComponent: PrometheusTimeSeriesQueryEditor,
+  createInitialOptions: () => ({
+    query: '',
+  }),
 };


### PR DESCRIPTION
The goal of this PR is to add a query input to the panel editor.

Originally, I tried to implement this entirely inside of TimeSeriesChartOptionsEditor alone, but that didn't work.

The reason is that the TimeSeriesChart is a panel plugin that is using other plugins -- namely, query plugins. 

Each query plugins need to tell the code that uses it how to edit it, since each query plugin can have different specs. In this PR, we're achieving this by adding `OptionsEditorComponent` and `createInitialOptions()` to the query plugins. 

Additionally, this PR:
* Converted `PanelSpecEditor` to a more generic `PluginSpecEditor` that can be used for editing panel plugins AND query plugins.
* Used `PluginSpecEditor` in both `PanelEditorForm` and `TimeSeriesChartOptionsEditor` to implement the query input. 

Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>