### PR TITLE
Use Perses Drawer component for variable editor 

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -164,7 +164,7 @@ export function VariableEditor(props: {
               </Button>
             </Stack>
           </Box>
-          <Box padding={2}>
+          <Box padding={2} sx={{ overflowY: 'scroll' }}>
             <Typography variant="h3" mb={2}>
               Variable List
             </Typography>

--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -153,7 +153,7 @@ export function VariableEditForm({
           </Button>
         </Stack>
       </Box>
-      <Box padding={2}>
+      <Box padding={2} sx={{ overflowY: 'scroll' }}>
         <Typography variant="h3" mb={2}>
           Edit Variable
         </Typography>

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -12,11 +12,12 @@
 // limitations under the License.
 
 import React, { useState } from 'react';
-import { Button, Stack, Box, Drawer, AppBar, useScrollTrigger, IconButton } from '@mui/material';
+import { Button, Stack, Box, AppBar, useScrollTrigger, IconButton } from '@mui/material';
 import EyeIcon from 'mdi-material-ui/Eye';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
+import { Drawer } from '@perses-dev/components';
 import { useTemplateVariableDefinitions, useEditMode, useTemplateVariableActions } from '../../context';
 import { TemplateVariable } from './Variable';
 import { VariableEditor } from './VariableEditor';
@@ -35,14 +36,17 @@ export function TemplateVariableList(props: TemplateVariableListProps) {
   const { setVariableDefinitions } = useTemplateVariableActions();
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
   const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
+
+  const onClose = () => {
+    setIsEditing(false);
+  };
+
   return (
     <Box>
-      <Drawer anchor={'right'} open={isEditing} PaperProps={{ sx: { width: '50%' } }}>
+      <Drawer isOpen={isEditing} onClose={onClose} PaperProps={{ sx: { width: '50%' } }}>
         <VariableEditor
-          onCancel={() => {
-            setIsEditing(false);
-          }}
           variableDefinitions={variableDefinitions}
+          onCancel={onClose}
           onChange={(v) => {
             setVariableDefinitions(v);
             setIsEditing(false);


### PR DESCRIPTION
Perses Drawer:
- has default right position
- has a default width
- requires a prop that tells it how to close when someone clicks outside the drawer 

Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>