### PR TITLE
add an endpoint to get the backend config

### DIFF
--- a/cmd/perses/main.go
+++ b/cmd/perses/main.go
@@ -56,7 +56,7 @@ func main() {
 		logrus.WithError(err).Fatal("unable to instantiate the persistence manager")
 	}
 	serviceManager := dependency.NewServiceManager(persistenceManager, conf)
-	persesAPI := core.NewPersesAPI(serviceManager, conf.Readonly)
+	persesAPI := core.NewPersesAPI(serviceManager, conf)
 	persesFrontend := ui.NewPersesFrontend()
 	runner := app.NewRunner().WithDefaultHTTPServer("perses").SetBanner(banner)
 

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -19,11 +19,11 @@ import (
 
 type Config struct {
 	// Readonly will deactivate any HTTP POST, PUT, DELETE endpoint
-	Readonly bool `yaml:"readonly"`
+	Readonly bool `json:"readonly" yaml:"readonly"`
 	// Database contains the different configuration depending on the database you want to use
-	Database Database `yaml:"database"`
+	Database Database `json:"database" yaml:"database"`
 	// Schemas contains the configuration to get access to the CUE schemas
-	Schemas Schemas `yaml:"schemas"`
+	Schemas Schemas `json:"schemas" yaml:"schemas"`
 }
 
 func Resolve(configFile string, dbFolder string, dbExtension string) (Config, error) {

--- a/internal/api/config/database.go
+++ b/internal/api/config/database.go
@@ -27,8 +27,8 @@ const (
 )
 
 type File struct {
-	Folder        string        `yaml:"folder"`
-	FileExtension FileExtension `yaml:"file_extension"`
+	Folder        string        `json:"folder" yaml:"folder"`
+	FileExtension FileExtension `json:"file_extension" yaml:"file_extension"`
 }
 
 func (f *File) Verify() error {
@@ -42,8 +42,8 @@ func (f *File) Verify() error {
 }
 
 type Database struct {
-	File *File              `yaml:"file,omitempty"`
-	Etcd *config.EtcdConfig `yaml:"etcd,omitempty"`
+	File *File              `json:"file,omitempty" yaml:"file,omitempty"`
+	Etcd *config.EtcdConfig `json:"etcd,omitempty" yaml:"etcd,omitempty"`
 }
 
 func (d *Database) Verify() error {

--- a/internal/api/config/schemas.go
+++ b/internal/api/config/schemas.go
@@ -13,7 +13,10 @@
 
 package config
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 const (
 	DefaultPanelsPath      = "schemas/panels"
@@ -22,6 +25,16 @@ const (
 	DefaultVariablesPath   = "schemas/variables"
 	defaultInterval        = 1 * time.Hour
 )
+
+// jsonSchemas is only used to marshal the config in a proper json format
+// (mainly because of the duration that is not yet supported by json).
+type jsonSchemas struct {
+	PanelsPath      string `json:"panels_path,omitempty"`
+	QueriesPath     string `json:"queries_path,omitempty" `
+	DatasourcesPath string `json:"datasources_path,omitempty" `
+	VariablesPath   string `json:"variables_path,omitempty"`
+	Interval        string `json:"interval,omitempty"`
+}
 
 type Schemas struct {
 	PanelsPath      string        `yaml:"panels_path,omitempty"`
@@ -48,4 +61,15 @@ func (s *Schemas) Verify() error {
 		s.Interval = defaultInterval
 	}
 	return nil
+}
+
+func (s Schemas) MarshalJSON() ([]byte, error) {
+	j := &jsonSchemas{
+		PanelsPath:      s.PanelsPath,
+		QueriesPath:     s.QueriesPath,
+		DatasourcesPath: s.DatasourcesPath,
+		VariablesPath:   s.VariablesPath,
+		Interval:        s.Interval.String(),
+	}
+	return json.Marshal(j)
 }

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -78,7 +78,7 @@ func CreateServer(t *testing.T) (*httptest.Server, *httpexpect.Expect, dependenc
 		}
 	}
 	handler.Use(middleware.CheckProject(serviceManager.GetProject()))
-	persesAPI := core.NewPersesAPI(serviceManager, false)
+	persesAPI := core.NewPersesAPI(serviceManager, conf)
 	persesAPI.RegisterRoute(handler)
 	server := httptest.NewServer(handler)
 	return server, httpexpect.WithConfig(httpexpect.Config{

--- a/internal/api/impl/config/config.go
+++ b/internal/api/impl/config/config.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configendpoint
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/perses/perses/internal/api/config"
+)
+
+type Endpoint struct {
+	cfg config.Config
+}
+
+func New(cfg config.Config) *Endpoint {
+	return &Endpoint{
+		cfg: cfg,
+	}
+}
+
+func (e *Endpoint) RegisterRoutes(g *echo.Group) {
+	g.GET("/config", e.getConfig)
+}
+
+func (e *Endpoint) getConfig(ctx echo.Context) error {
+	return ctx.JSON(http.StatusOK, e.cfg)
+}


### PR DESCRIPTION
This PR is adding a new endpoint `/api/config` that will provide the current config of the server. Ideally every secrets will be hidden. This will be address in a later PR.

Getting the config can be used by the UI to change its behaviour. For example, the config value `Readonly` can be used by the UI to hide the button `Edit`

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>