### PR TITLE
Fix duplicate panel keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [ENHANCEMENT] Add UI for configuring stat panel options #762
 - [ENHANCEMENT] Add validation for Variables #768
 - [BUGFIX] Fix the default config file used in the docker images and in the archive #745
+- [BUGFIX] Fix duplicate panel keys #765
 - [BUGFIX] Automatically add a Panel Group when adding a Panel to an empty dashboard #766
 
 ## 0.15.0 / 2022-11-09

--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -64,6 +64,31 @@ describe('Panel Drawer', () => {
     });
   });
 
+  it('should add panel with duplicate panel name', async () => {
+    const storeApi = renderPanelDrawer();
+
+    act(() => storeApi.getState().openAddPanel());
+
+    const nameInput = await screen.findByLabelText(/Name/);
+    userEvent.type(nameInput, 'cpu');
+    userEvent.click(screen.getByText('Add'));
+
+    const panels = storeApi.getState().panels;
+    expect(panels).toMatchObject({
+      // make sure we don't have duplicate panel key by appending "-1"
+      'cpu-1': {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'cpu' },
+          plugin: {
+            kind: '',
+            spec: {},
+          },
+        },
+      },
+    });
+  });
+
   it('should edit an existing panel', async () => {
     const storeApi = renderPanelDrawer();
 

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -197,7 +197,12 @@ export function createPanelEditorSlice(): StateCreator<
         },
         applyChanges: (next) => {
           const panelDef = createPanelDefinitionFromEditorValues(next);
-          const panelKey = removeWhiteSpacesAndSpecialCharacters(next.name);
+          const uniquePanelKeys = getUniquePanelKeys(get().panels);
+          let panelKey = removeWhiteSpacesAndSpecialCharacters(next.name);
+          // append count if panel key already exists
+          if (uniquePanelKeys[panelKey]) {
+            panelKey += `-${uniquePanelKeys[panelKey]}`;
+          }
           set((state) => {
             // Add a panel
             state.panels[panelKey] = panelDef;
@@ -265,4 +270,20 @@ function getYForNewRow(group: PanelGroupDefinition) {
     }
   }
   return newRowY;
+}
+
+// Find all the unique panel keys
+// ex: cpu, cpu-1, cpu-2 count as the same panel key since these panels have the same name
+function getUniquePanelKeys(panels: Record<string, PanelDefinition>): Record<string, number> {
+  const uniquePanelKeys: Record<string, number> = {};
+  Object.keys(panels).forEach((panelKey) => {
+    const key = panelKey.replace(/-([0-9]+)/, '');
+    const count = uniquePanelKeys[key];
+    if (count) {
+      uniquePanelKeys[key] = count + 1;
+    } else {
+      uniquePanelKeys[key] = 1;
+    }
+  });
+  return uniquePanelKeys;
 }


### PR DESCRIPTION
**Bug**
If you add two panels with the same name, then they reference the same panel. When you edit one panel, you'll also see the changes in the other panel

**Fix**
Create a unique panel key for each panel