### PR TITLE
modify script populate to generate a local db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ GENERATED_CHANGELOG.md
 
 cue.mod/pkg
 cue.mod/usr
+
+dev/local_db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,20 +28,12 @@ Both components can be started and tested individually as described below.
 Building and starting the backend API server requires the following tools:
 
 * [Go](https://go.dev/doc/install) (usually the latest version as we are following upstream Go releases closely)
-* [Docker](https://docs.docker.com/engine/install/), which includes docker-compose
 * Make
 * [jq](https://stedolan.github.io/jq/download/) to run the populate.sh script below
 
 With these dependencies installed, you can proceed as follows:
 
-* Change to the `dev` folder and start an [etcd](https://etcd.io/) server, which is currently still required for storing and retrieving dashboard definitions:
-
-```bash
-cd dev/
-docker-compose up -d
-```
-
-* To populate the etcd database with a default dashboard and datasource setup for demonstration purposes, run the `populate.sh` script:
+* Change to the `dev` folder and generate the local database by running the `populate.sh` script You will then be able to modify it on the fly.
 
 ```bash
 bash populate.sh

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,13 +1,13 @@
 database:
-  etcd:
-    protocol: "http"
-    request_timeout: 10
-    connections:
-      - host: 0.0.0.0
-        port: 2379
+  file:
+    folder: "dev/local_db"
+    file_extension: "json"
 
 schemas:
   panels_path: "schemas/panels"
   queries_path: "schemas/queries"
+  datasources_path: "schemas/datasources"
+  variables_path: "schemas/variables"
   interval: "5m"
-readonly: true
+
+readonly: false

--- a/dev/data/globaldatasource.json
+++ b/dev/data/globaldatasource.json
@@ -25,7 +25,7 @@
       "name": "PrometheusDemoBrowser"
     },
     "spec": {
-      "default": true,
+      "default": false,
       "plugin": {
         "kind": "PrometheusDatasource",
         "spec": {
@@ -40,7 +40,7 @@
       "name": "PrometheusLocal"
     },
     "spec": {
-      "default": true,
+      "default": false,
       "plugin": {
         "kind": "PrometheusDatasource",
         "spec": {

--- a/dev/populate.sh
+++ b/dev/populate.sh
@@ -13,18 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 docker_cmd=docker
-
-if podman -v; then
-  echo "using podman instead of docker binary"
-  docker_cmd=podman
-fi
-
 container=dev_etcd_1
-if [ "$( ${docker_cmd} ps -a | grep -c dev-etcd-1 )" -gt 0 ]; then
-  container=dev-etcd-1
-fi
+with_etcd=false
+local_folder_db=local_db
 
 function getKindID() {
   kind=$1
@@ -39,27 +31,60 @@ function getKindID() {
   fi
 }
 
+function injectDataInETCD() {
+  id=$1
+  entity=$2
+  MSYS_NO_PATHCONV=1 ${docker_cmd} exec ${container} etcdctl put "/${id}" "${entity}"
+}
+
+function injectDataInLocalFileDB() {
+  id="${local_folder_db}/""$1"".json"
+  entity=$2
+  folder=$(dirname "${id}")
+
+  mkdir -p "${folder}"
+  echo "${entity}" >"$id"
+}
 
 function insertResourceData() {
   file=$1
   isProjectResource=$2
 
   jq -c '.[]' ${file} | while read -r entity; do
-      _jq() {
-        echo ${entity} | jq -r "${1}"
-      }
-      id="/"$(getKindID $(_jq '.kind'))"/"
-      if [ "${isProjectResource}" ]; then
-        id=${id}$(_jq '.metadata.project')"/"
-      fi
-      id=${id}$(_jq '.metadata.name')
-      echo "injected document at with the key $id"
-      MSYS_NO_PATHCONV=1 ${docker_cmd} exec ${container} etcdctl put "${id}" "${entity}"
+    _jq() {
+      echo ${entity} | jq -r "${1}"
+    }
+    id=$(getKindID $(_jq '.kind'))"/"
+    if [ "${isProjectResource}" ]; then
+      id=${id}$(_jq '.metadata.project')"/"
+    fi
+    id=${id}$(_jq '.metadata.name')
+    echo "injected document at with the key $id"
+    if [[ "${with_etcd}" = true ]]; then
+      injectDataInETCD "${id}" "${entity}"
+    else
+      injectDataInLocalFileDB "${id}" "${entity}"
+    fi
   done
 }
 
+function injectAllData() {
+  insertResourceData ./data/localdatasource.json true
+  insertResourceData ./data/dashboard.json true
+  insertResourceData ./data/project.json
+  insertResourceData ./data/globaldatasource.json
+}
 
-insertResourceData ./data/localdatasource.json true
-insertResourceData ./data/dashboard.json true
-insertResourceData ./data/project.json
-insertResourceData ./data/globaldatasource.json
+if [[ "$1" == "--with-etcd" ]]; then
+  with_etcd=true
+  if podman -v; then
+    echo "using podman instead of docker binary"
+    docker_cmd=podman
+  fi
+
+  if [ "$(${docker_cmd} ps -a | grep -c dev-etcd-1)" -gt 0 ]; then
+    container=dev-etcd-1
+  fi
+fi
+
+injectAllData


### PR DESCRIPTION
I'm modifying the script `populate.sh` so it can generate a local DB.
That will allow us to modify on the fly the DB without requiring docker, or restarting the backend.

It will be easier like that when we want to modify a dashboard and see the result in the UI. It would be painful to run the script `populate.sh` in order to modify ETCD everytime we want to test new parameters on a dashboard.

/cc @LukeTillman @eunicorn @sjcobb @saminzadeh @cndonovan 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>