### PR TITLE
Fix variable editor styling

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -137,7 +137,7 @@ export function VariableEditor(props: {
                 props.onChange(variableDefinitions);
               }}
             >
-              Apply Changes
+              Apply
             </Button>
           </Stack>
           <Typography variant="h3" mb={2}>

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -124,13 +124,6 @@ export function VariableEditor(props: {
         <>
           <Stack direction="row" spacing={1} justifyContent="end">
             <Button
-              onClick={() => {
-                props.onCancel();
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
               disabled={props.variableDefinitions === variableDefinitions}
               variant="contained"
               onClick={() => {
@@ -138,6 +131,14 @@ export function VariableEditor(props: {
               }}
             >
               Apply
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={() => {
+                props.onCancel();
+              }}
+            >
+              Cancel
             </Button>
           </Stack>
           <Typography variant="h3" mb={2}>

--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -181,20 +181,20 @@ export function VariableEditForm({
 
       <Stack direction={'row'} spacing={2} justifyContent="end">
         <Button
-          onClick={() => {
-            onCancel();
-          }}
-        >
-          Cancel
-        </Button>
-
-        <Button
           variant="contained"
           onClick={() => {
             onChange(getVariableDefinitionFromState(state));
           }}
         >
           Update
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            onCancel();
+          }}
+        >
+          Cancel
         </Button>
       </Stack>
     </Box>

--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -55,6 +55,7 @@ export function VariableEditForm({
       <Grid container spacing={2} mb={2}>
         <Grid item xs={6}>
           <TextField
+            fullWidth
             label="Name"
             value={state.name}
             onChange={(v) => {
@@ -88,6 +89,7 @@ export function VariableEditForm({
         </Grid>
         <Grid item xs={6}>
           <TextField
+            fullWidth
             label="Label"
             value={state.label}
             onChange={(v) => {
@@ -99,6 +101,7 @@ export function VariableEditForm({
         </Grid>
         <Grid item xs={12}>
           <TextField
+            fullWidth
             label="Description"
             value={state.description}
             onChange={(v) => {
@@ -191,7 +194,7 @@ export function VariableEditForm({
             onChange(getVariableDefinitionFromState(state));
           }}
         >
-          Update Variable
+          Update
         </Button>
       </Stack>
     </Box>

--- a/ui/prometheus-plugin/src/plugins/MatcherEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/MatcherEditor.tsx
@@ -22,6 +22,7 @@ export function MatcherEditor(props: { initialMatchers?: string[]; onChange: (ma
       {matchers.map((matcher, index) => (
         <Box key={index} display="flex">
           <TextField
+            fullWidth
             onBlur={() => {
               props.onChange(matchers);
             }}


### PR DESCRIPTION
The changes made in #668 caused the variable editor styles to be wonky. This was fixed by adding the `fullWidth` property on the inputs.

<img width="787" alt="image" src="https://user-images.githubusercontent.com/6935733/196992473-70e0ede8-ace8-4373-924f-5aad31742f23.png">


Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>