### PR TITLE
PanelGroupDialog refactor to need less state, look more like PanelDrawer

### DIFF
--- a/ui/dashboards/src/components/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar.tsx
@@ -16,7 +16,7 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import AddPanelGroupIcon from 'mdi-material-ui/PlusBoxOutline';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
-import { usePanelGroupDialog, useEditMode, usePanels } from '../context';
+import { useDashboardActions, useEditMode } from '../context';
 import { TemplateVariableList, TimeRangeControls } from '../components';
 
 export interface DashboardToolbarProps {
@@ -27,8 +27,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   const { dashboardName } = props;
 
   const { isEditMode, setEditMode } = useEditMode();
-  const { openPanelGroupDialog } = usePanelGroupDialog();
-  const { addPanel } = usePanels();
+  const { addPanelGroup, addPanel } = useDashboardActions();
 
   const onEditButtonClick = () => {
     setEditMode(true);
@@ -64,10 +63,10 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               <TemplateVariableList />
             </ErrorBoundary>
             <Stack direction={'row'} spacing={1} sx={{ marginLeft: 'auto' }}>
-              <Button startIcon={<AddPanelGroupIcon />} onClick={() => openPanelGroupDialog()}>
+              <Button startIcon={<AddPanelGroupIcon />} onClick={addPanelGroup}>
                 Add Panel Group
               </Button>
-              <Button startIcon={<AddPanelIcon />} onClick={() => addPanel()}>
+              <Button startIcon={<AddPanelIcon />} onClick={addPanel}>
                 Add Panel
               </Button>
               <TimeRangeControls />

--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -20,15 +20,7 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import ArrowUpIcon from 'mdi-material-ui/ArrowUp';
 import ArrowDownIcon from 'mdi-material-ui/ArrowDown';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
-
-import {
-  usePanelGroupDialog,
-  useDeletePanelGroupDialog,
-  useEditMode,
-  usePanels,
-  PanelGroupId,
-  useMovePanelGroup,
-} from '../../context';
+import { usePanelGroupActions, useEditMode, PanelGroupId } from '../../context';
 
 export interface GridTitleProps {
   panelGroupId: PanelGroupId;
@@ -47,11 +39,8 @@ export function GridTitle(props: GridTitleProps) {
   const { panelGroupId, title, collapse } = props;
 
   const [isHovered, setIsHovered] = useState(false);
-  const { openPanelGroupDialog } = usePanelGroupDialog();
-  const { openDeletePanelGroupDialog } = useDeletePanelGroupDialog();
-  const { addPanel } = usePanels();
+  const { addPanelToGroup, editPanelGroup, deletePanelGroup, moveUp, moveDown } = usePanelGroupActions(panelGroupId);
   const { isEditMode } = useEditMode();
-  const { moveUp, moveDown } = useMovePanelGroup(panelGroupId);
 
   const text = (
     <Typography variant="h2" sx={{ marginLeft: collapse !== undefined ? 1 : undefined }}>
@@ -79,13 +68,13 @@ export function GridTitle(props: GridTitleProps) {
           {text}
           {isEditMode && isHovered && (
             <Stack direction="row" sx={{ marginLeft: 'auto' }}>
-              <IconButton aria-label="add panel to group" onClick={() => addPanel(panelGroupId)}>
+              <IconButton aria-label="add panel to group" onClick={addPanelToGroup}>
                 <AddIcon />
               </IconButton>
-              <IconButton aria-label="edit group" onClick={() => openPanelGroupDialog(panelGroupId)}>
+              <IconButton aria-label="edit group" onClick={editPanelGroup}>
                 <PencilIcon />
               </IconButton>
-              <IconButton aria-label="delete group" onClick={() => openDeletePanelGroupDialog(panelGroupId)}>
+              <IconButton aria-label="delete group" onClick={deletePanelGroup}>
                 <DeleteIcon />
               </IconButton>
               <IconButton aria-label="move group down" disabled={moveDown === undefined} onClick={moveDown}>

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -66,9 +66,6 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
 
   const handleSubmit: FormEventHandler = (e) => {
     e.preventDefault();
-    if (spec === undefined) {
-      throw new Error('Cannot submit without a plugin spec');
-    }
     const values: PanelEditorValues = { name, description, groupId, kind, spec };
     onSubmit(values);
   };

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
@@ -42,7 +42,7 @@ describe('Add Panel Group', () => {
     const storeApi = renderDialog();
 
     // Open the dialog for a new panel group
-    act(() => storeApi.getState().openPanelGroupDialog());
+    act(() => storeApi.getState().addPanelGroup());
 
     const nameInput = await screen.findByLabelText(/Name/);
     userEvent.type(nameInput, 'New Panel Group');
@@ -64,7 +64,7 @@ describe('Add Panel Group', () => {
     const storeApi = renderDialog();
 
     // Open the dialog for an existing panel group
-    act(() => storeApi.getState().openPanelGroupDialog(0));
+    act(() => storeApi.getState().editPanelGroup(0));
 
     const nameInput = await screen.findByLabelText(/Name/);
     userEvent.clear(nameInput);

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupEditorForm.tsx
@@ -1,0 +1,68 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { FormEventHandler, useState } from 'react';
+import { FormControl, InputLabel, TextField, Select, SelectProps, MenuItem } from '@mui/material';
+import { PanelGroupEditorValues } from '../../context';
+
+type CollapsedState = 'Open' | 'Closed';
+
+export interface PanelGroupEditorFormProps {
+  initialValues: PanelGroupEditorValues;
+  onSubmit: (next: PanelGroupEditorValues) => void;
+}
+
+export function PanelGroupEditorForm(props: PanelGroupEditorFormProps) {
+  const { initialValues, onSubmit } = props;
+
+  const [title, setTitle] = useState(initialValues.title);
+  const [isCollapsed, setIsCollapsed] = useState(initialValues.isCollapsed);
+
+  const handleCollapsedChange: SelectProps<CollapsedState>['onChange'] = (e) => {
+    const next = e.target.value;
+    setIsCollapsed(next === 'Closed');
+  };
+
+  const handleSubmit: FormEventHandler = (e) => {
+    e.preventDefault();
+    onSubmit({ title, isCollapsed });
+  };
+
+  return (
+    <form id={panelGroupEditorFormId} onSubmit={handleSubmit}>
+      <FormControl margin="normal">
+        <TextField required label="Name" variant="outlined" value={title} onChange={(e) => setTitle(e.target.value)} />
+      </FormControl>
+      <FormControl margin="normal">
+        <InputLabel id="select-collapse-state">Collapse State</InputLabel>
+        <Select<CollapsedState>
+          required
+          displayEmpty
+          labelId="select-collapse-state"
+          label="Collapse State"
+          size="small"
+          value={isCollapsed ? 'Closed' : 'Open'}
+          onChange={handleCollapsedChange}
+        >
+          <MenuItem value="Open">Open</MenuItem>
+          <MenuItem value="Closed">Closed</MenuItem>
+        </Select>
+      </FormControl>
+    </form>
+  );
+}
+
+/**
+ * The `id` attribute added to the `PanelGroupEditorForm` component, allowing submit buttons to live outside the form.
+ */
+export const panelGroupEditorFormId = 'panel-group-editor-form';

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -21,6 +21,19 @@ export function useEditMode() {
 }
 
 /**
+ * Returns actions that can be performed on the current dashboard.
+ */
+export function useDashboardActions() {
+  const addPanelGroup = useDashboardStore((store) => store.addPanelGroup);
+  const addPanel = useDashboardStore((store) => store.addPanel);
+
+  return {
+    addPanelGroup,
+    addPanel: () => addPanel(undefined),
+  };
+}
+
+/**
  * Returns an array of PanelGroupIds in the order they appear in the dashboard.
  */
 export function usePanelGroupIds() {
@@ -56,10 +69,28 @@ export function usePanelGroup(panelGroupId: PanelGroupId) {
 }
 
 /**
+ * Returns actions that can be performed on the given panel group.
+ */
+export function usePanelGroupActions(panelGroupId: PanelGroupId) {
+  const { moveUp, moveDown } = useMovePanelGroup(panelGroupId);
+  const editPanelGroup = useDashboardStore((store) => store.editPanelGroup);
+  const deletePanelGroup = useDashboardStore((store) => store.openDeletePanelGroupDialog);
+  const addPanel = useDashboardStore((store) => store.addPanel);
+
+  return {
+    editPanelGroup: () => editPanelGroup(panelGroupId),
+    deletePanelGroup: () => deletePanelGroup(panelGroupId),
+    addPanelToGroup: () => addPanel(panelGroupId),
+    moveUp,
+    moveDown,
+  };
+}
+
+/**
  * Returns functions for moving a panel group up or down. A function will be undefined if the panel group can't be
  * moved in that direction.
  */
-export function useMovePanelGroup(panelGroupId: PanelGroupId) {
+function useMovePanelGroup(panelGroupId: PanelGroupId) {
   const currentIndex = useDashboardStore((store) => store.panelGroupIdOrder.findIndex((id) => id === panelGroupId));
   const panelGroupsLength = useDashboardStore((store) => store.panelGroupIdOrder.length);
   const swapPanelGroups = useDashboardStore((store) => store.swapPanelGroups);
@@ -95,6 +126,13 @@ export function usePanel(panelGroupItemId: PanelGroupItemId) {
   return panel;
 }
 
+/**
+ * Gets the Panel Group editor state.
+ */
+export function usePanelGroupEditor() {
+  return useDashboardStore((store) => store.panelGroupEditor);
+}
+
 export function useLayouts() {
   return useDashboardStore(
     ({ addPanelToGroup, movePanelToGroup, updatePanelGroup, swapPanelGroups, deletePanelGroup }) => ({
@@ -105,16 +143,6 @@ export function useLayouts() {
       deletePanelGroup,
     })
   );
-}
-
-export function usePanelGroupDialog() {
-  return useDashboardStore(({ panelGroups, panelGroupDialog, openPanelGroupDialog, closePanelGroupDialog }) => ({
-    // TODO: Refactor this dialog so that it doesn't need access to all the panelGroups
-    panelGroups,
-    panelGroupDialog,
-    openPanelGroupDialog,
-    closePanelGroupDialog,
-  }));
 }
 
 export function useDeletePanelGroupDialog() {

--- a/ui/dashboards/src/context/DashboardProvider/index.ts
+++ b/ui/dashboards/src/context/DashboardProvider/index.ts
@@ -14,3 +14,4 @@
 export * from './dashboard-provider-api';
 export * from './DashboardProvider';
 export type { PanelGroupId, PanelGroupDefinition, PanelGroupItemId as LayoutItem } from './layout-slice';
+export type { PanelGroupEditor, PanelGroupEditorValues } from './panel-group-slice';

--- a/ui/dashboards/src/context/DashboardProvider/layout-slice.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/layout-slice.tsx
@@ -27,6 +27,9 @@ export interface LayoutSlice {
    */
   panelGroupIdOrder: PanelGroupId[];
 
+  // TODO: Remove this
+  createPanelGroupId: () => PanelGroupId;
+
   /**
    * Given a LayoutItem location, returns the panel's unique key at that location.
    */
@@ -116,6 +119,9 @@ export function createLayoutSlice(
   return (set, get) => ({
     panelGroups,
     panelGroupIdOrder,
+
+    // TODO: Reorder init logic so this isn't exposed
+    createPanelGroupId,
 
     getPanelKey({ panelGroupId, itemIndex }) {
       const { panelGroups } = get();

--- a/ui/dashboards/src/context/DashboardProvider/panel-group-slice.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/panel-group-slice.tsx
@@ -13,10 +13,18 @@
 
 import { StateCreator } from 'zustand';
 import { Middleware } from './common';
-import { LayoutSlice, PanelGroupId } from './layout-slice';
+import { LayoutSlice, PanelGroupDefinition, PanelGroupId } from './layout-slice';
 
-export interface PanelGroupDialog {
-  panelGroupId?: PanelGroupId;
+export interface PanelGroupEditor {
+  mode: 'Add' | 'Edit';
+  initialValues: PanelGroupEditorValues;
+  applyChanges: (next: PanelGroupEditorValues) => void;
+  close: () => void;
+}
+
+export interface PanelGroupEditorValues {
+  title: string;
+  isCollapsed: boolean;
 }
 
 export interface DeletePanelGroupDialog {
@@ -25,9 +33,20 @@ export interface DeletePanelGroupDialog {
 }
 
 export interface PanelGroupSlice {
-  panelGroupDialog?: PanelGroupDialog;
-  openPanelGroupDialog: (panelGroupId?: PanelGroupId) => void;
-  closePanelGroupDialog: () => void;
+  /**
+   * State that's present when the panel group editor is open.
+   */
+  panelGroupEditor?: PanelGroupEditor;
+
+  /**
+   * Opens the panel group editor to add a new panel group.
+   */
+  addPanelGroup: () => void;
+
+  /**
+   * Opens the panel group editor to edit an existing panel group.
+   */
+  editPanelGroup: (panelGroupId: PanelGroupId) => void;
 
   deletePanelGroupDialog?: DeletePanelGroupDialog;
   openDeletePanelGroupDialog: (panelGroupId: PanelGroupId) => void;
@@ -38,14 +57,76 @@ export const createPanelGroupSlice: StateCreator<PanelGroupSlice & LayoutSlice, 
   set,
   get
 ) => ({
-  openPanelGroupDialog: (panelGroupId) =>
-    set((state) => {
-      state.panelGroupDialog = { panelGroupId };
-    }),
-  closePanelGroupDialog: () =>
-    set((state) => {
-      state.panelGroupDialog = undefined;
-    }),
+  panelGroupEditor: undefined,
+
+  addPanelGroup: () => {
+    // Create the editor state
+    const editor: PanelGroupEditor = {
+      mode: 'Add',
+      initialValues: {
+        title: '',
+        isCollapsed: false,
+      },
+      applyChanges(next) {
+        const newGroup: PanelGroupDefinition = {
+          id: get().createPanelGroupId(),
+          items: [],
+          ...next,
+        };
+        set((draft) => {
+          draft.panelGroups[newGroup.id] = newGroup;
+          draft.panelGroupIdOrder.unshift(newGroup.id);
+        });
+      },
+      close() {
+        set((draft) => {
+          draft.panelGroupEditor = undefined;
+        });
+      },
+    };
+
+    // Open the editor
+    set((draft) => {
+      draft.panelGroupEditor = editor;
+    });
+  },
+
+  editPanelGroup: (panelGroupId) => {
+    const existingGroup = get().panelGroups[panelGroupId];
+    if (existingGroup === undefined) {
+      throw new Error(`Panel group with Id ${panelGroupId} does not exist`);
+    }
+
+    // Create the editor state
+    const editor: PanelGroupEditor = {
+      mode: 'Edit',
+      initialValues: {
+        title: existingGroup.title ?? '',
+        isCollapsed: existingGroup.isCollapsed,
+      },
+      applyChanges(next) {
+        set((draft) => {
+          const group = draft.panelGroups[panelGroupId];
+          if (group === undefined) {
+            throw new Error(`Panel group with Id ${panelGroupId} does not exist`);
+          }
+          group.title = next.title;
+          group.isCollapsed = next.isCollapsed;
+        });
+      },
+      close() {
+        set((draft) => {
+          draft.panelGroupEditor = undefined;
+        });
+      },
+    };
+
+    // Open the editor
+    set((draft) => {
+      draft.panelGroupEditor = editor;
+    });
+  },
+
   openDeletePanelGroupDialog: (panelGroupId) => {
     const panelGroup = get().panelGroups[panelGroupId];
     if (panelGroup === undefined) {


### PR DESCRIPTION
Following up on #633, this continues refactoring panel groups. This time it's the dialog so it basically follows the same pattern as the `PanelDrawer` where it exposes all the state the editor needs on open (including how to save or close without making changes). This was basically trying to make it so the editor dialog didn't need the state of _all_ panel groups just to do its work, as well as to try and be specific about what it _could_ edit (since that editor wasn't editing things like the items in the group). Hiding the "items in the group" from the editor is going to be more important as I go to split a group's items out so that drag and drop state is separate from the rest of the group's state.

Again, I left a few TODOs in here because there's more to come! 🥳 🙃 

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>