### PR TITLE
Decouple PanelPreview from edit state

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PanelGroupItemId, usePanel } from '../../context';
-import { Panel } from '../Panel/Panel';
+import { PanelGroupItemId, useEditMode, usePanel, usePanelActions } from '../../context';
+import { Panel, PanelProps } from '../Panel/Panel';
 
 export interface GridItemContentProps {
   panelGroupItemId: PanelGroupItemId;
@@ -24,5 +24,17 @@ export interface GridItemContentProps {
 export function GridItemContent(props: GridItemContentProps) {
   const { panelGroupItemId } = props;
   const panelDefinition = usePanel(panelGroupItemId);
-  return <Panel definition={panelDefinition} panelGroupItemId={panelGroupItemId} />;
+  const { isEditMode } = useEditMode();
+  const { openEditPanel, openDeletePanelDialog } = usePanelActions(panelGroupItemId);
+
+  // Provide actions to the panel when in edit mode
+  let editHandlers: PanelProps['editHandlers'] = undefined;
+  if (isEditMode) {
+    editHandlers = {
+      onEditPanelClick: openEditPanel,
+      onDeletePanelClick: openDeletePanelDialog,
+    };
+  }
+
+  return <Panel definition={panelDefinition} editHandlers={editHandlers} />;
 }

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -12,54 +12,54 @@
 // limitations under the License.
 
 import { PluginRegistry } from '@perses-dev/plugin-system';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithContext, mockPluginRegistryProps, FAKE_PANEL_PLUGIN, getTestDashboard } from '../../test';
-import { DashboardProvider } from '../../context';
+import { PanelDefinition } from '@perses-dev/core';
+import { renderWithContext, mockPluginRegistryProps, FAKE_PANEL_PLUGIN } from '../../test';
 import { Panel, PanelProps } from './Panel';
 
 describe('Panel', () => {
-  // Helper to create panel props for rendering tests
-  const createPanelProps = (): PanelProps => {
-    return {
-      definition: {
-        kind: 'Panel',
-        spec: {
-          display: {
-            name: 'Fake Panel',
-            description: 'This is a fake panel',
-          },
-          plugin: {
-            kind: 'FakePanel',
-            spec: {},
-          },
+  // Helper to render the panel with some context set
+  const renderPanel = (editHandlers?: PanelProps['editHandlers']) => {
+    const definition: PanelDefinition = {
+      kind: 'Panel',
+      spec: {
+        display: {
+          name: 'Fake Panel Title',
+          description: 'This is a fake panel',
+        },
+        plugin: {
+          kind: 'FakePanel',
+          spec: {},
         },
       },
-      // TODO: This is coupled to ID generation which is not good and the tests will probably fail
-      panelGroupItemId: { panelGroupId: 0, panelGroupItemLayoutId: '' },
     };
-  };
 
-  // Helper to render the panel with some context set
-  const renderPanel = (isEditMode = false) => {
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
     addMockPlugin('Panel', 'FakePanel', FAKE_PANEL_PLUGIN);
 
     renderWithContext(
       <PluginRegistry {...pluginRegistryProps}>
-        <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode }}>
-          <Panel {...createPanelProps()} />
-        </DashboardProvider>
+        <Panel definition={definition} editHandlers={editHandlers} />
       </PluginRegistry>
     );
   };
 
   it('should render name and info icon', async () => {
     renderPanel();
-    await screen.findByText('Fake Panel');
-    screen.queryByLabelText('info-tooltip');
+
+    const panel = screen.getByRole('region', { name: 'Fake Panel Title' });
+    expect(panel).toBeInTheDocument();
+
+    // Should diplay header with panel's title
+    const header = screen.getByRole('banner', { name: 'Fake Panel Title' });
+    expect(header).toHaveTextContent('Fake Panel Title');
+
+    // await screen.findByText('Fake Panel');
+    // screen.queryByLabelText('info-tooltip');
   });
 
+  /*
   it('should render edit icons when in edit mode', () => {
     renderPanel(true);
     const panelTitle = screen.getByText('Fake Panel');
@@ -68,4 +68,5 @@ describe('Panel', () => {
     screen.getByLabelText('edit panel');
     screen.getByLabelText('delete panel');
   });
+  */
 });

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -12,28 +12,30 @@
 // limitations under the License.
 
 import { PluginRegistry } from '@perses-dev/plugin-system';
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PanelDefinition } from '@perses-dev/core';
 import { renderWithContext, mockPluginRegistryProps, FAKE_PANEL_PLUGIN } from '../../test';
 import { Panel, PanelProps } from './Panel';
 
 describe('Panel', () => {
-  // Helper to render the panel with some context set
-  const renderPanel = (editHandlers?: PanelProps['editHandlers']) => {
-    const definition: PanelDefinition = {
-      kind: 'Panel',
-      spec: {
-        display: {
-          name: 'Fake Panel Title',
-          description: 'This is a fake panel',
-        },
-        plugin: {
-          kind: 'FakePanel',
-          spec: {},
-        },
+  const createTestPanel = (): PanelDefinition => ({
+    kind: 'Panel',
+    spec: {
+      display: {
+        name: 'Fake Panel Title',
+        description: 'This is a fake panel',
       },
-    };
+      plugin: {
+        kind: 'FakePanel',
+        spec: {},
+      },
+    },
+  });
+
+  // Helper to render the panel with some context set
+  const renderPanel = (definition?: PanelDefinition, editHandlers?: PanelProps['editHandlers']) => {
+    definition ??= createTestPanel();
 
     const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
     addMockPlugin('Panel', 'FakePanel', FAKE_PANEL_PLUGIN);
@@ -45,28 +47,81 @@ describe('Panel', () => {
     );
   };
 
-  it('should render name and info icon', async () => {
+  // Helper to get the panel once rendered
+  const getPanel = () => screen.getByRole('region', { name: 'Fake Panel Title' });
+
+  it('should render panel', async () => {
     renderPanel();
 
-    const panel = screen.getByRole('region', { name: 'Fake Panel Title' });
+    const panel = getPanel();
     expect(panel).toBeInTheDocument();
 
     // Should diplay header with panel's title
-    const header = screen.getByRole('banner', { name: 'Fake Panel Title' });
+    const header = screen.getByRole('banner');
     expect(header).toHaveTextContent('Fake Panel Title');
 
-    // await screen.findByText('Fake Panel');
-    // screen.queryByLabelText('info-tooltip');
+    // Should display chart's content from the fake panel plugin
+    const content = screen.getByRole('figure');
+    await waitFor(() => {
+      expect(content).toHaveTextContent('FakePanel chart');
+    });
+    expect(content);
   });
 
-  /*
-  it('should render edit icons when in edit mode', () => {
-    renderPanel(true);
-    const panelTitle = screen.getByText('Fake Panel');
-    userEvent.hover(panelTitle);
-    screen.getByLabelText('drag handle');
-    screen.getByLabelText('edit panel');
-    screen.getByLabelText('delete panel');
+  it('shows panel description', async () => {
+    renderPanel();
+
+    const panel = getPanel();
+
+    // Description button should not be visible until hover on panel
+    const missingButton = screen.queryByRole('button', { name: /description/i });
+    expect(missingButton).not.toBeInTheDocument();
+    userEvent.hover(panel);
+    const descriptionButton = screen.getByRole('button', { name: /description/i });
+    expect(descriptionButton).toBeInTheDocument();
+
+    // Can hover to see panel description in tooltip
+    userEvent.hover(descriptionButton);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('This is a fake panel');
   });
-  */
+
+  it('does not show description when panel does not have one', () => {
+    // Render a panel without a description set
+    const withoutDescription = createTestPanel();
+    withoutDescription.spec.display.description = undefined;
+    renderPanel(withoutDescription);
+
+    const panel = getPanel();
+    userEvent.hover(panel);
+    const descriptionButton = screen.queryByRole('button', { name: /description/i });
+    expect(descriptionButton).not.toBeInTheDocument();
+  });
+
+  it('does not show description in edit mode', () => {
+    renderPanel(undefined, { onEditPanelClick: jest.fn(), onDeletePanelClick: jest.fn() });
+
+    const panel = getPanel();
+    userEvent.hover(panel);
+    const descriptionButton = screen.queryByRole('button', { name: /description/i });
+    expect(descriptionButton).not.toBeInTheDocument();
+  });
+
+  it('can trigger panel actions in edit mode', () => {
+    const onEditPanelClick = jest.fn();
+    const onDeletePanelClick = jest.fn();
+    renderPanel(undefined, { onEditPanelClick, onDeletePanelClick });
+
+    const panel = getPanel();
+    userEvent.hover(panel);
+
+    const editButton = screen.getByRole('button', { name: /edit/i });
+    userEvent.click(editButton);
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    userEvent.click(deleteButton);
+
+    expect(onEditPanelClick).toHaveBeenCalledTimes(1);
+    expect(onDeletePanelClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -17,20 +17,19 @@ import { useInView } from 'react-intersection-observer';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
 import { Card, CardProps, CardContent } from '@mui/material';
-import { useEditMode, PanelGroupItemId, usePanelActions } from '../../context';
 import { PanelHeader, PanelHeaderProps } from './PanelHeader';
 import { PanelContent } from './PanelContent';
 
 export interface PanelProps extends CardProps {
   definition: PanelDefinition;
-  panelGroupItemId: PanelGroupItemId;
+  editHandlers?: PanelHeaderProps['editHandlers'];
 }
 
 /**
  * Renders a PanelDefinition's content inside of a Card.
  */
 export function Panel(props: PanelProps) {
-  const { definition, panelGroupItemId, onMouseEnter, onMouseLeave, ...others } = props;
+  const { definition, editHandlers, onMouseEnter, onMouseLeave, ...others } = props;
 
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null);
   const [isHovered, setIsHovered] = useState(false);
@@ -51,10 +50,6 @@ export function Panel(props: PanelProps) {
   // TODO: adjust padding for small panels, consistent way to determine isLargePanel here and in StatChart
   const panelPadding = 1.5;
 
-  const { isEditMode } = useEditMode();
-
-  const { openEditPanel, openDeletePanelDialog } = usePanelActions(panelGroupItemId);
-
   const handleMouseEnter: CardProps['onMouseEnter'] = (e) => {
     setIsHovered(true);
     onMouseEnter?.(e);
@@ -64,13 +59,6 @@ export function Panel(props: PanelProps) {
     setIsHovered(false);
     onMouseLeave?.(e);
   };
-
-  const description = isHovered ? definition.spec.display.description : undefined;
-
-  const editHandlers: PanelHeaderProps['editHandlers'] =
-    isEditMode && isHovered
-      ? { onEditPanelClick: openEditPanel, onDeletePanelClick: openDeletePanelDialog }
-      : undefined;
 
   return (
     <Card
@@ -89,8 +77,9 @@ export function Panel(props: PanelProps) {
     >
       <PanelHeader
         title={definition.spec.display.name}
-        description={description}
+        description={definition.spec.display.description}
         editHandlers={editHandlers}
+        isHovered={isHovered}
         sx={{ paddingX: (theme) => theme.spacing(panelPadding) }}
       />
       <CardContent

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -14,13 +14,14 @@
 import { useState, useMemo } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import { useInView } from 'react-intersection-observer';
-import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
+import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
 import { Card, CardProps, CardContent } from '@mui/material';
+import { useId } from '../../utils/component-ids';
 import { PanelHeader, PanelHeaderProps } from './PanelHeader';
 import { PanelContent } from './PanelContent';
 
-export interface PanelProps extends CardProps {
+export interface PanelProps extends CardProps<'section'> {
   definition: PanelDefinition;
   editHandlers?: PanelHeaderProps['editHandlers'];
 }
@@ -29,7 +30,11 @@ export interface PanelProps extends CardProps {
  * Renders a PanelDefinition's content inside of a Card.
  */
 export function Panel(props: PanelProps) {
-  const { definition, editHandlers, onMouseEnter, onMouseLeave, ...others } = props;
+  const { definition, editHandlers, onMouseEnter, onMouseLeave, sx, ...others } = props;
+
+  // Make sure we have an ID we can use for aria attributes
+  const generatedPanelId = useId('Panel');
+  const headerId = `${generatedPanelId}-header`;
 
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null);
   const [isHovered, setIsHovered] = useState(false);
@@ -63,19 +68,24 @@ export function Panel(props: PanelProps) {
   return (
     <Card
       ref={ref}
-      sx={{
-        ...others.sx,
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexFlow: 'column nowrap',
-      }}
+      component="section"
+      sx={combineSx(
+        {
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexFlow: 'column nowrap',
+        },
+        sx
+      )}
       variant="outlined"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      aria-labelledby={headerId}
       {...others}
     >
       <PanelHeader
+        id={headerId}
         title={definition.spec.display.name}
         description={definition.spec.display.description}
         editHandlers={editHandlers}

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -36,7 +36,7 @@ export function Panel(props: PanelProps) {
   const generatedPanelId = useId('Panel');
   const headerId = `${generatedPanelId}-header`;
 
-  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null);
+  const [contentElement, setContentElement] = useState<HTMLElement | null>(null);
   const [isHovered, setIsHovered] = useState(false);
 
   const { width, height } = useResizeObserver({ ref: contentElement });
@@ -82,6 +82,7 @@ export function Panel(props: PanelProps) {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       aria-labelledby={headerId}
+      aria-describedby={headerId}
       {...others}
     >
       <PanelHeader
@@ -93,10 +94,12 @@ export function Panel(props: PanelProps) {
         sx={{ paddingX: (theme) => theme.spacing(panelPadding) }}
       />
       <CardContent
+        component="figure"
         sx={{
           position: 'relative',
           overflow: 'hidden',
           flexGrow: 1,
+          margin: 0,
           padding: (theme) => theme.spacing(panelPadding),
           // Override MUI default style for last-child
           ':last-child': {

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CardHeader, Typography, Box, Stack, IconButton, CardHeaderProps, styled } from '@mui/material';
+import { CardHeader, Typography, Stack, IconButton, CardHeaderProps, styled } from '@mui/material';
 import { InfoTooltip, TooltipPlacement, combineSx } from '@perses-dev/components';
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import DragIcon from 'mdi-material-ui/DragVertical';
 
-type OmittedProps = 'children';
+type OmittedProps = 'children' | 'action' | 'title' | 'disableTypography';
 
 export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
   id: string;
@@ -35,65 +35,60 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
   const titleElementId = `${id}-title`;
   const descriptionTooltipId = `${id}-description`;
 
+  // Don't show any actions unless panel is hovered
+  let action: CardHeaderProps['action'] = undefined;
+  if (isHovered) {
+    if (editHandlers !== undefined) {
+      // If there are edit handlers, always just show the edit buttons
+      action = (
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <HeaderIconButton aria-label="edit panel" size="small" onClick={editHandlers.onEditPanelClick}>
+            <PencilIcon />
+          </HeaderIconButton>
+          <HeaderIconButton aria-label="delete panel" size="small" onClick={editHandlers.onDeletePanelClick}>
+            <DeleteIcon />
+          </HeaderIconButton>
+          <HeaderIconButton aria-label="drag handle" size="small">
+            <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
+          </HeaderIconButton>
+        </Stack>
+      );
+    } else if (description !== undefined) {
+      // If there aren't edit handlers and we have a description, show a button with a tooltip for the panel description
+      action = (
+        <InfoTooltip id={descriptionTooltipId} description={description} placement={TooltipPlacement.Bottom}>
+          <HeaderIconButton aria-label="Panel Description">
+            <InformationOutlineIcon
+              aria-describedby="info-tooltip"
+              aria-hidden={false}
+              sx={{ color: (theme) => theme.palette.grey[700] }}
+            />
+          </HeaderIconButton>
+        </InfoTooltip>
+      );
+    }
+  }
+
   return (
     <CardHeader
       id={id}
       component="header"
       aria-labelledby={titleElementId}
       aria-describedby={descriptionTooltipId}
+      disableTypography
       title={
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            minHeight: '32px',
-          }}
+        <Typography
+          id={titleElementId}
+          variant="subtitle1"
+          sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
         >
-          <Typography
-            id={titleElementId}
-            variant="subtitle1"
-            sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
-          >
-            {title}
-          </Typography>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              marginLeft: 'auto',
-            }}
-          >
-            {isHovered && editHandlers === undefined && description !== undefined && (
-              <InfoTooltip id={descriptionTooltipId} description={description} placement={TooltipPlacement.Bottom}>
-                <HeaderIconButton aria-label="Panel Description">
-                  <InformationOutlineIcon
-                    aria-describedby="info-tooltip"
-                    aria-hidden={false}
-                    sx={{ color: (theme) => theme.palette.grey[700] }}
-                  />
-                </HeaderIconButton>
-              </InfoTooltip>
-            )}
-            {isHovered && editHandlers !== undefined && (
-              <Stack direction="row" alignItems="center" spacing={0.5}>
-                <HeaderIconButton aria-label="edit panel" size="small" onClick={editHandlers.onEditPanelClick}>
-                  <PencilIcon />
-                </HeaderIconButton>
-                <HeaderIconButton aria-label="delete panel" size="small" onClick={editHandlers.onDeletePanelClick}>
-                  <DeleteIcon />
-                </HeaderIconButton>
-                <HeaderIconButton aria-label="drag handle" size="small">
-                  <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
-                </HeaderIconButton>
-              </Stack>
-            )}
-          </Box>
-        </Box>
+          {title}
+        </Typography>
       }
+      action={action}
       sx={combineSx(
         (theme) => ({
-          display: 'block',
-          padding: theme.spacing(0.5),
+          padding: theme.spacing(1),
           borderBottom: `solid 1px ${theme.palette.divider}`,
         }),
         sx

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -21,6 +21,7 @@ import DragIcon from 'mdi-material-ui/DragVertical';
 type OmittedProps = 'children';
 
 export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
+  id: string;
   title: string;
   description?: string;
   editHandlers?: {
@@ -30,10 +31,14 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
   isHovered: boolean;
 }
 
-export function PanelHeader({ title, description, editHandlers, isHovered, sx, ...rest }: PanelHeaderProps) {
+export function PanelHeader({ id, title, description, editHandlers, isHovered, sx, ...rest }: PanelHeaderProps) {
+  const titleElementId = `${id}-title`;
+
   return (
     <CardHeader
-      {...rest}
+      id={id}
+      component="header"
+      aria-labelledby={titleElementId}
       title={
         <Box
           sx={{
@@ -42,7 +47,11 @@ export function PanelHeader({ title, description, editHandlers, isHovered, sx, .
             minHeight: '32px',
           }}
         >
-          <Typography variant="subtitle1" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+          <Typography
+            id={titleElementId}
+            variant="subtitle1"
+            sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+          >
             {title}
           </Typography>
           <Box
@@ -85,6 +94,7 @@ export function PanelHeader({ title, description, editHandlers, isHovered, sx, .
         }),
         sx
       )}
+      {...rest}
     />
   );
 }

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -33,12 +33,14 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
 
 export function PanelHeader({ id, title, description, editHandlers, isHovered, sx, ...rest }: PanelHeaderProps) {
   const titleElementId = `${id}-title`;
+  const descriptionTooltipId = `${id}-description`;
 
   return (
     <CardHeader
       id={id}
       component="header"
       aria-labelledby={titleElementId}
+      aria-describedby={descriptionTooltipId}
       title={
         <Box
           sx={{
@@ -62,12 +64,14 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
             }}
           >
             {isHovered && editHandlers === undefined && description !== undefined && (
-              <InfoTooltip id="info-tooltip" description={description} placement={TooltipPlacement.Bottom}>
-                <InformationOutlineIcon
-                  aria-describedby="info-tooltip"
-                  aria-hidden={false}
-                  sx={{ cursor: 'pointer', color: (theme) => theme.palette.grey[700] }}
-                />
+              <InfoTooltip id={descriptionTooltipId} description={description} placement={TooltipPlacement.Bottom}>
+                <HeaderIconButton aria-label="Panel Description">
+                  <InformationOutlineIcon
+                    aria-describedby="info-tooltip"
+                    aria-hidden={false}
+                    sx={{ color: (theme) => theme.palette.grey[700] }}
+                  />
+                </HeaderIconButton>
               </InfoTooltip>
             )}
             {isHovered && editHandlers !== undefined && (

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -1,0 +1,94 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CardHeader, Typography, Box, Stack, IconButton, CardHeaderProps, styled } from '@mui/material';
+import { InfoTooltip, TooltipPlacement, combineSx } from '@perses-dev/components';
+import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
+import PencilIcon from 'mdi-material-ui/PencilOutline';
+import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import DragIcon from 'mdi-material-ui/DragVertical';
+
+type OmittedProps = 'children';
+
+export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
+  title: string;
+  description?: string;
+  editHandlers?: {
+    onEditPanelClick: () => void;
+    onDeletePanelClick: () => void;
+  };
+}
+
+export function PanelHeader({ title, description, editHandlers, sx, ...rest }: PanelHeaderProps) {
+  return (
+    <CardHeader
+      {...rest}
+      title={
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            minHeight: '32px',
+          }}
+        >
+          <Typography variant="subtitle1" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+            {title}
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              marginLeft: 'auto',
+            }}
+          >
+            {editHandlers === undefined && description !== undefined && (
+              <InfoTooltip id="info-tooltip" description={description} placement={TooltipPlacement.Bottom}>
+                <InformationOutlineIcon
+                  aria-describedby="info-tooltip"
+                  aria-hidden={false}
+                  sx={{ cursor: 'pointer', color: (theme) => theme.palette.grey[700] }}
+                />
+              </InfoTooltip>
+            )}
+            {editHandlers !== undefined && (
+              <Stack direction="row" alignItems="center" spacing={0.5}>
+                <HeaderIconButton aria-label="edit panel" size="small" onClick={editHandlers.onEditPanelClick}>
+                  <PencilIcon />
+                </HeaderIconButton>
+                <HeaderIconButton aria-label="delete panel" size="small" onClick={editHandlers.onDeletePanelClick}>
+                  <DeleteIcon />
+                </HeaderIconButton>
+                <HeaderIconButton aria-label="drag handle" size="small">
+                  <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
+                </HeaderIconButton>
+              </Stack>
+            )}
+          </Box>
+        </Box>
+      }
+      sx={combineSx(
+        (theme) => ({
+          display: 'block',
+          padding: theme.spacing(0.5),
+          borderBottom: `solid 1px ${theme.palette.divider}`,
+        }),
+        sx
+      )}
+    />
+  );
+}
+
+const HeaderIconButton = styled(IconButton)(({ theme }) => ({
+  borderRadius: theme.shape.borderRadius,
+  padding: '4px',
+}));

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -27,9 +27,10 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
     onEditPanelClick: () => void;
     onDeletePanelClick: () => void;
   };
+  isHovered: boolean;
 }
 
-export function PanelHeader({ title, description, editHandlers, sx, ...rest }: PanelHeaderProps) {
+export function PanelHeader({ title, description, editHandlers, isHovered, sx, ...rest }: PanelHeaderProps) {
   return (
     <CardHeader
       {...rest}
@@ -51,7 +52,7 @@ export function PanelHeader({ title, description, editHandlers, sx, ...rest }: P
               marginLeft: 'auto',
             }}
           >
-            {editHandlers === undefined && description !== undefined && (
+            {isHovered && editHandlers === undefined && description !== undefined && (
               <InfoTooltip id="info-tooltip" description={description} placement={TooltipPlacement.Bottom}>
                 <InformationOutlineIcon
                   aria-describedby="info-tooltip"
@@ -60,7 +61,7 @@ export function PanelHeader({ title, description, editHandlers, sx, ...rest }: P
                 />
               </InfoTooltip>
             )}
-            {editHandlers !== undefined && (
+            {isHovered && editHandlers !== undefined && (
               <Stack direction="row" alignItems="center" spacing={0.5}>
                 <HeaderIconButton aria-label="edit panel" size="small" onClick={editHandlers.onEditPanelClick}>
                   <PencilIcon />

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -12,26 +12,22 @@
 // limitations under the License.
 
 import { Box } from '@mui/material';
-import { PanelEditorValues } from '../../context/DashboardProvider/panel-editor-slice';
+import { PanelEditorValues } from '../../context';
 import { Panel, PanelProps } from '../Panel';
 
-export function PanelPreview({ name, description, kind, spec, groupId }: PanelEditorValues) {
-  const previewValues: PanelProps = {
-    definition: {
-      kind: 'Panel',
-      spec: {
-        display: {
-          name,
-          description,
-        },
-        plugin: {
-          kind,
-          spec,
-        },
+export function PanelPreview({ name, description, kind, spec }: PanelEditorValues) {
+  const definition: PanelProps['definition'] = {
+    kind: 'Panel',
+    spec: {
+      display: {
+        name,
+        description: description === '' ? undefined : description,
+      },
+      plugin: {
+        kind,
+        spec,
       },
     },
-    // TODO: this shouldn't be necessary for preview
-    panelGroupItemId: { panelGroupId: groupId, panelGroupItemLayoutId: '' },
   };
 
   if (!kind) {
@@ -40,7 +36,7 @@ export function PanelPreview({ name, description, kind, spec, groupId }: PanelEd
 
   return (
     <Box height={300}>
-      <Panel {...previewValues} />
+      <Panel definition={definition} />
     </Box>
   );
 }

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -30,7 +30,7 @@ export function PanelPreview({ name, description, kind, spec }: PanelEditorValue
     },
   };
 
-  if (!kind) {
+  if (kind === '') {
     return null;
   }
 

--- a/ui/dashboards/src/context/DashboardProvider/index.ts
+++ b/ui/dashboards/src/context/DashboardProvider/index.ts
@@ -21,3 +21,4 @@ export type {
 } from './panel-group-slice';
 export type { PanelGroupEditor, PanelGroupEditorValues } from './panel-group-editor-slice';
 export type { DeletePanelDialogState } from './delete-panel-slice';
+export type { PanelEditorValues } from './panel-editor-slice';

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -72,7 +72,7 @@ export function mockPluginRegistryProps() {
 
 export const FAKE_PANEL_PLUGIN: PanelPlugin = {
   PanelComponent: () => {
-    return <div role="figure">FakePanel chart</div>;
+    return <div>FakePanel chart</div>;
   },
   OptionsEditorComponent: () => {
     return <div>Edit options here</div>;

--- a/ui/dashboards/src/utils/component-ids.ts
+++ b/ui/dashboards/src/utils/component-ids.ts
@@ -11,23 +11,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * The middleware applied to the DashboardStore (can be used as generic argument in StateCreator).
- */
-export type Middleware = [['zustand/immer', never], ['zustand/devtools', never]];
+import { useRef } from 'react';
 
 declare global {
   // eslint-disable-next-line no-var
-  var dashboardStoreId: number;
+  var useIdValue: number;
 }
 
-if (globalThis.dashboardStoreId === undefined) {
-  globalThis.dashboardStoreId = 0;
+if (globalThis.useIdValue === undefined) {
+  globalThis.useIdValue = 0;
 }
 
 /**
- * Helper function to generate unique IDs for things in the dashboard store that don't have a "natural" ID.
+ * Generates a unique (stable) ID for a component. Should be replaced with React.useId once we support only React 18.
  */
-export function generateId() {
-  return globalThis.dashboardStoreId++;
+export function useId(prefix: string) {
+  const id = useRef<string | undefined>(undefined);
+  if (id.current === undefined) {
+    id.current = `${prefix}-${globalThis.useIdValue++}`;
+  }
+  return id.current;
 }


### PR DESCRIPTION
This decouples the `Panel` from dashboard store's edit state, allowing `PanelPreview` to be rendered in "view mode" when used in the panel editor. Here's what it looks like in action now (you'll see the "edit buttons" are gone in the preview component now):

https://user-images.githubusercontent.com/428023/198093684-87765333-8743-416f-a51b-1c799459051c.mov

I also tried to add a bunch of tests to `Panel` and improved some of the ARIA attributes in the process. This should start to make dashboard tests a little easier to write and (for example) look for individual panels.