### PR TITLE
Reset error boundary on spec change

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -108,7 +108,7 @@ export function Panel(props: PanelProps) {
         }}
         ref={setContentElement}
       >
-        <ErrorBoundary FallbackComponent={ErrorAlert}>
+        <ErrorBoundary FallbackComponent={ErrorAlert} resetKeys={[definition.spec.plugin.spec]}>
           {inView === true && (
             <PanelContent
               panelPluginKind={definition.spec.plugin.kind}


### PR DESCRIPTION
This should address the issue mentioned in #770 where a 400 (or any JS error via the TimeSeriesQuery plugin) causes the Panel to be stuck in an error state. 

Since some of our panel plugins [throw uncaught errors,](https://github.com/perses/perses/blob/9b5263a29b07a3bc1a537d095c740d9a68eaebbb/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx#L48) we need a way to reset the wrapping ErrorBoundary when the spec (query) changes.

Demo: https://www.loom.com/share/02b0651e45e340d89bd02edbd2ca557a

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>