### PR TITLE
Add UI for configuring gauge panel options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [ENHANCEMENT] User always sees edit icons in edit mode (instead of only seeing on hover) #748
 - [ENHANCEMENT] Add unit selector to time series chart options #744
 - [BUGFIX] Fix the default config file used in the docker images and in the archive #745
+- [ENHANCEMENT] Add UI for configuring gauge panel options #761
 
 ## 0.15.0 / 2022-11-09
 

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditor.tsx
@@ -12,12 +12,24 @@
 // limitations under the License.
 
 import { JSONEditor } from '@perses-dev/components';
-import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { OptionsEditorProps, OptionsEditorTabs } from '@perses-dev/plugin-system';
 import { GaugeChartOptions } from './gauge-chart-model';
+import { GaugeChartOptionsEditorSettings } from './GaugeChartOptionsEditorSettings';
 
 export type GaugeChartOptionsEditorProps = OptionsEditorProps<GaugeChartOptions>;
 
 export function GaugeChartOptionsEditor(props: GaugeChartOptionsEditorProps) {
   // TODO: replace with form controls for visual editing, leave temp JSON editor for thresholds
-  return <JSONEditor {...props} />;
+  return (
+    <OptionsEditorTabs
+      tabs={{
+        settings: {
+          content: <GaugeChartOptionsEditorSettings {...props} />,
+        },
+        json: {
+          content: <JSONEditor {...props} />,
+        },
+      }}
+    />
+  );
 }

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.test.tsx
@@ -1,0 +1,87 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GaugeChartOptions } from './gauge-chart-model';
+import { GaugeChartOptionsEditorSettings } from './GaugeChartOptionsEditorSettings';
+
+const MOCK_QUERY = {
+  kind: 'TimeSeriesQuery',
+  spec: {
+    plugin: {
+      kind: 'PrometheusTimeSeriesQuery',
+      spec: {
+        query: '',
+      },
+    },
+  },
+} as const;
+
+describe('GaugeChartOptionsEditorSettings', () => {
+  const renderGaugeChartOptionsEditorSettings = (value: GaugeChartOptions, onChange = jest.fn()) => {
+    render(<GaugeChartOptionsEditorSettings value={value} onChange={onChange} />);
+  };
+
+  it('can modify unit', () => {
+    const onChange = jest.fn();
+    renderGaugeChartOptionsEditorSettings(
+      {
+        unit: {
+          kind: 'Decimal',
+        },
+        calculation: 'First',
+        query: MOCK_QUERY,
+      },
+      onChange
+    );
+    const unitSelector = screen.getByRole('combobox', { name: 'Units' });
+    userEvent.click(unitSelector);
+    const yearOption = screen.getByRole('option', {
+      name: 'Years',
+    });
+    userEvent.click(yearOption);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unit: {
+          kind: 'Years',
+        },
+      })
+    );
+  });
+
+  it('can modify calculation', () => {
+    const onChange = jest.fn();
+    renderGaugeChartOptionsEditorSettings(
+      {
+        unit: {
+          kind: 'Days',
+        },
+        calculation: 'First',
+        query: MOCK_QUERY,
+      },
+      onChange
+    );
+    const calcSelector = screen.getByRole('combobox', { name: 'Calculation' });
+    userEvent.click(calcSelector);
+    const meanOption = screen.getByRole('option', {
+      name: 'Mean',
+    });
+    userEvent.click(meanOption);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calculation: 'Mean',
+      })
+    );
+  });
+});

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CalculationSelector } from '@perses-dev/plugin-system';
+import { CalculationSelector, CalculationSelectorProps } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
 import { DEFAULT_CALCULATION } from '@perses-dev/plugin-system';
 import { Stack, Typography } from '@mui/material';
