### PR TITLE
perf fix to pass echarts theme directly into chart init

### DIFF
--- a/ui/app/src/context/DarkMode.tsx
+++ b/ui/app/src/context/DarkMode.tsx
@@ -52,13 +52,13 @@ export function DarkModeContextProvider(props: { children: React.ReactNode }) {
 
   const theme = useMemo(() => getTheme(isDarkModeEnabled ? 'dark' : 'light'), [isDarkModeEnabled]);
   const chartsTheme: PersesChartsTheme = useMemo(() => {
-    return generateChartsTheme('perses', theme, ECHARTS_THEME_OVERRIDES);
+    return generateChartsTheme(theme, ECHARTS_THEME_OVERRIDES);
   }, [theme]);
 
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <ChartsThemeProvider themeName="perses" chartsTheme={chartsTheme}>
+      <ChartsThemeProvider chartsTheme={chartsTheme}>
         <DarkModeContext.Provider value={darkModeContext}>{props.children}</DarkModeContext.Provider>
       </ChartsThemeProvider>
     </ThemeProvider>

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -64,7 +64,7 @@ function ViewDashboard() {
       }}
     >
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <ChartsThemeProvider themeName="perses" chartsTheme={chartsTheme}>
+        <ChartsThemeProvider chartsTheme={chartsTheme}>
           <PluginRegistry pluginLoader={bundledPluginLoader}>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
               <DashboardView

--- a/ui/components/src/GaugeChart/GaugeChart.tsx
+++ b/ui/components/src/GaugeChart/GaugeChart.tsx
@@ -157,7 +157,7 @@ export function GaugeChart(props: GaugeChartProps) {
         height: height,
       }}
       option={option}
-      theme={chartsTheme.themeName}
+      theme={chartsTheme.echartsTheme}
     />
   );
 }

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -218,7 +218,7 @@ export function LineChart({ height, data, unit, grid, legend, visualMap, onDataZ
           height: '100%',
         }}
         option={option}
-        theme={chartsTheme.themeName}
+        theme={chartsTheme.echartsTheme}
         onEvents={handleEvents}
         _instance={chartRef}
       />

