### PR TITLE
add a button to stick the variable header

### DIFF
--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -56,7 +56,7 @@ function ViewDashboard() {
               dashboardTitleComponent={
                 <DashboardBreadcrumbs dashboardName={data.metadata.name} dashboardProject={data.metadata.project} />
               }
-              variableIsSticky={true}
+              initialVariableIsSticky={true}
             />
           </ErrorBoundary>
         </PluginRegistry>

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -23,13 +23,14 @@ import { TimeRangeControls } from '../TimeRangeControls';
 export interface DashboardToolbarProps {
   dashboardName: string;
   dashboardTitleComponent?: JSX.Element;
-  variableIsSticky?: boolean;
+  initialVariableIsSticky?: boolean;
   onEditButtonClick: () => void;
   onCancelButtonClick: () => void;
 }
 
 export const DashboardToolbar = (props: DashboardToolbarProps) => {
-  const { dashboardName, dashboardTitleComponent, variableIsSticky, onEditButtonClick, onCancelButtonClick } = props;
+  const { dashboardName, dashboardTitleComponent, initialVariableIsSticky, onEditButtonClick, onCancelButtonClick } =
+    props;
 
   const { isEditMode, setEditMode } = useEditMode();
   const { openAddPanelGroup, openAddPanel } = useDashboardActions();
@@ -70,7 +71,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             }}
           >
             <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <TemplateVariableList variableIsSticky={variableIsSticky} />
+              <TemplateVariableList initialVariableIsSticky={initialVariableIsSticky} />
             </ErrorBoundary>
             <Stack direction={'row'} spacing={1} sx={{ marginLeft: 'auto' }}>
               <Button startIcon={<AddPanelGroupIcon />} onClick={openAddPanelGroup}>
@@ -103,7 +104,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
           </Box>
           <Box paddingY={2}>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <TemplateVariableList variableIsSticky={variableIsSticky} />
+              <TemplateVariableList initialVariableIsSticky={initialVariableIsSticky} />
             </ErrorBoundary>
           </Box>
         </Stack>

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -12,10 +12,11 @@
 // limitations under the License.
 
 import React, { useState } from 'react';
-import { Button, Stack, Box, Drawer, AppBar, useScrollTrigger } from '@mui/material';
+import { Button, Stack, Box, Drawer, AppBar, useScrollTrigger, IconButton } from '@mui/material';
 import EyeIcon from 'mdi-material-ui/Eye';
 import PencilIcon from 'mdi-material-ui/Pencil';
-
+import PinOutline from 'mdi-material-ui/PinOutline';
+import PinOffOutline from 'mdi-material-ui/PinOffOutline';
 import { useTemplateVariableDefinitions, useEditMode, useTemplateVariableActions } from '../../context';
 import { TemplateVariable } from './Variable';
 import { VariableEditor } from './VariableEditor';
