### PR TITLE
Ability to change variable order

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -31,6 +31,8 @@ import { VariableDefinition } from '@perses-dev/core';
 import { useImmer } from 'use-immer';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import TrashIcon from 'mdi-material-ui/TrashCan';
+import ArrowUp from 'mdi-material-ui/ArrowUp';
+import ArrowDown from 'mdi-material-ui/ArrowDown';
 
 import { VariableEditForm } from './VariableEditorForm';
 
@@ -74,6 +76,26 @@ export function VariableEditor(props: {
         };
       }
       v.spec.display.hidden = visible === false;
+    });
+  };
+
+  const changeVariableOrder = (index: number, direction: 'up' | 'down') => {
+    setVariableDefinitions((draft) => {
+      if (direction === 'up') {
+        if (index === 0) {
+          return;
+        }
+        const tmp = draft[index - 1] as VariableDefinition;
+        draft[index - 1] = draft[index] as VariableDefinition;
+        draft[index] = tmp;
+      } else {
+        if (index === draft.length - 1) {
+          return;
+        }
+        const tmp = draft[index + 1];
+        draft[index + 1] = draft[index] as VariableDefinition;
+        draft[index] = tmp as VariableDefinition;
+      }
     });
   };
 
@@ -146,6 +168,16 @@ export function VariableEditor(props: {
                       </TableCell>
                       <TableCell>{v.kind}</TableCell>
                       <TableCell align="right">
+                        <IconButton onClick={() => changeVariableOrder(idx, 'up')} disabled={idx === 0}>
+                          <ArrowUp />
+                        </IconButton>
+                        <IconButton
+                          onClick={() => changeVariableOrder(idx, 'down')}
+                          disabled={idx === variableDefinitions.length - 1}
+                        >
+                          <ArrowDown />
+                        </IconButton>
+
                         <IconButton onClick={() => setVariableEditIdx(idx)}>
                           <PencilIcon />
                         </IconButton>

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -82,19 +82,21 @@ export function VariableEditor(props: {
   const changeVariableOrder = (index: number, direction: 'up' | 'down') => {
     setVariableDefinitions((draft) => {
       if (direction === 'up') {
-        if (index === 0) {
+        const prevElement = draft[index - 1];
+        const currentElement = draft[index];
+        if (index === 0 || !prevElement || !currentElement) {
           return;
         }
-        const tmp = draft[index - 1] as VariableDefinition;
-        draft[index - 1] = draft[index] as VariableDefinition;
-        draft[index] = tmp;
+        draft[index - 1] = currentElement;
+        draft[index] = prevElement;
       } else {
-        if (index === draft.length - 1) {
+        const nextElement = draft[index + 1];
+        const currentElement = draft[index];
+        if (index === draft.length - 1 || !nextElement || !currentElement) {
           return;
         }
-        const tmp = draft[index + 1];
-        draft[index + 1] = draft[index] as VariableDefinition;
-        draft[index] = tmp as VariableDefinition;
+        draft[index + 1] = currentElement;
+        draft[index] = nextElement;
       }
     });
   };


### PR DESCRIPTION
Demo: https://www.loom.com/share/6478791cda074913936271a57480f16d

This PR allows you to change the variable order through the UI. Until we land on a drag and drop solution, we can use up and down arrows.

<img width="763" alt="image" src="https://user-images.githubusercontent.com/6935733/196752562-3783ad8f-2988-479f-85a1-fac23a184b44.png">

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>