### PR TITLE
Implement variable state in URL parameters

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -762,10 +762,19 @@
           }
         },
         {
-          "kind": "TextVariable",
+          "kind": "ListVariable",
           "spec": {
             "name": "instance",
-            "value": "demo.do.prometheus.io:9100"
+            "allow_multiple": false,
+            "allow_all_value": false,
+            "default_value": "demo.do.prometheus.io:9100",
+            "plugin": {
+              "kind": "PrometheusLabelValuesVariable",
+              "spec": {
+                "label_name": "instance",
+                "matchers": ["up{job=~\"$job\"}"]
+              }
+            }
           }
         },
         {

--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -113,23 +113,10 @@ function ListVariable({ name }: TemplateVariableProps) {
 
   useEffect(() => {
     const firstOption = finalOptions?.[0];
-    const valueIsInOptions = Boolean(
-      finalOptions.find((v) => {
-        if (allowMultiple) {
-          return (value as string[]).includes(v.value);
-        }
-        return value === v.value;
-      })
-    );
 
     // If there is no value but there are options, set the value to the first option.
     if (!value && firstOption) {
       setVariableValue(name, firstOption.value);
-    }
-
-    // If there is a value but it's not in the options, select the first value or set to null
-    if (value && !valueIsInOptions && !definition.spec.default_value) {
-      setVariableValue(name, firstOption?.value || null);
     }
   }, [finalOptions, setVariableValue, value, name, allowMultiple]);
 
@@ -181,12 +168,14 @@ function TextVariable({ name }: TemplateVariableProps) {
   }, [state?.value]);
 
   return (
-    <TextField
-      value={tempValue}
-      onChange={(e) => setTempValue(e.target.value)}
-      onBlur={() => setVariableValue(name, tempValue)}
-      placeholder={name}
-      label={name}
-    />
+    <>
+      <TextField
+        value={tempValue}
+        onChange={(e) => setTempValue(e.target.value)}
+        onBlur={() => setVariableValue(name, tempValue)}
+        placeholder={name}
+        label={name}
+      />
+    </>
   );
 }

--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -168,14 +168,12 @@ function TextVariable({ name }: TemplateVariableProps) {
   }, [state?.value]);
 
   return (
-    <>
-      <TextField
-        value={tempValue}
-        onChange={(e) => setTempValue(e.target.value)}
-        onBlur={() => setVariableValue(name, tempValue)}
-        placeholder={name}
-        label={name}
-      />
-    </>
+    <TextField
+      value={tempValue}
+      onChange={(e) => setTempValue(e.target.value)}
+      onBlur={() => setVariableValue(name, tempValue)}
+      placeholder={name}
+      label={name}
+    />
   );
 }

--- a/ui/dashboards/src/context/TemplateVariableProvider/index.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './TemplateVariableProvider';

--- a/ui/dashboards/src/context/TemplateVariableProvider/query-params.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/query-params.ts
@@ -1,0 +1,60 @@
+import { VariableValue, VariableDefinition } from '@perses-dev/core';
+import { QueryParamConfig, useQueryParams } from 'use-query-params';
+
+const variableQueryParameterPrefix = 'var-';
+
+export function getURLQueryParamName(name: string) {
+  return `${variableQueryParameterPrefix}${name}`;
+}
+
+function encodeVariableValue(value: VariableValue) {
+  if (Array.isArray(value)) {
+    return value.join(',');
+  }
+  return value;
+}
+
+function decodeVariableValue(value: string): VariableValue {
+  if (!value) {
+    return null;
+  }
+  const values = value.split(',');
+  if (values.length === 1) {
+    return values[0] as string;
+  }
+  return values;
+}
+
+const VariableValueParam: QueryParamConfig<VariableValue> = {
+  encode: encodeVariableValue,
+  decode: (v) => {
+    if (typeof v === 'string') {
+      return decodeVariableValue(v);
+    }
+    return '';
+  },
+};
+
+export function useVariableQueryParams(defs: VariableDefinition[]) {
+  const config: Record<string, typeof VariableValueParam> = {};
+  defs.forEach((def) => {
+    const name = getURLQueryParamName(def.spec.name);
+    config[name] = VariableValueParam;
+  });
+  return useQueryParams(config);
+}
+
+export function getInitalValuesFromQueryParameters(
+  queryParamValues: Record<string, VariableValue>
+): Record<string, VariableValue> {
+  const values: Record<string, VariableValue> = {};
+  Object.keys(queryParamValues).forEach((key) => {
+    const value = queryParamValues[key];
+    if (!value) {
+      return;
+    }
+    const name = key.replace(variableQueryParameterPrefix, '');
+    values[name] = value;
+  });
+  return values;
+}


### PR DESCRIPTION
Video Demo: https://www.loom.com/share/6db09276573c4e9393fc19a8a05d5670

This implements syncing the template variable values in URL query parameters.
Each variable has a unique query parameter `var-${name}`. Multiple values for a query parameter are comma separated.

So for the following variable state:
```json
{ "foo": ["val1", "val2"], "bar": "val1" }
```

The URL query parameters would be:
```
?var-foo=val1,val2&var-bar=val1
```

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>