### PR TITLE
Fix file watching that was no longer detecting plugin addition

### DIFF
--- a/internal/api/shared/schemas/loader.go
+++ b/internal/api/shared/schemas/loader.go
@@ -207,8 +207,8 @@ func (w *watcher) Execute(ctx context.Context, cancel context.CancelFunc) error 
 				return fmt.Errorf("schemas watcher channel has been closed unexpectedly")
 			}
 			// NB room for improvement: the event fsnotify.Remove could be used to actually remove the CUE schema from the map
-			if event.Has(fsnotify.Write) || event.Has(fsnotify.Remove) {
-				logrus.Tracef("%s event on %s", event.Op, event.Name)
+			logrus.Tracef("%s event on %s", event.Op, event.Name)
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) || event.Has(fsnotify.Remove) {
 				for _, l := range w.loaders {
 					if strings.HasPrefix(event.Name, filepath.FromSlash(l.GetSchemaPath())) {
 						if err := l.Load(); err != nil {


### PR DESCRIPTION
For some reason https://github.com/perses/perses/commit/44282beb66ca14735ecf9754ce8428886a51f1ba#diff-88358bf82ecc8c2771379b628ade8c9769b02abc1f8f39f3b81112e7c0854c35 broke the detection of plugin addition, as adding a new file/folder in the watched folder produces a CREATE event and not a WRITE.