### PR TITLE
Update TimeSeriesQuery plugins to load based on variable state

### DIFF
--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -16,10 +16,22 @@ import { DatasourceStore, VariableStateMap } from '../runtime';
 import { Plugin } from './plugin-base';
 
 /**
+ * An object containing all the dependencies of a TimeSeriesQuery.
+ */
+type TimeSeriesQueryPluginDependencies = {
+  /**
+   * Returns a list of variables name this time series query depends on.
+   */
+  variables?: string[];
+};
+
+/**
  * A plugin for running time series queries.
  */
 export interface TimeSeriesQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
   getTimeSeriesData: (spec: Spec, ctx: TimeSeriesQueryContext) => Promise<TimeSeriesData>;
+
+  dependsOn?: (spec: Spec, ctx: TimeSeriesQueryContext) => TimeSeriesQueryPluginDependencies;
 }
 
 /**

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { createContext, useContext } from 'react';
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, useQueries, UseQueryOptions } from '@tanstack/react-query';
 import { PluginImplementation, PluginMetadata, PluginType } from '../model';
 
 export interface PluginRegistryContextType {
@@ -51,6 +51,21 @@ export function usePlugin<T extends PluginType>(pluginType: T, kind: string, opt
   };
   const { getPlugin } = usePluginRegistry();
   return useQuery(['getPlugin', pluginType, kind], () => getPlugin(pluginType, kind), options);
+}
+
+/**
+ * Loads a list of plugins and returns the plugin implementation, along with loading/error state.
+ */
+export function usePlugins<T extends PluginType>(pluginType: T, plugins: Array<{ kind: string }>) {
+  const { getPlugin } = usePluginRegistry();
+  return useQueries({
+    queries: plugins.map((p) => {
+      return {
+        queryKey: ['getPlugin', pluginType, p.kind],
+        queryFn: () => getPlugin(pluginType, p.kind),
+      };
+    }),
+  });
 }
 
 // Allow consumers to pass useQuery options from react-query when listing metadata

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -63,10 +63,10 @@ function getQueryOptions({
   if (variableDependencies) {
     waitToLoad = variableDependencies.some((v) => variableState[v]?.loading);
   }
-  const pluginEnabled = plugin !== undefined && !waitToLoad;
+  const queryEnabled = plugin !== undefined && !waitToLoad;
   return {
     queryKey,
-    pluginEnabled,
+    queryEnabled,
   };
 }
 
@@ -77,7 +77,7 @@ export const useTimeSeriesQuery = (definition: TimeSeriesQueryDefinition, option
   const { data: plugin } = usePlugin('TimeSeriesQuery', definition.spec.plugin.kind);
   const context = useTimeSeriesQueryContext();
 
-  const { pluginEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
+  const { queryEnabled: pluginEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
 
   return useQuery(
     queryKey,
@@ -110,9 +110,9 @@ export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], o
     queries: definitions.map((definition, idx) => {
       const resp = pluginLoaderResponse[idx];
       const plugin = resp?.data;
-      const { pluginEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
+      const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
       return {
-        enabled: pluginEnabled,
+        enabled: queryEnabled,
         queryKey: queryKey,
         queryFn: async () => {
           // Keep options out of query key so we don't re-run queries because suggested step changes

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -14,13 +14,60 @@
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { TimeSeriesQueryContext } from '../model';
+import { TimeSeriesQueryPlugin } from '../model';
+import { VariableStateMap } from './template-variables';
 import { useTemplateVariableValues } from './template-variables';
 import { useTimeRange } from './time-range';
 import { useDatasourceStore } from './datasources';
-import { usePlugin, usePluginRegistry } from './plugin-registry';
+import { usePlugin, usePluginRegistry, usePlugins } from './plugin-registry';
 
 export interface UseTimeSeriesQueryOptions {
   suggestedStepMs?: number;
+}
+
+/**
+ * Returns a serialized string of the current state of variable values.
+ */
+function getVariableValuesKey(v: VariableStateMap) {
+  return Object.values(v)
+    .map((v) => JSON.stringify(v.value))
+    .join(',');
+}
+
+function filterVariableStateMap(v: VariableStateMap, names?: string[]) {
+  if (!names) {
+    return v;
+  }
+  return Object.fromEntries(Object.entries(v).filter(([name]) => names.includes(name)));
+}
+
+function getQueryOptions({
+  plugin,
+  definition,
+  context,
+}: {
+  plugin?: TimeSeriesQueryPlugin;
+  definition: TimeSeriesQueryDefinition;
+  context: TimeSeriesQueryContext;
+}) {
+  const { timeRange, datasourceStore, suggestedStepMs, variableState } = context;
+
+  const dependencies = plugin?.dependsOn ? plugin.dependsOn(definition.spec.plugin.spec, context) : {};
+  const variableDependencies = dependencies?.variables;
+
+  const filteredVariabledState = filterVariableStateMap(variableState, variableDependencies);
+  const variablesValueKey = getVariableValuesKey(filteredVariabledState);
+  const queryKey = [definition, timeRange, datasourceStore, suggestedStepMs, variablesValueKey] as const;
+
+  let waitToLoad = false;
+  if (variableDependencies) {
+    waitToLoad = variableDependencies.some((v) => variableState[v]?.loading);
+  }
+  const pluginEnabled = plugin !== undefined && !waitToLoad;
+  return {
+    queryKey,
+    pluginEnabled,
+  };
 }
 
 /**
@@ -30,20 +77,20 @@ export const useTimeSeriesQuery = (definition: TimeSeriesQueryDefinition, option
   const { data: plugin } = usePlugin('TimeSeriesQuery', definition.spec.plugin.kind);
   const context = useTimeSeriesQueryContext();
 
-  const key = [definition, context] as const;
+  const { pluginEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
+
   return useQuery(
-    key,
-    ({ queryKey }) => {
+    queryKey,
+    () => {
       // The 'enabled' option should prevent this from happening, but make TypeScript happy by checking
       if (plugin === undefined) {
         throw new Error('Expected plugin to be loaded');
       }
-      const [definition, context] = queryKey;
       // Keep options out of query key so we don't re-run queries because suggested step changes
       const ctx: TimeSeriesQueryContext = { ...context, suggestedStepMs: options?.suggestedStepMs };
       return plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx);
     },
-    { enabled: plugin !== undefined }
+    { enabled: pluginEnabled }
   );
 };
 
@@ -54,17 +101,28 @@ export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], o
   const { getPlugin } = usePluginRegistry();
   const context = useTimeSeriesQueryContext();
 
+  const pluginLoaderResponse = usePlugins(
+    'TimeSeriesQuery',
+    definitions.map((d) => ({ kind: d.spec.plugin.kind }))
+  );
+
   return useQueries({
-    queries: definitions.map((definition) => ({
-      queryKey: [definition, context] as const,
-      queryFn: async () => {
-        // Keep options out of query key so we don't re-run queries because suggested step changes
-        const ctx: TimeSeriesQueryContext = { ...context, suggestedStepMs: options?.suggestedStepMs };
-        const plugin = await getPlugin('TimeSeriesQuery', definition.spec.plugin.kind);
-        const data = await plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx);
-        return data;
-      },
-    })),
+    queries: definitions.map((definition, idx) => {
+      const resp = pluginLoaderResponse[idx];
+      const plugin = resp?.data;
+      const { pluginEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
+      return {
+        enabled: pluginEnabled,
+        queryKey: queryKey,
+        queryFn: async () => {
+          // Keep options out of query key so we don't re-run queries because suggested step changes
+          const ctx: TimeSeriesQueryContext = { ...context, suggestedStepMs: options?.suggestedStepMs };
+          const plugin = await getPlugin('TimeSeriesQuery', definition.spec.plugin.kind);
+          const data = await plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx);
+          return data;
+        },
+      };
+    }),
   });
 }
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
+import { parseTemplateVariables } from '../../model';
 import { getTimeSeriesData } from './get-time-series-data';
 import { PrometheusTimeSeriesQueryEditor } from './PrometheusTimeSeriesQueryEditor';
 import { PrometheusTimeSeriesQuerySpec } from './time-series-query-model';
@@ -26,4 +27,9 @@ export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeri
     query: '',
     datasource: undefined,
   }),
+  dependsOn: (spec) => {
+    return {
+      variables: parseTemplateVariables(spec.query),
+    };
+  },
 };


### PR DESCRIPTION
This is a follow up to the draft PR #719 

> This addresses the problem that TimeSeries queries are run every time any variable value state is changed. This does the following:
> 
> Only load TS queries when the variables it depends on are loaded or changed.
> This requires an additional hook into the plugin dependsOn to define which variables a TS query depends on

Video demo: https://www.loom.com/share/211f502fef3c44f5977888dff44d5292

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>