### PR TITLE
removing Julius Volz from the Perses org

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -40,7 +40,6 @@ The current team members are:
 | Augustin Husson | [nexucis](https://github.com/Nexucis) | Amadeus IT Group |
 | Luke Tillman | [luketillman](https://github.com/LukeTillman) | Chronosphere |
 | Steven Cobb | [sjcobb](https://github.com/sjcobb) | Chronosphere |
-| Julius Volz | [juliusv](https://github.com/juliusv) | PromLabs |
 | Antoine Thebaud | [AntoineThebaud](https://github.com/AntoineThebaud) | Amadeus IT Group |
 | Eunice Wong | [eunicorn](https://github.com/eunicorn) | Chronosphere |
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,6 @@ be found in [GOVERNANCE.md](GOVERNANCE.md).
 | Augustin Husson | [nexucis](https://github.com/Nexucis) | Amadeus IT Group |
 | Luke Tillman | [luketillman](https://github.com/LukeTillman) | Chronosphere |
 | Steven Cobb | [sjcobb](https://github.com/sjcobb) | Chronosphere |
-| Julius Volz | [juliusv](https://github.com/juliusv) | PromLabs |
 | Antoine Thebaud | [AntoineThebaud](https://github.com/AntoineThebaud) | Amadeus IT Group |
 | Eunice Wong | [eunicorn](https://github.com/eunicorn) | Chronosphere |
 


### PR DESCRIPTION
With the agreement of @juliusv I'm removing him from the Perses org. Thank you for your help at the beginning of Perses Julius :).
Hope you will be around to try it :).

Signed-off-by: Augustin Husson <augustin.husson@amadeus.com>