### PR TITLE
Connect react-grid-layout changes with dashboard store

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { LayoutItem, usePanel } from '../../context';
+import { PanelGroupItemId, usePanel } from '../../context';
 import { Panel } from '../Panel/Panel';
 
 export interface GridItemContentProps {
-  panelGroupItemId: LayoutItem;
+  panelGroupItemId: PanelGroupItemId;
 }
 
 /**

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -62,10 +62,10 @@ export function GridLayout(props: GridLayoutProps) {
             isResizable={isEditMode}
             containerPadding={[0, 10]}
           >
-            {groupDefinition.items.map(({ x, y, width, height }, itemIndex) => (
-              <div key={itemIndex} data-grid={{ x, y, w: width, h: height }}>
+            {groupDefinition.itemLayouts.map(({ i, x, y, w, h }) => (
+              <div key={i} data-grid={{ i, x, y, w, h }}>
                 <ErrorBoundary FallbackComponent={ErrorAlert}>
-                  <GridItemContent panelGroupItemId={{ panelGroupId, itemIndex }} />
+                  <GridItemContent panelGroupItemId={{ panelGroupId, panelGroupLayoutId: i }} />
                 </ErrorBoundary>
               </div>
             ))}

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -12,10 +12,10 @@
 // limitations under the License.
 import { useState } from 'react';
 import { Responsive, WidthProvider } from 'react-grid-layout';
-import { Box, BoxProps, Collapse, GlobalStyles } from '@mui/material';
+import { Box, BoxProps, Collapse, GlobalStyles, useTheme } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { styles } from '../../css/styles';
-import { useEditMode, usePanelGroup, PanelGroupId } from '../../context';
+import { useEditMode, usePanelGroup, usePanelGroupActions, PanelGroupId } from '../../context';
 import { GridTitle } from './GridTitle';
 import { GridItemContent } from './GridItemContent';
 
@@ -30,7 +30,9 @@ export interface GridLayoutProps extends BoxProps {
  */
 export function GridLayout(props: GridLayoutProps) {
   const { panelGroupId, ...others } = props;
+  const theme = useTheme();
   const groupDefinition = usePanelGroup(panelGroupId);
+  const { updatePanelGroupLayouts } = usePanelGroupActions(panelGroupId);
 
   const [isOpen, setIsOpen] = useState(!groupDefinition.isCollapsed ?? true);
   const { isEditMode } = useEditMode();
@@ -53,17 +55,19 @@ export function GridLayout(props: GridLayoutProps) {
         <Collapse in={isOpen} unmountOnExit>
           <ResponsiveGridLayout
             className="layout"
-            breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
-            cols={{ lg: 24, md: 24, sm: 24, xs: 24, xxs: 2 }}
+            breakpoints={{ sm: theme.breakpoints.values.sm, xxs: 0 }}
+            cols={{ sm: 24, xxs: 2 }}
             rowHeight={30}
             draggableHandle={'.drag-handle'}
             resizeHandles={['se']}
             isDraggable={isEditMode}
             isResizable={isEditMode}
             containerPadding={[0, 10]}
+            layouts={{ sm: groupDefinition.itemLayouts }}
+            onLayoutChange={updatePanelGroupLayouts}
           >
-            {groupDefinition.itemLayouts.map(({ i, x, y, w, h }) => (
-              <div key={i} data-grid={{ i, x, y, w, h }}>
+            {groupDefinition.itemLayouts.map(({ i }) => (
+              <div key={i}>
                 <ErrorBoundary FallbackComponent={ErrorAlert}>
                   <GridItemContent panelGroupItemId={{ panelGroupId, panelGroupLayoutId: i }} />
                 </ErrorBoundary>

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -69,7 +69,7 @@ export function GridLayout(props: GridLayoutProps) {
             {groupDefinition.itemLayouts.map(({ i }) => (
               <div key={i}>
                 <ErrorBoundary FallbackComponent={ErrorAlert}>
-                  <GridItemContent panelGroupItemId={{ panelGroupId, panelGroupLayoutId: i }} />
+                  <GridItemContent panelGroupItemId={{ panelGroupId, panelGroupItemLayoutId: i }} />
                 </ErrorBoundary>
               </div>
             ))}

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -36,7 +36,7 @@ describe('Panel', () => {
         },
       },
       // TODO: This is coupled to ID generation which is not good and the tests will probably fail
-      panelGroupItemId: { panelGroupId: 0, panelGroupLayoutId: '' },
+      panelGroupItemId: { panelGroupId: 0, panelGroupItemLayoutId: '' },
     };
   };
 

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -35,7 +35,8 @@ describe('Panel', () => {
           },
         },
       },
-      panelGroupItemId: { panelGroupId: 0, itemIndex: 0 },
+      // TODO: This is coupled to ID generation which is not good and the tests will probably fail
+      panelGroupItemId: { panelGroupId: 0, panelGroupLayoutId: '' },
     };
   };
 

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -31,12 +31,12 @@ import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import DragIcon from 'mdi-material-ui/DragVertical';
-import { useEditMode, LayoutItem, usePanelActions } from '../../context';
+import { useEditMode, PanelGroupItemId, usePanelActions } from '../../context';
 import { PanelContent } from './PanelContent';
 
 export interface PanelProps extends CardProps {
   definition: PanelDefinition;
-  panelGroupItemId: LayoutItem;
+  panelGroupItemId: PanelGroupItemId;
 }
 
 /**

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -88,7 +88,7 @@ describe('Panel Drawer', () => {
     if (layout === undefined) {
       throw new Error('Test panel not found');
     }
-    act(() => storeApi.getState().openEditPanel({ panelGroupId: group.id, panelGroupLayoutId: layout[0] }));
+    act(() => storeApi.getState().openEditPanel({ panelGroupId: group.id, panelGroupItemLayoutId: layout[0] }));
 
     const nameInput = await screen.findByLabelText(/Name/);
     userEvent.clear(nameInput);

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -84,7 +84,11 @@ describe('Panel Drawer', () => {
     if (group === undefined) {
       throw new Error('Test group not found');
     }
-    act(() => storeApi.getState().openEditPanel({ panelGroupId: group.id, itemIndex: 0 }));
+    const layout = Object.entries(group.itemPanelKeys).find(([, panelKey]) => panelKey === 'cpu');
+    if (layout === undefined) {
+      throw new Error('Test panel not found');
+    }
+    act(() => storeApi.getState().openEditPanel({ panelGroupId: group.id, panelGroupLayoutId: layout[0] }));
 
     const nameInput = await screen.findByLabelText(/Name/);
     userEvent.clear(nameInput);

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -31,7 +31,7 @@ export function PanelPreview({ name, description, kind, spec, groupId }: PanelEd
       },
     },
     // TODO: this shouldn't be necessary for preview
-    panelGroupItemId: { panelGroupId: groupId, panelGroupLayoutId: '' },
+    panelGroupItemId: { panelGroupId: groupId, panelGroupItemLayoutId: '' },
   };
 
   if (!kind) {

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -30,8 +30,8 @@ export function PanelPreview({ name, description, kind, spec, groupId }: PanelEd
         },
       },
     },
-    // TODO: what should itemIndex be?
-    panelGroupItemId: { panelGroupId: groupId, itemIndex: 0 },
+    // TODO: this shouldn't be necessary for preview
+    panelGroupItemId: { panelGroupId: groupId, panelGroupLayoutId: '' },
   };
 
   if (!kind) {

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
@@ -16,7 +16,6 @@ import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 import { DashboardProvider } from '../../context';
 import { createDashboardProviderSpy, getTestDashboard, renderWithContext } from '../../test';
-import testDashboard from '../../test/testDashboard';
 import { PanelGroupDialog } from './PanelGroupDialog';
 
 describe('Add Panel Group', () => {
@@ -54,7 +53,8 @@ describe('Add Panel Group', () => {
       id: expect.any(Number),
       title: 'New Panel Group',
       isCollapsed: false,
-      items: [],
+      itemLayouts: expect.any(Array),
+      itemPanelKeys: expect.any(Object),
     });
   });
 
@@ -80,7 +80,6 @@ describe('Add Panel Group', () => {
         id: group.id,
         title: 'New Name',
         isCollapsed: false,
-        items: testDashboard.spec.layouts[0]?.spec.items,
       },
     });
   });

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getPanelKeyFromRef } from '@perses-dev/core';
 import { useMemo } from 'react';
 import { useDashboardStore } from './DashboardProvider';
 import { PanelGroupItemId, PanelGroupId } from './panel-group-slice';
@@ -136,12 +135,11 @@ export function useDeletePanelGroupDialog() {
  * Gets an individual panel in the store. Throws if the panel can't be found.
  */
 export function usePanel(panelGroupItemId: PanelGroupItemId) {
-  const { panelGroupId, itemIndex } = panelGroupItemId;
+  const { panelGroupId, panelGroupLayoutId } = panelGroupItemId;
 
   const panel = useDashboardStore((store) => {
-    const panelRef = store.panelGroups[panelGroupId]?.items[itemIndex]?.content;
-    if (panelRef === undefined) return;
-    const panelKey = getPanelKeyFromRef(panelRef);
+    const panelKey = store.panelGroups[panelGroupId]?.itemPanelKeys[panelGroupLayoutId];
+    if (panelKey === undefined) return;
     return store.panels[panelKey];
   });
 

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -13,7 +13,7 @@
 
 import { useMemo } from 'react';
 import { useDashboardStore } from './DashboardProvider';
-import { PanelGroupItemId, PanelGroupId } from './panel-group-slice';
+import { PanelGroupItemId, PanelGroupId, PanelGroupLayout } from './panel-group-slice';
 
 export function useEditMode() {
   return useDashboardStore(({ isEditMode, setEditMode }) => ({ isEditMode, setEditMode }));
@@ -79,6 +79,7 @@ export function usePanelGroupActions(panelGroupId: PanelGroupId) {
   const openEditPanelGroup = useDashboardStore((store) => store.openEditPanelGroup);
   const deletePanelGroup = useDashboardStore((store) => store.openDeletePanelGroupDialog);
   const openAddPanel = useDashboardStore((store) => store.openAddPanel);
+  const updatePanelGroupLayouts = useDashboardStore((store) => store.updatePanelGroupLayouts);
 
   return {
     openEditPanelGroup: () => openEditPanelGroup(panelGroupId),
@@ -86,6 +87,7 @@ export function usePanelGroupActions(panelGroupId: PanelGroupId) {
     openAddPanel: () => openAddPanel(panelGroupId),
     moveUp,
     moveDown,
+    updatePanelGroupLayouts: (itemLayouts: PanelGroupLayout[]) => updatePanelGroupLayouts(panelGroupId, itemLayouts),
   };
 }
 

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -13,7 +13,7 @@
 
 import { useMemo } from 'react';
 import { useDashboardStore } from './DashboardProvider';
-import { PanelGroupItemId, PanelGroupId, PanelGroupLayout } from './panel-group-slice';
+import { PanelGroupItemId, PanelGroupId, PanelGroupItemLayout } from './panel-group-slice';
 
 export function useEditMode() {
   return useDashboardStore(({ isEditMode, setEditMode }) => ({ isEditMode, setEditMode }));
@@ -87,7 +87,8 @@ export function usePanelGroupActions(panelGroupId: PanelGroupId) {
     openAddPanel: () => openAddPanel(panelGroupId),
     moveUp,
     moveDown,
-    updatePanelGroupLayouts: (itemLayouts: PanelGroupLayout[]) => updatePanelGroupLayouts(panelGroupId, itemLayouts),
+    updatePanelGroupLayouts: (itemLayouts: PanelGroupItemLayout[]) =>
+      updatePanelGroupLayouts(panelGroupId, itemLayouts),
   };
 }
 
@@ -137,7 +138,7 @@ export function useDeletePanelGroupDialog() {
  * Gets an individual panel in the store. Throws if the panel can't be found.
  */
 export function usePanel(panelGroupItemId: PanelGroupItemId) {
-  const { panelGroupId, panelGroupLayoutId } = panelGroupItemId;
+  const { panelGroupId, panelGroupItemLayoutId: panelGroupLayoutId } = panelGroupItemId;
 
   const panel = useDashboardStore((store) => {
     const panelKey = store.panelGroups[panelGroupId]?.itemPanelKeys[panelGroupLayoutId];

--- a/ui/dashboards/src/context/DashboardProvider/delete-panel-group-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/delete-panel-group-slice.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getPanelKeyFromRef } from '@perses-dev/core';
 import { StateCreator } from 'zustand';
 import { Middleware } from './common';
 import { PanelGroupId, PanelGroupSlice } from './panel-group-slice';

--- a/ui/dashboards/src/context/DashboardProvider/delete-panel-group-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/delete-panel-group-slice.ts
@@ -45,15 +45,15 @@ export const createDeletePanelGroupSlice: StateCreator<
   DeletePanelGroupSlice
 > = (set, get) => ({
   deletePanelGroup(panelGroupId) {
-    const { panelGroups, panelGroupOrder: panelGroupIdOrder } = get();
+    const { panelGroups, panelGroupOrder } = get();
     const group = panelGroups[panelGroupId];
-    const idIndex = panelGroupIdOrder.findIndex((id) => id === panelGroupId);
+    const idIndex = panelGroupOrder.findIndex((id) => id === panelGroupId);
     if (group === undefined || idIndex === -1) {
       throw new Error(`Panel group ${panelGroupId} not found`);
     }
 
     // Get the panel keys for all the panel items in the group we're going to delete
-    const panelKeys = group.items.map((item) => getPanelKeyFromRef(item.content));
+    const panelKeys = Object.values(group.itemPanelKeys);
 
     set((draft) => {
       // Delete the panel group which also deletes all its items
@@ -93,8 +93,8 @@ export const createDeletePanelGroupSlice: StateCreator<
 function getUsedPanelKeys(panelGroups: PanelGroupSlice['panelGroups']): Set<string> {
   const usedPanelKeys = new Set<string>();
   for (const group of Object.values(panelGroups)) {
-    for (const item of group.items) {
-      usedPanelKeys.add(getPanelKeyFromRef(item.content));
+    for (const panelKey of Object.values(group.itemPanelKeys)) {
+      usedPanelKeys.add(panelKey);
     }
   }
   return usedPanelKeys;

--- a/ui/dashboards/src/context/DashboardProvider/delete-panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/delete-panel-slice.ts
@@ -61,7 +61,7 @@ export function createDeletePanelSlice(): StateCreator<
   return (set, get) => ({
     deletePanel(panelGroupItemId: PanelGroupItemId) {
       set((draft) => {
-        const { panelGroupId, panelGroupLayoutId } = panelGroupItemId;
+        const { panelGroupId, panelGroupItemLayoutId: panelGroupLayoutId } = panelGroupItemId;
         const existingGroup = draft.panelGroups[panelGroupId];
         if (existingGroup === undefined) {
           throw new Error(`Missing panel group ${panelGroupId}`);
@@ -84,7 +84,7 @@ export function createDeletePanelSlice(): StateCreator<
     },
 
     openDeletePanelDialog(panelGroupItemId: PanelGroupItemId) {
-      const { panelGroupId, panelGroupLayoutId } = panelGroupItemId;
+      const { panelGroupId, panelGroupItemLayoutId: panelGroupLayoutId } = panelGroupItemId;
 
       const { panels, panelGroups } = get();
       const panelGroup = panelGroups[panelGroupId];

--- a/ui/dashboards/src/context/DashboardProvider/delete-panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/delete-panel-slice.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getPanelKeyFromRef } from '@perses-dev/core';
 import { StateCreator } from 'zustand';
 import { Middleware } from './common';
 import { PanelGroupSlice, PanelGroupItemId } from './panel-group-slice';
@@ -123,8 +122,8 @@ export function createDeletePanelSlice(): StateCreator<
 // Helper function to determine if a panel key is still being used somewhere in Panel Groups
 function isPanelKeyStillUsed(panelGroups: PanelGroupSlice['panelGroups'], panelKey: string) {
   for (const group of Object.values(panelGroups)) {
-    const found = group.itemPanelKeys[panelKey] !== undefined;
-    if (found) {
+    const found = Object.values(group.itemPanelKeys).find((key) => key === panelKey);
+    if (found !== undefined) {
       return true;
     }
   }

--- a/ui/dashboards/src/context/DashboardProvider/index.ts
+++ b/ui/dashboards/src/context/DashboardProvider/index.ts
@@ -13,6 +13,11 @@
 
 export * from './dashboard-provider-api';
 export * from './DashboardProvider';
-export type { PanelGroupId, PanelGroupDefinition, PanelGroupItemId, PanelGroupLayoutId } from './panel-group-slice';
+export type {
+  PanelGroupId,
+  PanelGroupDefinition,
+  PanelGroupItemId,
+  PanelGroupItemLayoutId as PanelGroupLayoutId,
+} from './panel-group-slice';
 export type { PanelGroupEditor, PanelGroupEditorValues } from './panel-group-editor-slice';
 export type { DeletePanelDialogState } from './delete-panel-slice';

--- a/ui/dashboards/src/context/DashboardProvider/index.ts
+++ b/ui/dashboards/src/context/DashboardProvider/index.ts
@@ -13,6 +13,6 @@
 
 export * from './dashboard-provider-api';
 export * from './DashboardProvider';
-export type { PanelGroupId, PanelGroupDefinition, PanelGroupItemId as LayoutItem } from './panel-group-slice';
+export type { PanelGroupId, PanelGroupDefinition, PanelGroupItemId, PanelGroupLayoutId } from './panel-group-slice';
 export type { PanelGroupEditor, PanelGroupEditorValues } from './panel-group-editor-slice';
 export type { DeletePanelDialogState } from './delete-panel-slice';

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -20,7 +20,7 @@ import {
   PanelGroupItemId,
   PanelGroupId,
   PanelGroupDefinition,
-  PanelGroupLayout,
+  PanelGroupItemLayout,
 } from './panel-group-slice';
 import { PanelSlice } from './panel-slice';
 
@@ -95,7 +95,7 @@ export function createPanelEditorSlice(): StateCreator<
       const { panels, panelGroups } = get();
 
       // Figure out the panel key at that location
-      const { panelGroupId, panelGroupLayoutId } = panelGroupItemId;
+      const { panelGroupId, panelGroupItemLayoutId: panelGroupLayoutId } = panelGroupItemId;
       const panelKey = panelGroups[panelGroupId]?.itemPanelKeys[panelGroupLayoutId];
       if (panelKey === undefined) {
         throw new Error(`Could not find Panel Group item ${panelGroupItemId}`);
@@ -205,7 +205,7 @@ export function createPanelEditorSlice(): StateCreator<
             if (group === undefined) {
               throw new Error(`Missing panel group ${next.groupId}`);
             }
-            const layout: PanelGroupLayout = {
+            const layout: PanelGroupItemLayout = {
               i: generateId().toString(),
               x: 0,
               y: getYForNewRow(group),

--- a/ui/dashboards/src/context/DashboardProvider/panel-group-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-group-editor-slice.ts
@@ -67,7 +67,8 @@ export const createPanelGroupEditorSlice: StateCreator<
       applyChanges(next) {
         const newGroup: PanelGroupDefinition = {
           id: generateId(),
-          items: [],
+          itemLayouts: [],
+          itemPanelKeys: {},
           ...next,
         };
         set((draft) => {

--- a/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
@@ -65,22 +65,22 @@ export interface PanelGroupDefinition {
   id: PanelGroupId;
   isCollapsed: boolean;
   title?: string;
-  itemLayouts: PanelGroupLayout[];
-  itemPanelKeys: Record<PanelGroupLayoutId, string>;
+  itemLayouts: PanelGroupItemLayout[];
+  itemPanelKeys: Record<PanelGroupItemLayoutId, string>;
 }
 
-export interface PanelGroupLayout extends Layout {
-  i: PanelGroupLayoutId;
+export interface PanelGroupItemLayout extends Layout {
+  i: PanelGroupItemLayoutId;
 }
 
-export type PanelGroupLayoutId = string;
+export type PanelGroupItemLayoutId = string;
 
 /**
  * Uniquely identifies an item in a PanelGroup.
  */
 export interface PanelGroupItemId {
   panelGroupId: PanelGroupId;
-  panelGroupLayoutId: PanelGroupLayoutId;
+  panelGroupItemLayoutId: PanelGroupItemLayoutId;
 }
 
 /**

--- a/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
@@ -44,6 +44,11 @@ export interface PanelGroupSlice {
   swapPanelGroups: (xIndex: number, yIndex: number) => void;
 
   /**
+   * Update the item layouts for a panel group when, for example, a panel is moved or resized.
+   */
+  updatePanelGroupLayouts: (panelGroupId: PanelGroupId, itemLayouts: PanelGroupDefinition['itemLayouts']) => void;
+
+  /**
    * save
    */
   savePanelGroups: () => void;
@@ -152,6 +157,16 @@ export function createPanelGroupSlice(
         }
         // assign yPanelGroup to layouts[x] and assign xGroup to layouts[y], swapping two panel groups
         [state.panelGroupOrder[x], state.panelGroupOrder[y]] = [yPanelGroup, xPanelGroup];
+      });
+    },
+
+    updatePanelGroupLayouts(panelGroupId, itemLayouts) {
+      set((state) => {
+        const group = state.panelGroups[panelGroupId];
+        if (group === undefined) {
+          throw new Error(`Cannot find panel group ${panelGroupId}`);
+        }
+        group.itemLayouts = itemLayouts;
       });
     },
   });

--- a/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
@@ -11,7 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GridItemDefinition, LayoutDefinition } from '@perses-dev/core';
+import { getPanelKeyFromRef, LayoutDefinition } from '@perses-dev/core';
+import { Layout } from 'react-grid-layout';
 import { StateCreator } from 'zustand';
 import { generateId, Middleware } from './common';
 
@@ -57,17 +58,24 @@ export type PanelGroupId = number;
 
 export interface PanelGroupDefinition {
   id: PanelGroupId;
-  items: GridItemDefinition[];
   isCollapsed: boolean;
   title?: string;
+  itemLayouts: PanelGroupLayout[];
+  itemPanelKeys: Record<PanelGroupLayoutId, string>;
 }
+
+export interface PanelGroupLayout extends Layout {
+  i: PanelGroupLayoutId;
+}
+
+export type PanelGroupLayoutId = string;
 
 /**
  * Uniquely identifies an item in a PanelGroup.
  */
 export interface PanelGroupItemId {
   panelGroupId: PanelGroupId;
-  itemIndex: number;
+  panelGroupLayoutId: PanelGroupLayoutId;
 }
 
 /**
@@ -76,18 +84,36 @@ export interface PanelGroupItemId {
 export function createPanelGroupSlice(
   layouts: LayoutDefinition[]
 ): StateCreator<PanelGroupSlice, Middleware, [], PanelGroupSlice> {
-  // Convert the initial layouts from the JSON to panel groups and keep track of the order
+  // Convert the initial layouts from the JSON
   const panelGroups: PanelGroupSlice['panelGroups'] = {};
   const panelGroupIdOrder: PanelGroupSlice['panelGroupOrder'] = [];
   for (const layout of layouts) {
-    const id = generateId();
-    panelGroups[id] = {
-      id,
-      items: layout.spec.items,
+    const itemLayouts: PanelGroupDefinition['itemLayouts'] = [];
+    const itemPanelKeys: PanelGroupDefinition['itemPanelKeys'] = {};
+
+    // Split layout information from panel keys to make it easier to update just layouts on move/resize of panels
+    for (const item of layout.spec.items) {
+      const panelGroupLayoutId = generateId().toString();
+      itemLayouts.push({
+        i: panelGroupLayoutId,
+        w: item.width,
+        h: item.height,
+        x: item.x,
+        y: item.y,
+      });
+      itemPanelKeys[panelGroupLayoutId] = getPanelKeyFromRef(item.content);
+    }
+
+    // Create the panel group and keep track of the ID order
+    const panelGroupId = generateId();
+    panelGroups[panelGroupId] = {
+      id: panelGroupId,
       isCollapsed: layout.spec.display?.collapse?.open === false,
       title: layout.spec.display?.title,
+      itemLayouts,
+      itemPanelKeys,
     };
-    panelGroupIdOrder.push(id);
+    panelGroupIdOrder.push(panelGroupId);
   }
 
   // Return the state creator function for Zustand

--- a/ui/dashboards/src/context/useDashboardSpec.tsx
+++ b/ui/dashboards/src/context/useDashboardSpec.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DashboardSpec, GridDefinition } from '@perses-dev/core';
+import { createPanelRef, DashboardSpec, GridDefinition } from '@perses-dev/core';
 import { PanelGroupDefinition, useDashboardStore } from './DashboardProvider';
 import { useTemplateVariableActions, useTemplateVariableDefinitions } from './TemplateVariableProvider';
 
@@ -53,7 +53,7 @@ export function useDashboardSpec() {
 function convertPanelGroupsToLayouts(panelGroups: Record<number, PanelGroupDefinition>): GridDefinition[] {
   const layouts: GridDefinition[] = [];
   Object.values(panelGroups).forEach((group) => {
-    const { title, isCollapsed, items } = group;
+    const { title, isCollapsed, itemLayouts, itemPanelKeys } = group;
     let display = undefined;
     if (title) {
       display = {
@@ -67,7 +67,19 @@ function convertPanelGroupsToLayouts(panelGroups: Record<number, PanelGroupDefin
       kind: 'Grid',
       spec: {
         display,
-        items,
+        items: itemLayouts.map((layout) => {
+          const panelKey = itemPanelKeys[layout.i];
+          if (panelKey === undefined) {
+            throw new Error(`Missing panel key of layout ${layout.i}`);
+          }
+          return {
+            x: layout.x,
+            y: layout.y,
+            width: layout.w,
+            height: layout.h,
+            content: createPanelRef(panelKey),
+          };
+        }),
       },
     };
     layouts.push(layout);


### PR DESCRIPTION
For each panel group, this PR splits the item state inside that panel group into two separate pieces of state:

- `itemLayouts`: an array of the layout information (`x`, `y`, `w`, `h`, and a unique ID `i`) which corresponds 1:1 with the model that `react-grid-layout` expects
- `itemPanelKeys`: a map of the unique ID of the item in `itemLayouts` -> the panel key referenced by that panel

By splitting this state up, I was then able to connect `react-grid-layout` with the store in a pretty straightforward manner. Its `onLayoutChange` handler can now just overwrite the `itemLayouts` property on a panel group every time a move/resize happens, while the content reference (i.e. panel key) remains stable. This also means that drag and drop actions should now be reflected in the object that's output for conversion to JSON. 🥳 