### PR TITLE
Add common json tab to options editor tabs

### DIFF
--- a/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.test.tsx
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.test.tsx
@@ -27,6 +27,9 @@ describe('OptionsEditorTabs', () => {
           settings: {
             content: <div>Edit settings configuration</div>,
           },
+          json: {
+            content: <div>JSON editor</div>,
+          },
           other: otherTabs,
         }}
       />
@@ -53,9 +56,10 @@ describe('OptionsEditorTabs', () => {
 
     const tabList = screen.getByRole('tablist');
     const tabs = getAllByRole(tabList, 'tab');
-    expect(tabs).toHaveLength(2);
+    expect(tabs).toHaveLength(3);
     expect(tabs[0]).toHaveTextContent('Query');
     expect(tabs[1]).toHaveTextContent('Settings');
+    expect(tabs[2]).toHaveTextContent('JSON');
   });
 
   it('defaults to selecting the first tab', () => {
@@ -72,16 +76,16 @@ describe('OptionsEditorTabs', () => {
 
   it('switches selected tab on click', () => {
     renderTabs();
-    const vizTab = screen.getByRole('tab', { name: 'Settings' });
-    userEvent.click(vizTab);
+    const jsonTab = screen.getByRole('tab', { name: 'JSON' });
+    userEvent.click(jsonTab);
 
     const activeTab = screen.getByRole('tab', {
       selected: true,
     });
-    expect(activeTab).toBe(vizTab);
+    expect(activeTab).toBe(jsonTab);
 
     const activeTabPanel = screen.getByRole('tabpanel');
-    expect(activeTabPanel).toHaveTextContent('settings configuration');
+    expect(activeTabPanel).toHaveTextContent('JSON editor');
   });
 
   it('switches selected tab on keyboard interactions', () => {
@@ -99,16 +103,17 @@ describe('OptionsEditorTabs', () => {
     expect(activeTabPanel).toHaveTextContent('settings configuration');
   });
 
-  it('renders custom tabs after common tabs', () => {
+  it('renders custom tabs between visual tabs and json editor', () => {
     renderCustomTabs();
 
     const tabList = screen.getByRole('tablist');
     const tabs = getAllByRole(tabList, 'tab');
-    expect(tabs).toHaveLength(4);
+    expect(tabs).toHaveLength(5);
     expect(tabs[0]).toHaveTextContent('Query');
     expect(tabs[1]).toHaveTextContent('Settings');
     expect(tabs[2]).toHaveTextContent('Table column');
     expect(tabs[3]).toHaveTextContent('Table options');
+    expect(tabs[4]).toHaveTextContent('JSON');
   });
 
   it('shows the correct content when selecting a custom tab', () => {
@@ -133,6 +138,9 @@ describe('OptionsEditorTabs', () => {
           settings: {
             content: <div>settings are alone</div>,
           },
+          json: {
+            content: <div>JSON is at the end</div>,
+          },
           other: [
             {
               id: 'custom',
@@ -145,8 +153,9 @@ describe('OptionsEditorTabs', () => {
     );
     const tabList = screen.getByRole('tablist');
     const tabs = getAllByRole(tabList, 'tab');
-    expect(tabs).toHaveLength(2);
+    expect(tabs).toHaveLength(3);
     expect(tabs[0]).toHaveTextContent('Settings');
     expect(tabs[1]).toHaveTextContent('Another tab');
+    expect(tabs[2]).toHaveTextContent('JSON');
   });
 });

--- a/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
+++ b/ui/panels-plugin/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
@@ -27,7 +27,7 @@ interface OtherTabConfig extends BaseTabConfig {
   label: TabProps['label'];
 }
 
-type CommonTabId = 'query' | 'settings';
+type CommonTabId = 'query' | 'settings' | 'json';
 
 /**
  * Common tabs that are frequently used in the options editor across multiple
@@ -48,11 +48,16 @@ export type OptionsEditorTabsProps = {
   tabs: CommonTabs & OtherTabs;
 };
 
-// Configuration of the order and labeling for common tabs across plugins
-// to enforce a consistent UX.
+// Configuration of the order and labeling for tabs across plugins to enforce a
+// consistent UX.
 const TAB_CONFIG = [
   { id: 'query', label: 'Query' },
   { id: 'settings', label: 'Settings' },
+
+  // Custom tabs go between the visual common tabs and the raw JSON editor.
+  'other',
+
+  { id: 'json', label: 'JSON' },
 ] as const;
 
 export const OptionsEditorTabs = ({ tabs }: OptionsEditorTabsProps) => {
@@ -65,17 +70,27 @@ export const OptionsEditorTabs = ({ tabs }: OptionsEditorTabsProps) => {
   // Normalize the common tabs that are managed via constants in this file
   // and custom tabs that bring their own config into a consistent shape for
   // rendering.
-  const commonTabs = TAB_CONFIG.filter((tabConfig) => {
-    // Only include common tabs that are specified.
-    return !!tabs[tabConfig.id];
-  }).map((tabConfig) => {
-    return {
-      ...tabConfig,
-      ...tabs[tabConfig.id],
-    };
-  });
-  const otherTabs = tabs?.other || [];
-  const normalizedTabs = [...commonTabs, ...otherTabs];
+  const normalizedTabs = TAB_CONFIG.reduce((combinedTabs, tabConfig) => {
+    // Custom tabs
+    if (tabConfig === 'other') {
+      const otherTabs = tabs?.other || [];
+      return [...combinedTabs, ...otherTabs];
+    }
+
+    // Common tabs
+    const commonTab = tabs[tabConfig.id];
+    if (commonTab) {
+      return [
+        ...combinedTabs,
+        {
+          ...tabConfig,
+          ...commonTab,
+        },
+      ];
+    }
+
+    return combinedTabs;
+  }, [] as OtherTabConfig[]);
 
   return (
     <>


### PR DESCRIPTION
This common tab will be used to display a JSON editor for editing raw content. It will always be displayed last.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>