### PR TITLE
fix panel preview unselected condition

### DIFF
--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -34,6 +34,10 @@ export function PanelPreview({ name, description, kind, spec, groupId }: PanelEd
     panelGroupItemId: { panelGroupId: groupId, itemIndex: 0 },
   };
 
+  if (!kind) {
+    return null;
+  }
+
   return (
     <Box height={300}>
       <Panel {...previewValues} />


### PR DESCRIPTION
- add condition to fix empty panel preview showing when no `kind` is selected
- TODO: in future, should we select TimeSeriesChart by default?