@@ -26,13 +27,14 @@ interface TemplateVariableListProps {
 
 export function TemplateVariableList(props: TemplateVariableListProps) {
   const [isEditing, setIsEditing] = useState(false);
+  const [isPin, setIsPin] = useState(props.variableIsSticky);
   const variableDefinitions = useTemplateVariableDefinitions();
   const { isEditMode } = useEditMode();
   const [showVariablesInEditMode, setShowVariablesInEditMode] = useState(true);
   const showVariables = isEditMode ? showVariablesInEditMode : true;
   const { setVariableDefinitions } = useTemplateVariableActions();
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
-  const isSticky = scrollTrigger && props.variableIsSticky;
+  const isSticky = scrollTrigger && props.variableIsSticky && isPin;
   return (
     <Box>
       <Drawer anchor={'right'} open={isEditing}>
@@ -68,6 +70,9 @@ export function TemplateVariableList(props: TemplateVariableListProps) {
                 </Box>
               ))}
           </Stack>
+          {props.variableIsSticky && (
+            <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
+          )}
         </Box>
       </AppBar>
     </Box>

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -22,19 +22,19 @@ import { TemplateVariable } from './Variable';
 import { VariableEditor } from './VariableEditor';
 
 interface TemplateVariableListProps {
-  variableIsSticky?: boolean;
+  initialVariableIsSticky?: boolean;
 }
 
 export function TemplateVariableList(props: TemplateVariableListProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const [isPin, setIsPin] = useState(props.variableIsSticky);
+  const [isPin, setIsPin] = useState(props.initialVariableIsSticky);
   const variableDefinitions = useTemplateVariableDefinitions();
   const { isEditMode } = useEditMode();
   const [showVariablesInEditMode, setShowVariablesInEditMode] = useState(true);
   const showVariables = isEditMode ? showVariablesInEditMode : true;
   const { setVariableDefinitions } = useTemplateVariableActions();
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
-  const isSticky = scrollTrigger && props.variableIsSticky && isPin;
+  const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
   return (
     <Box>
       <Drawer anchor={'right'} open={isEditing}>
@@ -70,7 +70,7 @@ export function TemplateVariableList(props: TemplateVariableListProps) {
                 </Box>
               ))}
           </Stack>
-          {props.variableIsSticky && (
+          {props.initialVariableIsSticky && (
             <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
           )}
         </Box>

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -29,11 +29,11 @@ import { useDashboard, useEditMode } from '../../context';
 export interface DashboardAppProps {
   dashboardResource: DashboardResource;
   dashboardTitleComponent?: JSX.Element;
-  variableIsSticky?: boolean;
+  initialVariableIsSticky?: boolean;
 }
 
 export const DashboardApp = (props: DashboardAppProps) => {
-  const { dashboardResource, dashboardTitleComponent, variableIsSticky } = props;
+  const { dashboardResource, dashboardTitleComponent, initialVariableIsSticky } = props;
   const { setEditMode } = useEditMode();
   const { dashboard, setDashboard } = useDashboard();
   const [originalDashboard, setOriginalDashboard] = useState<DashboardResource | undefined>(undefined);
@@ -80,7 +80,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
       <DashboardToolbar
         dashboardName={dashboardResource.metadata.name}
         dashboardTitleComponent={dashboardTitleComponent}
-        variableIsSticky={variableIsSticky}
+        initialVariableIsSticky={initialVariableIsSticky}
         onEditButtonClick={onEditButtonClick}
         onCancelButtonClick={onCancelButtonClick}
       />

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -28,14 +28,14 @@ export interface ViewDashboardProps extends Omit<BoxProps, 'children'> {
   dashboardResource: DashboardResource;
   datasourceApi: DatasourceStoreProviderProps['datasourceApi'];
   dashboardTitleComponent?: JSX.Element;
-  variableIsSticky?: boolean;
+  initialVariableIsSticky?: boolean;
 }
 
 /**
  * The View for displaying a Dashboard, along with the UI for selecting variable values.
  */
 export function ViewDashboard(props: ViewDashboardProps) {
-  const { dashboardResource, datasourceApi, dashboardTitleComponent, variableIsSticky, sx, ...others } = props;
+  const { dashboardResource, datasourceApi, dashboardTitleComponent, initialVariableIsSticky, sx, ...others } = props;
   const { spec } = dashboardResource;
   const dashboardDuration = spec.duration ?? '1h';
   const initialTimeRange = useInitialTimeRange(dashboardDuration);
@@ -63,7 +63,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
                 <DashboardApp
                   dashboardResource={dashboardResource}
                   dashboardTitleComponent={dashboardTitleComponent}
-                  variableIsSticky={variableIsSticky}
+                  initialVariableIsSticky={initialVariableIsSticky}
                 />
               </ErrorBoundary>
             </Box>


### PR DESCRIPTION
I'm adding a little button to be able to remove the sticky header at runtime. I'm thinking sometimes you want the full space to see the dashboard.

https://user-images.githubusercontent.com/4548045/199757533-4442f495-5952-4ee0-a346-5d2b741a1123.mov

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>