### PR TITLE
Add variable plugin editors

### DIFF
--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -30,7 +30,7 @@ export function PluginEditor(props: PluginEditorProps) {
   const { pendingKind, isLoading, error, onKindChange, onSpecChange } = usePluginEditor(props);
   return (
     <Box {...others}>
-      <FormControl margin="dense" fullWidth={false} disabled={isLoading} error={error !== null} sx={{ mb: 1 }}>
+      <FormControl margin="dense" fullWidth={false} disabled={isLoading} error={error !== null} sx={{ mb: 2 }}>
         {/* TODO: How to ensure ids are unique? */}
         <InputLabel id="plugin-kind-label">{pluginKindLabel}</InputLabel>
         <PluginKindSelect

--- a/ui/prometheus-plugin/src/plugins/MatcherEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/MatcherEditor.tsx
@@ -1,0 +1,60 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react';
+import { Stack, TextField, Button, Box, IconButton } from '@mui/material';
+import TrashIcon from 'mdi-material-ui/TrashCan';
+
+export function MatcherEditor(props: { initialMatchers?: string[]; onChange: (matchers: string[]) => void }) {
+  const [matchers, setMatchers] = useState<string[]>(props.initialMatchers ?? []);
+  return (
+    <Stack spacing={1}>
+      {matchers.map((matcher, index) => (
+        <Box key={index} display="flex">
+          <TextField
+            onBlur={() => {
+              props.onChange(matchers);
+            }}
+            label="Series Selector"
+            value={matcher}
+            onChange={(e) => {
+              const newMatchers = [...matchers];
+              newMatchers[index] = e.target.value;
+              setMatchers(newMatchers);
+            }}
+          />
+          <IconButton
+            onClick={() => {
+              const newMatchers = [...matchers];
+              newMatchers.splice(index, 1);
+              setMatchers(newMatchers);
+            }}
+          >
+            <TrashIcon />
+          </IconButton>
+        </Box>
+      ))}
+      <Box>
+        <Button
+          fullWidth={false}
+          variant="outlined"
+          onClick={() => {
+            setMatchers([...matchers, '']);
+          }}
+        >
+          Add Series Selector
+        </Button>
+      </Box>
+    </Stack>
+  );
+}

--- a/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
@@ -10,28 +10,45 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { VariablePlugin, VariableOption } from '@perses-dev/plugin-system';
-import {
-  replaceTemplateVariables,
-  parseTemplateVariables,
-  PrometheusClient,
-  DEFAULT_PROM,
-  PrometheusDatasourceSelector,
-} from '../model';
-import { JSONSpecEditor } from './JSONSpecEditor';
+import { VariablePlugin, VariableOption, OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Stack, TextField } from '@mui/material';
+import { replaceTemplateVariables, parseTemplateVariables, PrometheusClient, DEFAULT_PROM } from '../model';
+import { PrometheusLabelNamesVariableOptions, PrometheusLabelValuesVariableOptions } from './types';
+import { MatcherEditor } from './MatcherEditor';
 
-interface PrometheusVariableOptionsBase {
-  datasource?: PrometheusDatasourceSelector;
+function PrometheusLabelValuesVariableEditor(props: OptionsEditorProps<PrometheusLabelValuesVariableOptions>) {
+  return (
+    <Stack spacing={1}>
+      <TextField
+        sx={{ mb: 1 }}
+        label="Label Name"
+        value={props.value.label_name}
+        onChange={(e) => {
+          props.onChange({ ...props.value, label_name: e.target.value });
+        }}
+      />
+      <MatcherEditor
+        initialMatchers={props.value.matchers}
+        onChange={(e) => {
+          props.onChange({ ...props.value, matchers: e });
+        }}
+      />
+    </Stack>
+  );
 }
 
-type PrometheusLabelNamesVariableOptions = PrometheusVariableOptionsBase & {
-  matchers?: [string];
-};
-
-type PrometheusLabelValuesVariableOptions = PrometheusVariableOptionsBase & {
-  label_name: string;
-  matchers?: [string];
-};
+function PrometheusLabelNamesVariableEditor(props: OptionsEditorProps<PrometheusLabelNamesVariableOptions>) {
+  return (
+    <Stack spacing={1}>
+      <MatcherEditor
+        initialMatchers={props.value.matchers}
+        onChange={(e) => {
+          props.onChange({ ...props.value, matchers: e });
+        }}
+      />
+    </Stack>
+  );
+}
 
 /**
  * Takes a list of strings and returns a list of VariableOptions
@@ -54,7 +71,7 @@ export const PrometheusLabelNamesVariable: VariablePlugin<PrometheusLabelNamesVa
     };
   },
   dependsOn: () => [],
-  OptionsEditorComponent: JSONSpecEditor,
+  OptionsEditorComponent: PrometheusLabelNamesVariableEditor,
   createInitialOptions: () => ({}),
 };
 
@@ -73,6 +90,6 @@ export const PrometheusLabelValuesVariable: VariablePlugin<PrometheusLabelValues
   dependsOn: (spec) => {
     return spec.matchers?.map((m) => parseTemplateVariables(m)).flat() || [];
   },
-  OptionsEditorComponent: JSONSpecEditor,
+  OptionsEditorComponent: PrometheusLabelValuesVariableEditor,
   createInitialOptions: () => ({ label_name: '' }),
 };

--- a/ui/prometheus-plugin/src/plugins/types.ts
+++ b/ui/prometheus-plugin/src/plugins/types.ts
@@ -1,0 +1,27 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PrometheusDatasourceSelector } from '../model';
+
+export interface PrometheusVariableOptionsBase {
+  datasource?: PrometheusDatasourceSelector;
+}
+
+export type PrometheusLabelNamesVariableOptions = PrometheusVariableOptionsBase & {
+  matchers?: string[];
+};
+
+export type PrometheusLabelValuesVariableOptions = PrometheusVariableOptionsBase & {
+  label_name: string;
+  matchers?: string[];
+};

--- a/ui/prometheus-plugin/src/plugins/variable.tsx
+++ b/ui/prometheus-plugin/src/plugins/variable.tsx
@@ -11,14 +11,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { VariablePlugin, VariableOption } from '@perses-dev/plugin-system';
-import { JSONSpecEditor } from './JSONSpecEditor';
+import { VariablePlugin, VariableOption, OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Autocomplete, TextField } from '@mui/material';
 
 type StaticListOption = string | VariableOption;
 
 type StaticListVariableOptions = {
   values: StaticListOption[];
 };
+
+function StaticListVariableOptionEditor(props: OptionsEditorProps<StaticListVariableOptions>) {
+  const value = props.value.values.map((v) => {
+    if (typeof v === 'string') {
+      return v;
+    } else {
+      return v.value;
+    }
+  });
+
+  const onChange = (__: unknown, value: string[]) => {
+    props.onChange({
+      values: value.map((v) => {
+        return { value: v, label: v };
+      }),
+    });
+  };
+
+  return (
+    <div>
+      <Autocomplete
+        multiple
+        value={value}
+        onChange={onChange}
+        options={[]}
+        freeSolo
+        renderInput={(params) => <TextField {...params} label="Values" placeholder="Values" />}
+      />
+    </div>
+  );
+}
 
 export const StaticListVariable: VariablePlugin<StaticListVariableOptions> = {
   getVariableOptions: async (spec) => {
@@ -33,6 +64,6 @@ export const StaticListVariable: VariablePlugin<StaticListVariableOptions> = {
     };
   },
   dependsOn: () => [],
-  OptionsEditorComponent: JSONSpecEditor,
+  OptionsEditorComponent: StaticListVariableOptionEditor,
   createInitialOptions: () => ({ values: [] }),
 };


### PR DESCRIPTION
Loom demo: https://www.loom.com/share/0dfd6ccf99ce419d9e270d2ab5c7010a

This adds in the Variable plugin editors for 3 plugin types: StaticList, PromLabelValues, PromLabelNames

Eventually, the Series Selectors will be replaced with [CodeMirror](https://codemirror.net/) for syntax highlighting and autocomplete.

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>