### PR TITLE
Add PluginLoader type, export test util for mocking PluginRegistry

### DIFF
--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -23,7 +23,7 @@ import {
 } from '@perses-dev/components';
 import { useMemo } from 'react';
 import { PluginRegistry } from '@perses-dev/plugin-system';
-import { useBundledPlugins } from '../model/bundled-plugins';
+import { bundledPluginLoader } from '../model/bundled-plugins';
 import { useDashboard } from '../model/dashboard-client';
 import { useDatasourceApi } from '../model/datasource-api';
 
@@ -35,7 +35,6 @@ const ECHARTS_THEME_OVERRIDES = {};
  * The View for viewing a Dashboard.
  */
 function ViewDashboard() {
-  const { getInstalledPlugins, importPluginModule } = useBundledPlugins();
   const muiTheme = useTheme();
   const chartsTheme: PersesChartsTheme = useMemo(() => {
     return generateChartsTheme('perses', muiTheme, ECHARTS_THEME_OVERRIDES);
@@ -65,7 +64,7 @@ function ViewDashboard() {
     >
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <ChartsThemeProvider themeName="perses" chartsTheme={chartsTheme}>
-          <PluginRegistry getInstalledPlugins={getInstalledPlugins} importPluginModule={importPluginModule}>
+          <PluginRegistry pluginLoader={bundledPluginLoader}>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
               <DashboardView dashboardResource={data} datasourceApi={datasourceApi} />;
             </ErrorBoundary>

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PluginRegistry } from '@perses-dev/plugin-system';
+import { mockPluginRegistry, PluginRegistry } from '@perses-dev/plugin-system';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PanelDefinition } from '@perses-dev/core';
-import { renderWithContext, mockPluginRegistryProps, FAKE_PANEL_PLUGIN } from '../../test';
+import { renderWithContext, MOCK_TIME_SERIES_PANEL } from '../../test';
 import { Panel, PanelProps } from './Panel';
 
 describe('Panel', () => {
@@ -27,7 +27,7 @@ describe('Panel', () => {
         description: 'This is a fake panel',
       },
       plugin: {
-        kind: 'FakePanel',
+        kind: 'TimeSeriesChart',
         spec: {},
       },
     },
@@ -37,11 +37,8 @@ describe('Panel', () => {
   const renderPanel = (definition?: PanelDefinition, editHandlers?: PanelProps['editHandlers']) => {
     definition ??= createTestPanel();
 
-    const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
-    addMockPlugin('Panel', 'FakePanel', FAKE_PANEL_PLUGIN);
-
     renderWithContext(
-      <PluginRegistry {...pluginRegistryProps}>
+      <PluginRegistry {...mockPluginRegistry(MOCK_TIME_SERIES_PANEL)}>
         <Panel definition={definition} editHandlers={editHandlers} />
       </PluginRegistry>
     );
@@ -63,7 +60,7 @@ describe('Panel', () => {
     // Should display chart's content from the fake panel plugin
     const content = screen.getByRole('figure');
     await waitFor(() => {
-      expect(content).toHaveTextContent('FakePanel chart');
+      expect(content).toHaveTextContent('TimeSeriesChart panel');
     });
     expect(content);
   });

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -11,11 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { mockPluginRegistry, PluginRegistry } from '@perses-dev/plugin-system';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PanelDefinition } from '@perses-dev/core';
-import { renderWithContext, MOCK_TIME_SERIES_PANEL } from '../../test';
+import { renderWithContext } from '../../test';
 import { Panel, PanelProps } from './Panel';
 
 describe('Panel', () => {
@@ -37,11 +36,7 @@ describe('Panel', () => {
   const renderPanel = (definition?: PanelDefinition, editHandlers?: PanelProps['editHandlers']) => {
     definition ??= createTestPanel();
 
-    renderWithContext(
-      <PluginRegistry {...mockPluginRegistry(MOCK_TIME_SERIES_PANEL)}>
-        <Panel definition={definition} editHandlers={editHandlers} />
-      </PluginRegistry>
-    );
+    renderWithContext(<Panel definition={definition} editHandlers={editHandlers} />);
   };
 
   // Helper to get the panel once rendered

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -15,25 +15,17 @@ import { PluginRegistry } from '@perses-dev/plugin-system';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
-import {
-  createDashboardProviderSpy,
-  FAKE_PANEL_PLUGIN,
-  getTestDashboard,
-  mockPluginRegistryProps,
-  renderWithContext,
-} from '../../test';
+import { mockPluginRegistry } from '@perses-dev/plugin-system';
+import { createDashboardProviderSpy, getTestDashboard, MOCK_TIME_SERIES_PANEL, renderWithContext } from '../../test';
 import { DashboardProvider } from '../../context/DashboardProvider';
 import { PanelDrawer } from './PanelDrawer';
 
 describe('Panel Drawer', () => {
   const renderPanelDrawer = () => {
-    const { addMockPlugin, pluginRegistryProps } = mockPluginRegistryProps();
-    addMockPlugin('Panel', 'TimeSeriesChart', FAKE_PANEL_PLUGIN);
-
     const { store, DashboardProviderSpy } = createDashboardProviderSpy();
 
     renderWithContext(
-      <PluginRegistry {...pluginRegistryProps}>
+      <PluginRegistry {...mockPluginRegistry(MOCK_TIME_SERIES_PANEL)}>
         <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
           <DashboardProviderSpy />
           <PanelDrawer />

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -11,12 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PluginRegistry } from '@perses-dev/plugin-system';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
-import { mockPluginRegistry } from '@perses-dev/plugin-system';
-import { createDashboardProviderSpy, getTestDashboard, MOCK_TIME_SERIES_PANEL, renderWithContext } from '../../test';
+import { createDashboardProviderSpy, getTestDashboard, renderWithContext } from '../../test';
 import { DashboardProvider } from '../../context/DashboardProvider';
 import { PanelDrawer } from './PanelDrawer';
 
@@ -25,12 +23,10 @@ describe('Panel Drawer', () => {
     const { store, DashboardProviderSpy } = createDashboardProviderSpy();
 
     renderWithContext(
-      <PluginRegistry {...mockPluginRegistry(MOCK_TIME_SERIES_PANEL)}>
-        <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
-          <DashboardProviderSpy />
-          <PanelDrawer />
-        </DashboardProvider>
-      </PluginRegistry>
+      <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
+        <DashboardProviderSpy />
+        <PanelDrawer />
+      </DashboardProvider>
     );
 
     const { value: storeApi } = store;

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 import { UnknownSpec } from '@perses-dev/core';
 import {
-  PluginRegistryProps,
+  PluginLoader,
   PluginModuleResource,
   PluginImplementation,
   PluginType,
@@ -55,7 +55,7 @@ export function mockPluginRegistryProps() {
     mockPluginModule[kind] = plugin;
   };
 
-  const pluginRegistryProps: Omit<PluginRegistryProps, 'children'> = {
+  const pluginLoader: PluginLoader = {
     getInstalledPlugins() {
       return Promise.resolve([mockPluginResource]);
     },
@@ -65,7 +65,7 @@ export function mockPluginRegistryProps() {
   };
 
   return {
-    pluginRegistryProps,
+    pluginRegistryProps: { pluginLoader },
     addMockPlugin,
   };
 }

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -10,72 +10,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 import { UnknownSpec } from '@perses-dev/core';
-import {
-  PluginLoader,
-  PluginModuleResource,
-  PluginImplementation,
-  PluginType,
-  PanelPlugin,
-  Plugin,
-} from '@perses-dev/plugin-system';
+import { PanelPlugin, MockPlugin } from '@perses-dev/plugin-system';
 
-/**
- * Helper for mocking `PluginRegistry` data during tests. Returns props that can be spread on the `PluginRegistry`
- * component so that it will load the mock plugins you setup. You can use the `addMockPlugin` function that's returned
- * to add mock plugins before rendering components that use them.
- */
-export function mockPluginRegistryProps() {
-  const mockPluginResource: PluginModuleResource = {
-    kind: 'PluginModule',
-    metadata: {
-      name: 'Fake Plugin Module for Tests',
-      created_at: '',
-      updated_at: '',
-      version: 0,
-    },
-    spec: {
-      plugins: [],
-    },
-  };
-
-  const mockPluginModule: Record<string, Plugin<UnknownSpec>> = {};
-
-  // Allow adding mock plugins in tests
-  const addMockPlugin = <T extends PluginType>(pluginType: T, kind: string, plugin: PluginImplementation<T>) => {
-    mockPluginResource.spec.plugins.push({
-      pluginType,
-      kind,
-      display: {
-        name: `Fake ${pluginType} Plugin for ${kind}`,
-      },
-    });
-
-    // "Export" on the module under the same name as the kind the plugin handles
-    mockPluginModule[kind] = plugin;
-  };
-
-  const pluginLoader: PluginLoader = {
-    getInstalledPlugins() {
-      return Promise.resolve([mockPluginResource]);
-    },
-    importPluginModule(/* resource */) {
-      return Promise.resolve(mockPluginModule);
-    },
-  };
-
-  return {
-    pluginRegistryProps: { pluginLoader },
-    addMockPlugin,
-  };
-}
-
-export const FAKE_PANEL_PLUGIN: PanelPlugin = {
+const FakeTimeSeriesPlugin: PanelPlugin<UnknownSpec> = {
   PanelComponent: () => {
-    return <div>FakePanel chart</div>;
+    return <div>TimeSeriesChart panel</div>;
   },
   OptionsEditorComponent: () => {
-    return <div>Edit options here</div>;
+    return <div>TimeSeriesChart options</div>;
   },
   createInitialOptions: () => ({}),
+};
+
+export const MOCK_TIME_SERIES_PANEL: MockPlugin = {
+  pluginType: 'Panel',
+  kind: 'TimeSeriesChart',
+  plugin: FakeTimeSeriesPlugin,
 };

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -24,8 +24,11 @@ const FakeTimeSeriesPlugin: PanelPlugin<UnknownSpec> = {
   createInitialOptions: () => ({}),
 };
 
-export const MOCK_TIME_SERIES_PANEL: MockPlugin = {
+const MOCK_TIME_SERIES_PANEL: MockPlugin = {
   pluginType: 'Panel',
   kind: 'TimeSeriesChart',
   plugin: FakeTimeSeriesPlugin,
 };
+
+// Array of default mock plugins added to the PluginRegistry during test renders
+export const MOCK_PLUGINS: MockPlugin[] = [MOCK_TIME_SERIES_PANEL];

--- a/ui/dashboards/src/test/render.tsx
+++ b/ui/dashboards/src/test/render.tsx
@@ -18,6 +18,8 @@ import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ChartsThemeProvider, testChartsTheme } from '@perses-dev/components';
+import { mockPluginRegistry, PluginRegistry } from '@perses-dev/plugin-system';
+import { MOCK_PLUGINS } from './plugin-registry';
 
 /**
  * Test helper to render a React component with some common app-level providers wrapped around it.
@@ -38,7 +40,7 @@ export function renderWithContext(
         <QueryClientProvider client={queryClient}>
           <QueryParamProvider adapter={ReactRouter6Adapter}>
             <ChartsThemeProvider themeName="perses" chartsTheme={testChartsTheme}>
-              {ui}
+              <PluginRegistry {...mockPluginRegistry(...MOCK_PLUGINS)}>{ui}</PluginRegistry>
             </ChartsThemeProvider>
           </QueryParamProvider>
         </QueryClientProvider>

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -11,22 +11,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { mockPluginRegistry, PluginRegistry } from '@perses-dev/plugin-system';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DashboardProvider, TemplateVariableProvider, TimeRangeProvider } from '../../../context';
-import { getTestDashboard, renderWithContext } from '../../../test';
+import { getTestDashboard, MOCK_TIME_SERIES_PANEL, renderWithContext } from '../../../test';
 import { DashboardApp } from '../DashboardApp';
 
 describe('Panel Groups', () => {
   const renderDashboard = () => {
     renderWithContext(
-      <TimeRangeProvider timeRange={{ pastDuration: '30m' }}>
-        <TemplateVariableProvider>
-          <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
-            <DashboardApp dashboardResource={getTestDashboard()} />
-          </DashboardProvider>
-        </TemplateVariableProvider>
-      </TimeRangeProvider>
+      <PluginRegistry {...mockPluginRegistry(MOCK_TIME_SERIES_PANEL)}>
+        <TimeRangeProvider timeRange={{ pastDuration: '30m' }}>
+          <TemplateVariableProvider>
+            <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
+              <DashboardApp dashboardResource={getTestDashboard()} />
+            </DashboardProvider>
+          </TemplateVariableProvider>
+        </TimeRangeProvider>
+      </PluginRegistry>
     );
   };
   it('should delete panel', () => {

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -11,25 +11,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { mockPluginRegistry, PluginRegistry } from '@perses-dev/plugin-system';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DashboardProvider, TemplateVariableProvider, TimeRangeProvider } from '../../../context';
-import { getTestDashboard, MOCK_TIME_SERIES_PANEL, renderWithContext } from '../../../test';
+import { getTestDashboard, renderWithContext } from '../../../test';
 import { DashboardApp } from '../DashboardApp';
 
 describe('Panel Groups', () => {
   const renderDashboard = () => {
     renderWithContext(
-      <PluginRegistry {...mockPluginRegistry(MOCK_TIME_SERIES_PANEL)}>
-        <TimeRangeProvider timeRange={{ pastDuration: '30m' }}>
-          <TemplateVariableProvider>
-            <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
-              <DashboardApp dashboardResource={getTestDashboard()} />
-            </DashboardProvider>
-          </TemplateVariableProvider>
-        </TimeRangeProvider>
-      </PluginRegistry>
+      <TimeRangeProvider timeRange={{ pastDuration: '30m' }}>
+        <TemplateVariableProvider>
+          <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
+            <DashboardApp dashboardResource={getTestDashboard()} />
+          </DashboardProvider>
+        </TemplateVariableProvider>
+      </TimeRangeProvider>
     );
   };
   it('should delete panel', () => {

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -13,14 +13,13 @@
 
 import { UnknownSpec, useEvent } from '@perses-dev/core';
 import { useRef, useCallback, useMemo } from 'react';
-import { PluginModuleResource, PluginType, PluginImplementation, Plugin } from '../../model';
+import { PluginModuleResource, PluginType, PluginImplementation, Plugin, PluginLoader } from '../../model';
 import { PluginRegistryContext } from '../../runtime';
-import { GetInstalledPlugins, usePluginIndexes, getTypeAndKindKey } from './plugin-indexes';
+import { usePluginIndexes, getTypeAndKindKey } from './plugin-indexes';
 
 export interface PluginRegistryProps {
   children?: React.ReactNode;
-  getInstalledPlugins: GetInstalledPlugins;
-  importPluginModule: (resource: PluginModuleResource) => Promise<unknown>;
+  pluginLoader: PluginLoader;
 }
 
 /**
@@ -28,7 +27,10 @@ export interface PluginRegistryProps {
  * querying the metadata about them.
  */
 export function PluginRegistry(props: PluginRegistryProps) {
-  const { getInstalledPlugins, importPluginModule, children } = props;
+  const {
+    pluginLoader: { getInstalledPlugins, importPluginModule },
+    children,
+  } = props;
 
   const getPluginIndexes = usePluginIndexes(getInstalledPlugins);
 

--- a/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
+++ b/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
@@ -13,9 +13,7 @@
 
 import { useEvent } from '@perses-dev/core';
 import { useCallback, useRef } from 'react';
-import { PluginMetadata, PluginModuleResource, PluginType } from '../../model';
-
-export type GetInstalledPlugins = () => Promise<PluginModuleResource[]>;
+import { PluginLoader, PluginMetadata, PluginModuleResource, PluginType } from '../../model';
 
 export interface PluginIndexes {
   // Plugin resources by plugin type and kind (i.e. look up what module a plugin type and kind is in)
@@ -27,7 +25,7 @@ export interface PluginIndexes {
 /**
  * Returns an async callback for getting indexes of the installed plugin data.
  */
-export function usePluginIndexes(getInstalledPlugins: GetInstalledPlugins) {
+export function usePluginIndexes(getInstalledPlugins: PluginLoader['getInstalledPlugins']) {
   // Creates indexes from the installed plugins data (does useEvent because this accesses the getInstalledPlugins prop
   // and we want a stable reference for the callback below)
   const createPluginIndexes = useEvent(async (): Promise<PluginIndexes> => {

--- a/ui/plugin-system/src/model/index.ts
+++ b/ui/plugin-system/src/model/index.ts
@@ -17,3 +17,4 @@ export * from './plugins';
 export * from './time-series-queries';
 export * from './variables';
 export * from './plugin-base';
+export * from './plugin-loading';

--- a/ui/plugin-system/src/model/plugin-loading.ts
+++ b/ui/plugin-system/src/model/plugin-loading.ts
@@ -1,0 +1,54 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PluginModuleResource } from './plugins';
+
+/**
+ * A component capable of loading the resource/metadata for all available plugins, then loading individual plugins for
+ * those resources on-demand.
+ */
+export interface PluginLoader {
+  getInstalledPlugins: () => Promise<PluginModuleResource[]>;
+  importPluginModule: (resource: PluginModuleResource) => Promise<unknown>;
+}
+
+/**
+ * The dynamic import for a single plugin resource.
+ */
+export interface DynamicImportPlugin {
+  resource: PluginModuleResource;
+  importPlugin(): Promise<unknown>;
+}
+
+/**
+ * A PluginLoader for the common pattern in Perses where we eagerly import a plugin's resource file, and then lazy load
+ * the plugin itself via a dynamic `import()` statement.
+ */
+export function dynamicImportPluginLoader(plugins: DynamicImportPlugin[]): PluginLoader {
+  const importMap: Map<PluginModuleResource, DynamicImportPlugin['importPlugin']> = new Map(
+    plugins.map((plugin) => [plugin.resource, plugin.importPlugin])
+  );
+
+  return {
+    async getInstalledPlugins() {
+      return Promise.resolve(Array.from(importMap.keys()));
+    },
+    importPluginModule(resource) {
+      const importFn = importMap.get(resource);
+      if (importFn === undefined) {
+        throw new Error('Plugin not found');
+      }
+      return importFn();
+    },
+  };
+}

--- a/ui/plugin-system/src/test-utils/index.ts
+++ b/ui/plugin-system/src/test-utils/index.ts
@@ -11,7 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export * from './model';
-export * from './runtime';
-export * from './test-utils';
+export * from './mock-plugin-registry';

--- a/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
+++ b/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
@@ -1,0 +1,77 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { UnknownSpec } from '@perses-dev/core';
+import { PluginRegistryProps } from '../components';
+import { PluginModuleResource, Plugin, PluginLoader, PluginImplementation, PluginType } from '../model';
+
+export type MockPlugin = {
+  [T in PluginType]: {
+    pluginType: T;
+    kind: string;
+    plugin: PluginImplementation<T>;
+  };
+}[PluginType];
+
+/**
+ * Helper for mocking `PluginRegistry` data during tests. Returns props that can be spread on the `PluginRegistry`
+ * component so that it will load the mock plugins you provide.
+ */
+export function mockPluginRegistry(...mockPlugins: MockPlugin[]): Omit<PluginRegistryProps, 'children'> {
+  const mockPluginResource: PluginModuleResource = {
+    kind: 'PluginModule',
+    metadata: {
+      name: 'Fake Plugin Module for Tests',
+      created_at: '',
+      updated_at: '',
+      version: 0,
+    },
+    spec: {
+      // Add metadata for all mock plugins
+      plugins: mockPlugins.map(({ pluginType, kind }) => ({
+        pluginType,
+        kind,
+        display: {
+          name: getMockPluginName(pluginType, kind),
+        },
+      })),
+    },
+  };
+
+  const mockPluginModule: Record<string, Plugin<UnknownSpec>> = {};
+  for (const mockPlugin of mockPlugins) {
+    // "Export" on the module under the same name as the kind the plugin handles
+    mockPluginModule[mockPlugin.kind] = mockPlugin.plugin;
+  }
+
+  const pluginLoader: PluginLoader = {
+    getInstalledPlugins() {
+      return Promise.resolve([mockPluginResource]);
+    },
+    importPluginModule(/* resource */) {
+      return Promise.resolve(mockPluginModule);
+    },
+  };
+
+  return {
+    pluginLoader,
+  };
+}
+
+/**
+ * The function that's used to generate the display name of mocked plugins in mockPluginRegistry. Can be useful if you
+ * need to interact with some UI component that's displaying it.
+ */
+export function getMockPluginName(pluginType: PluginType, kind: string) {
+  return `${pluginType} Plugin for ${kind}`;
+}

--- a/ui/plugin-system/src/test/render.tsx
+++ b/ui/plugin-system/src/test/render.tsx
@@ -14,7 +14,7 @@
 import { render, RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PluginRegistry } from '../components/PluginRegistry';
-import { testRegistryProps } from './test-plugins';
+import { testPluginLoader } from './test-plugins';
 
 const testLogger = {
   log: console.log,
@@ -36,7 +36,7 @@ export function renderWithContext(ui: React.ReactNode, options?: Omit<RenderOpti
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <PluginRegistry {...testRegistryProps}>{ui}</PluginRegistry>
+      <PluginRegistry pluginLoader={testPluginLoader}>{ui}</PluginRegistry>
     </QueryClientProvider>,
     options
   );

--- a/ui/plugin-system/src/test/test-plugins/index.ts
+++ b/ui/plugin-system/src/test/test-plugins/index.ts
@@ -11,29 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PluginModuleResource } from '../../model';
-import { PluginRegistryProps } from '../../components/PluginRegistry/PluginRegistry';
+import { dynamicImportPluginLoader, PluginLoader, PluginModuleResource } from '../../model';
 import bertResource from './bert/plugin.json';
 import ernieResource from './ernie/plugin.json';
 
-// Put all the test plugins into a Map
-const testPlugins = new Map<PluginModuleResource, () => Promise<unknown>>();
-testPlugins.set(bertResource as PluginModuleResource, () => import('./bert'));
-testPlugins.set(ernieResource as PluginModuleResource, () => import('./ernie'));
-
 /**
- * Some props for testing the PluginRegistry that use the test plugins/metadata in this folder.
+ * A PluginLoader for tests that will dynamically load the plugins in this folder.
  */
-export const testRegistryProps: Omit<PluginRegistryProps, 'children'> = {
-  getInstalledPlugins: () => {
-    const resources = Array.from(testPlugins.keys());
-    return Promise.resolve(resources);
-  },
-  importPluginModule: (resource) => {
-    const importFn = testPlugins.get(resource);
-    if (importFn === undefined) {
-      throw new Error('Plugin not found');
-    }
-    return importFn();
-  },
-};
+export const testPluginLoader: PluginLoader = dynamicImportPluginLoader([
+  { resource: bertResource as PluginModuleResource, importPlugin: () => import('./bert') },
+  { resource: ernieResource as PluginModuleResource, importPlugin: () => import('./ernie') },
+]);


### PR DESCRIPTION
This is a breaking change to the `PluginRegistry` props. It introduces a `PluginLoader` interface which encapsulates the two things needed by the `PluginRegistry` in order to load plugins (`getInstalledPlugins` and `importPluginModule`). I added a helper function called `dynamicImportPluginLoader` which should reduce some of the repetition we have in the codebase where we eagerly load a plugin's JSON, but then dynamically import the plugin module code itself.

I also added a shared test helper in the `plugin-system` package (`mockPluginRegistry`) to make it easier for people writing/consuming plugins to mock out the plugins available in tests. I changed up our `dashboards` package tests to start using this when rendering tests and included one mock `TimeSeriesChart` plugin to start with. That list of mock plugins should be pretty straightforward to add to if we need more in the dashboards tests.

Next on the test helpers list is probably adding some more helpers to `plugin-system` to make mocking some of the runtime easier (e.g. variable state, time range state, etc.).