### PR TITLE
Fix select multi value bug when options arent present

### DIFF
--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -125,7 +125,11 @@ function ListVariable({ name }: TemplateVariableProps) {
       ),
     [finalOptions, value, allowMultiple]
   );
-  const selectValue = valueIsInOptions ? value ?? '' : '';
+
+  let selectValue = value;
+  if (!valueIsInOptions) {
+    selectValue = allowMultiple ? [] : '';
+  }
 
   useEffect(() => {
     const firstOption = finalOptions?.[0];


### PR DESCRIPTION
This fixes some regression that happened in #690. This ensures the default value is an empty array when the value allows for multiple. This is a good reminder to come up with some good comprehensive tests after the autocomplete refactor.

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>