### PR TITLE
Run queries in editor on input blur

### DIFF
--- a/ui/prometheus-plugin/src/index.ts
+++ b/ui/prometheus-plugin/src/index.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PrometheusTimeSeriesQuery } from './plugins/time-series-query';
+import { PrometheusTimeSeriesQuery } from './plugins/prometheus-time-series-query';
 // @TODO: Move this to a more generic location;
 import { StaticListVariable } from './plugins/variable';
 import { PrometheusLabelNamesVariable, PrometheusLabelValuesVariable } from './plugins/prometheus-variables';

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
@@ -1,0 +1,29 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
+import { getTimeSeriesData } from './get-time-series-data';
+import { PrometheusTimeSeriesQueryEditor } from './PrometheusTimeSeriesQueryEditor';
+import { PrometheusTimeSeriesQuerySpec } from './time-series-query-model';
+
+/**
+ * The core Prometheus TimeSeriesQuery plugin for Perses.
+ */
+export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec> = {
+  getTimeSeriesData,
+  OptionsEditorComponent: PrometheusTimeSeriesQueryEditor,
+  createInitialOptions: () => ({
+    query: '',
+    datasource: undefined,
+  }),
+};

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -11,26 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ChangeEvent } from 'react';
-import produce from 'immer';
+import { produce } from 'immer';
 import { Box, TextField, FormControl, InputLabel } from '@mui/material';
-import { OptionsEditorProps, DatasourceSelect, DatasourceSelectProps } from '@perses-dev/plugin-system';
-import { DEFAULT_PROM, isDefaultPromSelector, isPrometheusDatasourceSelector } from '../model';
-import { PrometheusTimeSeriesQuerySpec } from './time-series-query';
+import { DatasourceSelect, DatasourceSelectProps } from '@perses-dev/plugin-system';
+import { DEFAULT_PROM, isDefaultPromSelector, isPrometheusDatasourceSelector } from '../../model';
+import { PrometheusTimeSeriesQueryEditorProps, useQueryState } from './query-editor-model';
 
-export type PrometheusTimeSeriesQueryEditorProps = OptionsEditorProps<PrometheusTimeSeriesQuerySpec>;
-
+/**
+ * The options editor component for editing a PrometheusTimeSeriesQuery's spec.
+ */
 export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQueryEditorProps) {
   const { onChange, value } = props;
-  const { query, datasource } = value;
+  const { datasource } = value;
 
-  const handleQueryChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange(
-      produce(value, (draft) => {
-        draft.query = e.target.value;
-      })
-    );
-  };
+  const { query, handleQueryChange, handleQueryBlur } = useQueryState(props);
 
   const handleDatasourceChange: DatasourceSelectProps['onChange'] = (next) => {
     if (isPrometheusDatasourceSelector(next)) {
@@ -49,7 +43,14 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
 
   return (
     <Box>
-      <TextField fullWidth label="Query" value={query} onChange={handleQueryChange} margin="dense" />
+      <TextField
+        fullWidth
+        label="Query"
+        value={query}
+        onChange={handleQueryChange}
+        onBlur={handleQueryBlur}
+        margin="dense"
+      />
       <FormControl margin="dense" fullWidth={false}>
         {/* TODO: How do we ensure unique ID values if there are multiple of these? Can we use React 18 useId and
             maintain 17 compatibility somehow with a polyfill/shim? */}

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -11,30 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DurationString } from '@perses-dev/core';
 import { TimeSeriesData, TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
 import { fromUnixTime } from 'date-fns';
 import {
   parseValueTuple,
-  PrometheusDatasourceSelector,
   PrometheusClient,
-  TemplateString,
   getDurationStringSeconds,
   getPrometheusTimeRange,
   getRangeStep,
   replaceTemplateVariables,
   DEFAULT_PROM,
-} from '../model';
-import { PrometheusTimeSeriesQueryEditor } from './PrometheusTimeSeriesQueryEditor';
+} from '../../model';
+import { PrometheusTimeSeriesQuerySpec } from './time-series-query-model';
 
-export interface PrometheusTimeSeriesQuerySpec {
-  query: TemplateString;
-  min_step?: DurationString;
-  resolution?: number;
-  datasource?: PrometheusDatasourceSelector;
-}
-
-const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
+export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
   spec,
   context
 ) => {
@@ -94,15 +84,4 @@ const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec>['g
     }),
   };
   return chartData;
