### PR TITLE
Add options editor tabs component

### DIFF
--- a/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.test.tsx
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.test.tsx
@@ -1,0 +1,152 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { screen, render, getAllByRole } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { OptionsEditorTabs, OptionsEditorTabsProps } from './OptionsEditorTabs';
+
+describe('OptionsEditorTabs', () => {
+  const renderTabs = (otherTabs?: OptionsEditorTabsProps['tabs']['other']) => {
+    render(
+      <OptionsEditorTabs
+        tabs={{
+          query: {
+            content: <div>Edit query configuration</div>,
+          },
+          settings: {
+            content: <div>Edit settings configuration</div>,
+          },
+          other: otherTabs,
+        }}
+      />
+    );
+  };
+
+  const renderCustomTabs = () => {
+    renderTabs([
+      {
+        id: 'tableCols',
+        label: 'Table columns',
+        content: <div>custom table column</div>,
+      },
+      {
+        id: 'tableOpts',
+        label: 'Table options',
+        content: <div>custom table options</div>,
+      },
+    ]);
+  };
+
+  it('renders all specified tabs in a tab list', () => {
+    renderTabs();
+
+    const tabList = screen.getByRole('tablist');
+    const tabs = getAllByRole(tabList, 'tab');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]).toHaveTextContent('Query');
+    expect(tabs[1]).toHaveTextContent('Settings');
+  });
+
+  it('defaults to selecting the first tab', () => {
+    renderTabs();
+
+    const activeTab = screen.getByRole('tab', {
+      selected: true,
+    });
+    expect(activeTab).toHaveTextContent('Query');
+
+    const activeTabPanel = screen.getByRole('tabpanel');
+    expect(activeTabPanel).toHaveTextContent('query configuration');
+  });
+
+  it('switches selected tab on click', () => {
+    renderTabs();
+    const vizTab = screen.getByRole('tab', { name: 'Settings' });
+    userEvent.click(vizTab);
+
+    const activeTab = screen.getByRole('tab', {
+      selected: true,
+    });
+    expect(activeTab).toBe(vizTab);
+
+    const activeTabPanel = screen.getByRole('tabpanel');
+    expect(activeTabPanel).toHaveTextContent('settings configuration');
+  });
+
+  it('switches selected tab on keyboard interactions', () => {
+    renderTabs();
+    const vizTab = screen.getByRole('tab', { name: 'Settings' });
+    userEvent.tab();
+    userEvent.keyboard('{arrowright}{space}');
+
+    const activeTab = screen.getByRole('tab', {
+      selected: true,
+    });
+    expect(activeTab).toBe(vizTab);
+
+    const activeTabPanel = screen.getByRole('tabpanel');
+    expect(activeTabPanel).toHaveTextContent('settings configuration');
+  });
+
+  it('renders custom tabs after common tabs', () => {
+    renderCustomTabs();
+
+    const tabList = screen.getByRole('tablist');
+    const tabs = getAllByRole(tabList, 'tab');
+    expect(tabs).toHaveLength(4);
+    expect(tabs[0]).toHaveTextContent('Query');
+    expect(tabs[1]).toHaveTextContent('Settings');
+    expect(tabs[2]).toHaveTextContent('Table column');
+    expect(tabs[3]).toHaveTextContent('Table options');
+  });
+
+  it('shows the correct content when selecting a custom tab', () => {
+    renderCustomTabs();
+
+    const tableColTab = screen.getByRole('tab', { name: 'Table columns' });
+    userEvent.click(tableColTab);
+
+    const activeTab = screen.getByRole('tab', {
+      selected: true,
+    });
+    expect(activeTab).toBe(tableColTab);
+
+    const activeTabPanel = screen.getByRole('tabpanel');
+    expect(activeTabPanel).toHaveTextContent('custom table column');
+  });
+
+  it('only renders common tabs that are specified', () => {
+    render(
+      <OptionsEditorTabs
+        tabs={{
+          settings: {
+            content: <div>settings are alone</div>,
+          },
+          other: [
+            {
+              id: 'custom',
+              label: 'Another tab',
+              content: <div>another tab content</div>,
+            },
+          ],
+        }}
+      />
+    );
+    const tabList = screen.getByRole('tablist');
+    const tabs = getAllByRole(tabList, 'tab');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]).toHaveTextContent('Settings');
+    expect(tabs[1]).toHaveTextContent('Another tab');
+  });
+});