--- a/ui/components/src/StatChart/StatChart.test.tsx
+++ b/ui/components/src/StatChart/StatChart.test.tsx
@@ -47,7 +47,7 @@ describe('StatChart', () => {
   describe('Render default options (no sparkline)', () => {
     it('should render', () => {
       render(
-        <ChartsThemeProvider themeName="perses" chartsTheme={testChartsTheme}>
+        <ChartsThemeProvider chartsTheme={testChartsTheme}>
           <StatChart
             width={contentDimensions.width}
             height={contentDimensions.height}

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -134,7 +134,7 @@ export function StatChart(props: StatChartProps) {
             left: 0,
           }}
           option={option}
-          theme={chartsTheme.themeName}
+          theme={chartsTheme.echartsTheme}
           renderer="svg"
         />
       )}

--- a/ui/components/src/context/ChartsThemeProvider.tsx
+++ b/ui/components/src/context/ChartsThemeProvider.tsx
@@ -12,23 +12,15 @@
 // limitations under the License.
 
 import React, { createContext, useContext } from 'react';
-import { registerTheme } from 'echarts';
 import { PersesChartsTheme } from '../model';
 
 export interface ChartsThemeProviderProps {
-  themeName: string;
   chartsTheme?: PersesChartsTheme;
   children?: React.ReactNode;
 }
 
 export function ChartsThemeProvider(props: ChartsThemeProviderProps) {
-  const { children, themeName, chartsTheme } = props;
-
-  if (chartsTheme !== undefined && chartsTheme.echartsTheme !== undefined) {
-    // register ECharts theme to be used in individual charts, see: https://apache.github.io/echarts-handbook/en/concepts/style/#theme
-    registerTheme(themeName, chartsTheme.echartsTheme);
-  }
-
+  const { children, chartsTheme } = props;
   return <ChartsThemeContext.Provider value={chartsTheme}>{children}</ChartsThemeContext.Provider>;
 }
 

--- a/ui/components/src/model/theme.ts
+++ b/ui/components/src/model/theme.ts
@@ -14,7 +14,6 @@
 import type { EChartsOption, EChartsCoreOption, BarSeriesOption, LineSeriesOption, GaugeSeriesOption } from 'echarts';
 
 export interface PersesChartsTheme {
-  themeName: string;
   echartsTheme: EChartsTheme;
   noDataOption: EChartsCoreOption;
   sparkline: {

--- a/ui/components/src/test-utils/theme.ts
+++ b/ui/components/src/test-utils/theme.ts
@@ -14,7 +14,6 @@
 import { PersesChartsTheme } from '../model';
 
 export const testChartsTheme: PersesChartsTheme = {
-  themeName: 'perses',
   echartsTheme: {},
   noDataOption: {},
   sparkline: {

--- a/ui/components/src/utils/theme-gen.test.ts
+++ b/ui/components/src/utils/theme-gen.test.ts
@@ -28,7 +28,7 @@ describe('generateChartsTheme', () => {
       smooth: true,
     },
   };
-  const chartsTheme: PersesChartsTheme = generateChartsTheme('perses', muiTheme, echartsThemeOverrides);
+  const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, echartsThemeOverrides);
 
   it('should return perses specific charts theme from converted MUI theme', () => {
     expect(chartsTheme).toMatchInlineSnapshot(`
@@ -190,8 +190,7 @@ describe('generateChartsTheme', () => {
         "sparkline": Object {
           "color": "#1976d2",
           "width": 2,
-        },
-        "themeName": "perses",
+        }
       }
     `);
   });

--- a/ui/components/src/utils/theme-gen.test.ts
+++ b/ui/components/src/utils/theme-gen.test.ts
@@ -190,7 +190,7 @@ describe('generateChartsTheme', () => {
         "sparkline": Object {
           "color": "#1976d2",
           "width": 2,
-        }
+        },
       }
     `);
   });

--- a/ui/components/src/utils/theme-gen.ts
+++ b/ui/components/src/utils/theme-gen.ts
@@ -20,11 +20,7 @@ const DEFAULT_TEXT_COLOR = '#222';
 // avoid component override type errors since only palette and typography are used
 type MuiTheme = Omit<Theme, 'components'>;
 
-export function generateChartsTheme(
-  themeName: string,
-  muiTheme: MuiTheme,
-  echartsTheme: EChartsTheme
-): PersesChartsTheme {
+export function generateChartsTheme(muiTheme: MuiTheme, echartsTheme: EChartsTheme): PersesChartsTheme {
   const primaryTextColor = muiTheme.palette.text?.primary ?? DEFAULT_TEXT_COLOR;
 
   const muiConvertedTheme: EChartsTheme = {
@@ -156,7 +152,6 @@ export function generateChartsTheme(
   };
 
   return {
-    themeName,
     echartsTheme: merge(muiConvertedTheme, echartsTheme),
     noDataOption: {
       title: {

--- a/ui/dashboards/src/test/render.tsx
+++ b/ui/dashboards/src/test/render.tsx
@@ -39,7 +39,7 @@ export function renderWithContext(
       <HistoryRouter history={history}>
         <QueryClientProvider client={queryClient}>
           <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ChartsThemeProvider themeName="perses" chartsTheme={testChartsTheme}>
+            <ChartsThemeProvider chartsTheme={testChartsTheme}>
               <PluginRegistry {...mockPluginRegistry(...MOCK_PLUGINS)}>{ui}</PluginRegistry>
             </ChartsThemeProvider>
           </QueryParamProvider>

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -92,7 +92,7 @@ describe('TimeSeriesChartPanel', () => {
 
     render(
       <PluginRegistry {...mockPluginRegistry(MOCK_PROM_QUERY_PLUGIN)}>
-        <ChartsThemeProvider themeName="perses" chartsTheme={testChartsTheme}>
+        <ChartsThemeProvider chartsTheme={testChartsTheme}>
           <TimeRangeContext.Provider value={mockTimeRangeContext}>
             <TimeSeriesChartPanel {...TEST_TIME_SERIES_PANEL} />
           </TimeRangeContext.Provider>


### PR DESCRIPTION
Performance bugfix to remove using registerTheme to share an ECharts theme between charts and instead pass the generated theme obj directly into our echarts wrapper component.