### PR TITLE
Constrain plugin types to those that use Plugin base

### DIFF
--- a/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
+++ b/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
@@ -13,7 +13,7 @@
 
 import { useEvent } from '@perses-dev/core';
 import { useCallback, useRef } from 'react';
-import { PluginMetadata, PluginModuleResource } from '../../model';
+import { PluginMetadata, PluginModuleResource, PluginType } from '../../model';
 import { getTypeAndKindKey } from '../../utils/cache-keys';
 
 export type GetInstalledPlugins = () => Promise<PluginModuleResource[]>;
@@ -22,7 +22,7 @@ export interface PluginIndexes {
   // Plugin resources by plugin type and kind (i.e. look up what module a plugin type and kind is in)
   pluginResourcesByTypeAndKind: Map<string, PluginModuleResource>;
   // Plugin metadata by plugin type
-  pluginMetadataByType: Map<string, PluginMetadata[]>;
+  pluginMetadataByType: Map<PluginType, PluginMetadata[]>;
 }
 
 /**
@@ -36,7 +36,7 @@ export function usePluginIndexes(getInstalledPlugins: GetInstalledPlugins) {
 
     // Create the two indexes from the installed plugins
     const pluginResourcesByTypeAndKind = new Map<string, PluginModuleResource>();
-    const pluginMetadataByType = new Map<string, PluginMetadata[]>();
+    const pluginMetadataByType = new Map<PluginType, PluginMetadata[]>();
 
     for (const resource of installedPlugins) {
       for (const pluginMetadata of resource.spec.plugins) {

--- a/ui/plugin-system/src/model/plugin-base.ts
+++ b/ui/plugin-system/src/model/plugin-base.ts
@@ -20,18 +20,13 @@ export interface Plugin<Spec> {
   /**
    * React component for editing the plugin's options in the UI.
    */
-  OptionsEditorComponent: OptionsEditor<Spec>;
+  OptionsEditorComponent: React.ComponentType<OptionsEditorProps<Spec>>;
 
   /**
    * Callback for creating the initial options for the plugin.
    */
-  createInitialOptions: InitialOptionsCallback<Spec>;
+  createInitialOptions: () => Spec;
 }
-
-/**
- * A component for visual editing of a plugin's options.
- */
-export type OptionsEditor<Spec> = React.ComponentType<OptionsEditorProps<Spec>>;
 
 /**
  * Common props passed to options editor components.
@@ -42,8 +37,3 @@ export interface OptionsEditorProps<Spec> {
   value: Spec;
   onChange: (next: Spec) => void;
 }
-
-/**
- * Callback for creating initial/empty options for a plugin.
- */
-export type InitialOptionsCallback<Spec> = () => Spec;

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -11,11 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Metadata } from '@perses-dev/core';
+import { Metadata, UnknownSpec } from '@perses-dev/core';
 import { TimeSeriesQueryPlugin } from './time-series-queries';
 import { PanelPlugin } from './panels';
 import { VariablePlugin } from './variables';
 import { DatasourcePlugin } from './datasource';
+import { Plugin } from './plugin-base';
 
 /**
  * Information about a module/package that contains plugins.
@@ -43,12 +44,17 @@ export interface PluginMetadata {
 }
 
 /**
- * All supported plugin types.
+ * All supported plugin types. A plugin's implementation must extend from `Plugin<UnknownSpec>` to be considered a valid
+ * `PluginType`.
  */
-export type PluginType = keyof SupportedPlugins;
+export type PluginType = {
+  // Filter out implementations on SupportedPlugins that don't extend `Plugin<UnknownSpec>`
+  [K in keyof SupportedPlugins]: SupportedPlugins[K] extends Plugin<UnknownSpec> ? K : never;
+}[keyof SupportedPlugins];
 
 /**
- * Map of plugin type key/string -> implementation type
+ * Map of plugin type key/string -> implementation type. Use Typescript module augmentation to extend the plugin system
+ * with new plugin types.
  */
 export interface SupportedPlugins {
   Variable: VariablePlugin;

--- a/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
+++ b/ui/plugin-system/src/runtime/PluginSpecEditor.tsx
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 import { UnknownSpec } from '@perses-dev/core';
-import { OptionsEditorProps } from '../model';
+import { OptionsEditorProps, PluginType } from '../model';
 import { usePlugin } from './plugins';
 
 export interface PluginSpecEditorProps extends OptionsEditorProps<UnknownSpec> {
-  pluginType: 'Panel' | 'TimeSeriesQuery';
+  pluginType: PluginType;
   pluginKind: string;
 }
 

--- a/ui/plugin-system/src/runtime/plugins.ts
+++ b/ui/plugin-system/src/runtime/plugins.ts
@@ -17,7 +17,7 @@ import { PluginImplementation, PluginMetadata, PluginType } from '../model';
 
 // Allows consumers to pass useQuery options from react-query when loading a plugin
 type UsePluginOptions<T extends PluginType> = Omit<
-  UseQueryOptions<PluginImplementation<T>, unknown, PluginImplementation<T>, [string, string]>,
+  UseQueryOptions<PluginImplementation<T>, unknown, PluginImplementation<T>, [PluginType, string]>,
   'queryKey' | 'queryFn'
 >;
 
@@ -31,7 +31,7 @@ export function usePlugin<T extends PluginType>(pluginType: T, kind: string, opt
 
 // Allow consumers to pass useQuery options from react-query when listing metadata
 type UseListPluginMetadataOptions = Omit<
-  UseQueryOptions<PluginMetadata[], unknown, PluginMetadata[], [string]>,
+  UseQueryOptions<PluginMetadata[], unknown, PluginMetadata[], [PluginType]>,
   'queryKey' | 'queryFn'
 >;
 


### PR DESCRIPTION
This is a small follow-up to #615. In that PR, I added a `Plugin` base type that is meant to be the common props for all plugins in the `plugin-system`. The only thing missing was some kind of "enforcement mechanism" in the type system that ensured that all plugins use it. I tried out a bunch of different ways to do this, but the most straightforward way to add this enforcement mechanism was to change `PluginType` to only include plugin implementations that extend from `Plugin`.

I also realized that this basically means that consumers can now extend the plugin system with their own plugin types. For example, if in my Perses-based application I wanted to add a new plugin type, I could do something like this:

```ts
import { UnknownSpec } from '@perses-dev/core';
import { usePlugin } from '@perses-dev/plugin-system';

declare module '@perses-dev/plugin-system' {
  // Use interface augmentation to add a new plugin type and implementation
  interface SupportedPlugins {
    MyPluginType: MyPlugin;
  }
}

export interface MyPlugin<Spec = UnknownSpec> {
  doSomethingCool: () => Spec;
  createInitialOptions: () => Spec;
  OptionsEditorComponent: () => null;
}

export function useMyPlugin() {
  const { data: plugin } = usePlugin('MyPluginType', 'somekind');
  if (plugin !== undefined) {
    plugin.doSomethingCool();
  }
}
```

If the consumer were to forget to add `createInitialOptions` or `OptionsEditorComponent` (from the `Plugin` base type), then their call to `usePlugin` would fail with a compiler error because `MyPluginType` would not be considered a valid plugin type yet.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>