### PR TITLE
Make it possible to expand/collapse queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [FEATURE] Add a breadcrumbs as a dashboard title #702
 - [FEATURE] Add a Project view with a dashboard list section #697
+- [FEATURE] User can collapse / expand queries in the panel editor #718
 - [ENHANCEMENT] Dashboard variables list is displayed as a sticky header #703
 
 ## 0.13.0 / 2022-10-31

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useState } from 'react';
 import { produce } from 'immer';
 import {
   Button,
@@ -27,6 +28,8 @@ import {
 } from '@mui/material';
 import AddIcon from 'mdi-material-ui/Plus';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import ChevronDown from 'mdi-material-ui/ChevronDown';
+import ChevronUp from 'mdi-material-ui/ChevronUp';
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { OptionsEditorProps, TimeSeriesQueryEditor, usePlugin } from '@perses-dev/plugin-system';
 import { TimeSeriesChartOptions, DEFAULT_LEGEND, LEGEND_POSITIONS, LegendPosition } from './time-series-chart-model';
@@ -45,6 +48,10 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
     useErrorBoundary: true,
     enabled: true,
   });
+
+  // State for which queries are collapsed
+  // TODO: Would be easier if we had IDs for queries.
+  const [queriesCollapsed, setQueriesCollapsed] = useState(queries.map(() => false));
 
   // Query handlers
   const handleQueryChange = (index: number, queryDef: TimeSeriesQueryDefinition) => {
@@ -67,6 +74,10 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
         });
       })
     );
+    setQueriesCollapsed((queriesCollapsed) => {
+      queriesCollapsed.push(false);
+      return [...queriesCollapsed];
+    });
   };
 
   const handleQueryDelete = (index: number) => {
@@ -75,6 +86,17 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
         draft.queries.splice(index, 1);
       })
     );
+    setQueriesCollapsed((queriesCollapsed) => {
+      queriesCollapsed.splice(index, 1);
+      return [...queriesCollapsed];
+    });
+  };
+
+  const handleQueryCollapseExpand = (index: number) => {
+    setQueriesCollapsed((queriesCollapsed) => {
+      queriesCollapsed[index] = !queriesCollapsed[index];
+      return [...queriesCollapsed];
+    });
   };
 
   // Legend options handlers
@@ -105,6 +127,9 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
       {queries.map((query: TimeSeriesQueryDefinition, i: number) => (
         <Stack key={i} spacing={1}>
           <Stack direction="row" alignItems="center" borderBottom={1} borderColor="grey.300">
+            <IconButton size="small" onClick={() => handleQueryCollapseExpand(i)}>
+              {queriesCollapsed[i] ? <ChevronUp /> : <ChevronDown />}
+            </IconButton>
             <Typography variant="overline" component="h4">
               Query {i + 1}
             </Typography>
@@ -117,7 +142,9 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
               <DeleteIcon />
             </IconButton>
           </Stack>
-          <TimeSeriesQueryEditor value={query} onChange={(next) => handleQueryChange(i, next)} />
+          {!queriesCollapsed[i] && (
+            <TimeSeriesQueryEditor value={query} onChange={(next) => handleQueryChange(i, next)} />
+          )}
         </Stack>
       ))}
       <Stack spacing={1}>


### PR DESCRIPTION
This PR makes it possible for a user to expand/collapse queries in the panel editor.

## Notes / TODOs
Things that could make this implementation easier:
- if we had IDs on queries
- if we wanted to persist the "collapsed/not collapsed" state to the backend, because then I could just attach a field to the queries themselves

Curious if anyone has thoughts on either of these things (i.e. does that sound nice / do you think it makes sense) 

## Screenshot
<img width="1512" alt="Screen Shot 2022-11-01 at 3 21 30 PM" src="https://user-images.githubusercontent.com/2584129/199353134-e12e30d6-1b10-4cd9-b32c-71d0ac22fabd.png">

Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>