### PR TITLE
Fix dashboard.name when migrating from a Grafana dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 - [FEATURE] Add ability to refresh dashboard #777
 - [FEATURE] Add a migration page #774
 - [ENHANCEMENT] Dashboard view can be configured to be readonly #731
+- [BUGFIX] Fix button wrapping when too many vars #803
+- [BUGFIX] Fix dashboard.name when migrating from a Grafana dashboard #812
 - [BREAKINGCHANGE] bump peer-dependencies @mui/material to v5.10.0 #782
 - [BREAKINGCHANGE] useTimeRange now returns timeRange and absoluteTimeRange #777
-- [BUGFIX] Fix button wrapping when too many vars #803
 - [BREAKINGCHANGE] Remove empty chart #809
 
 ## 0.17.0 / 2022-11-21

--- a/internal/api/impl/migrate/mapping.cuepart
+++ b/internal/api/impl/migrate/mapping.cuepart
@@ -1,13 +1,18 @@
 import (
+	// regexp is not used at the current stage in this file. It is used when merging the different cuepart file together. This is a way to shared the import across the different files
     "regexp"
+    "strings"
 )
 
 kind: "Dashboard",
 metadata: {
-    name: #grafanaDashboard.title
+    name: strings.Replace(#grafanaDashboard.title, " ", "", -1)
 },
 spec: {
     duration: "1h" // fixed value, we don't really care translating this one
+    display: {
+    	name: #grafanaDashboard.title
+    }
     variables: [ for _, grafanaVar in #grafanaDashboard.templating.list {
         if grafanaVar.type == "constant" {
             kind: "TextVariable"

--- a/internal/api/impl/migrate/testdata/perses_dashboard.json
+++ b/internal/api/impl/migrate/testdata/perses_dashboard.json
@@ -1,13 +1,16 @@
 {
     "kind": "Dashboard",
     "metadata": {
-        "name": "Simple grafana dashboard",
+        "name": "Simplegrafanadashboard",
         "created_at": "0001-01-01T00:00:00Z",
         "updated_at": "0001-01-01T00:00:00Z",
         "project": ""
     },
     "spec": {
         "duration": "1h",
+        "display": {
+            "name": "Simple grafana dashboard"
+        },
         "variables": [
             {
                 "kind": "ListVariable",


### PR DESCRIPTION
Before migrating the node exporter dashboard (as an example) would lead to having an error from the server when going to create the dashboard migrated because the name contains space.

This PR tackles this issue by removing any space in the dashboard title. The title is used in the display object.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>