### PR TITLE
Add visual editing props to all plugins

### DIFF
--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -38,7 +38,7 @@ export function mockPluginRegistryProps() {
     },
   };
 
-  const mockPluginModule: Record<string, Plugin> = {};
+  const mockPluginModule: Record<string, unknown> = {};
 
   // Allow adding mock plugins in tests
   const addMockPlugin = <T extends PluginType>(pluginType: T, kind: string, plugin: PluginImplementation<T>) => {

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -10,13 +10,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { UnknownSpec } from '@perses-dev/core';
 import {
   PluginRegistryProps,
   PluginModuleResource,
   PluginImplementation,
   PluginType,
-  Plugin,
   PanelPlugin,
+  Plugin,
 } from '@perses-dev/plugin-system';
 
 /**
@@ -38,7 +39,7 @@ export function mockPluginRegistryProps() {
     },
   };
 
-  const mockPluginModule: Record<string, unknown> = {};
+  const mockPluginModule: Record<string, Plugin<UnknownSpec>> = {};
 
   // Allow adding mock plugins in tests
   const addMockPlugin = <T extends PluginType>(pluginType: T, kind: string, plugin: PluginImplementation<T>) => {

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -13,7 +13,7 @@
 
 import { useEvent } from '@perses-dev/core';
 import { useRef, useCallback, useMemo } from 'react';
-import { PluginModuleResource, PluginType, Plugin, PluginImplementation } from '../../model';
+import { PluginModuleResource, PluginType, PluginImplementation } from '../../model';
 import { getTypeAndKindKey } from '../../utils/cache-keys';
 import { GetInstalledPlugins, usePluginIndexes } from './plugin-indexes';
 import { PluginRegistryContext } from './plugin-registry-model';
@@ -63,7 +63,7 @@ export function PluginRegistry(props: PluginRegistryProps) {
       }
 
       // Treat the plugin module as a bunch of named exports that have plugins
-      const pluginModule = (await loadPluginModule(resource)) as Record<string, Plugin>;
+      const pluginModule = (await loadPluginModule(resource)) as Record<string, unknown>;
 
       // We currently assume that plugin modules will have named exports that match the kinds they handle
       const plugin = pluginModule[kind];

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useEvent } from '@perses-dev/core';
+import { UnknownSpec, useEvent } from '@perses-dev/core';
 import { useRef, useCallback, useMemo } from 'react';
-import { PluginModuleResource, PluginType, PluginImplementation } from '../../model';
+import { PluginModuleResource, PluginType, PluginImplementation, Plugin } from '../../model';
 import { getTypeAndKindKey } from '../../utils/cache-keys';
 import { GetInstalledPlugins, usePluginIndexes } from './plugin-indexes';
 import { PluginRegistryContext } from './plugin-registry-model';
@@ -63,7 +63,7 @@ export function PluginRegistry(props: PluginRegistryProps) {
       }
 
       // Treat the plugin module as a bunch of named exports that have plugins
-      const pluginModule = (await loadPluginModule(resource)) as Record<string, unknown>;
+      const pluginModule = (await loadPluginModule(resource)) as Record<string, Plugin<UnknownSpec>>;
 
       // We currently assume that plugin modules will have named exports that match the kinds they handle
       const plugin = pluginModule[kind];

--- a/ui/plugin-system/src/components/PluginRegistry/test-plugins/ernie/index.ts
+++ b/ui/plugin-system/src/components/PluginRegistry/test-plugins/ernie/index.ts
@@ -21,4 +21,6 @@ const data: VariableOption[] = [
 // Dummy plugin to test loading
 export const ErnieVariable: VariablePlugin = {
   getVariableOptions: async () => ({ data }),
+  OptionsEditorComponent: () => null,
+  createInitialOptions: () => ({}),
 };

--- a/ui/plugin-system/src/model/datasource.ts
+++ b/ui/plugin-system/src/model/datasource.ts
@@ -12,15 +12,13 @@
 // limitations under the License.
 
 import { UnknownSpec } from '@perses-dev/core';
-import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
+import { Plugin } from './plugin-base';
 
 /**
  * Plugin that defines options for an external system that Perses talks to for data.
  */
-export interface DatasourcePlugin<Spec = UnknownSpec, Client = unknown> {
+export interface DatasourcePlugin<Spec = UnknownSpec, Client = unknown> extends Plugin<Spec> {
   createClient: (spec: Spec, options: DatasourceClientOptions) => Client;
-  OptionsEditorComponent: OptionsEditor<Spec>;
-  createInitialOptions: InitialOptionsCallback<Spec>;
 }
 
 export interface DatasourceClientOptions {

--- a/ui/plugin-system/src/model/index.ts
+++ b/ui/plugin-system/src/model/index.ts
@@ -16,4 +16,4 @@ export * from './panels';
 export * from './plugins';
 export * from './time-series-queries';
 export * from './variables';
-export * from './visual-editing';
+export * from './plugin-base';

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -12,15 +12,13 @@
 // limitations under the License.
 
 import { UnknownSpec } from '@perses-dev/core';
-import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
+import { Plugin } from './plugin-base';
 
 /**
  * Plugin the provides custom visualizations inside of a Panel.
  */
-export interface PanelPlugin<Spec = UnknownSpec> {
+export interface PanelPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
   PanelComponent: React.ComponentType<PanelProps<Spec>>;
-  OptionsEditorComponent: OptionsEditor<Spec>;
-  createInitialOptions: InitialOptionsCallback<Spec>;
 }
 
 /**

--- a/ui/plugin-system/src/model/plugin-base.ts
+++ b/ui/plugin-system/src/model/plugin-base.ts
@@ -14,6 +14,21 @@
 import React from 'react';
 
 /**
+ * Base type of all plugin implementations.
+ */
+export interface Plugin<Spec> {
+  /**
+   * React component for editing the plugin's options in the UI.
+   */
+  OptionsEditorComponent: OptionsEditor<Spec>;
+
+  /**
+   * Callback for creating the initial options for the plugin.
+   */
+  createInitialOptions: InitialOptionsCallback<Spec>;
+}
+
+/**
  * A component for visual editing of a plugin's options.
  */
 export type OptionsEditor<Spec> = React.ComponentType<OptionsEditorProps<Spec>>;

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -58,13 +58,6 @@ export interface SupportedPlugins {
 }
 
 /**
- * Union type of all available plugin implementations.
- */
-export type Plugin = {
-  [Type in PluginType]: PluginImplementation<Type>;
-}[PluginType];
-
-/**
  * The implementation for a given plugin type.
  */
 export type PluginImplementation<Type extends PluginType> = SupportedPlugins[Type];

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -13,15 +13,13 @@
 
 import { AbsoluteTimeRange, UnixTimeMs, UnknownSpec } from '@perses-dev/core';
 import { DatasourceStore, VariableStateMap } from '../runtime';
-import { InitialOptionsCallback, OptionsEditor } from './visual-editing';
+import { Plugin } from './plugin-base';
 
 /**
  * A plugin for running time series queries.
  */
-export interface TimeSeriesQueryPlugin<Spec = UnknownSpec> {
+export interface TimeSeriesQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
   getTimeSeriesData: (spec: Spec, ctx: TimeSeriesQueryContext) => Promise<TimeSeriesData>;
-  OptionsEditorComponent: OptionsEditor<Spec>;
-  createInitialOptions: InitialOptionsCallback<Spec>;
 }
 
 /**

--- a/ui/plugin-system/src/model/variables.ts
+++ b/ui/plugin-system/src/model/variables.ts
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import { UnknownSpec } from '@perses-dev/core';
-import { VariableStateMap } from '../runtime';
-import { DatasourceStore } from '../runtime';
+import { VariableStateMap, DatasourceStore } from '../runtime';
+import { Plugin } from './plugin-base';
 
 export type VariableOption = { label: string; value: string };
 
@@ -25,10 +25,12 @@ export interface GetVariableOptionsContext {
 /**
  * Plugin for handling custom VariableDefinitions.
  */
-export interface VariablePlugin<Spec = UnknownSpec> {
+export interface VariablePlugin<Spec = UnknownSpec> extends Plugin<Spec> {
   getVariableOptions: GetVariableOptions<Spec>;
 
-  /** Returns a list of variables name this variable depends on. Used to optimize fetching */
+  /**
+   * Returns a list of variables name this variable depends on. Used to optimize fetching
+   */
   dependsOn?: (definition: Spec) => string[];
 }
 

--- a/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
+++ b/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { UnknownSpec } from '@perses-dev/core';
-import { OptionsEditorProps } from '../model/visual-editing';
+import { OptionsEditorProps } from '../model';
 import { usePlugin } from './plugins';
 
 export interface PluginSpecEditorProps extends OptionsEditorProps<UnknownSpec> {

--- a/ui/prometheus-plugin/src/plugins/prometheus-variables.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-variables.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { VariablePlugin, VariableOption } from '@perses-dev/plugin-system';
-import {} from '../model/utils';
 import {
   replaceTemplateVariables,
   parseTemplateVariables,
@@ -52,6 +51,8 @@ export const PrometheusLabelNamesVariable: VariablePlugin<PrometheusLabelNamesVa
     };
   },
   dependsOn: () => [],
+  OptionsEditorComponent: () => null,
+  createInitialOptions: () => ({}),
 };
 
 export const PrometheusLabelValuesVariable: VariablePlugin<PrometheusLabelValuesVariableOptions> = {
@@ -69,4 +70,6 @@ export const PrometheusLabelValuesVariable: VariablePlugin<PrometheusLabelValues
   dependsOn: (spec) => {
     return spec.matchers?.map((m) => parseTemplateVariables(m)).flat() || [];
   },
+  OptionsEditorComponent: () => null,
+  createInitialOptions: () => ({ label_name: '' }),
 };

--- a/ui/prometheus-plugin/src/plugins/variable.ts
+++ b/ui/prometheus-plugin/src/plugins/variable.ts
@@ -32,4 +32,6 @@ export const StaticListVariable: VariablePlugin<StaticListVariableOptions> = {
     };
   },
   dependsOn: () => [],
+  OptionsEditorComponent: () => null,
+  createInitialOptions: () => ({ values: [] }),
 };


### PR DESCRIPTION
At this point, we know all plugins are going to have at least two props for visual editing (`OptionsEditorComponent` and `createInitialOptions`). This just moves those props into a `Plugin` type and makes all the plugins extend from that type. Variable plugins were the ones that hadn't been updated yet with placeholder values, so I also went ahead and added those placeholders in the `prometheus-plugin` package.