### PR TITLE
Clean up imports and exports to help with package and bundle size

### DIFF
--- a/ui/.eslintrc.base.js
+++ b/ui/.eslintrc.base.js
@@ -67,6 +67,30 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     // Not necessary in React 17
     'react/react-in-jsx-scope': 'off',
+
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            /**
+             * This library is gigantic and named imports end up slowing down builds/blowing out bundle sizes,
+             * so this prevents that style of import.
+             */
+            group: ['mdi-material-ui', '!mdi-material-ui/'],
+            message: `
+Please use the default import from the icon file directly rather than using a named import.
+
+Good:
+import IconName from 'mdi-material-ui/IconName';
+
+Bad:
+import { IconName } from 'mdi-material-ui';
+`,
+          },
+        ],
+      },
+    ],
   },
 
   ignorePatterns: ['**/dist'],

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -16,10 +16,10 @@ import { Routes, Route } from 'react-router-dom';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 // Default route is eagerly loaded
 import ViewDashboardList from './views/ViewDashboardList';
-import ViewProject from './views/ViewProject';
 
 // Other routes are lazy-loaded for code-splitting
 const ViewDashboard = lazy(() => import('./views/ViewDashboard'));
+const ViewProject = lazy(() => import('./views/ViewProject'));
 
 function Router() {
   return (

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -11,16 +11,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Suspense, lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
-import ViewDashboard from './views/ViewDashboard';
+import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
+// Default route is eagerly loaded
 import ViewDashboardList from './views/ViewDashboardList';
+
+// Other routes are lazy-loaded for code-splitting
+const ViewDashboard = lazy(() => import('./views/ViewDashboard'));
 
 function Router() {
   return (
-    <Routes>
-      <Route path="/projects/:projectName/dashboards/:dashboardName" element={<ViewDashboard />} />
-      <Route path="/" element={<ViewDashboardList />} />
-    </Routes>
+    <ErrorBoundary FallbackComponent={ErrorAlert}>
+      {/* TODO: What sort of loading fallback to we want? */}
+      <Suspense>
+        <Routes>
+          <Route path="/projects/:projectName/dashboards/:dashboardName" element={<ViewDashboard />} />
+          <Route path="/" element={<ViewDashboardList />} />
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 

--- a/ui/app/src/context/DarkMode.tsx
+++ b/ui/app/src/context/DarkMode.tsx
@@ -13,8 +13,13 @@
 
 import React, { createContext, useContext, useMemo } from 'react';
 import { CssBaseline, ThemeProvider, useMediaQuery } from '@mui/material';
+import { ChartsThemeProvider, generateChartsTheme, PersesChartsTheme } from '@perses-dev/components';
 import { useLocalStorage } from '../utils/browser-storage';
 import { getTheme } from '../theme/theme';
+
+// app specific echarts option overrides, empty since perses uses default
+// https://apache.github.io/echarts-handbook/en/concepts/style/#theme
+const ECHARTS_THEME_OVERRIDES = {};
 
 const DARK_MODE_PREFERENCE_KEY = 'PERSES_ENABLE_DARK_MODE';
 
@@ -46,12 +51,16 @@ export function DarkModeContextProvider(props: { children: React.ReactNode }) {
   );
 
   const theme = useMemo(() => getTheme(isDarkModeEnabled ? 'dark' : 'light'), [isDarkModeEnabled]);
+  const chartsTheme: PersesChartsTheme = useMemo(() => {
+    return generateChartsTheme('perses', theme, ECHARTS_THEME_OVERRIDES);
+  }, [theme]);
 
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-
-      <DarkModeContext.Provider value={darkModeContext}>{props.children}</DarkModeContext.Provider>
+      <ChartsThemeProvider themeName="perses" chartsTheme={chartsTheme}>
+        <DarkModeContext.Provider value={darkModeContext}>{props.children}</DarkModeContext.Provider>
+      </ChartsThemeProvider>
     </ThemeProvider>
   );
 }

--- a/ui/app/src/render-app.tsx
+++ b/ui/app/src/render-app.tsx
@@ -16,7 +16,6 @@ import ReactDOM from 'react-dom/client';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { BrowserRouter } from 'react-router-dom';
-import { CssBaseline } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SnackbarProvider } from './context/SnackbarProvider';
 import { DarkModeContextProvider } from './context/DarkMode';
@@ -41,7 +40,6 @@ export function renderApp(container: Element | null) {
           <QueryParamProvider adapter={ReactRouter6Adapter}>
             <DarkModeContextProvider>
               <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
-                <CssBaseline />
                 <App />
               </SnackbarProvider>
             </DarkModeContextProvider>

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -50,13 +50,13 @@ function ViewDashboard() {
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry pluginLoader={bundledPluginLoader}>
           <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <DashboardView
-                dashboardResource={data}
-                datasourceApi={datasourceApi}
-                dashboardTitleComponent={
-                  <DashboardBreadcrumbs dashboardName={data.metadata.name} dashboardProject={data.metadata.project} />
-                }
-              />
+            <DashboardView
+              dashboardResource={data}
+              datasourceApi={datasourceApi}
+              dashboardTitleComponent={
+                <DashboardBreadcrumbs dashboardName={data.metadata.name} dashboardProject={data.metadata.project} />
+              }
+            />
           </ErrorBoundary>
         </PluginRegistry>
       </ErrorBoundary>

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -13,33 +13,17 @@
 
 import { ViewDashboard as DashboardView } from '@perses-dev/dashboards';
 import { useParams } from 'react-router-dom';
-import { Box, useTheme } from '@mui/material';
-import {
-  ChartsThemeProvider,
-  ErrorAlert,
-  ErrorBoundary,
-  generateChartsTheme,
-  PersesChartsTheme,
-} from '@perses-dev/components';
-import { useMemo } from 'react';
+import { Box } from '@mui/material';
+import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../model/bundled-plugins';
 import { useDashboard } from '../model/dashboard-client';
 import { useDatasourceApi } from '../model/datasource-api';
 
-// app specific echarts option overrides, empty since perses uses default
-// https://apache.github.io/echarts-handbook/en/concepts/style/#theme
-const ECHARTS_THEME_OVERRIDES = {};
-
 /**
  * The View for viewing a Dashboard.
  */
 function ViewDashboard() {
-  const muiTheme = useTheme();
-  const chartsTheme: PersesChartsTheme = useMemo(() => {
-    return generateChartsTheme('perses', muiTheme, ECHARTS_THEME_OVERRIDES);
-  }, [muiTheme]);
-
   const { projectName, dashboardName } = useParams();
 
   if (projectName === undefined || dashboardName === undefined) {
@@ -63,13 +47,11 @@ function ViewDashboard() {
       }}
     >
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <ChartsThemeProvider themeName="perses" chartsTheme={chartsTheme}>
-          <PluginRegistry pluginLoader={bundledPluginLoader}>
-            <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <DashboardView dashboardResource={data} datasourceApi={datasourceApi} />;
-            </ErrorBoundary>
-          </PluginRegistry>
-        </ChartsThemeProvider>
+        <PluginRegistry pluginLoader={bundledPluginLoader}>
+          <ErrorBoundary FallbackComponent={ErrorAlert}>
+            <DashboardView dashboardResource={data} datasourceApi={datasourceApi} />;
+          </ErrorBoundary>
+        </PluginRegistry>
       </ErrorBoundary>
     </Box>
   );

--- a/ui/app/src/views/ViewDashboardList.tsx
+++ b/ui/app/src/views/ViewDashboardList.tsx
@@ -28,7 +28,8 @@ import {
 import { DashboardResource } from '@perses-dev/core';
 import { useNavigate } from 'react-router-dom';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { ChevronDown, FolderPound } from 'mdi-material-ui';
+import ChevronDown from 'mdi-material-ui/ChevronDown';
+import FolderPound from 'mdi-material-ui/FolderPound';
 import { useDashboardList } from '../model/dashboard-client';
 
 function RenderDashboardList() {

--- a/ui/app/src/views/ViewProject.tsx
+++ b/ui/app/src/views/ViewProject.tsx
@@ -14,7 +14,8 @@
 import { useParams } from 'react-router-dom';
 import { Box, Container, Paper, Stack, Typography } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { FolderPound, ViewDashboard } from 'mdi-material-ui';
+import FolderPound from 'mdi-material-ui/FolderPound';
+import ViewDashboard from 'mdi-material-ui/ViewDashboard';
 import { useDashboardList } from '../model/dashboard-client';
 import DashboardList from '../components/DashboardList';
 

--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -14,6 +14,11 @@
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": [
+    "./dist/GaugeChart/GaugeChart.js",
+    "./dist/LineChart/LineChart.js",
+    "./dist/StatChart/StatChart.js"
+  ],
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",

--- a/ui/components/src/StatChart/StatChart.test.tsx
+++ b/ui/components/src/StatChart/StatChart.test.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ChartsThemeProvider } from '../context/ChartsThemeProvider';
 import { UnitOptions } from '../model';
-import { testChartsTheme } from '../test';
+import { testChartsTheme } from '../test-utils';
 import { StatChart, StatChartData } from './StatChart';
 
 describe('StatChart', () => {

--- a/ui/components/src/context/ChartsThemeProvider.tsx
+++ b/ui/components/src/context/ChartsThemeProvider.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import React, { createContext, useContext } from 'react';
-import { registerTheme } from 'echarts';
+import { registerTheme } from 'echarts/core';
 import { PersesChartsTheme } from '../model';
 
 export interface ChartsThemeProviderProps {

--- a/ui/components/src/model/units.ts
+++ b/ui/components/src/model/units.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Duration, milliseconds } from 'date-fns';
-import { round } from 'mathjs';
+import { round } from '../utils/mathjs';
 
 export const DEFAULT_DECIMAL_PLACES = 2;
 

--- a/ui/components/src/test-utils/index.ts
+++ b/ui/components/src/test-utils/index.ts
@@ -11,14 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PersesChartsTheme } from '../';
-
-export const testChartsTheme: PersesChartsTheme = {
-  themeName: 'perses',
-  echartsTheme: {},
-  noDataOption: {},
-  sparkline: {
-    width: 1,
-    color: '#000000',
-  },
-};
+export * from './theme';

--- a/ui/components/src/test-utils/theme.ts
+++ b/ui/components/src/test-utils/theme.ts
@@ -11,18 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './Drawer';
-export * from './EChart';
-export * from './ErrorAlert';
-export * from './ErrorBoundary';
-export * from './InfoTooltip';
-export * from './JSONEditor';
-export * from './Legend';
-export * from './LineChart';
-export * from './GaugeChart';
-export * from './StatChart';
-export * from './TimeRangeSelector';
-export * from './context/ChartsThemeProvider';
-export * from './utils';
-export * from './model';
-export * from './test-utils';
+import { PersesChartsTheme } from '../model';
+
+export const testChartsTheme: PersesChartsTheme = {
+  themeName: 'perses',
+  echartsTheme: {},
+  noDataOption: {},
+  sparkline: {
+    width: 1,
+    color: '#000000',
+  },
+};

--- a/ui/components/src/test/index.ts
+++ b/ui/components/src/test/index.ts
@@ -12,4 +12,3 @@
 // limitations under the License.
 
 export * from './render';
-export * from './theme';

--- a/ui/components/src/utils/mathjs.ts
+++ b/ui/components/src/utils/mathjs.ts
@@ -1,0 +1,18 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { roundDependencies, create } from 'mathjs';
+
+// This ensures we get a minimal mathjs bundle for just what we need (see https://mathjs.org/docs/custom_bundling.html)
+const { round } = create({ roundDependencies });
+export { round };

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",

--- a/ui/dashboards/src/context/DashboardProvider/common.ts
+++ b/ui/dashboards/src/context/DashboardProvider/common.ts
@@ -21,13 +21,12 @@ declare global {
   var dashboardStoreId: number;
 }
 
-if (globalThis.dashboardStoreId === undefined) {
-  globalThis.dashboardStoreId = 0;
-}
-
 /**
  * Helper function to generate unique IDs for things in the dashboard store that don't have a "natural" ID.
  */
 export function generateId() {
+  if (globalThis.dashboardStoreId === undefined) {
+    globalThis.dashboardStoreId = 0;
+  }
   return globalThis.dashboardStoreId++;
 }

--- a/ui/dashboards/src/utils/component-ids.ts
+++ b/ui/dashboards/src/utils/component-ids.ts
@@ -18,14 +18,14 @@ declare global {
   var useIdValue: number;
 }
 
-if (globalThis.useIdValue === undefined) {
-  globalThis.useIdValue = 0;
-}
-
 /**
  * Generates a unique (stable) ID for a component. Should be replaced with React.useId once we support only React 18.
  */
 export function useId(prefix: string) {
+  if (globalThis.useIdValue === undefined) {
+    globalThis.useIdValue = 0;
+  }
+
   const id = useRef<string | undefined>(undefined);
   if (id.current === undefined) {
     id.current = `${prefix}-${globalThis.useIdValue++}`;

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GaugeSeriesOption } from 'echarts';
+import type { GaugeSeriesOption } from 'echarts';
 import { useTimeSeriesQuery, PanelProps } from '@perses-dev/plugin-system';
 import { GaugeChart, GaugeChartData } from '@perses-dev/components';
 import { Skeleton } from '@mui/material';

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -14,7 +14,7 @@
 import { useMemo, useState } from 'react';
 import { merge } from 'lodash-es';
 import { PanelProps, useTimeSeriesQueries, useTimeRange } from '@perses-dev/plugin-system';
-import { GridComponentOption } from 'echarts';
+import type { GridComponentOption } from 'echarts';
 import { Box, Skeleton } from '@mui/material';
 import { LineChart, EChartsDataFormat, ZoomEventData, Legend } from '@perses-dev/components';
 import { useSuggestedStepMs } from '../../model/time';

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -14,9 +14,9 @@
 import { AbsoluteTimeRange } from '@perses-dev/core';
 import { EChartsTimeSeries } from '@perses-dev/components';
 import { TimeSeries, useTimeSeriesQueries } from '@perses-dev/plugin-system';
-import { gcd } from 'mathjs';
-import { getRandomColor } from '../utils/palette-gen';
+import { gcd } from '../../../utils/mathjs';
 import { StepOptions } from '../../../model/thresholds';
+import { getRandomColor } from './palette-gen';
 
 export interface TimeScale {
   startMs: number;

--- a/ui/panels-plugin/src/utils/mathjs.ts
+++ b/ui/panels-plugin/src/utils/mathjs.ts
@@ -1,0 +1,18 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { gcdDependencies, create } from 'mathjs';
+
+// This ensures we get a minimal mathjs bundle for just what we need (see https://mathjs.org/docs/custom_bundling.html)
+const { gcd } = create({ gcdDependencies });
+export { gcd };

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.js",
   "main": "dist//cjs/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",


### PR DESCRIPTION
While looking into some bundle size issues internally, I noticed that there were a lot of third party libraries coming from Perses packages that probably shouldn't be. This made me go an take a look at our JavaScript bundles for the Perses app (i.e. `npm run analyze -w app`). This was what it looked like when I started:

![Screen Shot 2022-11-02 at 11 57 17 AM](https://user-images.githubusercontent.com/428023/199565606-682d0792-8259-4125-bb6f-99a3fc5c1ecc.png)

You can see we have 2.7 MB of Javascript total (before gzipping which would happen on the wire). After doing some digging around and cleaning up a bunch of things, including adding a bit of code splitting to the app, this is what things look like now:

![Screen Shot 2022-11-02 at 11 58 38 AM](https://user-images.githubusercontent.com/428023/199566061-cb0b62f2-5302-4e83-8b90-8abe9707dc07.png)

This ended up cutting almost 800 KB of JavaScript from our bundles. This should also help folks using the Perses packages in their own bundles. I'll add a few comments inline about a few of the more interesting changes.