-};
-
-/**
- * The core Prometheus TimeSeriesQuery plugin for Perses.
- */
-export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec> = {
-  getTimeSeriesData,
-  OptionsEditorComponent: PrometheusTimeSeriesQueryEditor,
-  createInitialOptions: () => ({
-    query: '',
-  }),
 };

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/index.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './PrometheusTimeSeriesQuery';

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/query-editor-model.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/query-editor-model.ts
@@ -1,0 +1,59 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react';
+import { TextFieldProps } from '@mui/material';
+import { produce } from 'immer';
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { PrometheusTimeSeriesQuerySpec } from './time-series-query-model';
+
+export type PrometheusTimeSeriesQueryEditorProps = OptionsEditorProps<PrometheusTimeSeriesQuerySpec>;
+
+/**
+ * A hook for managing the `query` state in PrometheusTimeSeriesQuerySpec. Returns the `query` value, along with
+ * `onChange` and `onBlur` event handlers to the input. Keeps a local copy of the user's input and only syncs those
+ * changes with the overall spec value once the input is blurred to prevent re-running queries in the panel's preview
+ * every time the user types.
+ */
+export function useQueryState(props: PrometheusTimeSeriesQueryEditorProps) {
+  const { onChange, value } = props;
+
+  // Local copy of the query's value
+  const [query, setQuery] = useState(value.query);
+
+  // This is basically "getDerivedStateFromProps" to make sure if spec's value changes external to this component,
+  // we render with the latest value
+  const [lastSyncedQuery, setLastSyncedQuery] = useState(value.query);
+  if (value.query !== lastSyncedQuery) {
+    setQuery(value.query);
+    setLastSyncedQuery(value.query);
+  }
+
+  // Update our local state's copy as the user types
+  const handleQueryChange: TextFieldProps['onChange'] = (e) => {
+    setQuery(e.target.value);
+  };
+
+  // Propagate changes to the query's value when the input is blurred to avoid constantly re-running queries in the
+  // PanelPreview
+  const handleQueryBlur: TextFieldProps['onBlur'] = () => {
+    setLastSyncedQuery(query);
+    onChange(
+      produce(value, (draft) => {
+        draft.query = query;
+      })
+    );
+  };
+
+  return { query, handleQueryChange, handleQueryBlur };
+}

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/time-series-query-model.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/time-series-query-model.ts
@@ -1,0 +1,25 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DurationString } from '@perses-dev/core';
+import { PrometheusDatasourceSelector, TemplateString } from '../../model';
+
+/**
+ * The spec/options for the PrometheusTimeSeriesQuery plugin.
+ */
+export interface PrometheusTimeSeriesQuerySpec {
+  query: TemplateString;
+  min_step?: DurationString;
+  resolution?: number;
+  datasource?: PrometheusDatasourceSelector;
+}


### PR DESCRIPTION
This fixes an issue in the panel editor where every time a user types into the query editor, the state change propagates up to the `PanelPreview` and it re-runs the Prom query. With this change, we keep a local copy of the state in the editor and then only propagate those changes once the query editor input is blurred. Here's what that looks like in action:

https://user-images.githubusercontent.com/428023/198675185-150c89b4-32b8-4987-aa83-8099004a8767.mov

Once we get a "proper" query editor in (i.e. CodeMirror), we may want to consider adding something like a "Run Query" button to make the interaction more obvious to the user.

Signed-off-by: Luke Tillman <LukeTillman@users.noreply.github.com>