### PR TITLE
Always show the edit icons in edit mode (instead of on hover)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BREAKINGCHANGE] TimeRangeProvider props changed, `paramsEnabled` added #735
 - [BREAKINGCHANGE] Variable display configuration has been aligned with panel display configuration. `display.label`
   becomes `display.name` #734
+- [ENHANCEMENT] User always sees edit icons in edit mode (instead of only seeing on hover) #748
 
 ## 0.14.0 / 2022-11-02
 

--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -11,11 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState } from 'react';
 import { Box, IconButton, Stack, Typography } from '@mui/material';
 import ExpandedIcon from 'mdi-material-ui/ChevronUp';
 import CollapsedIcon from 'mdi-material-ui/ChevronDown';
-import AddIcon from 'mdi-material-ui/Plus';
+import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
 import ArrowUpIcon from 'mdi-material-ui/ArrowUp';
 import ArrowDownIcon from 'mdi-material-ui/ArrowDown';
@@ -38,7 +37,6 @@ export interface GridTitleProps {
 export function GridTitle(props: GridTitleProps) {
   const { panelGroupId, title, collapse } = props;
 
-  const [isHovered, setIsHovered] = useState(false);
   const { openAddPanel, openEditPanelGroup, moveUp, moveDown } = usePanelGroupActions(panelGroupId);
   const { openDeletePanelGroupDialog } = useDeletePanelGroupDialog();
   const { isEditMode } = useEditMode();
@@ -58,8 +56,6 @@ export function GridTitle(props: GridTitleProps) {
         padding: (theme) => theme.spacing(1),
         backgroundColor: (theme) => theme.palette.background.default,
       }}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       {collapse ? (
         <>
@@ -67,21 +63,21 @@ export function GridTitle(props: GridTitleProps) {
             {collapse.isOpen ? <ExpandedIcon /> : <CollapsedIcon />}
           </IconButton>
           {text}
-          {isEditMode && isHovered && (
+          {isEditMode && (
             <Stack direction="row" sx={{ marginLeft: 'auto' }}>
-              <IconButton aria-label="add panel to group" onClick={openAddPanel}>
-                <AddIcon />
+              <IconButton aria-label={`add panel to group ${title}`} onClick={openAddPanel}>
+                <AddPanelIcon />
               </IconButton>
-              <IconButton aria-label="edit group" onClick={openEditPanelGroup}>
+              <IconButton aria-label={`edit group ${title}`} onClick={openEditPanelGroup}>
                 <PencilIcon />
               </IconButton>
-              <IconButton aria-label="delete group" onClick={() => openDeletePanelGroupDialog(panelGroupId)}>
+              <IconButton aria-label={`delete group ${title}`} onClick={() => openDeletePanelGroupDialog(panelGroupId)}>
                 <DeleteIcon />
               </IconButton>
-              <IconButton aria-label="move group down" disabled={moveDown === undefined} onClick={moveDown}>
+              <IconButton aria-label={`move group ${title} down`} disabled={moveDown === undefined} onClick={moveDown}>
                 <ArrowDownIcon />
               </IconButton>
-              <IconButton aria-label="move group up" disabled={moveUp === undefined} onClick={moveUp}>
+              <IconButton aria-label={`move group ${title} up`} disabled={moveUp === undefined} onClick={moveUp}>
                 <ArrowUpIcon />
               </IconButton>
             </Stack>

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -40,13 +40,13 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
     // If there are edit handlers, always just show the edit buttons
     action = (
       <Stack direction="row" alignItems="center" spacing={0.5}>
-        <HeaderIconButton aria-label="edit panel" size="small" onClick={editHandlers.onEditPanelClick}>
+        <HeaderIconButton aria-label={`edit panel ${title}`} size="small" onClick={editHandlers.onEditPanelClick}>
           <PencilIcon />
         </HeaderIconButton>
-        <HeaderIconButton aria-label="delete panel" size="small" onClick={editHandlers.onDeletePanelClick}>
+        <HeaderIconButton aria-label={`delete panel ${title}`} size="small" onClick={editHandlers.onDeletePanelClick}>
           <DeleteIcon />
         </HeaderIconButton>
-        <HeaderIconButton aria-label="drag handle" size="small">
+        <HeaderIconButton aria-label={`move panel ${title}`} size="small">
           <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
         </HeaderIconButton>
       </Stack>

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -74,7 +74,15 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
       aria-describedby={descriptionTooltipId}
       disableTypography
       title={
-        <Typography id={titleElementId} variant="subtitle1">
+        <Typography
+          id={titleElementId}
+          variant="subtitle1"
+          sx={{
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
           {title}
         </Typography>
       }
@@ -84,9 +92,7 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
           padding: theme.spacing(1),
           borderBottom: `solid 1px ${theme.palette.divider}`,
           '.MuiCardHeader-content': {
-            whiteSpace: 'nowrap',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
           },
         }),
         sx

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -35,38 +35,35 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
   const titleElementId = `${id}-title`;
   const descriptionTooltipId = `${id}-description`;
 
-  // Don't show any actions unless panel is hovered
   let action: CardHeaderProps['action'] = undefined;
-  if (isHovered) {
-    if (editHandlers !== undefined) {
-      // If there are edit handlers, always just show the edit buttons
-      action = (
-        <Stack direction="row" alignItems="center" spacing={0.5}>
-          <HeaderIconButton aria-label="edit panel" size="small" onClick={editHandlers.onEditPanelClick}>
-            <PencilIcon />
-          </HeaderIconButton>
-          <HeaderIconButton aria-label="delete panel" size="small" onClick={editHandlers.onDeletePanelClick}>
-            <DeleteIcon />
-          </HeaderIconButton>
-          <HeaderIconButton aria-label="drag handle" size="small">
-            <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
-          </HeaderIconButton>
-        </Stack>
-      );
-    } else if (description !== undefined) {
-      // If there aren't edit handlers and we have a description, show a button with a tooltip for the panel description
-      action = (
-        <InfoTooltip id={descriptionTooltipId} description={description} placement={TooltipPlacement.Bottom}>
-          <HeaderIconButton aria-label="Panel Description">
-            <InformationOutlineIcon
-              aria-describedby="info-tooltip"
-              aria-hidden={false}
-              sx={{ color: (theme) => theme.palette.grey[700] }}
-            />
-          </HeaderIconButton>
-        </InfoTooltip>
-      );
-    }
+  if (editHandlers !== undefined) {
+    // If there are edit handlers, always just show the edit buttons
+    action = (
+      <Stack direction="row" alignItems="center" spacing={0.5}>
+        <HeaderIconButton aria-label="edit panel" size="small" onClick={editHandlers.onEditPanelClick}>
+          <PencilIcon />
+        </HeaderIconButton>
+        <HeaderIconButton aria-label="delete panel" size="small" onClick={editHandlers.onDeletePanelClick}>
+          <DeleteIcon />
+        </HeaderIconButton>
+        <HeaderIconButton aria-label="drag handle" size="small">
+          <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
+        </HeaderIconButton>
+      </Stack>
+    );
+  } else if (description !== undefined && isHovered) {
+    // If there aren't edit handlers and we have a description, show a button with a tooltip for the panel description
+    action = (
+      <InfoTooltip id={descriptionTooltipId} description={description} placement={TooltipPlacement.Bottom}>
+        <HeaderIconButton aria-label="Panel Description">
+          <InformationOutlineIcon
+            aria-describedby="info-tooltip"
+            aria-hidden={false}
+            sx={{ color: (theme) => theme.palette.grey[700] }}
+          />
+        </HeaderIconButton>
+      </InfoTooltip>
+    );
   }
 
   return (

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -31,37 +31,35 @@ describe('Panel Groups', () => {
   };
   it('should delete panel', () => {
     renderDashboard();
-    const panel = screen.getByText('CPU');
-    userEvent.hover(panel);
-    const deletePanelButton = screen.getByLabelText('delete panel');
+    const panelTitle = 'CPU';
+    const deletePanelButton = screen.getByLabelText(`delete panel ${panelTitle}`);
     userEvent.click(deletePanelButton);
     screen.getByText('Delete Panel');
     const deleteButton = screen.getByText('Delete');
     userEvent.click(deleteButton);
 
     // The panel should disappear
-    const deletedPanel = screen.queryByText('CPU');
+    const deletedPanel = screen.queryByText(panelTitle);
     expect(deletedPanel).not.toBeInTheDocument();
   });
 
   it('should only delete panel from panel group if panel is not referenced more than once', () => {
     renderDashboard();
 
-    const panels = screen.getAllByText('Disk I/O Utilization');
+    const panelTitle = 'Disk I/O Utilization';
+    const panels = screen.getAllByText(panelTitle);
     expect(panels).toHaveLength(2);
 
-    const panel = panels[0];
-    if (panel === undefined) throw new Error('Missing panel');
+    const deletePanelButton = screen.getAllByLabelText(`delete panel ${panelTitle}`)[0];
+    if (deletePanelButton === undefined) throw new Error('Missing delete button');
 
-    userEvent.hover(panel);
-    const deletePanelButton = screen.getByLabelText('delete panel');
     userEvent.click(deletePanelButton);
     screen.getByText('Delete Panel');
     const deleteButton = screen.getByText('Delete');
     userEvent.click(deleteButton);
 
     // The deleted panel should still be on screen in the other group
-    const deletedPanel = screen.queryByText('Disk I/O Utilization');
+    const deletedPanel = screen.queryByText(panelTitle);
     expect(deletedPanel).toBeInTheDocument();
   });
 
@@ -69,16 +67,13 @@ describe('Panel Groups', () => {
     renderDashboard();
 
     // should move panel down
-    const group1 = screen.getByText('CPU Stats');
-    userEvent.hover(group1);
-    const moveGroupDownBtn = screen.getByLabelText('move group down');
+    const groupTitle1 = 'CPU Stats';
+    const moveGroupDownBtn = screen.getByLabelText(`move group ${groupTitle1} down`);
     userEvent.click(moveGroupDownBtn);
-    userEvent.unhover(moveGroupDownBtn);
 
     // should move panel up
-    const group2 = screen.getByText('Disk Stats');
-    userEvent.hover(group2);
-    const moveGroupUpBtn = screen.getByLabelText('move group up');
+    const groupTitle2 = 'Disk Stats';
+    const moveGroupUpBtn = screen.getByLabelText(`move group ${groupTitle2} up`);
     userEvent.click(moveGroupUpBtn);
 
     /* TODO: Figure out how to test this visually without coupling to the store
@@ -91,16 +86,15 @@ describe('Panel Groups', () => {
 
   it('should delete a panel group', () => {
     renderDashboard();
-    const group = screen.getByText('CPU Stats');
-    userEvent.hover(group);
-    const deleteGroupIcon = screen.getByLabelText('delete group');
+    const groupTitle = 'CPU Stats';
+    const deleteGroupIcon = screen.getByLabelText(`delete group ${groupTitle}`);
     userEvent.click(deleteGroupIcon);
     screen.getByText('Delete Panel Group');
     const deleteButton = screen.getByText('Delete');
     userEvent.click(deleteButton);
 
     // should remove group
-    const deletedGroup = screen.queryByText('CPU Stats');
+    const deletedGroup = screen.queryByText(groupTitle);
     expect(deletedGroup).not.toBeInTheDocument();
 
     // CPU panel should be completely gone since it wasn't in any other group


### PR DESCRIPTION
When the user enters edit mode, we want to always show the panel edit icons, instead of only showing them when the user is hovering over the panel. 

In view mode, nothing changes (the user only sees the description icon when they hover over a panel). 

# Edit mode
<img width="1512" alt="Screen Shot 2022-11-09 at 8 10 52 AM" src="https://user-images.githubusercontent.com/2584129/200883297-4623d733-d1ee-4311-86bd-9f1f16d5f85d.png">

# View mode
<img width="1512" alt="Screen Shot 2022-11-09 at 8 11 01 AM" src="https://user-images.githubusercontent.com/2584129/200883445-b7b49fe3-147c-42b2-8d14-378f8a012dec.png">
<img width="1512" alt="Screen Shot 2022-11-09 at 8 11 07 AM" src="https://user-images.githubusercontent.com/2584129/200883474-848a7596-f46d-4ed9-9897-c4939321b500.png">