### PR TITLE
Update the expanded/collapsed icons for panel groups

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import { Box, IconButton, Stack, Typography } from '@mui/material';
-import ExpandedIcon from 'mdi-material-ui/ChevronUp';
-import CollapsedIcon from 'mdi-material-ui/ChevronDown';
+import ExpandedIcon from 'mdi-material-ui/ChevronDown';
+import CollapsedIcon from 'mdi-material-ui/ChevronRight';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
 import ArrowUpIcon from 'mdi-material-ui/ArrowUp';


### PR DESCRIPTION
Mohit updated the designs for these two icons! (looks so great now)

## Before 
<img width="1512" alt="Screen Shot 2022-11-18 at 1 58 28 PM" src="https://user-images.githubusercontent.com/2584129/202810104-e7ed0326-448b-474c-aaa4-bf16274befc6.png">

## After 
<img width="1512" alt="Screen Shot 2022-11-18 at 1 57 51 PM" src="https://user-images.githubusercontent.com/2584129/202810017-9b01a660-f05f-475a-9482-32c61224ef95.png">

## Before
<img width="1512" alt="Screen Shot 2022-11-18 at 1 58 30 PM" src="https://user-images.githubusercontent.com/2584129/202810113-f2e4cca8-57a3-46ab-aa59-62fe2cbce252.png">

## After
<img width="1512" alt="Screen Shot 2022-11-18 at 1 57 54 PM" src="https://user-images.githubusercontent.com/2584129/202810023-12b42008-749a-4704-84b5-def51f3e155a.png">

