### PR TITLE
Adjust gauge chart radius to avoid clipping

### DIFF
--- a/ui/components/src/GaugeChart/GaugeChart.tsx
+++ b/ui/components/src/GaugeChart/GaugeChart.tsx
@@ -53,7 +53,7 @@ export function GaugeChart(props: GaugeChartProps) {
         {
           type: 'gauge',
           center: ['50%', '65%'],
-          radius: '100%',
+          radius: '86%',
           startAngle: 200,
           endAngle: -20,
           min: 0,
@@ -106,7 +106,7 @@ export function GaugeChart(props: GaugeChartProps) {
         {
           type: 'gauge',
           center: ['50%', '65%'],
-          radius: '114%',
+          radius: '100%',
           startAngle: 200,
           endAngle: -20,
           min: 0,


### PR DESCRIPTION
Prior to this fix, the gauge chart would sometimes be clipped on the horizontal edges depending on the size of the chart.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Notes for reviewers

- This change was made previously to try to fit more tightly in small screens, but led to inconsistencies with clipping.
- This PR provides a quick fix to address the gauges looking broken in some cases.
- A better long-term fix for the tighter fit on small screens will be to change how padding within panel components is managed to move it from a constant in `Panel` to being handled by individual panel components, so we can potentially do things like hide the padding on gauges based on the size. This will be done in a follow-up by the team at some point in the future.

### Before fix

Gauges looked fine at some sizes:
<img width="299" alt="Screen Shot 2022-10-31 at 1 52 04 PM" src="https://user-images.githubusercontent.com/396962/199110130-d00e0808-0ef5-4b5e-970d-7e7d23a0f64d.png">

But would be clipped at the horizontal edges at other sizes:
<img width="219" alt="Screen Shot 2022-10-31 at 1 52 11 PM" src="https://user-images.githubusercontent.com/396962/199110214-23a732d4-dc44-4eeb-9ebc-01adcf4aa917.png">

### After fix

Gauges are not on the horizontal edges, no matter the size:
<img width="299" alt="Screen Shot 2022-10-31 at 1 55 28 PM" src="https://user-images.githubusercontent.com/396962/199110435-c0cff944-75e2-4969-98fc-a27ed22922bb.png">
<img width="227" alt="Screen Shot 2022-10-31 at 1 55 42 PM" src="https://user-images.githubusercontent.com/396962/199110432-4bd39012-c6b1-422f-9663-967f3b5af474.png">


