### PR TITLE
provide a way to determinate the build order of the variables

### DIFF
--- a/internal/api/shared/validate/validate.go
+++ b/internal/api/shared/validate/validate.go
@@ -18,10 +18,14 @@ import (
 
 	"github.com/perses/perses/internal/api/shared/schemas"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/dashboard"
 	"github.com/perses/perses/pkg/model/api/v1/datasource/http"
 )
 
 func Dashboard(entity *modelV1.Dashboard, sch schemas.Schemas) error {
+	if _, err := dashboard.BuildVariableOrder(entity.Spec.Variables); err != nil {
+		return err
+	}
 	if sch != nil {
 		return sch.ValidatePanels(entity.Spec.Panels)
 	}

--- a/pkg/model/api/v1/common/reflect.go
+++ b/pkg/model/api/v1/common/reflect.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "reflect"
+
+func GetReflectNextElem(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Interface || (v.Kind() == reflect.Ptr && !v.IsNil()) {
+		return v.Elem()
+	}
+	return v
+}

--- a/pkg/model/api/v1/dashboard/variable_build_order.go
+++ b/pkg/model/api/v1/dashboard/variable_build_order.go
@@ -1,0 +1,284 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+
+	"github.com/perses/perses/pkg/model/api/v1/common"
+)
+
+var variableRegexp = regexp.MustCompile(`\$([a-zA-Z0-9_-]+)`)
+
+type VariableGroup struct {
+	Variables []string
+}
+
+// BuildVariableOrder determinate which variable we have to build first (aka to perform the query).
+// Here is the description of the algorithm followed:
+//
+// 1. First calculate which variable depend on others
+// 2. Then, thanks to the dependencies, we can create a dependency graph.
+// 3. Then we have to determinate the build order.
+func BuildVariableOrder(variables []Variable) ([]VariableGroup, error) {
+	g, err := buildGraph(variables)
+	if err != nil {
+		return nil, err
+	}
+	return g.buildOrder()
+}
+
+func buildGraph(variables []Variable) (*graph, error) {
+	deps, err := buildVariableDependencies(variables)
+	if err != nil {
+		return nil, err
+	}
+	variableNameList := make([]string, 0, len(variables))
+	for _, v := range variables {
+		variableNameList = append(variableNameList, v.Spec.GetName())
+	}
+	return newGraph(variableNameList, deps), nil
+}
+
+func buildVariableDependencies(variables []Variable) (map[string][]string, error) {
+	variableNames := make(map[string]bool, len(variables))
+	// First build a list of the available variable name. That will be useful when creating the dependencies
+	// per variable to know if the dependencies are defined.
+	for _, variable := range variables {
+		variableNames[variable.Spec.GetName()] = true
+	}
+	result := make(map[string][]string)
+	for _, variable := range variables {
+		name := variable.Spec.GetName()
+		var matches [][]string
+		switch variableSpec := variable.Spec.(type) {
+		case *TextVariableSpec:
+			matches = parseVariableUsed(variableSpec.Value)
+		case *ListVariableSpec:
+			matches = findAllVariableUsedInPlugin(variableSpec.Plugin)
+		}
+		deps := make(map[string]bool)
+		for _, match := range matches {
+			// match[0] is the string that is matching the regexp (including the $)
+			// match[1] is the string that is matching the group defined by the regexp. (the string without the $)
+			if _, ok := variableNames[match[1]]; !ok {
+				return nil, fmt.Errorf("variable %q is used in the variable %q but not defined", match[1], name)
+			}
+			deps[match[1]] = true
+		}
+		for dep := range deps {
+			result[name] = append(result[name], dep)
+		}
+	}
+	return result, nil
+}
+
+func findAllVariableUsedInPlugin(plugin common.Plugin) [][]string {
+	var matches [][]string
+	findAllVariableUsed(reflect.ValueOf(plugin.Spec), &matches)
+	return matches
+}
+
+func findAllVariableUsed(v reflect.Value, matches *[][]string) {
+	if len(v.Type().PkgPath()) > 0 {
+		// the field is not exported, so no need to look at it as we won't be able to set it in a later stage
+		return
+	}
+	v = common.GetReflectNextElem(v)
+
+	switch v.Kind() {
+	case reflect.Map:
+		findVariableInMap(v, matches)
+	case reflect.Slice:
+		findVariableInSlice(v, matches)
+	case reflect.Struct:
+		findVariableInStruct(v, matches)
+	}
+}
+
+func findVariableInMap(v reflect.Value, matches *[][]string) {
+	// It's not possible that a variable is used a key in a map.
+	// Simply because the key is supposed to be the name of a field in a proper struct.
+	// Map here is the generic struct that represents the JSON / Yaml file
+	for _, key := range v.MapKeys() {
+		extractVariableInStringOrInSomethingElse(v.MapIndex(key), matches)
+	}
+}
+
+func findVariableInSlice(v reflect.Value, matches *[][]string) {
+	for i := 0; i < v.Len(); i++ {
+		extractVariableInStringOrInSomethingElse(v.Index(i), matches)
+	}
+}
+
+func findVariableInStruct(v reflect.Value, matches *[][]string) {
+	// Same logic than for the map, we are only looking for the value and not the field itself.
+	for i := 0; i < v.NumField(); i++ {
+		extractVariableInStringOrInSomethingElse(v.Field(i), matches)
+	}
+}
+
+func extractVariableInStringOrInSomethingElse(v reflect.Value, matches *[][]string) {
+	// It's highly possible, the value is a pointer or an interface.
+	// As we are not interested in these two type, we want to move forward and see what is behind the pointer / interface.
+	v = common.GetReflectNextElem(v)
+	if v.Kind() == reflect.String {
+		*matches = append(*matches, parseVariableUsed(v.String())...)
+	}
+	findAllVariableUsed(v, matches)
+}
+
+func parseVariableUsed(str string) [][]string {
+	return variableRegexp.FindAllStringSubmatch(str, -1)
+}
+
+type node struct {
+	name     string
+	children map[string]*node
+	// dependencies is the number of node that the current node depends on. Saying differently it's the number of incoming edge to this node.
+	// Once this number is dropping to 0, the variable holt by this node can be built.
+	dependencies uint64
+}
+
+func (n *node) addChild(node *node) {
+	n.children[node.name] = node
+	node.dependencies++
+}
+
+type graph struct {
+	nodes map[string]*node
+}
+
+// newGraph creates a graph based on the variableListName available and the list of dependencies per variableName.
+// dependencies key is the name of variable, the value is the list of variable on which the current variable depends on.
+func newGraph(variableNameList []string, dependencies map[string][]string) *graph {
+	g := &graph{
+		nodes: make(map[string]*node),
+	}
+	for _, variableName := range variableNameList {
+		g.nodes[variableName] = &node{
+			name:     variableName,
+			children: make(map[string]*node),
+		}
+	}
+	for variable, deps := range dependencies {
+		for _, dep := range deps {
+			// here we add to the node representing the dep, a child which is the variable that depend on the dep.
+			// Like that once, we can build the dep, then we can loop others all variable that depend on the dep to reduce by the dependencies number.
+			g.addEdge(dep, variable)
+		}
+	}
+	return g
+}
+
+// buildOrder determinate the build order of the variables
+// For example we could have:
+//
+//	   (f)         (d)
+//	  / | \         |
+//	(c) |  (b)     (g)
+//	 \  |  /|
+//	   (a)  /
+//	    |  /
+//	    | /
+//	    (e)
+//
+// In this example, we should build first (f) and (d), because there is no incoming edge to these nodes.
+// Once it is done, it is irrelevant that some nodes are dependent on (f) and (d) since they have already been built.
+// So we can remove the d and f's outgoing edges.
+//
+//	build order, (f), (d)
+//	    (f)         (d)
+//
+//	 (c)    (b)     (g)
+//	  \     /|
+//	    (a)  /
+//	     |  /
+//	     | /
+//	     (e)
+//
+// Also we can notice (f) and (d) can be built in parallel.
+// So instead of having an ordered list of the different variable/node to build, we could have instead a list of ordered variable's group.
+// Where every variable contained in the group can be built in parallel.
+// Like that we have now the following build order:
+//
+//	build order: group0
+//	group0: (f), (d)
+//
+// Next we can build (c), (b) and (g) (also in parallel applying the same logic as above) And then we can remove their outgoing edges
+//
+//	build order: group0, group1
+//	group0: (f), (d)
+//	group1: (c), (b), (g)
+//	    (f)         (d)
+//
+//	 (c)    (b)     (g)
+//
+//	    (a)
+//	     |
+//	     |
+//	    (e)
+//
+// Then variable (a) can be built which is removing the outgoing edge to (e). This leaves just (e) to be built and we have the final build order:
+//
+//	build order: group0, group1, group2, group3
+//	group0: (f), (d)
+//	group1: (c), (b), (g)
+//	group2: (a)
+//	group3: (e)
+func (g *graph) buildOrder() ([]VariableGroup, error) {
+	remainingNodes := g.buildInitialRemainingNodes()
+	var groups []VariableGroup
+	for len(remainingNodes) > 0 {
+		group := VariableGroup{}
+		// First thing to do is to loop other the remaining node and find the one that has 0 incoming edge.
+		// When we found a node that has no dep, then we remove it from the list of the remainingNode
+		var newRemainingNode []*node
+		for _, n := range remainingNodes {
+			if n.dependencies == 0 {
+				group.Variables = append(group.Variables, n.name)
+			} else {
+				newRemainingNode = append(newRemainingNode, n)
+			}
+		}
+		// if no variable has been added to the current node, then it means there are no nodes with no deps which means there is a circular dependency
+		if len(group.Variables) == 0 {
+			return nil, fmt.Errorf("circular dependency detected")
+		}
+		remainingNodes = newRemainingNode
+		// Then we loop other the available node in the current group to decrease for each children the number of dependencies
+		for _, v := range group.Variables {
+			for _, child := range g.nodes[v].children {
+				child.dependencies--
+			}
+		}
+		// Finally we add the group to the groupOrder
+		groups = append(groups, group)
+	}
+	return groups, nil
+}
+
+func (g *graph) addEdge(startName string, endName string) {
+	g.nodes[startName].addChild(g.nodes[endName])
+}
+
+func (g *graph) buildInitialRemainingNodes() []*node {
+	remainingNodes := make([]*node, 0, len(g.nodes))
+	for _, n := range g.nodes {
+		remainingNodes = append(remainingNodes, n)
+	}
+	return remainingNodes
+}

