### PR TITLE
Update VariablePlugin dependsOn API

### DIFF
--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -57,12 +57,17 @@ function ListVariable({ name }: TemplateVariableProps) {
   const { data: variablePlugin } = usePlugin('Variable', definition.spec.plugin.kind);
   const { setVariableValue, setVariableLoading, setVariableOptions } = useTemplateVariableActions();
   const datasourceStore = useDatasourceStore();
+  const allVariables = useTemplateVariableValues();
+  const { timeRange } = useTimeRange();
+
+  const variablePluginCtx = { timeRange, datasourceStore, variables: allVariables };
 
   const spec = definition.spec.plugin.spec;
 
   let dependsOnVariables: string[] | undefined;
   if (variablePlugin?.dependsOn) {
-    dependsOnVariables = variablePlugin.dependsOn(spec);
+    const dependencies = variablePlugin.dependsOn(spec, variablePluginCtx);
+    dependsOnVariables = dependencies.variables;
   }
 
   const variables = useTemplateVariableValues(dependsOnVariables);
@@ -76,7 +81,6 @@ function ListVariable({ name }: TemplateVariableProps) {
   }
 
   const variablesValueKey = getVariableValuesKey(variables);
-  const { timeRange } = useTimeRange();
 
   const variablesOptionsQuery = useQuery(
     [name, definition, variablesValueKey, timeRange],

--- a/ui/plugin-system/src/model/variables.ts
+++ b/ui/plugin-system/src/model/variables.ts
@@ -24,22 +24,23 @@ export interface GetVariableOptionsContext {
 }
 
 /**
+ * An object containing all the dependencies of a VariablePlugin.
+ */
+type VariablePluginDependencies = {
+  /**
+   * Returns a list of variables name this time series query depends on.
+   */
+  variables?: string[];
+};
+
+/**
  * Plugin for handling custom VariableDefinitions.
  */
 export interface VariablePlugin<Spec = UnknownSpec> extends Plugin<Spec> {
-  getVariableOptions: GetVariableOptions<Spec>;
+  getVariableOptions: (definition: Spec, ctx: GetVariableOptionsContext) => Promise<{ data: VariableOption[] }>;
 
   /**
    * Returns a list of variables name this variable depends on. Used to optimize fetching
    */
-  dependsOn?: (definition: Spec) => string[];
+  dependsOn?: (definition: Spec, ctx: GetVariableOptionsContext) => VariablePluginDependencies;
 }
-
-/**
- * Plugin hook responsible for getting the options of a custom variable
- * definition.
- */
-export type GetVariableOptions<Spec> = (
-  definition: Spec,
-  ctx: GetVariableOptionsContext
-) => Promise<{ data: VariableOption[] }>;

--- a/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
@@ -78,7 +78,9 @@ export const PrometheusLabelNamesVariable: VariablePlugin<PrometheusLabelNamesVa
       data: stringArrayToVariableOptions(options),
     };
   },
-  dependsOn: () => [],
+  dependsOn: () => {
+    return { variables: [] };
+  },
   OptionsEditorComponent: PrometheusLabelNamesVariableEditor,
   createInitialOptions: () => ({}),
 };
@@ -103,7 +105,7 @@ export const PrometheusLabelValuesVariable: VariablePlugin<PrometheusLabelValues
     };
   },
   dependsOn: (spec) => {
-    return spec.matchers?.map((m) => parseTemplateVariables(m)).flat() || [];
+    return { variables: spec.matchers?.map((m) => parseTemplateVariables(m)).flat() || [] };
   },
   OptionsEditorComponent: PrometheusLabelValuesVariableEditor,
   createInitialOptions: () => ({ label_name: '' }),

--- a/ui/prometheus-plugin/src/plugins/variable.tsx
+++ b/ui/prometheus-plugin/src/plugins/variable.tsx
@@ -63,7 +63,9 @@ export const StaticListVariable: VariablePlugin<StaticListVariableOptions> = {
       data: values,
     };
   },
-  dependsOn: () => [],
+  dependsOn: () => {
+    return { variables: [] };
+  },
   OptionsEditorComponent: StaticListVariableOptionEditor,
   createInitialOptions: () => ({ values: [] }),
 };


### PR DESCRIPTION
This updates the `dependsOn` API in the VariablePlugin to be consistent with TimeSeriesQuery plugin (see #732 for more info)