### PR TITLE
align the format of the different ID used

### DIFF
--- a/internal/api/shared/toolbox.go
+++ b/internal/api/shared/toolbox.go
@@ -119,7 +119,7 @@ func (t *toolbox) bind(ctx echo.Context, entity api.Entity) error {
 	if err := ctx.Bind(entity); err != nil {
 		return HandleError(fmt.Errorf("%w: %s", BadRequestError, err))
 	}
-	if err := validateMetadata(entity.GetMetadata()); err != nil {
+	if err := validateMetadata(ctx, entity.GetMetadata()); err != nil {
 		return HandleError(fmt.Errorf("%w: %s", BadRequestError, err))
 	}
 	return nil

--- a/pkg/model/api/v1/common/jsonref.go
+++ b/pkg/model/api/v1/common/jsonref.go
@@ -22,7 +22,8 @@ import (
 var (
 	// jsonRefMatching is only used to validate the whole reference.
 	jsonRefMatching = regexp.MustCompile(`^#?/([a-zA-Z0-9_-]+)(?:/([a-zA-Z0-9_-]+))*$`)
-	// jsonRefCapturedGroup is used to captured every part of the reference
+	// jsonRefCapturedGroup is used to capture every part of the reference
+	// Note: the captured part must match idRegexp for the coherence between the different ID used.
 	jsonRefCapturedGroup = regexp.MustCompile(`(?:/([a-zA-Z0-9_-]+))`)
 )
 

--- a/pkg/model/api/v1/common/validate.go
+++ b/pkg/model/api/v1/common/validate.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var idRegexp = regexp.MustCompile("[a-zA-Z0-9_-]+$")
+
+// ValidateID checks for forbidden items in substring used inside id
+func ValidateID(name string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name cannot be empty")
+	}
+	keyMinLength := 2
+	keyMaxLength := 75
+
+	if len(name) < keyMinLength {
+		return fmt.Errorf("cannot contain less than %d characters", keyMinLength)
+	}
+
+	if len(name) > keyMaxLength {
+		return fmt.Errorf("cannot contain more than %d characters", keyMaxLength)
+	}
+
+	if len(idRegexp.FindAllString(name, -1)) <= 0 {
+		return fmt.Errorf("%q is not a correct name. It should match the regexp: %s", name, idRegexp.String())
+	}
+
+	return nil
+}

--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -16,15 +16,12 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
 	"github.com/prometheus/common/model"
 )
-
-var keyRegexp = regexp.MustCompile("(?m)^[a-zA-Z0-9_-]")
 
 func GenerateDashboardID(project string, name string) string {
 	return generateProjectResourceID("dashboards", project, name)
@@ -84,9 +81,6 @@ func (d *DashboardSpec) validate() error {
 	variables := make(map[string]bool, len(d.Variables))
 	for i, variable := range d.Variables {
 		name := variable.Spec.GetName()
-		if len(keyRegexp.FindAllString(name, -1)) <= 0 {
-			return fmt.Errorf("variable reference %q is containing spaces or special characters", name)
-		}
 		if !variables[name] {
 			variables[name] = true
 		} else {
@@ -94,8 +88,8 @@ func (d *DashboardSpec) validate() error {
 		}
 	}
 	for panelKey := range d.Panels {
-		if len(keyRegexp.FindAllString(panelKey, -1)) <= 0 {
-			return fmt.Errorf("panel reference %q is containing spaces or special characters", panelKey)
+		if err := common.ValidateID(panelKey); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -16,13 +16,10 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"gopkg.in/yaml.v2"
 )
-
-var variableNameRegexp = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 
 type VariableKind string
 
@@ -115,11 +112,8 @@ func (v *TextVariableSpec) UnmarshalYAML(unmarshal func(interface{}) error) erro
 }
 
 func (v *TextVariableSpec) validate() error {
-	if len(v.Name) == 0 {
-		return fmt.Errorf("name cannot be empty")
-	}
-	if !variableNameRegexp.MatchString(v.Name) {
-		return fmt.Errorf("%q is not a correct variable name. It should match the regexp: %s", v.Name, variableNameRegexp.String())
+	if err := common.ValidateID(v.Name); err != nil {
+		return err
 	}
 	if len(v.Value) == 0 {
 		return fmt.Errorf("value for the variable %q cannot be empty", v.Name)
@@ -167,11 +161,8 @@ func (v *ListVariableSpec) UnmarshalYAML(unmarshal func(interface{}) error) erro
 }
 
 func (v *ListVariableSpec) validate() error {
-	if len(v.Name) == 0 {
-		return fmt.Errorf("name cannot be empty")
-	}
-	if !variableNameRegexp.MatchString(v.Name) {
-		return fmt.Errorf("%q is not a correct variable name. It should match the regexp: %s", v.Name, variableNameRegexp.String())
+	if err := common.ValidateID(v.Name); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
All resource name, variable name and panel name follow the same rule:
- more than 2 characters
- less than 75 characters
- cannot contain any space or special characters 

/cc @saminzadeh @LukeTillman 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>