--- a/pkg/model/api/v1/dashboard/variable_build_order_test.go
+++ b/pkg/model/api/v1/dashboard/variable_build_order_test.go
@@ -1,0 +1,475 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildVariableDependencies(t *testing.T) {
+	testSuite := []struct {
+		title     string
+		variables []Variable
+		result    map[string][]string
+	}{
+		{
+			title:     "no variable, not dep",
+			variables: nil,
+			result:    map[string][]string{},
+		},
+		{
+			title: "constant variable, no dep",
+			variables: []Variable{
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						Name:  "myVariable",
+						Value: "myConstant",
+					},
+				},
+			},
+			result: map[string][]string{},
+		},
+		{
+			title: "query variable with no variable used",
+			variables: []Variable{
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "myVariable",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "vector(1)",
+							},
+						},
+					},
+				},
+			},
+			result: map[string][]string{},
+		},
+		{
+			title: "query variable with variable used",
+			variables: []Variable{
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "myVariable",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "sum by($doe) (rate($foo{label='$bar'}))",
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "foo",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "test",
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "bar",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "vector($foo)",
+							},
+						},
+					},
+				},
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						Name:  "doe",
+						Value: "myConstant",
+					},
+				},
+			},
+			result: map[string][]string{
+				"myVariable": {
+					"doe", "foo", "bar",
+				},
+				"bar": {
+					"foo",
+				},
+			},
+		},
+		{
+			title: "query variable label_values with variable used",
+			variables: []Variable{
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "myVariable",
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[string]interface{}{
+								"label_name": "$foo",
+								"matchers": []interface{}{
+									"$foo{$bar='test'}",
+								},
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "foo",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "test",
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "bar",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "vector($foo)",
+							},
+						},
+					},
+				},
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						Name:  "doe",
+						Value: "myConstant",
+					},
+				},
+			},
+			result: map[string][]string{
+				"myVariable": {
+					"foo", "bar",
+				},
+				"bar": {
+					"foo",
+				},
+			},
+		},
+		{
+			title: "multiple usage of the same variable",
+			variables: []Variable{
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "myVariable",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "foo",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "test",
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "bar",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "vector($foo)",
+							},
+						},
+					},
+				},
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						Name:  "doe",
+						Value: "myConstant",
+					},
+				},
+			},
+			result: map[string][]string{
+				"myVariable": {
+					"doe", "bar", "foo",
+				},
+				"bar": {
+					"foo",
+				},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result, err := buildVariableDependencies(test.variables)
+			assert.NoError(t, err)
+			assert.Equal(t, len(test.result), len(result))
+			for k, v := range test.result {
+				assert.ElementsMatch(t, v, result[k])
+			}
+		})
+	}
+}
+
+func TestBuildVariableDependenciesError(t *testing.T) {
+	testSuite := []struct {
+		title     string
+		variables []Variable
+		err       error
+	}{
+		{
+			title: "variable used but not defined",
+			variables: []Variable{
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "myVariable",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+							},
+						},
+					},
+				},
+			},
+			err: fmt.Errorf("variable %q is used in the variable %q but not defined", "doe", "myVariable"),
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			_, err := buildVariableDependencies(test.variables)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}
+
+func TestGraph_BuildOrder(t *testing.T) {
+	testSuite := []struct {
+		title        string
+		variables    []string
+		dependencies map[string][]string
+		result       []VariableGroup
+	}{
+		{
+			title:     "single variable",
+			variables: []string{"myVariable"},
+			result:    []VariableGroup{{Variables: []string{"myVariable"}}},
+		},
+		{
+			title:     "independent variable",
+			variables: []string{"a", "d", "e"},
+			result:    []VariableGroup{{Variables: []string{"a", "d", "e"}}},
+		},
+		{
+			title:     "a depend on d depend on e",
+			variables: []string{"a", "d", "e"},
+			dependencies: map[string][]string{
+				"a": {"d"},
+				"d": {"e"},
+			},
+			result: []VariableGroup{
+				{Variables: []string{"e"}},
+				{Variables: []string{"d"}},
+				{Variables: []string{"a"}},
+			},
+		},
+		{
+			title:     "complete dep graph",
+			variables: []string{"f", "d", "c", "b", "g", "a", "h", "e"},
+			dependencies: map[string][]string{
+				"e": {"a", "b"},
+				"a": {"c", "f", "b"},
+				"h": {"b"},
+				"g": {"d"},
+				"c": {"f"},
+				"b": {"f"},
+			},
+			result: []VariableGroup{
+				{Variables: []string{"f", "d"}},
+				{Variables: []string{"c", "b", "g"}},
+				{Variables: []string{"a", "h"}},
+				{Variables: []string{"e"}},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			g := newGraph(test.variables, test.dependencies)
+			result, err := g.buildOrder()
+			assert.NoError(t, err)
+			assert.Equal(t, len(test.result), len(result))
+			for i := 0; i < len(result); i++ {
+				assert.ElementsMatch(t, test.result[i].Variables, result[i].Variables)
+			}
+		})
+	}
+}
+
+func TestGraph_BuildOrderError(t *testing.T) {
+	testSuite := []struct {
+		title        string
+		variables    []string
+		dependencies map[string][]string
+	}{
+		{
+			title:     "simple circular dep",
+			variables: []string{"a", "b"},
+			dependencies: map[string][]string{
+				"a": {"b"},
+				"b": {"a"},
+			},
+		},
+		{
+			title:     "circular dep on the same node",
+			variables: []string{"a"},
+			dependencies: map[string][]string{
+				"a": {"a"},
+			},
+		},
+		{
+			title:     "circular dep with transition",
+			variables: []string{"f", "d", "c", "b", "g", "a", "h", "e"},
+			dependencies: map[string][]string{
+				"e": {"a", "b"},
+				"a": {"c", "f", "b"},
+				"h": {"b"},
+				"g": {"d", "c"},
+				"c": {"f"},
+				"b": {"f"},
+				"d": {"d"},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			g := newGraph(test.variables, test.dependencies)
+			_, err := g.buildOrder()
+			assert.Equal(t, fmt.Errorf("circular dependency detected"), err)
+		})
+	}
+}
+
+func TestBuildOrder(t *testing.T) {
+	testSuite := []struct {
+		title     string
+		variables []Variable
+		result    []VariableGroup
+	}{
+		{
+			title: "no variable",
+		},
+		{
+			title: "constant variable, no dep",
+			variables: []Variable{
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						Name:  "myVariable",
+						Value: "myConstant",
+					},
+				},
+			},
+			result: []VariableGroup{{Variables: []string{"myVariable"}}},
+		},
+		{
+			title: "multiple usage of same variable",
+			variables: []Variable{
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "myVariable",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "foo",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "test",
+							},
+						},
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						Name: "bar",
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr": "vector($foo)",
+							},
+						},
+					},
+				},
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						Name:  "doe",
+						Value: "myConstant",
+					},
+				},
+			},
+			result: []VariableGroup{
+				{Variables: []string{"doe", "foo"}},
+				{Variables: []string{"bar"}},
+				{Variables: []string{"myVariable"}},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			groups, err := BuildVariableOrder(test.variables)
+			assert.NoError(t, err)
+			assert.Equal(t, len(test.result), len(groups))
+			for i := 0; i < len(groups); i++ {
+				assert.ElementsMatch(t, test.result[i].Variables, groups[i].Variables)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With this PR, the server is now able to determinate the build order of the variables, whatever the format of the variable would be and whatever the plugin is.

As a side effect, it can detect circular dependencies and if a not defined variable is used in another variable definition.

Perhaps this build order could be exposed through an HTTP endpoint so the UI can use it. I'm not sure this calcul is already done in the front end.
/cc @saminzadeh 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>