### PR TITLE
add new variable plugin: PrometheusPromQLVariable

### DIFF
--- a/schemas/variables/prometheus-promql/prometheus-promql.cue
+++ b/schemas/variables/prometheus-promql/prometheus-promql.cue
@@ -1,0 +1,20 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusPromQL
+
+kind: "PrometheusPromQLVariable"
+spec: close({
+	expr: string
+	label_name: string
+})

--- a/schemas/variables/prometheus-promql/prometheus-promql.cue
+++ b/schemas/variables/prometheus-promql/prometheus-promql.cue
@@ -15,6 +15,6 @@ package prometheusPromQL
 
 kind: "PrometheusPromQLVariable"
 spec: close({
-	expr: string
+	expr:       string
 	label_name: string
 })

--- a/schemas/variables/prometheus-promql/prometheus-promql.json
+++ b/schemas/variables/prometheus-promql/prometheus-promql.json
@@ -1,0 +1,8 @@
+
+{
+  "kind": "PrometheusPromQLVariable",
+  "spec": {
+    "expr": "up",
+    "label_name": "instance"
+  }
+}

--- a/ui/prometheus-plugin/plugin.json
+++ b/ui/prometheus-plugin/plugin.json
@@ -30,6 +30,14 @@
         }
       },
       {
+        "pluginType": "Variable",
+        "kind": "PrometheusPromQLVariable",
+        "display": {
+          "name": "PrometheusPromQLVariable",
+          "description": ""
+        }
+      },
+      {
         "pluginType": "TimeSeriesQuery",
         "kind": "PrometheusTimeSeriesQuery",
         "display": {

--- a/ui/prometheus-plugin/src/index.ts
+++ b/ui/prometheus-plugin/src/index.ts
@@ -14,7 +14,11 @@
 import { PrometheusTimeSeriesQuery } from './plugins/prometheus-time-series-query';
 // @TODO: Move this to a more generic location;
 import { StaticListVariable } from './plugins/variable';
-import { PrometheusLabelNamesVariable, PrometheusLabelValuesVariable } from './plugins/prometheus-variables';
+import {
+  PrometheusLabelNamesVariable,
+  PrometheusLabelValuesVariable,
+  PrometheusPromQLVariable,
+} from './plugins/prometheus-variables';
 import { PrometheusDatasource } from './plugins/prometheus-datasource';
 
 // Export plugins under the same name as the kinds they handle from the plugin.json
@@ -23,5 +27,6 @@ export {
   StaticListVariable,
   PrometheusLabelNamesVariable,
   PrometheusLabelValuesVariable,
+  PrometheusPromQLVariable,
   PrometheusDatasource,
 };

--- a/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
@@ -169,11 +169,12 @@ export const PrometheusPromQLVariable: VariablePlugin<PrometheusPromQLVariableOp
     const { data: options } = await client.instantQuery({
       query: replaceTemplateVariables(spec.expr, ctx.variables),
     });
+    const labelName = replaceTemplateVariables(spec.label_name, ctx.variables);
     let values: string[] = [];
     if (options?.resultType === 'matrix') {
-      values = capturingMatrix(options, spec.label_name);
+      values = capturingMatrix(options, labelName);
     } else if (options?.resultType === 'vector') {
-      values = capturingVector(options, spec.label_name);
+      values = capturingVector(options, labelName);
     }
 
     return {

--- a/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
@@ -18,8 +18,14 @@ import {
   PrometheusClient,
   DEFAULT_PROM,
   getPrometheusTimeRange,
+  MatrixData,
+  VectorData,
 } from '../model';
-import { PrometheusLabelNamesVariableOptions, PrometheusLabelValuesVariableOptions } from './types';
+import {
+  PrometheusLabelNamesVariableOptions,
+  PrometheusLabelValuesVariableOptions,
+  PrometheusPromQLVariableOptions,
+} from './types';
 import { MatcherEditor } from './MatcherEditor';
 
 function PrometheusLabelValuesVariableEditor(props: OptionsEditorProps<PrometheusLabelValuesVariableOptions>) {
@@ -54,6 +60,51 @@ function PrometheusLabelNamesVariableEditor(props: OptionsEditorProps<Prometheus
       />
     </Stack>
   );
+}
+
+function PrometheusPromQLVariableEditor(props: OptionsEditorProps<PrometheusPromQLVariableOptions>) {
+  return (
+    <Stack spacing={1}>
+      <TextField
+        sx={{ mb: 1 }}
+        label="PromQL Expression"
+        value={props.value.expr}
+        onChange={(e) => {
+          props.onChange({ ...props.value, expr: e.target.value });
+        }}
+      />
+      <TextField
+        sx={{ mb: 1 }}
+        label="Label Name"
+        value={props.value.label_name}
+        onChange={(e) => {
+          props.onChange({ ...props.value, label_name: e.target.value });
+        }}
+      />
+    </Stack>
+  );
+}
+
+function capturingMatrix(matrix: MatrixData, label_name: string): string[] {
+  const captured = new Set<string>();
+  for (const sample of matrix.result) {
+    const value = sample.metric[label_name];
+    if (value !== undefined) {
+      captured.add(value);
+    }
+  }
+  return Array.from(captured.values());
+}
+
+function capturingVector(vector: VectorData, label_name: string): string[] {
+  const captured = new Set<string>();
+  for (const sample of vector.result) {
+    const value = sample.metric[label_name];
+    if (value !== undefined) {
+      captured.add(value);
+    }
+  }
+  return Array.from(captured.values());
 }
 
 /**
@@ -109,4 +160,29 @@ export const PrometheusLabelValuesVariable: VariablePlugin<PrometheusLabelValues
   },
   OptionsEditorComponent: PrometheusLabelValuesVariableEditor,
   createInitialOptions: () => ({ label_name: '' }),
+};
+
+export const PrometheusPromQLVariable: VariablePlugin<PrometheusPromQLVariableOptions> = {
+  getVariableOptions: async (spec, ctx) => {
+    const client: PrometheusClient = await ctx.datasourceStore.getDatasourceClient(spec.datasource ?? DEFAULT_PROM);
+    // TODO we may want to manage a range query as well.
+    const { data: options } = await client.instantQuery({
+      query: replaceTemplateVariables(spec.expr, ctx.variables),
+    });
+    let values: string[] = [];
+    if (options?.resultType === 'matrix') {
+      values = capturingMatrix(options, spec.label_name);
+    } else if (options?.resultType === 'vector') {
+      values = capturingVector(options, spec.label_name);
+    }
+
+    return {
+      data: stringArrayToVariableOptions(values),
+    };
+  },
+  dependsOn: (spec) => {
+    return { variables: parseTemplateVariables(spec.expr).concat(parseTemplateVariables(spec.label_name)) };
+  },
+  OptionsEditorComponent: PrometheusPromQLVariableEditor,
+  createInitialOptions: () => ({ expr: '', label_name: '' }),
 };

--- a/ui/prometheus-plugin/src/plugins/types.ts
+++ b/ui/prometheus-plugin/src/plugins/types.ts
@@ -25,3 +25,11 @@ export type PrometheusLabelValuesVariableOptions = PrometheusVariableOptionsBase
   label_name: string;
   matchers?: string[];
 };
+
+export type PrometheusPromQLVariableOptions = PrometheusVariableOptionsBase & {
+  // expr is the PromQL expression.
+  expr: string;
+  // label_name is the name of the label that will be used after the PromQL query is performed to select the label value.
+  // Note: This field is not part of the Prometheus API.
+  label_name: string;
+};


### PR DESCRIPTION
This PR is adding a new Variable plugin named `PrometheusPromQLVariable`. It allows user to enter a PromQL expression and then to select a `label_name` that will finally give the value for the variable.


https://user-images.githubusercontent.com/4548045/201677724-d31b951b-2329-4678-abd4-6b6e227e0ed4.mov

Side Note: Pretty cool to see it tooks me only 2h to implement a new simple variable plugin from scratch (aka without not so much knowledge about how it works).

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>