### PR TITLE
Adjust panel editor padding

### DIFF
--- a/ui/components/src/Drawer/Drawer.tsx
+++ b/ui/components/src/Drawer/Drawer.tsx
@@ -34,7 +34,6 @@ export const Drawer = ({ anchor = 'right', isOpen, onClose, PaperProps, children
         sx: combineSx(
           {
             width: `${DRAWER_DEFAULT_WIDTH}px`,
-            padding: (theme) => theme.spacing(2),
             overflow: 'hidden',
           },
           PaperProps?.sx

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.tsx
@@ -54,8 +54,7 @@ export const PanelDrawer = () => {
             sx={{
               display: 'flex',
               alignItems: 'center',
-              marginBottom: (theme) => theme.spacing(2),
-              paddingBottom: (theme) => theme.spacing(2),
+              padding: (theme) => theme.spacing(1, 2),
               borderBottom: (theme) => `1px solid ${theme.palette.grey[100]}`,
             }}
           >

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -13,6 +13,7 @@
 
 import { FormEventHandler, useState } from 'react';
 import {
+  Box,
   FormControl,
   FormHelperText,
   Grid,
@@ -72,8 +73,13 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
 
   return (
     // Grid maxHeight allows user to scroll inside Drawer to see all content
-    <form id={panelEditorFormId} onSubmit={handleSubmit}>
-      <Grid container spacing={2} sx={{ overflowY: 'scroll', maxHeight: '90vh' }}>
+    <Box
+      component="form"
+      id={panelEditorFormId}
+      onSubmit={handleSubmit}
+      sx={{ flex: 1, overflowY: 'scroll', padding: (theme) => theme.spacing(2) }}
+    >
+      <Grid container spacing={2}>
         <Grid item xs={8}>
           <TextField
             required
@@ -133,7 +139,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
           </ErrorBoundary>
         </Grid>
       </Grid>
-    </form>
+    </Box>
   );
 }
 


### PR DESCRIPTION
This adjustment:
- Brings the UI more in line with the designs.
- Allows the scrollbar for the panel to sit on the right side of the
  screen (instead of floating ~16 pixels from the right).
- Panel content fully fills the space not used by the header (instead
  of sometimes having some extra whitespace).

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Screenshots

<table>
<tr>
<th>before</th>
<th>after</th>
</tr>
<tr>
<td><img width="902" alt="image" src="https://user-images.githubusercontent.com/396962/199352028-a162388c-4806-4d15-ab8f-e72637bdc0ad.png"></td>
<td><img width="902" alt="image" src="https://user-images.githubusercontent.com/396962/199351937-ca0bf605-979b-4732-9a60-c6c9635a338b.png"><td>
</tr>
</table>