### PR TITLE
Update setDashboard to also set metadata

### DIFF
--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -77,11 +77,7 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
       aria-describedby={descriptionTooltipId}
       disableTypography
       title={
-        <Typography
-          id={titleElementId}
-          variant="subtitle1"
-          sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
-        >
+        <Typography id={titleElementId} variant="subtitle1">
           {title}
         </Typography>
       }
@@ -90,6 +86,11 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
         (theme) => ({
           padding: theme.spacing(1),
           borderBottom: `solid 1px ${theme.palette.divider}`,
+          '.MuiCardHeader-content': {
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          },
         }),
         sx
       )}

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -95,8 +95,9 @@ function initStore(props: DashboardProviderProps) {
           defaultTimeRange: { pastDuration: duration },
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
-          setDashboard: ({ spec: { panels, layouts } }) => {
+          setDashboard: ({ metadata, spec: { panels, layouts } }) => {
             set((state) => {
+              state.metadata = metadata;
               const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
               state.panels = panels;
               state.panelGroups = panelGroups;


### PR DESCRIPTION
Right now `setDashboard` does not actually reset metadata, so there is no way to edit dashboard name/version/others fields.

This also fixes an issue where the panel icons are missing if panel is too small