### PR TITLE
Add border to each query in time series chart editor

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -46,7 +46,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
     enabled: true,
   });
 
-  // Query editing handlers
+  // Query handlers
   const handleQueryChange = (index: number, queryDef: TimeSeriesQueryDefinition) => {
     onChange(
       produce(value, (draft: TimeSeriesChartOptions) => {
@@ -77,8 +77,8 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
     );
   };
 
-  // edit legend options handlers
-  const updateLegendShow = (show: boolean) => {
+  // Legend options handlers
+  const handleLegendShowChange = (show: boolean) => {
     onChange(
       produce(value, (draft: TimeSeriesChartOptions) => {
         draft.legend = show ? DEFAULT_LEGEND : undefined;
@@ -86,7 +86,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
     );
   };
 
-  const updateLegendPosition: SelectProps<LegendPosition>['onChange'] = (e) => {
+  const handleLegendPositionChange: SelectProps<LegendPosition>['onChange'] = (e) => {
     onChange(
       produce(value, (draft: TimeSeriesChartOptions) => {
         // TODO: type cast should not be necessary
@@ -103,8 +103,8 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
         Add Query
       </Button>
       {queries.map((query, i) => (
-        <Stack key={i}>
-          <Stack direction="row">
+        <Stack key={i} spacing={1}>
+          <Stack direction="row" borderBottom={1} borderColor="grey.300">
             <Typography variant="overline" component="h3">
               Query {i + 1}
             </Typography>
@@ -127,7 +127,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
             <Switch
               checked={value.legend !== undefined}
               onChange={(e) => {
-                updateLegendShow(e.target.checked);
+                handleLegendShowChange(e.target.checked);
               }}
             />
           }
@@ -140,7 +140,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
             id="legend-position-select"
             label="Position"
             value={value.legend && value.legend.position ? value.legend.position : DEFAULT_LEGEND.position}
-            onChange={updateLegendPosition}
+            onChange={handleLegendPositionChange}
           >
             {LEGEND_POSITIONS.map((position) => (
               <MenuItem key={position} value={position}>


### PR DESCRIPTION
Now queries have nice borders that match the designs!

<img width="1512" alt="Screen Shot 2022-10-20 at 12 21 01 PM" src="https://user-images.githubusercontent.com/2584129/197038881-3e2be322-e9b3-4eee-9ea0-cb70fb4dfbdc.png">

Also, updated the names of the handler functions to be more consistent in this file (Steven lemme know what you think)