### PR TITLE
Export json button for dashboard 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [FEATURE] add line_width and point_radius visual options in time series panel #754
+- [FEATURE] Add ability to download dashboard json #764
 - [ENHANCEMENT] User always sees edit icons in edit mode (instead of only seeing on hover) #748
 - [ENHANCEMENT] Add unit selector to time series chart options #744
 - [ENHANCEMENT] Add UI for configuring gauge panel options #761

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -19,6 +19,7 @@ import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 import { useDashboardActions, useEditMode } from '../../context';
 import { TemplateVariableList } from '../Variables';
 import { TimeRangeControls } from '../TimeRangeControls';
+import { DownloadButton } from '../DownloadButton';
 
 export interface DashboardToolbarProps {
   dashboardName: string;
@@ -90,6 +91,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             {dashboardTitle}
             <Stack direction="row" spacing={2} sx={{ marginLeft: 'auto' }}>
               <TimeRangeControls />
+              <DownloadButton />
               {isLaptopSize && (
                 <Button
                   variant="outlined"

--- a/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
+++ b/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
@@ -1,0 +1,44 @@
+import React, { useRef } from 'react';
+import DownloadIcon from 'mdi-material-ui/DownloadOutline';
+import { IconButton, styled } from '@mui/material';
+import { useDashboard } from '../../context';
+
+// Button to download the dashboard as a JSON file.
+export function DownloadButton() {
+  const { dashboard } = useDashboard();
+  const hiddenLinkRef = useRef<HTMLAnchorElement>(null);
+
+  const onDownloadButtonClick = () => {
+    if (!hiddenLinkRef || !hiddenLinkRef.current) return;
+    // Create blob URL
+    const hiddenLinkUrl = URL.createObjectURL(
+      new Blob([JSON.stringify(dashboard)], {
+        type: 'application/json',
+      })
+    );
+    // Simulate click
+    hiddenLinkRef.current.href = hiddenLinkUrl;
+    hiddenLinkRef.current.click();
+    // Remove blob URL (for memory management)
+    URL.revokeObjectURL(hiddenLinkUrl);
+  };
+
+  return (
+    <>
+      <DownloadIconButton title="Download JSON" onClick={onDownloadButtonClick}>
+        <DownloadIcon />
+      </DownloadIconButton>
+      {/* Hidden link to download the dashboard as a JSON file */}
+      {/* eslint-disable jsx-a11y/anchor-has-content */}
+      {/* eslint-disable jsx-a11y/anchor-is-valid  */}
+      <a ref={hiddenLinkRef} style={{ display: 'none' }} download={`${dashboard.metadata.name}.json`} />
+    </>
+  );
+}
+
+const DownloadIconButton = styled(IconButton)(({ theme }) => ({
+  border: `1px solid ${theme.palette.grey[300]}`,
+  borderRadius: theme.shape.borderRadius,
+  padding: '4px',
+  color: theme.palette.grey[900],
+}));

--- a/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
+++ b/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
@@ -1,3 +1,16 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { useRef } from 'react';
 import DownloadIcon from 'mdi-material-ui/DownloadOutline';
 import { IconButton, styled } from '@mui/material';

--- a/ui/dashboards/src/components/DownloadButton/index.ts
+++ b/ui/dashboards/src/components/DownloadButton/index.ts
@@ -1,1 +1,14 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from './DownloadButton';

--- a/ui/dashboards/src/components/DownloadButton/index.ts
+++ b/ui/dashboards/src/components/DownloadButton/index.ts
@@ -1,0 +1,1 @@
+export * from './DownloadButton';

--- a/ui/dashboards/src/components/index.ts
+++ b/ui/dashboards/src/components/index.ts
@@ -15,6 +15,7 @@ export * from './Dashboard';
 export * from './DashboardToolbar';
 export * from './DeletePanelDialog';
 export * from './DeletePanelGroupDialog';
+export * from './DownloadButton';
 export * from './GridLayout';
 export * from './Panel';
 export * from './PanelDrawer';


### PR DESCRIPTION
![downloadJson](https://user-images.githubusercontent.com/9817826/201995125-6088e83a-92fc-4c21-9ba6-ed0b9136319d.gif)

- Creates a blob url each time the dashboard changes (and deletes the previous blob url)
- Renders a hidden link
- When user clicks on the download button, we programmatically click on the hidden link with the download attribute and the correct blob url (the download attribute is the API that triggers putting the file into the downloads folder)

credits to @cndonovan for original implementation :) 