### PR TITLE
Add query editor to stat and gauge charts

### DIFF
--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditor.tsx
@@ -12,12 +12,42 @@
 // limitations under the License.
 
 import { JSONEditor } from '@perses-dev/components';
-import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import {
+  OptionsEditorProps,
+  OptionsEditorTabs,
+  TimeSeriesQueryEditor,
+  TimeSeriesQueryEditorProps,
+} from '@perses-dev/plugin-system';
+import { produce } from 'immer';
 import { GaugeChartOptions } from './gauge-chart-model';
 
 export type GaugeChartOptionsEditorProps = OptionsEditorProps<GaugeChartOptions>;
 
+/**
+ * Component for visually editing a Gauge Chart's spec.
+ */
 export function GaugeChartOptionsEditor(props: GaugeChartOptionsEditorProps) {
-  // TODO: replace with form controls for visual editing, leave temp JSON editor for thresholds
-  return <JSONEditor {...props} />;
+  const { onChange, value } = props;
+  const { query } = value;
+
+  const handleQueryChange: TimeSeriesQueryEditorProps['onChange'] = (next) => {
+    onChange(
+      produce(value, (draft) => {
+        draft.query = next;
+      })
+    );
+  };
+
+  return (
+    <OptionsEditorTabs
+      tabs={{
+        query: {
+          content: <TimeSeriesQueryEditor value={query} onChange={handleQueryChange} />,
+        },
+        json: {
+          content: <JSONEditor {...props} />,
+        },
+      }}
+    />
+  );
 }

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditor.tsx
@@ -12,12 +12,42 @@
 // limitations under the License.
 
 import { JSONEditor } from '@perses-dev/components';
-import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import {
+  OptionsEditorProps,
+  OptionsEditorTabs,
+  TimeSeriesQueryEditor,
+  TimeSeriesQueryEditorProps,
+} from '@perses-dev/plugin-system';
+import { produce } from 'immer';
 import { StatChartOptions } from './stat-chart-model';
 
 export type StatChartOptionsEditorProps = OptionsEditorProps<StatChartOptions>;
 
+/**
+ * Component for visually editing a Stat Chart's spec.
+ */
 export function StatChartOptionsEditor(props: StatChartOptionsEditorProps) {
-  // TODO: replace with form controls for visual editing
-  return <JSONEditor {...props} />;
+  const { onChange, value } = props;
+  const { query } = value;
+
+  const handleQueryChange: TimeSeriesQueryEditorProps['onChange'] = (next) => {
+    onChange(
+      produce(value, (draft) => {
+        draft.query = next;
+      })
+    );
+  };
+
+  return (
+    <OptionsEditorTabs
+      tabs={{
+        query: {
+          content: <TimeSeriesQueryEditor value={query} onChange={handleQueryChange} />,
+        },
+        json: {
+          content: <JSONEditor {...props} />,
+        },
+      }}
+    />
+  );
 }


### PR DESCRIPTION
This just adds the query editor to both stat and gauge charts while leaving the raw JSON editor in a separate tab for now to allow editing the other options we haven't built editors for yet. For example, in Stat Chart:

![Screen Shot 2022-11-14 at 8 08 19 AM](https://user-images.githubusercontent.com/428023/201694562-ae607c92-a544-4ecb-9c13-33bb51f85570.png)

And in Gauge Chart:

![Screen Shot 2022-11-14 at 8 09 32 AM](https://user-images.githubusercontent.com/428023/201694839-7aac8ff2-66a2-4293-a0b1-76de1da390c3.png)
