### PR TITLE
Wrap browser navigation in act

### DIFF
--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -14,7 +14,7 @@
 import { generatePath } from 'react-router';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
-import { screen } from '@testing-library/react';
+import { screen, act } from '@testing-library/react';
 import { renderWithContext } from '../../test';
 import testDashboard from '../../test/testDashboard';
 import { DashboardProvider, DashboardStoreProps, TimeRangeProvider } from '../../context';
@@ -70,7 +70,9 @@ describe('TimeRangeControls', () => {
     expect(history.location.search).toEqual('?start=12h');
 
     // back button should return to first option selected
-    history.back();
+    act(() => {
+      history.back();
+    });
     expect(history.location.search).toEqual('?start=5m');
   });
 


### PR DESCRIPTION
This fixes a test unnecessarily emitting a console error like this: "Warning: An update to unstable_HistoryRouter inside a test was not wrapped in act"

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Notes for reviewers

Fixing this while I was poking at the jest console errors/warnings I mentioned in the matrix chat. This is the one that is fixable. I think the rest are related to https://github.com/remix-run/react-router/issues/8809.