### PR TITLE
improve linter by supporting datasources schema and online validation

### DIFF
--- a/internal/cli/opt/opt.go
+++ b/internal/cli/opt/opt.go
@@ -56,7 +56,7 @@ type ProjectOption struct {
 func (o *ProjectOption) Complete() error {
 	if len(o.Project) == 0 {
 		if len(config.Global.Project) == 0 {
-			return fmt.Errorf("project is not defined. Please set it using the flag --project or using the command argos project <project_name>")
+			return fmt.Errorf("project is not defined. Please set it using the flag --project or using the command perses project <project_name>")
 		}
 		o.Project = config.Global.Project
 	}


### PR DESCRIPTION
With this PR, maybe you will more understand the need of the package `validate` @AntoineThebaud :).

I'm also wondering if we should provide an endpoint in the API to be able to download the different schemas.
WDYT @AntoineThebaud @chucknthem @LukeTillman ? 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>