### PR TITLE
Fix bug with grid layout responsive behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [ENHANCEMENT] Add validation for Variables #768
 - [BUGFIX] Fix the default config file used in the docker images and in the archive #745
 - [BUGFIX] Automatically add a Panel Group when adding a Panel to an empty dashboard #766
+- [BUGFIX] Fix bug with grid layout responsive behavior #778
 
 ## 0.15.0 / 2022-11-09
 

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -25,7 +25,7 @@ export interface GridLayoutProps {
   panelGroupId: PanelGroupId;
 }
 
-const STORED_LAYOUT_BREAKPOINT = 'sm' as const;
+const SMALL_LAYOUT_BREAKPOINT = 'sm' as const;
 
 /**
  * Layout component that arranges children in a Grid based on the definition.
@@ -44,7 +44,7 @@ export function GridLayout(props: GridLayoutProps) {
     // a bug in react-layout-grid where `currentLayout` does not adjust properly
     // when going to a smaller breakpoint and then back to a larger breakpoint.
     // https://github.com/react-grid-layout/react-grid-layout/issues/1663
-    const smallLayout = allLayouts[STORED_LAYOUT_BREAKPOINT];
+    const smallLayout = allLayouts[SMALL_LAYOUT_BREAKPOINT];
     if (smallLayout) {
       updatePanelGroupLayouts(smallLayout);
     }
@@ -74,7 +74,7 @@ export function GridLayout(props: GridLayoutProps) {
           isDraggable={isEditMode}
           isResizable={isEditMode}
           containerPadding={[0, 10]}
-          layouts={{ [STORED_LAYOUT_BREAKPOINT]: groupDefinition.itemLayouts }}
+          layouts={{ [SMALL_LAYOUT_BREAKPOINT]: groupDefinition.itemLayouts }}
           onLayoutChange={handleLayoutChange}
         >
           {groupDefinition.itemLayouts.map(({ i }) => (

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { useState } from 'react';
-import { Responsive, WidthProvider } from 'react-grid-layout';
+import { Responsive, WidthProvider, Layouts, Layout } from 'react-grid-layout';
 import { Collapse, useTheme } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { useEditMode, usePanelGroup, usePanelGroupActions, PanelGroupId } from '../../context';
@@ -25,6 +25,8 @@ export interface GridLayoutProps {
   panelGroupId: PanelGroupId;
 }
 
+const STORED_LAYOUT_BREAKPOINT = 'sm' as const;
+
 /**
  * Layout component that arranges children in a Grid based on the definition.
  */
@@ -36,6 +38,17 @@ export function GridLayout(props: GridLayoutProps) {
 
   const [isOpen, setIsOpen] = useState(!groupDefinition.isCollapsed ?? true);
   const { isEditMode } = useEditMode();
+
+  const handleLayoutChange = (currentLayout: Layout[], allLayouts: Layouts) => {
+    // Using the value from `allLayouts` instead of `currentLayout` because of
+    // a bug in react-layout-grid where `currentLayout` does not adjust properly
+    // when going to a smaller breakpoint and then back to a larger breakpoint.
+    // https://github.com/react-grid-layout/react-grid-layout/issues/1663
+    const smallLayout = allLayouts[STORED_LAYOUT_BREAKPOINT];
+    if (smallLayout) {
+      updatePanelGroupLayouts(smallLayout);
+    }
+  };
 
   return (
     <GridContainer>
@@ -61,8 +74,8 @@ export function GridLayout(props: GridLayoutProps) {
           isDraggable={isEditMode}
           isResizable={isEditMode}
           containerPadding={[0, 10]}
-          layouts={{ sm: groupDefinition.itemLayouts }}
-          onLayoutChange={updatePanelGroupLayouts}
+          layouts={{ [STORED_LAYOUT_BREAKPOINT]: groupDefinition.itemLayouts }}
+          onLayoutChange={handleLayoutChange}
         >
           {groupDefinition.itemLayouts.map(({ i }) => (
             <div key={i}>


### PR DESCRIPTION
Before this fix, the contents of the grid would stay small and look strange after making the browser window small and then large again.

After the fix, the grid behaves responsively, as expected.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Steps to reproduce the bug
- Open a dashboard.
- Make your browser window small to trigger the responsive behavior.
- Maker your browser window wider to go back to the larger responsive size. 
- See a dashboard with very scrunched up charts that looks odd and is hard to use.

This appears to be related to https://github.com/react-grid-layout/react-grid-layout/issues/1663.

## Screenshots

### Before the fix


After following the steps to reproduce the bug:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/396962/202324838-81439102-1484-4017-992f-433b1daa23c3.png">


### After the fix

After following the steps to reproduce the bug:
<img width="1257" alt="image" src="https://user-images.githubusercontent.com/396962/202324945-838ae329-5c07-4345-bdf9-657da9de15e4.png">