@@ -22,7 +22,7 @@ import { GaugeChartOptions, DEFAULT_UNIT } from './gauge-chart-model';
 export function GaugeChartOptionsEditorSettings(props: GaugeChartOptionsEditorProps) {
   const { onChange, value } = props;
 
-  const handleCalculationChange = (newCalculation: GaugeChartOptions['calculation']) => {
+  const handleCalculationChange: CalculationSelectorProps['onChange'] = (newCalculation) => {
     onChange(
       produce(value, (draft: GaugeChartOptions) => {
         draft.calculation = newCalculation;

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
@@ -1,0 +1,37 @@
+import { CalculationSelector } from '@perses-dev/plugin-system';
+import { produce } from 'immer';
+import { DEFAULT_CALCULATION } from '@perses-dev/plugin-system';
+import { Stack, Typography } from '@mui/material';
+import { UnitSelector, UnitSelectorProps } from '@perses-dev/components';
+import { GaugeChartOptionsEditorProps } from './GaugeChartOptionsEditor';
+import { GaugeChartOptions, DEFAULT_UNIT } from './gauge-chart-model';
+
+export function GaugeChartOptionsEditorSettings(props: GaugeChartOptionsEditorProps) {
+  const { onChange, value } = props;
+
+  const handleCalculationChange = (newCalculation: GaugeChartOptions['calculation']) => {
+    onChange(
+      produce(value, (draft: GaugeChartOptions) => {
+        draft.calculation = newCalculation;
+      })
+    );
+  };
+
+  const handleUnitChange: UnitSelectorProps['onChange'] = (newUnit) => {
+    onChange(
+      produce(value, (draft: GaugeChartOptions) => {
+        draft.unit = newUnit;
+      })
+    );
+  };
+
+  return (
+    <Stack spacing={1} alignItems="flex-start">
+      <Typography variant="overline" component="h4">
+        Misc
+      </Typography>
+      <UnitSelector value={value.unit ?? DEFAULT_UNIT} onChange={handleUnitChange} />
+      <CalculationSelector value={value.calculation ?? DEFAULT_CALCULATION} onChange={handleCalculationChange} />
+    </Stack>
+  );
+}

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
@@ -1,3 +1,16 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { CalculationSelector } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
 import { DEFAULT_CALCULATION } from '@perses-dev/plugin-system';

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -12,14 +12,13 @@
 // limitations under the License.
 
 import type { GaugeSeriesOption } from 'echarts';
-import { useTimeSeriesQuery, PanelProps } from '@perses-dev/plugin-system';
+import { useTimeSeriesQuery, PanelProps, CalculationsMap } from '@perses-dev/plugin-system';
 import { GaugeChart, GaugeChartData } from '@perses-dev/components';
 import { Skeleton } from '@mui/material';
 import { useMemo } from 'react';
 import { convertThresholds, defaultThresholdInput } from '../../model/thresholds';
-import { CalculationsMap } from '../../model/calculations';
 import { useSuggestedStepMs } from '../../model/time';
-import { GaugeChartOptions } from './gauge-chart-model';
+import { GaugeChartOptions, DEFAULT_UNIT } from './gauge-chart-model';
 
 export type GaugeChartPanelProps = PanelProps<GaugeChartOptions>;
 
@@ -27,7 +26,7 @@ export function GaugeChartPanel(props: GaugeChartPanelProps) {
   const { spec: pluginSpec, contentDimensions } = props;
   const { query, calculation, max } = pluginSpec;
 
-  const unit = pluginSpec.unit ?? { kind: 'PercentDecimal', decimal_places: 1 };
+  const unit = pluginSpec.unit ?? DEFAULT_UNIT;
   const thresholds = pluginSpec.thresholds ?? defaultThresholdInput;
 
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -13,8 +13,10 @@
 
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
+import { CalculationType } from '@perses-dev/plugin-system';
 import { ThresholdOptions } from '../../model/thresholds';
-import { CalculationType } from '../../model/calculations';
+
+export const DEFAULT_UNIT: UnitOptions = { kind: 'PercentDecimal', decimal_places: 1 };
 
 /**
  * The Options object type supported by the GaugeChart panel plugin.

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -16,7 +16,7 @@ import { Box, Skeleton } from '@mui/material';
 import { LineSeriesOption } from 'echarts/charts';
 import { useMemo } from 'react';
 import { TimeSeriesData, useTimeSeriesQuery, PanelProps } from '@perses-dev/plugin-system';
-import { CalculationsMap, CalculationType } from '../../model/calculations';
+import { CalculationsMap, CalculationType } from '@perses-dev/plugin-system';
 import { useSuggestedStepMs } from '../../model/time';
 import { SparklineOptions, StatChartOptions } from './stat-chart-model';
 

--- a/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
@@ -13,8 +13,8 @@
 
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
+import { CalculationType } from '@perses-dev/plugin-system';
 import { ThresholdOptions } from '../../model/thresholds';
-import { CalculationType } from '../../model/calculations';
 
 export interface SparklineOptions {
   color?: string;

--- a/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.test.tsx
+++ b/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.test.tsx
@@ -1,0 +1,64 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CalculationType } from '../../model/calculations';
+import { CalculationSelector } from './CalculationSelector';
+
+describe('CalculationSelector', () => {
+  const renderCalculationSelector = (value: CalculationType, onChange = jest.fn()) => {
+    render(
+      <div>
+        <CalculationSelector value={value} onChange={onChange} />
+      </div>
+    );
+  };
+
+  const getCalculationSelector = () => {
+    return screen.getByRole('combobox', { name: 'Calculation' });
+  };
+
+  it('can change the calculation by clicking', () => {
+    const onChange = jest.fn();
+    renderCalculationSelector('Last', onChange);
+
+    const calcSelector = getCalculationSelector();
+    userEvent.click(calcSelector);
+    const sumOption = screen.getByRole('option', {
+      name: 'Sum',
+    });
+    userEvent.click(sumOption);
+
+    expect(onChange).toHaveBeenCalledWith('Sum');
+  });
+
+  it('can change the calculation using a keyboard', () => {
+    const onChange = jest.fn();
+    renderCalculationSelector('First', onChange);
+
+    const calcSelector = getCalculationSelector();
+    userEvent.tab();
+    expect(calcSelector).toHaveFocus();
+
+    userEvent.clear(calcSelector);
+    userEvent.keyboard('first');
+    screen.getByRole('option', {
+      name: 'First',
+    });
+
+    userEvent.keyboard('{arrowup}{enter}');
+
+    expect(onChange).toHaveBeenCalledWith('First');
+  });
+});

--- a/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.tsx
+++ b/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.tsx
@@ -1,0 +1,52 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { FormControl, TextField, Autocomplete } from '@mui/material';
+import { CALCULATIONS_CONFIG, CalculationConfig, CalculationType } from '../../model/calculations';
+
+type AutocompleteCalculationOption = CalculationConfig & { id: CalculationType };
+const CALC_OPTIONS: AutocompleteCalculationOption[] = Object.entries(CALCULATIONS_CONFIG).map(([id, config]) => {
+  return {
+    id: id as CalculationType,
+    ...config,
+  };
+});
+
+export interface CalculationSelectorProps {
+  value: CalculationType;
+  onChange: (unit: CalculationType) => void;
+}
+
+export function CalculationSelector({ value, onChange }: CalculationSelectorProps) {
+  const handleCalculationChange = (_: unknown, newValue: AutocompleteCalculationOption) => {
+    onChange(newValue.id);
+  };
+
+  const calcConfig = CALCULATIONS_CONFIG[value];
+
+  return (
+    <FormControl sx={{ minWidth: 200 }}>
+      <Autocomplete
+        value={{
+          ...calcConfig,
+          id: value,
+        }}
+        options={CALC_OPTIONS}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        renderInput={(params) => <TextField {...params} label="Calculation" />}
+        onChange={handleCalculationChange}
+        disableClearable
+      ></Autocomplete>
+    </FormControl>
+  );
+}

--- a/ui/plugin-system/src/components/CalculationSelector/index.ts
+++ b/ui/plugin-system/src/components/CalculationSelector/index.ts
@@ -12,10 +12,3 @@
 // limitations under the License.
 
 export * from './CalculationSelector';
-export * from './DatasourceSelect';
-export * from './OptionsEditorTabs';
-export * from './PluginEditor';
-export * from './PluginKindSelect';
-export * from './PluginRegistry';
-export * from './PluginSpecEditor';
-export * from './TimeSeriesQueryEditor';

--- a/ui/plugin-system/src/model/calculations.ts
+++ b/ui/plugin-system/src/model/calculations.ts
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TimeSeriesValueTuple } from '@perses-dev/plugin-system';
 import { findLast, meanBy, sumBy } from 'lodash-es';
+import { TimeSeriesValueTuple } from './time-series-queries';
 
 export const CalculationsMap = {
   First: first,
@@ -23,6 +23,29 @@ export const CalculationsMap = {
 };
 
 export type CalculationType = keyof typeof CalculationsMap;
+
+export type CalculationConfig = {
+  label: string;
+};
+export const CALCULATIONS_CONFIG: Readonly<Record<CalculationType, CalculationConfig>> = {
+  First: {
+    label: 'First',
+  },
+  Last: {
+    label: 'Last',
+  },
+  LastNumber: {
+    label: 'Last number',
+  },
+  Mean: {
+    label: 'Mean',
+  },
+  Sum: {
+    label: 'Sum',
+  },
+} as const;
+
+export const DEFAULT_CALCULATION: CalculationType = 'Sum';
 
 function first(values: TimeSeriesValueTuple[]): number | undefined {
   const tuple = values[0];

--- a/ui/plugin-system/src/model/index.ts
+++ b/ui/plugin-system/src/model/index.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export * from './calculations';
 export * from './datasource';
 export * from './panels';
 export * from './plugins';


### PR DESCRIPTION
This commit also includes the following changes as side effects:
- Add CalculationSelector component for configuring the `calculation` option for a panel plugin.
- Moved `calculations.ts` model to avoid circular dependencies.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Notes for reviewers

- I am starting with the gauge chart to keep this PR relatively small. I'll do something similar with the stat chart in a follow-up PR.
- The `CalculationSelector` fit best in `plugin-system` based on various dependencies and preexisting models. `UnitSelector` was put in `components` because of where the `units` model was, but I wonder if `UnitSelector` should also go in `plugin-system`. It seems like a more appropriate location and would be more consistent. Thoughts?
- The units not always behaving as expected is a known issue that was found when building the `UnitSelector` and is being handled separately.

## Screenshots
<img width="900" alt="image" src="https://user-images.githubusercontent.com/396962/201794386-cf7c08d4-7384-4435-beeb-c55603dc44fd.png">

<img width="900" alt="image" src="https://user-images.githubusercontent.com/396962/201794420-fa639781-75aa-47b0-a16e-90fde5b8a925.png">
