### PR TITLE
Even out the spacing between query options

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -94,7 +94,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
       tabs={{
         query: {
           content: (
-            <Stack spacing={2}>
+            <Stack spacing={1}>
               <Button variant="contained" startIcon={<AddIcon />} sx={{ marginLeft: 'auto' }} onClick={handleQueryAdd}>
                 Add Query
               </Button>

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -30,7 +30,7 @@ export function PluginEditor(props: PluginEditorProps) {
   const { pendingKind, isLoading, error, onKindChange, onSpecChange } = usePluginEditor(props);
   return (
     <Box {...others}>
-      <FormControl margin="dense" fullWidth={false} disabled={isLoading} error={error !== null} sx={{ mb: 2 }}>
+      <FormControl margin="dense" fullWidth={false} disabled={isLoading} error={error !== null} sx={{ mb: 1 }}>
         {/* TODO: How to ensure ids are unique? */}
         <InputLabel id="plugin-kind-label">{pluginKindLabel}</InputLabel>
         <PluginKindSelect

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { produce } from 'immer';
-import { Box, TextField, FormControl, InputLabel } from '@mui/material';
+import { Stack, TextField, FormControl, InputLabel } from '@mui/material';
 import { DatasourceSelect, DatasourceSelectProps } from '@perses-dev/plugin-system';
 import { DEFAULT_PROM, isDefaultPromSelector, isPrometheusDatasourceSelector } from '../../model';
 import { PrometheusTimeSeriesQueryEditorProps, useQueryState, useFormatState } from './query-editor-model';
@@ -43,7 +43,7 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
   };
 
   return (
-    <Box>
+    <Stack spacing={2}>
       <TextField
         fullWidth
         label="Query"
@@ -72,6 +72,6 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           label="Prometheus Datasource"
         />
       </FormControl>
-    </Box>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Before
<img width="1512" alt="Screen Shot 2022-11-16 at 4 37 41 PM" src="https://user-images.githubusercontent.com/2584129/202325489-44ef3f53-c7d3-4976-bf5a-6e72ea634580.png">

## After
<img width="1512" alt="Screen Shot 2022-11-16 at 4 37 24 PM" src="https://user-images.githubusercontent.com/2584129/202325476-a5109017-e970-41f6-8633-7ecbc300762a.png">

Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>