### PR TITLE
Fix variable preview bugs

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -263,17 +263,19 @@ export function VariableEditForm({
                   }}
                 />
               </Grid>
-              <Grid item xs={12}>
-                <ErrorBoundary FallbackComponent={() => <div>Error</div>}>
-                  <Stack direction={'row'} spacing={1} alignItems="center">
-                    <Typography variant="caption">Preview Values</Typography>
-                    <IconButton onClick={refreshPreview} size="small">
-                      <Refresh />
-                    </IconButton>
-                  </Stack>
-                  <VariableListPreview definition={previewSpec} />
-                </ErrorBoundary>
-              </Grid>
+              {state.listVariableFields.plugin.kind && (
+                <Grid item xs={12}>
+                  <ErrorBoundary FallbackComponent={() => <div>Error previewing values</div>} resetKeys={[previewSpec]}>
+                    <Stack direction={'row'} spacing={1} alignItems="center">
+                      <Typography variant="caption">Preview Values</Typography>
+                      <IconButton onClick={refreshPreview} size="small">
+                        <Refresh />
+                      </IconButton>
+                    </Stack>
+                    <VariableListPreview definition={previewSpec} />
+                  </ErrorBoundary>
+                </Grid>
+              )}
             </Grid>
 
             <SectionHeader>Dropdown Options</SectionHeader>

--- a/ui/prometheus-plugin/src/plugins/MatcherEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/MatcherEditor.tsx
@@ -11,34 +11,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState } from 'react';
 import { Stack, TextField, Button, Box, IconButton } from '@mui/material';
+import { produce } from 'immer';
 import TrashIcon from 'mdi-material-ui/TrashCan';
 
-export function MatcherEditor(props: { initialMatchers?: string[]; onChange: (matchers: string[]) => void }) {
-  const [matchers, setMatchers] = useState<string[]>(props.initialMatchers ?? []);
+type MatcherEditorProps = {
+  matchers: string[];
+  onChange: (matchers: string[]) => void;
+};
+
+export function MatcherEditor({ matchers, onChange }: MatcherEditorProps) {
   return (
     <Stack spacing={1}>
       {matchers.map((matcher, index) => (
         <Box key={index} display="flex">
           <TextField
             fullWidth
-            onBlur={() => {
-              props.onChange(matchers);
-            }}
             label="Series Selector"
             value={matcher}
             onChange={(e) => {
-              const newMatchers = [...matchers];
-              newMatchers[index] = e.target.value;
-              setMatchers(newMatchers);
+              const newMatchers = produce(matchers, (draft) => {
+                draft[index] = e.target.value;
+              });
+              onChange(newMatchers);
             }}
           />
           <IconButton
             onClick={() => {
-              const newMatchers = [...matchers];
-              newMatchers.splice(index, 1);
-              setMatchers(newMatchers);
+              const newMatchers = produce(matchers, (draft) => {
+                draft.splice(index, 1);
+              });
+              onChange(newMatchers);
             }}
           >
             <TrashIcon />
@@ -50,7 +53,10 @@ export function MatcherEditor(props: { initialMatchers?: string[]; onChange: (ma
           fullWidth={false}
           variant="outlined"
           onClick={() => {
-            setMatchers([...matchers, '']);
+            const newMatchers = produce(matchers, (draft) => {
+              draft.push('');
+            });
+            onChange(newMatchers);
           }}
         >
           Add Series Selector

--- a/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-variables.tsx
@@ -40,7 +40,7 @@ function PrometheusLabelValuesVariableEditor(props: OptionsEditorProps<Prometheu
         }}
       />
       <MatcherEditor
-        initialMatchers={props.value.matchers}
+        matchers={props.value.matchers || []}
         onChange={(e) => {
           props.onChange({ ...props.value, matchers: e });
         }}
@@ -53,7 +53,7 @@ function PrometheusLabelNamesVariableEditor(props: OptionsEditorProps<Prometheus
   return (
     <Stack spacing={1}>
       <MatcherEditor
-        initialMatchers={props.value.matchers}
+        matchers={props.value.matchers || []}
         onChange={(e) => {
           props.onChange({ ...props.value, matchers: e });
         }}


### PR DESCRIPTION
This fixes the following issues:
- Preview failed when there was not a source selected. This would kick in the ErrorBoundary so we need to resetKey to let it update it.
- Series matchers weren't being updated

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>