### PR TITLE
Fix release title and propose a template title in the release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 0.10.0 / 2022-10-12
+## 0.10.0 / 2022-10-12
 
 - [FEATURE] Implement new datasource format #570
 - [FEATURE] Add PluginSpecEditor to support a query input and static panel options for TimeSeriesChart #596, #612
@@ -17,7 +17,7 @@
 - [ENHANCEMENT] New common UI components for working with the plugin system #624
 - [BUGFIX] Fix redundant no data in StatChart #606
 
-# 0.9.0 / 2022-10-04
+## 0.9.0 / 2022-10-04
 
 - [FEATURE] New ListVariable plugin for StaticListVariables #547
 - [FEATURE] New Prometheus plugin for ListVariable (LabelName, LabelValues) #565

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,18 +46,20 @@ You should start to create a branch that follows the pattern `release/v<X.Y>`. R
 for any given major or minor release happen in the same release/v<major>.<minor> branch. Do not create release/<version>
 for patch or release candidate releases.
 
-Update the file `VERSION` with the new version to be created.
+- Update the file `VERSION` with the new version to be created.
 
-Update the file `CHANGELOG.md` and the different `package.json` with the corresponding version:
+- Update the file `CHANGELOG.md` and the different `package.json` with the corresponding version:
 
 ```bash
 make bump-version
 ```
 
-Do this in a proper PR pointing to the release branch as this gives others the opportunity to chime in on the release in
-general and on the addition to the changelog in particular.
+- Do this in a proper PR pointing to the release branch as this gives others the opportunity to chime in on the release
+  in general and on the addition to the changelog in particular.
 
-Entries in the `CHANGELOG.md` are meant to be in this order:
+- Create a proper title for the release following this template : `## <version_number> / <Date>`
+
+- Entries in the `CHANGELOG.md` are meant to be in this order:
 
 * `[FEATURE]`
 * `[ENHANCEMENT]`


### PR DESCRIPTION
I just realised that the script we are using to generate the changelog that has to be pushed in the github release is catching everything between two title starting with two `#`.

This PR aims to aligne the different release title in the changelog, and to add a template title in the release documentation