### PR TITLE
Refactor DashboardProvider and useDashboardSpec

### DIFF
--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -30,11 +30,10 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   const { dashboardName, onEditButtonClick, onCancelButtonClick } = props;
 
   const { isEditMode, setEditMode } = useEditMode();
-  const { openAddPanelGroup, openAddPanel, save } = useDashboardActions();
+  const { openAddPanelGroup, openAddPanel } = useDashboardActions();
   const isLaptopSize = useMediaQuery(useTheme().breakpoints.up('sm'));
 
   const onSave = () => {
-    save();
     setEditMode(false);
   };
 

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -23,7 +23,7 @@ describe('Panel Drawer', () => {
     const { store, DashboardProviderSpy } = createDashboardProviderSpy();
 
     renderWithContext(
-      <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
+      <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
         <DashboardProviderSpy />
         <PanelDrawer />
       </DashboardProvider>

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
@@ -23,7 +23,7 @@ describe('Add Panel Group', () => {
     const { store, DashboardProviderSpy } = createDashboardProviderSpy();
 
     renderWithContext(
-      <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
+      <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
         <DashboardProviderSpy />
         <PanelGroupDialog />
       </DashboardProvider>

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -30,7 +30,7 @@ describe('TimeRangeControls', () => {
 
   beforeEach(() => {
     initialState = {
-      dashboardSpec: testDashboard.spec,
+      dashboardResource: testDashboard,
     };
   });
 

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -16,7 +16,7 @@ import type { StoreApi } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import shallow from 'zustand/shallow';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useState } from 'react';
 import { DashboardSpec, RelativeTimeRange } from '@perses-dev/core';
 import { createPanelGroupEditorSlice, PanelGroupEditorSlice } from './panel-group-editor-slice';
 import { createPanelGroupSlice, PanelGroupSlice } from './panel-group-slice';
@@ -60,14 +60,22 @@ export function useDashboardStore<T>(selector: (state: DashboardStoreState) => T
 }
 
 export function DashboardProvider(props: DashboardProviderProps) {
+  const [store] = useState(createDashboardStore(props)); // prevent calling createDashboardStore every time it rerenders
+
+  return (
+    <DashboardContext.Provider value={store as StoreApi<DashboardStoreState>}>
+      {props.children}
+    </DashboardContext.Provider>
+  );
+}
+
+function createDashboardStore(props: DashboardProviderProps) {
   const {
-    children,
     initialState: { dashboardSpec, isEditMode },
   } = props;
 
   const { layouts, panels } = dashboardSpec;
-
-  const dashboardStore = createStore<DashboardStoreState>()(
+  const store = createStore<DashboardStoreState>()(
     immer(
       devtools((...args) => {
         const [set, get] = args;
@@ -96,9 +104,5 @@ export function DashboardProvider(props: DashboardProviderProps) {
     )
   );
 
-  return (
-    <DashboardContext.Provider value={dashboardStore as StoreApi<DashboardStoreState>}>
-      {children}
-    </DashboardContext.Provider>
-  );
+  return store;
 }

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -23,13 +23,11 @@ export function useEditMode() {
  * Returns actions that can be performed on the current dashboard.
  */
 export function useDashboardActions() {
-  const save = useDashboardStore((store) => store.save);
   const reset = useDashboardStore((store) => store.reset);
   const openAddPanelGroup = useDashboardStore((store) => store.openAddPanelGroup);
   const openAddPanel = useDashboardStore((store) => store.openAddPanel);
 
   return {
-    save,
     reset,
     openAddPanelGroup,
     openAddPanel: () => openAddPanel(undefined),

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -23,12 +23,12 @@ export function useEditMode() {
  * Returns actions that can be performed on the current dashboard.
  */
 export function useDashboardActions() {
-  const reset = useDashboardStore((store) => store.reset);
+  const setDashboard = useDashboardStore((store) => store.setDashboard);
   const openAddPanelGroup = useDashboardStore((store) => store.openAddPanelGroup);
   const openAddPanel = useDashboardStore((store) => store.openAddPanel);
 
   return {
-    reset,
+    setDashboard,
     openAddPanelGroup,
     openAddPanel: () => openAddPanel(undefined),
   };

--- a/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
@@ -39,11 +39,6 @@ export interface PanelGroupSlice {
    * Update the item layouts for a panel group when, for example, a panel is moved or resized.
    */
   updatePanelGroupLayouts: (panelGroupId: PanelGroupId, itemLayouts: PanelGroupDefinition['itemLayouts']) => void;
-
-  /**
-   * set to panel groups
-   */
-  setPanelGroups: (layouts: LayoutDefinition[]) => void;
 }
 
 export type PanelGroupId = number;
@@ -83,14 +78,6 @@ export function createPanelGroupSlice(
     panelGroups,
     panelGroupOrder,
 
-    setPanelGroups(layouts) {
-      set((state) => {
-        const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
-        state.panelGroups = panelGroups;
-        state.panelGroupOrder = panelGroupOrder;
-      });
-    },
-
     swapPanelGroups(x, y) {
       set((state) => {
         if (x < 0 || x >= state.panelGroupOrder.length || y < 0 || y >= state.panelGroupOrder.length) {
@@ -119,7 +106,7 @@ export function createPanelGroupSlice(
   });
 }
 
-function convertLayoutsToPanelGroups(
+export function convertLayoutsToPanelGroups(
   layouts: LayoutDefinition[]
 ): Pick<PanelGroupSlice, 'panelGroups' | 'panelGroupOrder'> {
   // Convert the initial layouts from the JSON

--- a/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-group-slice.ts
@@ -31,14 +31,6 @@ export interface PanelGroupSlice {
   panelGroupOrder: PanelGroupId[];
 
   /**
-   * previous state
-   */
-  previousPanelGroupState: {
-    panelGroups: PanelGroupSlice['panelGroups'];
-    panelGroupIdOrder: PanelGroupSlice['panelGroupOrder'];
-  };
-
-  /**
    * Rearrange the order of panel groups by swapping the positions
    */
   swapPanelGroups: (xIndex: number, yIndex: number) => void;
@@ -49,14 +41,9 @@ export interface PanelGroupSlice {
   updatePanelGroupLayouts: (panelGroupId: PanelGroupId, itemLayouts: PanelGroupDefinition['itemLayouts']) => void;
 
   /**
-   * save
+   * set to panel groups
    */
-  savePanelGroups: () => void;
-
-  /**
-   * reset to previous panel group states
-   */
-  resetPanelGroups: () => void;
+  setPanelGroups: (layouts: LayoutDefinition[]) => void;
 }
 
 export type PanelGroupId = number;
@@ -89,6 +76,52 @@ export interface PanelGroupItemId {
 export function createPanelGroupSlice(
   layouts: LayoutDefinition[]
 ): StateCreator<PanelGroupSlice, Middleware, [], PanelGroupSlice> {
+  const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
+
+  // Return the state creator function for Zustand
+  return (set) => ({
+    panelGroups,
+    panelGroupOrder,
+
+    setPanelGroups(layouts) {
+      set((state) => {
+        const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
+        state.panelGroups = panelGroups;
+        state.panelGroupOrder = panelGroupOrder;
+      });
+    },
+
+    swapPanelGroups(x, y) {
+      set((state) => {
+        if (x < 0 || x >= state.panelGroupOrder.length || y < 0 || y >= state.panelGroupOrder.length) {
+          throw new Error('index out of bound');
+        }
+        const xPanelGroup = state.panelGroupOrder[x];
+        const yPanelGroup = state.panelGroupOrder[y];
+
+        if (xPanelGroup === undefined || yPanelGroup === undefined) {
+          throw new Error('panel group is undefined');
+        }
+        // assign yPanelGroup to layouts[x] and assign xGroup to layouts[y], swapping two panel groups
+        [state.panelGroupOrder[x], state.panelGroupOrder[y]] = [yPanelGroup, xPanelGroup];
+      });
+    },
+
+    updatePanelGroupLayouts(panelGroupId, itemLayouts) {
+      set((state) => {
+        const group = state.panelGroups[panelGroupId];
+        if (group === undefined) {
+          throw new Error(`Cannot find panel group ${panelGroupId}`);
+        }
+        group.itemLayouts = itemLayouts;
+      });
+    },
+  });
+}
+
+function convertLayoutsToPanelGroups(
+  layouts: LayoutDefinition[]
+): Pick<PanelGroupSlice, 'panelGroups' | 'panelGroupOrder'> {
   // Convert the initial layouts from the JSON
   const panelGroups: PanelGroupSlice['panelGroups'] = {};
   const panelGroupIdOrder: PanelGroupSlice['panelGroupOrder'] = [];
@@ -120,54 +153,8 @@ export function createPanelGroupSlice(
     };
     panelGroupIdOrder.push(panelGroupId);
   }
-
-  // Return the state creator function for Zustand
-  return (set) => ({
+  return {
     panelGroups,
     panelGroupOrder: panelGroupIdOrder,
-
-    previousPanelGroupState: { panelGroups, panelGroupIdOrder },
-
-    savePanelGroups() {
-      set((state) => {
-        state.previousPanelGroupState = {
-          panelGroups: state.panelGroups,
-          panelGroupIdOrder: state.panelGroupOrder,
-        };
-      });
-    },
-
-    resetPanelGroups() {
-      set((state) => {
-        state.panelGroups = state.previousPanelGroupState.panelGroups;
-        state.panelGroupOrder = state.previousPanelGroupState.panelGroupIdOrder;
-      });
-    },
-
-    swapPanelGroups(x, y) {
-      set((state) => {
-        if (x < 0 || x >= state.panelGroupOrder.length || y < 0 || y >= state.panelGroupOrder.length) {
-          throw new Error('index out of bound');
-        }
-        const xPanelGroup = state.panelGroupOrder[x];
-        const yPanelGroup = state.panelGroupOrder[y];
-
-        if (xPanelGroup === undefined || yPanelGroup === undefined) {
-          throw new Error('panel group is undefined');
-        }
-        // assign yPanelGroup to layouts[x] and assign xGroup to layouts[y], swapping two panel groups
-        [state.panelGroupOrder[x], state.panelGroupOrder[y]] = [yPanelGroup, xPanelGroup];
-      });
-    },
-
-    updatePanelGroupLayouts(panelGroupId, itemLayouts) {
-      set((state) => {
-        const group = state.panelGroups[panelGroupId];
-        if (group === undefined) {
-          throw new Error(`Cannot find panel group ${panelGroupId}`);
-        }
-        group.itemLayouts = itemLayouts;
-      });
-    },
-  });
+  };
 }

--- a/ui/dashboards/src/context/DashboardProvider/panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-slice.ts
@@ -20,17 +20,11 @@ import { Middleware } from './common';
  */
 export interface PanelSlice {
   panels: Record<string, PanelDefinition>;
-  previousPanels: Record<string, PanelDefinition>;
 
   /**
-   * Reset panels to previous state
+   * set panels
    */
-  resetPanels: () => void;
-
-  /**
-   * Save panels
-   */
-  savePanels: () => void;
+  setPanels: (panels: Record<string, PanelDefinition>) => void;
 }
 
 /**
@@ -39,17 +33,10 @@ export interface PanelSlice {
 export function createPanelSlice(panels: PanelSlice['panels']): StateCreator<PanelSlice, Middleware, [], PanelSlice> {
   return (set) => ({
     panels,
-    previousPanels: panels,
 
-    resetPanels() {
+    setPanels(panels) {
       set((state) => {
-        state.panels = state.previousPanels;
-      });
-    },
-
-    savePanels() {
-      set((state) => {
-        state.previousPanels = state.panels;
+        state.panels = panels;
       });
     },
   });

--- a/ui/dashboards/src/context/DashboardProvider/panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-slice.ts
@@ -20,24 +20,13 @@ import { Middleware } from './common';
  */
 export interface PanelSlice {
   panels: Record<string, PanelDefinition>;
-
-  /**
-   * set panels
-   */
-  setPanels: (panels: Record<string, PanelDefinition>) => void;
 }
 
 /**
  * Curried function for creating the PanelSlice.
  */
 export function createPanelSlice(panels: PanelSlice['panels']): StateCreator<PanelSlice, Middleware, [], PanelSlice> {
-  return (set) => ({
+  return () => ({
     panels,
-
-    setPanels(panels) {
-      set((state) => {
-        state.panels = panels;
-      });
-    },
   });
 }

--- a/ui/dashboards/src/context/index.ts
+++ b/ui/dashboards/src/context/index.ts
@@ -15,4 +15,4 @@ export * from './DashboardProvider';
 export * from './DatasourceStoreProvider';
 export * from './TemplateVariableProvider';
 export * from './TimeRangeProvider';
-export * from './useDashboardSpec';
+export * from './useDashboardResource';

--- a/ui/dashboards/src/context/index.ts
+++ b/ui/dashboards/src/context/index.ts
@@ -15,4 +15,4 @@ export * from './DashboardProvider';
 export * from './DatasourceStoreProvider';
 export * from './TemplateVariableProvider';
 export * from './TimeRangeProvider';
-export * from './useDashboardResource';
+export * from './useDashboard';

--- a/ui/dashboards/src/context/useDashboard.tsx
+++ b/ui/dashboards/src/context/useDashboard.tsx
@@ -15,27 +15,27 @@ import { createPanelRef, DashboardResource, GridDefinition } from '@perses-dev/c
 import { PanelGroupDefinition, PanelGroupId, useDashboardStore } from './DashboardProvider';
 import { useTemplateVariableActions, useTemplateVariableDefinitions } from './TemplateVariableProvider';
 
-export function useDashboardResource() {
+export function useDashboard() {
   const {
     panels,
     panelGroups,
     panelGroupOrder,
     defaultTimeRange,
-    reset: setDashboardResource,
     metadata,
-  } = useDashboardStore(({ panels, panelGroups, panelGroupOrder, defaultTimeRange, reset, metadata }) => ({
+    setDashboard: setDashboardResource,
+  } = useDashboardStore(({ panels, panelGroups, panelGroupOrder, defaultTimeRange, setDashboard, metadata }) => ({
     panels,
     panelGroups,
     panelGroupOrder,
     defaultTimeRange,
-    reset,
+    setDashboard,
     metadata,
   }));
   const { setVariableDefinitions } = useTemplateVariableActions();
   const variables = useTemplateVariableDefinitions();
   const layouts = convertPanelGroupsToLayouts(panelGroups, panelGroupOrder);
 
-  const dashboardResource: DashboardResource = {
+  const dashboard: DashboardResource = {
     kind: 'Dashboard',
     metadata,
     spec: {
@@ -46,14 +46,14 @@ export function useDashboardResource() {
     },
   };
 
-  const resetDashboardResource = (dashboardResource: DashboardResource) => {
+  const setDashboard = (dashboardResource: DashboardResource) => {
     setVariableDefinitions(dashboardResource.spec.variables);
     setDashboardResource(dashboardResource);
   };
 
   return {
-    dashboardResource,
-    resetDashboardResource,
+    dashboard,
+    setDashboard,
   };
 }
 

--- a/ui/dashboards/src/context/useDashboardResource.tsx
+++ b/ui/dashboards/src/context/useDashboardResource.tsx
@@ -11,44 +11,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createPanelRef, DashboardSpec, GridDefinition } from '@perses-dev/core';
+import { createPanelRef, DashboardResource, GridDefinition } from '@perses-dev/core';
 import { PanelGroupDefinition, PanelGroupId, useDashboardStore } from './DashboardProvider';
 import { useTemplateVariableActions, useTemplateVariableDefinitions } from './TemplateVariableProvider';
 
-export function useDashboardSpec() {
+export function useDashboardResource() {
   const {
     panels,
     panelGroups,
     panelGroupOrder,
     defaultTimeRange,
-    reset: resetDashboardStore,
-  } = useDashboardStore(({ panels, panelGroups, panelGroupOrder, defaultTimeRange, reset }) => ({
+    reset: setDashboardResource,
+    metadata,
+  } = useDashboardStore(({ panels, panelGroups, panelGroupOrder, defaultTimeRange, reset, metadata }) => ({
     panels,
     panelGroups,
     panelGroupOrder,
     defaultTimeRange,
     reset,
+    metadata,
   }));
   const { setVariableDefinitions } = useTemplateVariableActions();
   const variables = useTemplateVariableDefinitions();
   const layouts = convertPanelGroupsToLayouts(panelGroups, panelGroupOrder);
 
-  const spec = {
-    panels,
-    layouts,
-    variables,
-    duration: defaultTimeRange.pastDuration,
+  const dashboardResource: DashboardResource = {
+    kind: 'Dashboard',
+    metadata,
+    spec: {
+      panels,
+      layouts,
+      variables,
+      duration: defaultTimeRange.pastDuration,
+    },
   };
 
-  const resetSpec = (spec: DashboardSpec) => {
-    setVariableDefinitions(spec.variables);
-    // TODO: Should we call reset on the dashboard store with the spec?
-    resetDashboardStore();
+  const resetDashboardResource = (dashboardResource: DashboardResource) => {
+    setVariableDefinitions(dashboardResource.spec.variables);
+    setDashboardResource(dashboardResource);
   };
 
   return {
-    spec,
-    resetSpec,
+    dashboardResource,
+    resetDashboardResource,
   };
 }
 

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -14,7 +14,7 @@
 import { useState } from 'react';
 import { Box } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { DashboardResource, DashboardSpec } from '@perses-dev/core';
+import { DashboardResource } from '@perses-dev/core';
 import {
   PanelDrawer,
   Dashboard,
@@ -24,7 +24,7 @@ import {
   DashboardToolbar,
   DeletePanelDialog,
 } from '../../components';
-import { useDashboardActions, useDashboardSpec, useEditMode } from '../../context';
+import { useDashboard, useEditMode } from '../../context';
 
 export interface DashboardAppProps {
   dashboardResource: DashboardResource;
@@ -32,22 +32,20 @@ export interface DashboardAppProps {
 
 export const DashboardApp = (props: DashboardAppProps) => {
   const { dashboardResource } = props;
-  const { save } = useDashboardActions();
   const { setEditMode } = useEditMode();
-  const { spec, resetSpec } = useDashboardSpec();
-  const [originalSpec, setOriginalSpec] = useState<DashboardSpec | undefined>(undefined);
+  const { dashboard, setDashboard } = useDashboard();
+  const [originalDashboard, setOriginalDashboard] = useState<DashboardResource | undefined>(undefined);
   const [isUnsavedDashboardDialogOpen, setUnsavedDashboardDialogIsOpen] = useState(false);
 
   const saveDashboard = async () => {
-    save();
     setEditMode(false);
     setUnsavedDashboardDialogIsOpen(false);
   };
 
   const cancelDashboard = () => {
     // Reset to the original spec and exit edit mode
-    if (originalSpec) {
-      resetSpec(originalSpec);
+    if (originalDashboard) {
+      setDashboard(originalDashboard);
     }
     setUnsavedDashboardDialogIsOpen(false);
     setEditMode(false);
@@ -55,12 +53,12 @@ export const DashboardApp = (props: DashboardAppProps) => {
 
   const onEditButtonClick = () => {
     setEditMode(true);
-    setOriginalSpec(spec);
+    setOriginalDashboard(dashboard);
   };
 
   const onCancelButtonClick = () => {
     // check if dashboard has been modified
-    if (JSON.stringify(spec) === JSON.stringify(originalSpec)) {
+    if (JSON.stringify(dashboard) === JSON.stringify(originalDashboard)) {
       setEditMode(false);
     } else {
       setUnsavedDashboardDialogIsOpen(true);

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -41,7 +41,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
 
   return (
     <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>
-      <DashboardProvider initialState={{ dashboardSpec: spec }}>
+      <DashboardProvider initialState={{ dashboardResource }}>
         <TimeRangeProvider timeRange={timeRange} setTimeRange={setTimeRange}>
           <TemplateVariableProvider initialVariableDefinitions={spec.variables}>
             <Box

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -22,7 +22,7 @@ describe('Panel Groups', () => {
     renderWithContext(
       <TimeRangeProvider timeRange={{ pastDuration: '30m' }}>
         <TemplateVariableProvider>
-          <DashboardProvider initialState={{ dashboardSpec: getTestDashboard().spec, isEditMode: true }}>
+          <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
             <DashboardApp dashboardResource={getTestDashboard()} />
           </DashboardProvider>
         </TemplateVariableProvider>


### PR DESCRIPTION
- useDashboardSpec (renamed to useDashboardResource) now returns the dashboard resource, which makes it easier for save/export to work.  
- rather than saving previous state in the store, reset function now takes in dashboard resource (similar to how setVariables works)
- prevent calling createDashboardStore every time DashboardProvider renders