### PR TITLE
Make the headers in editors all look the same 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [ENHANCEMENT] Add UI for configuring gauge panel options #761
 - [ENHANCEMENT] Add UI for configuring stat panel options #762
 - [ENHANCEMENT] Add validation for Variables #768
+- [ENHANCEMENT] Standardize headers across editors (variable and panel editors) #783
 - [BUGFIX] Fix the default config file used in the docker images and in the archive #745
 - [BUGFIX] Fix duplicate panel keys #765
 - [BUGFIX] Automatically add a Panel Group when adding a Panel to an empty dashboard #766

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -120,111 +120,118 @@ export function VariableEditor(props: {
   };
 
   return (
-    <Box p={4}>
+    <>
       {currentEditingVariableDefinition && (
-        <>
-          <Typography variant="h3" mb={2}>
-            Edit Variable
-          </Typography>
-          <VariableEditForm
-            initialVariableDefinition={currentEditingVariableDefinition}
-            onChange={(definition) => {
-              setVariableDefinitions((draft) => {
-                draft[variableEditIdx] = definition;
-                setVariableEditIdx(null);
-              });
-            }}
-            onCancel={() => setVariableEditIdx(null)}
-          />
-        </>
+        <VariableEditForm
+          initialVariableDefinition={currentEditingVariableDefinition}
+          onChange={(definition) => {
+            setVariableDefinitions((draft) => {
+              draft[variableEditIdx] = definition;
+              setVariableEditIdx(null);
+            });
+          }}
+          onCancel={() => setVariableEditIdx(null)}
+        />
       )}
       {!currentEditingVariableDefinition && (
         <>
-          <Stack direction="row" spacing={1} justifyContent="end">
-            <Button
-              disabled={props.variableDefinitions === variableDefinitions || !validation.isValid}
-              variant="contained"
-              onClick={() => {
-                props.onChange(variableDefinitions);
-              }}
-            >
-              Apply
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={() => {
-                props.onCancel();
-              }}
-            >
-              Cancel
-            </Button>
-          </Stack>
-          <Typography variant="h3" mb={2}>
-            Variable List
-          </Typography>
-          <Stack spacing={2}>
-            {!validation.isValid &&
-              validation.errors.map((error) => (
-                <Alert severity="error" key={error}>
-                  {error}
-                </Alert>
-              ))}
-            <TableContainer component={Paper}>
-              <Table sx={{ minWidth: 650 }} aria-label="simple table">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Visibility</TableCell>
-                    <TableCell>Variable Name</TableCell>
-                    <TableCell>Variable Type</TableCell>
-                    <TableCell align="right">Action</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {variableDefinitions.map((v, idx) => (
-                    <TableRow key={v.spec.name}>
-                      <TableCell component="th" scope="row">
-                        <Switch
-                          checked={v.spec.display?.hidden !== true}
-                          onChange={(e) => {
-                            toggleVariableVisibility(idx, e.target.checked);
-                          }}
-                        />
-                      </TableCell>
-                      <TableCell component="th" scope="row" sx={{ fontWeight: 'bold' }}>
-                        {v.spec.name}
-                      </TableCell>
-                      <TableCell>{v.kind}</TableCell>
-                      <TableCell align="right">
-                        <IconButton onClick={() => changeVariableOrder(idx, 'up')} disabled={idx === 0}>
-                          <ArrowUp />
-                        </IconButton>
-                        <IconButton
-                          onClick={() => changeVariableOrder(idx, 'down')}
-                          disabled={idx === variableDefinitions.length - 1}
-                        >
-                          <ArrowDown />
-                        </IconButton>
-
-                        <IconButton onClick={() => setVariableEditIdx(idx)}>
-                          <PencilIcon />
-                        </IconButton>
-                        <IconButton onClick={() => removeVariable(idx)}>
-                          <TrashIcon />
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-            <Box display="flex">
-              <Button onClick={addVariable} variant="contained">
-                Add New Variable
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              padding: (theme) => theme.spacing(1, 2),
+              borderBottom: (theme) => `1px solid ${theme.palette.grey[100]}`,
+            }}
+          >
+            <Typography variant="h2">Template Variables</Typography>
+            <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
+              <Button
+                disabled={props.variableDefinitions === variableDefinitions || !validation.isValid}
+                variant="contained"
+                onClick={() => {
+                  props.onChange(variableDefinitions);
+                }}
+              >
+                Apply
               </Button>
-            </Box>
-          </Stack>
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  props.onCancel();
+                }}
+              >
+                Cancel
+              </Button>
+            </Stack>
+          </Box>
+          <Box padding={2}>
+            <Typography variant="h3" mb={2}>
+              Variable List
+            </Typography>
+            <Stack spacing={2}>
+              {!validation.isValid &&
+                validation.errors.map((error) => (
+                  <Alert severity="error" key={error}>
+                    {error}
+                  </Alert>
+                ))}
+              <TableContainer component={Paper}>
+                <Table sx={{ minWidth: 650 }} aria-label="simple table">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Visibility</TableCell>
+                      <TableCell>Variable Name</TableCell>
+                      <TableCell>Variable Type</TableCell>
+                      <TableCell align="right">Action</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {variableDefinitions.map((v, idx) => (
+                      <TableRow key={v.spec.name}>
+                        <TableCell component="th" scope="row">
+                          <Switch
+                            checked={v.spec.display?.hidden !== true}
+                            onChange={(e) => {
+                              toggleVariableVisibility(idx, e.target.checked);
+                            }}
+                          />
+                        </TableCell>
+                        <TableCell component="th" scope="row" sx={{ fontWeight: 'bold' }}>
+                          {v.spec.name}
+                        </TableCell>
+                        <TableCell>{v.kind}</TableCell>
+                        <TableCell align="right">
+                          <IconButton onClick={() => changeVariableOrder(idx, 'up')} disabled={idx === 0}>
+                            <ArrowUp />
+                          </IconButton>
+                          <IconButton
+                            onClick={() => changeVariableOrder(idx, 'down')}
+                            disabled={idx === variableDefinitions.length - 1}
+                          >
+                            <ArrowDown />
+                          </IconButton>
+
+                          <IconButton onClick={() => setVariableEditIdx(idx)}>
+                            <PencilIcon />
+                          </IconButton>
+                          <IconButton onClick={() => removeVariable(idx)}>
+                            <TrashIcon />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <Box display="flex">
+                <Button onClick={addVariable} variant="contained">
+                  Add New Variable
+                </Button>
+              </Box>
+            </Stack>
+          </Box>
         </>
       )}
-    </Box>
+    </>
   );
 }

--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -123,95 +123,58 @@ export function VariableEditForm({
   }, [previewKey]);
 
   return (
-    <Box>
-      <SectionHeader>General</SectionHeader>
-      <Grid container spacing={2} mb={2}>
-        <Grid item xs={6}>
-          <TextField
-            required
-            error={!!validation.name}
-            fullWidth
-            label="Name"
-            value={state.name}
-            helperText={validation.name}
-            onChange={(v) => {
-              setState((draft) => {
-                draft.name = v.target.value as string;
-              });
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: (theme) => theme.spacing(1, 2),
+          borderBottom: (theme) => `1px solid ${theme.palette.grey[100]}`,
+        }}
+      >
+        <Typography variant="h2">Template Variables / Edit Variable</Typography>
+        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
+          <Button
+            disabled={!validation.isValid}
+            variant="contained"
+            onClick={() => {
+              onChange(getVariableDefinitionFromState(state));
             }}
-          />
-        </Grid>
-        <Grid item xs={6}>
-          <FormControl fullWidth>
-            <InputLabel id="variable-type-select-label">Type</InputLabel>
-            <Select
-              labelId="variable-type-select-label"
-              id="variable-type-select"
-              label="Type"
-              value={state.kind}
-              onChange={(v) => {
-                setState((draft) => {
-                  draft.kind = v.target.value as VariableEditorState['kind'];
-                });
-              }}
-            >
-              {VARIABLE_TYPES.map((v) => (
-                <MenuItem key={v} value={v}>
-                  {v}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Grid>
-        <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="Label"
-            value={state.title}
-            onChange={(v) => {
-              setState((draft) => {
-                draft.title = v.target.value;
-              });
+          >
+            Update
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              onCancel();
             }}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            fullWidth
-            label="Description"
-            value={state.description}
-            onChange={(v) => {
-              setState((draft) => {
-                draft.description = v.target.value;
-              });
-            }}
-          />
-        </Grid>
-      </Grid>
-
-      {state.kind === 'TextVariable' && (
-        <>
-          <SectionHeader>Text Options</SectionHeader>
+          >
+            Cancel
+          </Button>
+        </Stack>
+      </Box>
+      <Box p={2}>
+        <Typography variant="h3" mb={2}>
+          Edit Variable
+        </Typography>
+        <Box>
+          <SectionHeader>General</SectionHeader>
           <Grid container spacing={2} mb={2}>
-            <Grid item xs={12}>
+            <Grid item xs={6}>
               <TextField
-                label="Value"
-                value={state.textVariableFields.value}
+                required
+                error={!!validation.name}
+                fullWidth
+                label="Name"
+                value={state.name}
+                helperText={validation.name}
                 onChange={(v) => {
                   setState((draft) => {
-                    draft.textVariableFields.value = v.target.value;
+                    draft.name = v.target.value as string;
                   });
                 }}
               />
             </Grid>
-          </Grid>
-        </>
-      )}
-
-      {state.kind === 'ListVariable' && (
-        <>
-          <SectionHeader>List Options</SectionHeader>
-          <Grid container spacing={2} mb={2}>
             <Grid item xs={6}>
               {/** Hack?: Cool technique to refresh the preview to simulate onBlur event */}
               <ClickAwayListener onClickAway={() => refreshPreview()}>
@@ -251,45 +214,92 @@ export function VariableEditForm({
                 checked={state.listVariableFields.allowMultiple}
                 onChange={(e) => {
                   setState((draft) => {
-                    draft.listVariableFields.allowMultiple = e.target.checked;
+                    draft.title = v.target.value;
                   });
                 }}
               />
             </Grid>
             <Grid item xs={12}>
-              Allow All
-              <Switch
-                checked={state.listVariableFields.allowAll}
-                onChange={(e) => {
+              <TextField
+                fullWidth
+                label="Description"
+                value={state.description}
+                onChange={(v) => {
                   setState((draft) => {
-                    draft.listVariableFields.allowAll = e.target.checked;
+                    draft.description = v.target.value;
                   });
                 }}
               />
             </Grid>
           </Grid>
-        </>
-      )}
 
-      <Stack direction={'row'} spacing={2} justifyContent="end">
-        <Button
-          disabled={!validation.isValid}
-          variant="contained"
-          onClick={() => {
-            onChange(getVariableDefinitionFromState(state));
-          }}
-        >
-          Update
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={() => {
-            onCancel();
-          }}
-        >
-          Cancel
-        </Button>
-      </Stack>
-    </Box>
+          {state.kind === 'TextVariable' && (
+            <>
+              <SectionHeader>Text Options</SectionHeader>
+              <Grid container spacing={2} mb={2}>
+                <Grid item xs={12}>
+                  <TextField
+                    label="Value"
+                    value={state.textVariableFields.value}
+                    onChange={(v) => {
+                      setState((draft) => {
+                        draft.textVariableFields.value = v.target.value;
+                      });
+                    }}
+                  />
+                </Grid>
+              </Grid>
+            </>
+          )}
+
+          {state.kind === 'ListVariable' && (
+            <>
+              <SectionHeader>List Options</SectionHeader>
+              <Grid container spacing={2} mb={2}>
+                <Grid item xs={6}>
+                  <PluginEditor
+                    width={500}
+                    pluginType="Variable"
+                    pluginKindLabel="Source"
+                    value={state.listVariableFields.plugin}
+                    onChange={(val) => {
+                      setState((draft) => {
+                        draft.listVariableFields.plugin = val;
+                      });
+                    }}
+                  />
+                </Grid>
+              </Grid>
+
+              <SectionHeader>Dropdown Options</SectionHeader>
+              <Grid container spacing={1} mb={1}>
+                <Grid item xs={12}>
+                  Allow Multiple
+                  <Switch
+                    checked={state.listVariableFields.allowMultiple}
+                    onChange={(e) => {
+                      setState((draft) => {
+                        draft.listVariableFields.allowMultiple = e.target.checked;
+                      });
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  Allow All
+                  <Switch
+                    checked={state.listVariableFields.allowAll}
+                    onChange={(e) => {
+                      setState((draft) => {
+                        draft.listVariableFields.allowAll = e.target.checked;
+                      });
+                    }}
+                  />
+                </Grid>
+              </Grid>
+            </>
+          )}
+        </Box>
+      </Box>
+    </>
   );
 }

--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -18,10 +18,6 @@ import {
   Switch,
   TextField,
   Grid,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
   Button,
   Stack,
   Alert,
@@ -36,9 +32,8 @@ import { ErrorBoundary } from '@perses-dev/components';
 import Refresh from 'mdi-material-ui/Refresh';
 
 import { useListVariablePluginValues } from '../variable-model';
-import { VariableEditorState, getVariableDefinitionFromState, getInitialState } from './variable-editor-form-model';
+import { getVariableDefinitionFromState, getInitialState } from './variable-editor-form-model';
 
-const VARIABLE_TYPES = ['ListVariable', 'TextVariable'] as const;
 const DEFAULT_MAX_PREVIEW_VALUES = 50;
 
 // TODO: Replace with proper validation library
@@ -212,7 +207,7 @@ export function VariableEditForm({
               Allow Multiple
               <Switch
                 checked={state.listVariableFields.allowMultiple}
-                onChange={(e) => {
+                onChange={(v) => {
                   setState((draft) => {
                     draft.title = v.target.value;
                   });


### PR DESCRIPTION
Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>

This is just a visual update: Makes the headers in the "variable list" editor,  variable editor, and panel editor all look the same!

## Before
<img width="1512" alt="Screen Shot 2022-11-17 at 1 22 34 PM" src="https://user-images.githubusercontent.com/2584129/202562573-c42a2f95-01e6-4bcc-b186-e1dac97a7c70.png">
<img width="1512" alt="Screen Shot 2022-11-17 at 1 22 36 PM" src="https://user-images.githubusercontent.com/2584129/202562594-a072a11c-ae44-4132-a273-a4f277b808fe.png">
<img width="1512" alt="Screen Shot 2022-11-17 at 1 22 42 PM" src="https://user-images.githubusercontent.com/2584129/202562598-911f02e2-0b63-4015-b4ed-5bea880a7246.png">

## After
<img width="1512" alt="Screen Shot 2022-11-17 at 1 20 23 PM" src="https://user-images.githubusercontent.com/2584129/202562229-b7737cf5-80ce-4b3d-8a1e-cb1544b78bc6.png">
<img width="1512" alt="Screen Shot 2022-11-17 at 1 20 29 PM" src="https://user-images.githubusercontent.com/2584129/202562240-d1a748e6-03b2-4806-b591-829778172501.png">
<img width="1512" alt="Screen Shot 2022-11-17 at 1 20 33 PM" src="https://user-images.githubusercontent.com/2584129/202562242-97629cdc-4dc8-46c4-b38c-a9c057d96e04.png">
