### PR TITLE
Add ability to select multiple legend items

### DIFF
--- a/ui/components/src/Legend/CompactLegend.tsx
+++ b/ui/components/src/Legend/CompactLegend.tsx
@@ -26,7 +26,7 @@ interface CompactLegendProps {
  */
 export function CompactLegend({ height, items }: CompactLegendProps) {
   return (
-    <Box sx={{ width: '100%', height, paddingTop: 1, overflowY: 'scroll' }}>
+    <Box component="ul" sx={{ width: '100%', height, padding: [0, 1, 0, 0], overflowY: 'scroll', margin: 0 }}>
       {items.map((item) => (
         <ListLegendItem
           key={item.id}

--- a/ui/components/src/Legend/ListLegendItem.tsx
+++ b/ui/components/src/Legend/ListLegendItem.tsx
@@ -33,7 +33,6 @@ export const ListLegendItem = React.memo(function ListLegendItem({ item, sx, ...
         sx
       )}
       dense={true}
-      data-testid={`legend-item-${item.color}`}
       key={item.id}
       onClick={item.onClick}
       selected={item.isSelected}

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -77,6 +77,18 @@ const TEST_TIME_SERIES_PANEL: TimeSeriesChartProps = {
   },
 };
 
+function getLegendByName(name?: string) {
+  if (typeof name !== 'string') {
+    throw new Error('Legend name must be a string.');
+  }
+
+  return screen.getByRole('listitem', {
+    name: (content, element) => {
+      return element.innerHTML.includes(name);
+    },
+  });
+}
+
 describe('TimeSeriesChartPanel', () => {
   beforeEach(() => {
     // TODO: remove and instead use addMockPlugin after rest of runtime dependencies are mocked
@@ -115,7 +127,92 @@ describe('TimeSeriesChartPanel', () => {
 
   it('should toggle selected state when a legend item is clicked', async () => {
     renderPanel();
-    await userEvent.click(screen.getByTestId('legend-item-hsla(-141599372,50%,50%,0.8)'));
-    expect(screen.getByTestId('legend-item-hsla(-141599372,50%,50%,0.8)')).toHaveClass('Mui-selected');
+
+    const seriesArr = Array.from(MOCK_TIME_SERIES_DATA.series);
+    const firstLegend = getLegendByName(seriesArr[0]?.name);
+    const secondLegend = getLegendByName(seriesArr[1]?.name);
+
+    userEvent.click(firstLegend);
+    expect(firstLegend).toHaveClass('Mui-selected');
+    expect(secondLegend).not.toHaveClass('Mui-selected');
+
+    userEvent.click(secondLegend);
+    expect(firstLegend).not.toHaveClass('Mui-selected');
+    expect(secondLegend).toHaveClass('Mui-selected');
+  });
+
+  it('should modify selected state when a legend item is clicked with shift key', async () => {
+    renderPanel();
+    const seriesArr = Array.from(MOCK_TIME_SERIES_DATA.series);
+    const firstLegend = getLegendByName(seriesArr[0]?.name);
+    const secondLegend = getLegendByName(seriesArr[1]?.name);
+
+    // Add first legend item
+    userEvent.click(firstLegend, {
+      shiftKey: true,
+    });
+    expect(firstLegend).toHaveClass('Mui-selected');
+    expect(secondLegend).not.toHaveClass('Mui-selected');
+
+    // Add second legend item
+    userEvent.click(secondLegend, {
+      shiftKey: true,
+    });
+    expect(firstLegend).toHaveClass('Mui-selected');
+    expect(secondLegend).toHaveClass('Mui-selected');
+
+    // Remove first legend item
+    userEvent.click(firstLegend, {
+      shiftKey: true,
+    });
+    expect(firstLegend).not.toHaveClass('Mui-selected');
+    expect(secondLegend).toHaveClass('Mui-selected');
+
+    // Remove second legend item
+    userEvent.click(secondLegend, {
+      shiftKey: true,
+    });
+    expect(firstLegend).not.toHaveClass('Mui-selected');
+    expect(secondLegend).not.toHaveClass('Mui-selected');
+  });
+
+  it('should modify selected state when a legend item is clicked with meta key', async () => {
+    renderPanel();
+    const seriesArr = Array.from(MOCK_TIME_SERIES_DATA.series);
+
+    // Falling back to a bogus string if not set to appease typescript.
+    const firstName = seriesArr[0]?.name;
+    const secondName = seriesArr[1]?.name;
+
+    const firstLegend = getLegendByName(firstName);
+    const secondLegend = getLegendByName(secondName);
+
+    // Add first legend item
+    userEvent.click(firstLegend, {
+      metaKey: true,
+    });
+    expect(firstLegend).toHaveClass('Mui-selected');
+    expect(secondLegend).not.toHaveClass('Mui-selected');
+
+    // Add second legend item
+    userEvent.click(secondLegend, {
+      metaKey: true,
+    });
+    expect(firstLegend).toHaveClass('Mui-selected');
+    expect(secondLegend).toHaveClass('Mui-selected');
+
+    // Remove first legend item
+    userEvent.click(firstLegend, {
+      metaKey: true,
+    });
+    expect(firstLegend).not.toHaveClass('Mui-selected');
+    expect(secondLegend).toHaveClass('Mui-selected');
+
+    // Remove second legend item
+    userEvent.click(secondLegend, {
+      metaKey: true,
+    });
+    expect(firstLegend).not.toHaveClass('Mui-selected');
+    expect(secondLegend).not.toHaveClass('Mui-selected');
   });
 });

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -59,8 +59,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     max: y_axis?.max,
   };
 
-  // TODO: change to array, support multi select on Shift-click
-  const [selectedSeriesName, setSelectedSeriesName] = useState<string | null>(null);
+  const [selectedSeriesNames, setSelectedSeriesNames] = useState<string[]>([]);
 
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);
   const queryResults = useTimeSeriesQueries(queries, { suggestedStepMs });
@@ -69,12 +68,30 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
   const { setTimeRange } = useTimeRange();
 
-  const onLegendItemClick = (seriesName: string) => {
-    setSelectedSeriesName((current) => {
-      if (current === null || current !== seriesName) {
-        return seriesName;
+  const onLegendItemClick = (e: React.MouseEvent<HTMLLIElement, MouseEvent>, seriesName: string) => {
+    const isModifiedClick = e.metaKey || e.shiftKey;
+
+    setSelectedSeriesNames((current) => {
+      const isSelected = current.includes(seriesName);
+
+      // Clicks with modifier key can select multiple items.
+      if (isModifiedClick) {
+        if (isSelected) {
+          // Modified click on already selected item. Remove that item.
+          return current.filter((name) => name !== seriesName);
+        }
+
+        // Modified click on not-selected item. Add it.
+        return [...current, seriesName];
       }
-      return null;
+
+      if (isSelected) {
+        // Clicked item was already selected. Unselect it.
+        return [];
+      }
+
+      // Select clicked item.
+      return [seriesName];
     });
   };
 
@@ -103,16 +120,18 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         const formattedSeriesName = timeSeries.formattedName ?? timeSeries.name;
         const yValues = getYValues(timeSeries, timeScale);
         const lineSeries = getLineSeries(timeSeries.name, formattedSeriesName, yValues, visual);
-        if (selectedSeriesName === null || selectedSeriesName === timeSeries.name) {
+        const isSelected = selectedSeriesNames.includes(timeSeries.name);
+
+        if (!selectedSeriesNames.length || isSelected) {
           graphData.timeSeries.push(lineSeries);
         }
         if (legend && graphData.legendItems) {
           graphData.legendItems.push({
             id: timeSeries.name, // TODO: should query generate an id instead of using full name here and in getRandomColor?
             label: formattedSeriesName,
-            isSelected: selectedSeriesName === timeSeries.name,
+            isSelected,
             color: getRandomColor(timeSeries.name),
-            onClick: () => onLegendItemClick(timeSeries.name),
+            onClick: (e) => onLegendItemClick(e, timeSeries.name),
           });
         }
       }
@@ -139,7 +158,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     return {
       graphData,
     };
-  }, [queryResults, thresholds, selectedSeriesName, legend, visual]);
+  }, [queryResults, thresholds, selectedSeriesNames, legend, visual]);
 
   if (contentDimensions === undefined) {
     return null;


### PR DESCRIPTION
Multiple legend items can be selected with a modified click using:
- Shift key
- Meta key (varies depending on operating system)

Additional small changes in this commit:
- Adjust tests to avoid need for `data-testid` attribute
- Fix case where `li` elements were not parented by a `ul`

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>