--- a/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
@@ -1,0 +1,99 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Tab, TabProps, Tabs, TabsProps, Box } from '@mui/material';
+import { useState } from 'react';
+import { TabPanel } from './TabPanel';
+
+interface BaseTabConfig {
+  /**
+   * Content rendered when the tab is active.
+   */
+  content: React.ReactNode;
+}
+
+interface OtherTabConfig extends BaseTabConfig {
+  id: string;
+  label: TabProps['label'];
+}
+
+type CommonTabId = 'query' | 'settings';
+
+/**
+ * Common tabs that are frequently used in the options editor across multiple
+ * plugins. The label and display order of these tabs is not configurable to
+ * avoid user experience inconsistencies across plugins.
+ */
+type CommonTabs = { [property in CommonTabId]?: BaseTabConfig };
+
+/**
+ * Custom tabs specified for a given plugin. They are displayed after common
+ * tabs.
+ */
+type OtherTabs = {
+  other?: OtherTabConfig[];
+};
+
+export type OptionsEditorTabsProps = {
+  tabs: CommonTabs & OtherTabs;
+};
+
+// Configuration of the order and labeling for common tabs across plugins
+// to enforce a consistent UX.
+const TAB_CONFIG = [
+  { id: 'query', label: 'Query' },
+  { id: 'settings', label: 'Settings' },
+] as const;
+
+export const OptionsEditorTabs = ({ tabs }: OptionsEditorTabsProps) => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleChange: TabsProps['onChange'] = (_, newValue) => {
+    setActiveTab(newValue);
+  };
+
+  // Normalize the common tabs that are managed via constants in this file
+  // and custom tabs that bring their own config into a consistent shape for
+  // rendering.
+  const commonTabs = TAB_CONFIG.filter((tabConfig) => {
+    // Only include common tabs that are specified.
+    return !!tabs[tabConfig.id];
+  }).map((tabConfig) => {
+    return {
+      ...tabConfig,
+      ...tabs[tabConfig.id],
+    };
+  });
+  const otherTabs = tabs?.other || [];
+  const normalizedTabs = [...commonTabs, ...otherTabs];
+
+  // TODO: check on divider color
+  return (
+    <>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={activeTab} onChange={handleChange}>
+          {normalizedTabs.map(({ id, label }) => {
+            return <Tab key={id} label={label} />;
+          })}
+        </Tabs>
+      </Box>
+      {normalizedTabs.map(({ id, content }, i) => {
+        return (
+          <TabPanel key={id} value={activeTab} index={i}>
+            {content}
+          </TabPanel>
+        );
+      })}
+    </>
+  );
+};

