### PR TITLE
Provide a way to pass the API in a readonly mode by config

### DIFF
--- a/cmd/perses/main.go
+++ b/cmd/perses/main.go
@@ -56,7 +56,7 @@ func main() {
 		logrus.WithError(err).Fatal("unable to instantiate the persistence manager")
 	}
 	serviceManager := dependency.NewServiceManager(persistenceManager, conf)
-	persesAPI := core.NewPersesAPI(serviceManager)
+	persesAPI := core.NewPersesAPI(serviceManager, conf.Readonly)
 	persesFrontend := ui.NewPersesFrontend()
 	runner := app.NewRunner().WithDefaultHTTPServer("perses").SetBanner(banner)
 

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -10,3 +10,4 @@ schemas:
   panels_path: "schemas/panels"
   queries_path: "schemas/queries"
   interval: "5m"
+readonly: true

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -18,8 +18,12 @@ import (
 )
 
 type Config struct {
+	// Readonly will deactivate any HTTP POST, PUT, DELETE endpoint
+	Readonly bool `yaml:"readonly"`
+	// Database contains the different configuration depending on the database you want to use
 	Database Database `yaml:"database"`
-	Schemas  Schemas  `yaml:"schemas"`
+	// Schemas contains the configuration to get access to the CUE schemas
+	Schemas Schemas `yaml:"schemas"`
 }
 
 func Resolve(configFile string, dbFolder string, dbExtension string) (Config, error) {

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -35,15 +35,15 @@ type api struct {
 	endpoints []endpoint
 }
 
-func NewPersesAPI(serviceManager dependency.ServiceManager) echoUtils.Register {
+func NewPersesAPI(serviceManager dependency.ServiceManager, readonly bool) echoUtils.Register {
 	endpoints := []endpoint{
-		dashboard.NewEndpoint(serviceManager.GetDashboard()),
-		datasource.NewEndpoint(serviceManager.GetDatasource()),
-		folder.NewEndpoint(serviceManager.GetFolder()),
-		globaldatasource.NewEndpoint(serviceManager.GetGlobalDatasource()),
+		dashboard.NewEndpoint(serviceManager.GetDashboard(), readonly),
+		datasource.NewEndpoint(serviceManager.GetDatasource(), readonly),
+		folder.NewEndpoint(serviceManager.GetFolder(), readonly),
+		globaldatasource.NewEndpoint(serviceManager.GetGlobalDatasource(), readonly),
 		health.NewEndpoint(serviceManager.GetHealth()),
-		project.NewEndpoint(serviceManager.GetProject()),
-		user.NewEndpoint(serviceManager.GetUser()),
+		project.NewEndpoint(serviceManager.GetProject(), readonly),
+		user.NewEndpoint(serviceManager.GetUser(), readonly),
 	}
 	return &api{
 		endpoints: endpoints,

--- a/utils/test.go
+++ b/utils/test.go
@@ -225,7 +225,7 @@ func CreateServer(t *testing.T) (*httptest.Server, dependency.PersistenceManager
 			t.Fatal(err)
 		}
 	}
-	persesAPI := core.NewPersesAPI(serviceManager)
+	persesAPI := core.NewPersesAPI(serviceManager, false)
 	persesAPI.RegisterRoute(handler)
 	return httptest.NewServer(handler), persistenceManager
 }


### PR DESCRIPTION
By configuration, you are now able to deactivate any HTTP endpoint that would modify the database.

Quite useful when you are in "as code" mode and you want to provide the datasource / dashboard via a file

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>