### PR TITLE
provide kind and default query parameter to filter the list of datasources

### DIFF
--- a/internal/api/impl/v1/datasource/service.go
+++ b/internal/api/impl/v1/datasource/service.go
@@ -124,7 +124,12 @@ func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
 }
 
 func (s *service) List(q etcd.Query, _ shared.Parameters) (interface{}, error) {
-	return s.dao.List(q)
+	dtsList, err := s.dao.List(q)
+	if err != nil {
+		return nil, err
+	}
+	dtsQuery := q.(*datasource.Query)
+	return v1.FilterDatasource(dtsQuery.Kind, dtsQuery.Default, dtsList), nil
 }
 
 func (s *service) validate(entity *v1.Datasource) error {

--- a/internal/api/impl/v1/globaldatasource/service.go
+++ b/internal/api/impl/v1/globaldatasource/service.go
@@ -118,7 +118,12 @@ func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
 }
 
 func (s *service) List(q etcd.Query, _ shared.Parameters) (interface{}, error) {
-	return s.dao.List(q)
+	dtsList, err := s.dao.List(q)
+	if err != nil {
+		return nil, err
+	}
+	dtsQuery := q.(*globaldatasource.Query)
+	return v1.FilterDatasource(dtsQuery.Kind, dtsQuery.Default, dtsList), nil
 }
 
 func (s *service) validate(entity *v1.GlobalDatasource) error {

--- a/internal/api/interface/v1/datasource/interface.go
+++ b/internal/api/interface/v1/datasource/interface.go
@@ -27,6 +27,10 @@ type Query struct {
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
 	Project string `param:"project" query:"project"`
+	// Kind is the type of the datasource.
+	Kind string `query:"kind"`
+	// Default will filter the list of datasource and return only the default datasource, whatever the kind of the datasource is.
+	Default *bool `query:"default"`
 }
 
 func (q *Query) Build() (string, error) {

--- a/internal/api/interface/v1/globaldatasource/interface.go
+++ b/internal/api/interface/v1/globaldatasource/interface.go
@@ -24,6 +24,10 @@ type Query struct {
 	// NamePrefix is a prefix of the GlobalDatasource.metadata.name that is used to filter the list of the GlobalDatasource.
 	// NamePrefix can be empty in case you want to return the full list of GlobalDatasource available.
 	NamePrefix string `query:"name"`
+	// Kind is the type of the datasource.
+	Kind string `query:"kind"`
+	// Default will filter the list of datasource and return only the default datasource, whatever the kind of the datasource is.
+	Default *bool `query:"default"`
 }
 
 func (q *Query) Build() (string, error) {

--- a/pkg/model/api/v1/datasource.go
+++ b/pkg/model/api/v1/datasource.go
@@ -20,6 +20,23 @@ import (
 	"github.com/perses/perses/pkg/model/api/v1/common"
 )
 
+func FilterDatasource[T DatasourceInterface](kind string, defaultDTS *bool, list []T) []T {
+	result := make([]T, 0, len(list))
+	for _, d := range list {
+		keep := true
+		if len(kind) > 0 && kind != d.GetSpec().Plugin.Kind {
+			keep = false
+		}
+		if defaultDTS != nil && *defaultDTS != d.GetSpec().Default {
+			keep = false
+		}
+		if keep {
+			result = append(result, d)
+		}
+	}
+	return result
+}
+
 func GenerateGlobalDatasourceID(name string) string {
 	return fmt.Sprintf("/globaldatasources/%s", name)
 }

--- a/pkg/model/api/v1/datasource.go
+++ b/pkg/model/api/v1/datasource.go
@@ -23,16 +23,11 @@ import (
 func FilterDatasource[T DatasourceInterface](kind string, defaultDTS *bool, list []T) []T {
 	result := make([]T, 0, len(list))
 	for _, d := range list {
-		keep := true
-		if len(kind) > 0 && kind != d.GetSpec().Plugin.Kind {
-			keep = false
+		if (len(kind) > 0 && kind != d.GetSpec().Plugin.Kind) ||
+			(defaultDTS != nil && *defaultDTS != d.GetSpec().Default) {
+			continue
 		}
-		if defaultDTS != nil && *defaultDTS != d.GetSpec().Default {
-			keep = false
-		}
-		if keep {
-			result = append(result, d)
-		}
+		result = append(result, d)
 	}
 	return result
 }


### PR DESCRIPTION
I'm adding two new query parameters `kind` and `default` when getting the list of datasources or global datasources.

For example:

```bash
curl -XGET http://localhost:8080/api/v1/globaldatasources?kind=PrometheusDatasource&default=true
```

This kind of request will return at most one element in the array.

/cc @LukeTillman 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>