--- a/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
@@ -81,9 +81,16 @@ export const OptionsEditorTabs = ({ tabs }: OptionsEditorTabsProps) => {
   return (
     <>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={activeTab} onChange={handleChange}>
-          {normalizedTabs.map(({ id, label }) => {
-            return <Tab key={id} label={label} />;
+        <Tabs value={activeTab} onChange={handleChange} aria-label="Panel configuration tabs">
+          {normalizedTabs.map(({ id, label }, i) => {
+            return (
+              <Tab
+                key={id}
+                label={label}
+                id={`options-editor-tab-${i}`}
+                aria-controls={`options-editor-tabpanel-${i}`}
+              />
+            );
           })}
         </Tabs>
       </Box>

--- a/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
@@ -77,10 +77,9 @@ export const OptionsEditorTabs = ({ tabs }: OptionsEditorTabsProps) => {
   const otherTabs = tabs?.other || [];
   const normalizedTabs = [...commonTabs, ...otherTabs];
 
-  // TODO: check on divider color
   return (
     <>
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'grey.300' }}>
         <Tabs value={activeTab} onChange={handleChange} aria-label="Panel configuration tabs">
           {normalizedTabs.map(({ id, label }, i) => {
             return (

--- a/ui/panels-plugin/src/components/OptionsEditorTabs/TabPanel.tsx
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/TabPanel.tsx
@@ -1,0 +1,38 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box } from '@mui/material';
+
+interface TabPanelProps {
+  children: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+export function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  const isActive = value === index;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={!isActive}
+      id={`options-editor-tabpanel-${index}`}
+      aria-labelledby={`options-editor-tab-${index}`}
+      {...other}
+    >
+      {isActive && <Box mt={2}>{children}</Box>}
+    </div>
+  );
+}

--- a/ui/panels-plugin/src/components/OptionsEditorTabs/index.ts
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './OptionsEditorTabs';

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -32,7 +32,6 @@ import ChevronDown from 'mdi-material-ui/ChevronDown';
 import ChevronUp from 'mdi-material-ui/ChevronUp';
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { OptionsEditorProps, TimeSeriesQueryEditor, usePlugin } from '@perses-dev/plugin-system';
-import { OptionsEditorTabs } from '../../components/OptionsEditorTabs';
 import { TimeSeriesChartOptions, DEFAULT_LEGEND, LEGEND_POSITIONS, LegendPosition } from './time-series-chart-model';
 
 const DEFAULT_QUERY_PLUGIN_TYPE = 'TimeSeriesQuery';
@@ -121,78 +120,66 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
   };
 
   return (
-    <OptionsEditorTabs
-      tabs={{
-        query: {
-          content: (
-            <Stack spacing={2}>
-              <Button variant="contained" startIcon={<AddIcon />} sx={{ marginLeft: 'auto' }} onClick={handleQueryAdd}>
-                Add Query
-              </Button>
-              {queries.map((query: TimeSeriesQueryDefinition, i: number) => (
-                <Stack key={i} spacing={1}>
-                  <Stack direction="row" alignItems="center" borderBottom={1} borderColor="grey.300">
-                    <IconButton size="small" onClick={() => handleQueryCollapseExpand(i)}>
-                      {queriesCollapsed[i] ? <ChevronUp /> : <ChevronDown />}
-                    </IconButton>
-                    <Typography variant="overline" component="h4">
-                      Query {i + 1}
-                    </Typography>
-                    <IconButton
-                      size="small"
-                      // Use `visibility` to ensure that the row has the same height when delete button is visible or not visible
-                      sx={{ marginLeft: 'auto', visibility: `${hasMoreThanOneQuery ? 'visible' : 'hidden'}` }}
-                      onClick={() => handleQueryDelete(i)}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </Stack>
-                  {!queriesCollapsed[i] && (
-                    <TimeSeriesQueryEditor value={query} onChange={(next) => handleQueryChange(i, next)} />
-                  )}
-                </Stack>
-              ))}
-            </Stack>
-          ),
-        },
-        settings: {
-          content: (
-            <Stack spacing={1}>
-              <Typography variant="overline" component="h4">
-                Legend
-              </Typography>
-              <FormControlLabel
-                label="Show"
-                control={
-                  <Switch
-                    checked={value.legend !== undefined}
-                    onChange={(e) => {
-                      handleLegendShowChange(e.target.checked);
-                    }}
-                  />
-                }
-              />
-              <FormControl>
-                <InputLabel id="legend-position-select-label">Position</InputLabel>
-                <Select
-                  sx={{ maxWidth: 100 }}
-                  labelId="legend-position-select-label"
-                  id="legend-position-select"
-                  label="Position"
-                  value={value.legend && value.legend.position ? value.legend.position : DEFAULT_LEGEND.position}
-                  onChange={handleLegendPositionChange}
-                >
-                  {LEGEND_POSITIONS.map((position) => (
-                    <MenuItem key={position} value={position}>
-                      {position}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Stack>
-          ),
-        },
-      }}
-    />
+    <Stack spacing={2}>
+      <Button variant="contained" startIcon={<AddIcon />} sx={{ marginLeft: 'auto' }} onClick={handleQueryAdd}>
+        Add Query
+      </Button>
+      {queries.map((query: TimeSeriesQueryDefinition, i: number) => (
+        <Stack key={i} spacing={1}>
+          <Stack direction="row" alignItems="center" borderBottom={1} borderColor="grey.300">
+            <IconButton size="small" onClick={() => handleQueryCollapseExpand(i)}>
+              {queriesCollapsed[i] ? <ChevronUp /> : <ChevronDown />}
+            </IconButton>
+            <Typography variant="overline" component="h4">
+              Query {i + 1}
+            </Typography>
+            <IconButton
+              size="small"
+              // Use `visibility` to ensure that the row has the same height when delete button is visible or not visible
+              sx={{ marginLeft: 'auto', visibility: `${hasMoreThanOneQuery ? 'visible' : 'hidden'}` }}
+              onClick={() => handleQueryDelete(i)}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Stack>
+          {!queriesCollapsed[i] && (
+            <TimeSeriesQueryEditor value={query} onChange={(next) => handleQueryChange(i, next)} />
+          )}
+        </Stack>
+      ))}
+      <Stack spacing={1}>
+        <Typography variant="overline" component="h4">
+          Legend
+        </Typography>
+        <FormControlLabel
+          label="Show"
+          control={
+            <Switch
+              checked={value.legend !== undefined}
+              onChange={(e) => {
+                handleLegendShowChange(e.target.checked);
+              }}
+            />
+          }
+        />
+        <FormControl>
+          <InputLabel id="legend-position-select-label">Position</InputLabel>
+          <Select
+            sx={{ maxWidth: 100 }}
+            labelId="legend-position-select-label"
+            id="legend-position-select"
+            label="Position"
+            value={value.legend && value.legend.position ? value.legend.position : DEFAULT_LEGEND.position}
+            onChange={handleLegendPositionChange}
+          >
+            {LEGEND_POSITIONS.map((position) => (
+              <MenuItem key={position} value={position}>
+                {position}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Stack>
+    </Stack>
   );
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -32,6 +32,7 @@ import ChevronDown from 'mdi-material-ui/ChevronDown';
 import ChevronUp from 'mdi-material-ui/ChevronUp';
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { OptionsEditorProps, TimeSeriesQueryEditor, usePlugin } from '@perses-dev/plugin-system';
+import { OptionsEditorTabs } from '../../components/OptionsEditorTabs';
 import { TimeSeriesChartOptions, DEFAULT_LEGEND, LEGEND_POSITIONS, LegendPosition } from './time-series-chart-model';
 
 const DEFAULT_QUERY_PLUGIN_TYPE = 'TimeSeriesQuery';
@@ -120,66 +121,78 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
   };
 
   return (
-    <Stack spacing={2}>
-      <Button variant="contained" startIcon={<AddIcon />} sx={{ marginLeft: 'auto' }} onClick={handleQueryAdd}>
-        Add Query
-      </Button>
-      {queries.map((query: TimeSeriesQueryDefinition, i: number) => (
-        <Stack key={i} spacing={1}>
-          <Stack direction="row" alignItems="center" borderBottom={1} borderColor="grey.300">
-            <IconButton size="small" onClick={() => handleQueryCollapseExpand(i)}>
-              {queriesCollapsed[i] ? <ChevronUp /> : <ChevronDown />}
-            </IconButton>
-            <Typography variant="overline" component="h4">
-              Query {i + 1}
-            </Typography>
-            <IconButton
-              size="small"
-              // Use `visibility` to ensure that the row has the same height when delete button is visible or not visible
-              sx={{ marginLeft: 'auto', visibility: `${hasMoreThanOneQuery ? 'visible' : 'hidden'}` }}
-              onClick={() => handleQueryDelete(i)}
-            >
-              <DeleteIcon />
-            </IconButton>
-          </Stack>
-          {!queriesCollapsed[i] && (
-            <TimeSeriesQueryEditor value={query} onChange={(next) => handleQueryChange(i, next)} />
-          )}
-        </Stack>
-      ))}
-      <Stack spacing={1}>
-        <Typography variant="overline" component="h4">
-          Legend
-        </Typography>
-        <FormControlLabel
-          label="Show"
-          control={
-            <Switch
-              checked={value.legend !== undefined}
-              onChange={(e) => {
-                handleLegendShowChange(e.target.checked);
-              }}
-            />
-          }
-        />
-        <FormControl>
-          <InputLabel id="legend-position-select-label">Position</InputLabel>
-          <Select
-            sx={{ maxWidth: 100 }}
-            labelId="legend-position-select-label"
-            id="legend-position-select"
-            label="Position"
-            value={value.legend && value.legend.position ? value.legend.position : DEFAULT_LEGEND.position}
-            onChange={handleLegendPositionChange}
-          >
-            {LEGEND_POSITIONS.map((position) => (
-              <MenuItem key={position} value={position}>
-                {position}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Stack>
-    </Stack>
+    <OptionsEditorTabs
+      tabs={{
+        query: {
+          content: (
+            <Stack spacing={2}>
+              <Button variant="contained" startIcon={<AddIcon />} sx={{ marginLeft: 'auto' }} onClick={handleQueryAdd}>
+                Add Query
+              </Button>
+              {queries.map((query: TimeSeriesQueryDefinition, i: number) => (
+                <Stack key={i} spacing={1}>
+                  <Stack direction="row" alignItems="center" borderBottom={1} borderColor="grey.300">
+                    <IconButton size="small" onClick={() => handleQueryCollapseExpand(i)}>
+                      {queriesCollapsed[i] ? <ChevronUp /> : <ChevronDown />}
+                    </IconButton>
+                    <Typography variant="overline" component="h4">
+                      Query {i + 1}
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      // Use `visibility` to ensure that the row has the same height when delete button is visible or not visible
+                      sx={{ marginLeft: 'auto', visibility: `${hasMoreThanOneQuery ? 'visible' : 'hidden'}` }}
+                      onClick={() => handleQueryDelete(i)}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Stack>
+                  {!queriesCollapsed[i] && (
+                    <TimeSeriesQueryEditor value={query} onChange={(next) => handleQueryChange(i, next)} />
+                  )}
+                </Stack>
+              ))}
+            </Stack>
+          ),
+        },
+        settings: {
+          content: (
+            <Stack spacing={1}>
+              <Typography variant="overline" component="h4">
+                Legend
+              </Typography>
+              <FormControlLabel
+                label="Show"
+                control={
+                  <Switch
+                    checked={value.legend !== undefined}
+                    onChange={(e) => {
+                      handleLegendShowChange(e.target.checked);
+                    }}
+                  />
+                }
+              />
+              <FormControl>
+                <InputLabel id="legend-position-select-label">Position</InputLabel>
+                <Select
+                  sx={{ maxWidth: 100 }}
+                  labelId="legend-position-select-label"
+                  id="legend-position-select"
+                  label="Position"
+                  value={value.legend && value.legend.position ? value.legend.position : DEFAULT_LEGEND.position}
+                  onChange={handleLegendPositionChange}
+                >
+                  {LEGEND_POSITIONS.map((position) => (
+                    <MenuItem key={position} value={position}>
+                      {position}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+          ),
+        },
+      }}
+    />
   );
 }


### PR DESCRIPTION
This component will be used across a variety of plugin options to organize configuration like queries and settings into tabs.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Notes for reviewers

- I'm temporarily including the changes to the time series options in this PR, but I think it should probably be done in a quick follow-up to avoid some merge issues, since many people are touching that file.
  - Similarly, I am intentionally not fixing how the content inside the tabs looks to more closely match the mocks. I think that should be done in a separate task.
- The tab configuration mixes two types based on a zoom conversation with Steven and Mohit about the future of the tabs. This enables us to both manage consistency where it makes sense while still enabling customization.
  - **common** tabs: These are tabs we expect to see across many plugins and would like them to have consistency (e.g. Query, Settings). The ordering and label of these tabs is managed in a constant for consistency. You can only specify the content when the tab is selected. 
  - **custom** tabs: These are tabs that tend to be specific to a single plugin (e.g. Table Columns). You must specify the label, order, and content for these. 

## Screenshots

<img width="900" alt="image" src="https://user-images.githubusercontent.com/396962/200089403-01a501b1-217a-4668-a57b-5d39a942e970.png">

<img width="900" alt="image" src="https://user-images.githubusercontent.com/396962/200089442-d80f7ce2-566f-483e-b38a-d87c8aa4e5fd.png">



