### PR TITLE
Fix pressing back button removes query param individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [ENHANCEMENT] Dashboard view can be configured to be readonly #731
 - [ENHANCEMENT] reduce line_width and point_radius max allowed values #798
 - [BUGFIX] Fix button wrapping when too many vars #803
+- [BUGFIX] Fix pressing back button removes query param individually #811
 - [BUGFIX] Fix dashboard.name when migrating from a Grafana dashboard #812
 - [BREAKINGCHANGE] bump peer-dependencies @mui/material to v5.10.0 #782
 - [BREAKINGCHANGE] useTimeRange now returns timeRange and absoluteTimeRange #777

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -22,7 +22,7 @@ import { DashboardProvider, DashboardStoreProps } from '../../context';
 import { TimeRangeControls } from './TimeRangeControls';
 
 const history = createMemoryHistory({
-  initialEntries: [generatePath('/dashboards/:id', { id: 'test' })],
+  initialEntries: [generatePath('/home'), generatePath('/dashboards/:id', { id: 'test' })],
 });
 
 describe('TimeRangeControls', () => {
@@ -70,11 +70,11 @@ describe('TimeRangeControls', () => {
     userEvent.click(secondSelected);
     expect(history.location.search).toEqual('?start=12h');
 
-    // back button should return to first option selected
+    // back button should return to previous page selected
     act(() => {
       history.back();
     });
-    expect(history.location.search).toEqual('?start=5m');
+    expect(history.location.pathname).toEqual('/home');
   });
 
   // TODO: add additional tests for absolute time selection, other inputs, form validation, etc.

--- a/ui/dashboards/src/context/TemplateVariableProvider/query-params.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/query-params.ts
@@ -54,7 +54,7 @@ export function useVariableQueryParams(defs: VariableDefinition[]) {
     const name = getURLQueryParamName(def.spec.name);
     config[name] = VariableValueParam;
   });
-  return useQueryParams(config, { updateType: 'replace' });
+  return useQueryParams(config, { updateType: 'replaceIn' });
 }
 
 export function getInitalValuesFromQueryParameters(

--- a/ui/dashboards/src/context/TemplateVariableProvider/query-params.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/query-params.ts
@@ -54,7 +54,7 @@ export function useVariableQueryParams(defs: VariableDefinition[]) {
     const name = getURLQueryParamName(def.spec.name);
     config[name] = VariableValueParam;
   });
-  return useQueryParams(config);
+  return useQueryParams(config, { updateType: 'replace' });
 }
 
 export function getInitalValuesFromQueryParameters(

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/query-params.ts
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/query-params.ts
@@ -96,7 +96,7 @@ export const timeRangeQueryConfig = {
  * Sets start query param if it is empty on page load
  */
 export function useInitialTimeRange(dashboardDuration: DurationString): TimeRangeValue {
-  const [query] = useQueryParams(timeRangeQueryConfig, { updateType: 'replace' });
+  const [query] = useQueryParams(timeRangeQueryConfig, { updateType: 'replaceIn' });
   const { start, end } = query;
   return useMemo(() => {
     let initialTimeRange: TimeRangeValue = { pastDuration: dashboardDuration };
@@ -120,7 +120,7 @@ export function useSetTimeRangeParams(
   initialTimeRange: TimeRangeValue,
   enabledURLParams = true
 ): Pick<TimeRange, 'timeRange' | 'setTimeRange'> {
-  const [query, setQuery] = useQueryParams(timeRangeQueryConfig, { updateType: 'replace' });
+  const [query, setQuery] = useQueryParams(timeRangeQueryConfig, { updateType: 'replaceIn' });
 
   // determine whether initial param had previously been populated to fix back btn
   const [paramsLoaded, setParamsLoaded] = useState<boolean>(false);

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/query-params.ts
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/query-params.ts
@@ -96,7 +96,7 @@ export const timeRangeQueryConfig = {
  * Sets start query param if it is empty on page load
  */
 export function useInitialTimeRange(dashboardDuration: DurationString): TimeRangeValue {
-  const [query] = useQueryParams(timeRangeQueryConfig);
+  const [query] = useQueryParams(timeRangeQueryConfig, { updateType: 'replace' });
   const { start, end } = query;
   return useMemo(() => {
     let initialTimeRange: TimeRangeValue = { pastDuration: dashboardDuration };
@@ -120,7 +120,7 @@ export function useSetTimeRangeParams(
   initialTimeRange: TimeRangeValue,
   enabledURLParams = true
 ): Pick<TimeRange, 'timeRange' | 'setTimeRange'> {
-  const [query, setQuery] = useQueryParams(timeRangeQueryConfig);
+  const [query, setQuery] = useQueryParams(timeRangeQueryConfig, { updateType: 'replace' });
 
   // determine whether initial param had previously been populated to fix back btn
   const [paramsLoaded, setParamsLoaded] = useState<boolean>(false);


### PR DESCRIPTION
Pressing browser back button removes each query param individually instead actually navigating to the previous page

**Before**
![before-back-button](https://user-images.githubusercontent.com/9817826/203437931-12839731-abfc-4d30-966c-6bb99dafa2e6.gif)


**After**
![after-back-button](https://user-images.githubusercontent.com/9817826/203437950-ace78c9d-2bac-44c6-a61a-645af2641c46.gif)
