### PR TITLE
Migration: Manage Grafana dashboard input

### DIFF
--- a/internal/api/core/middleware/proxy.go
+++ b/internal/api/core/middleware/proxy.go
@@ -89,14 +89,14 @@ func getGlobalDatasourceAndPath(dao globaldatasource.DAO, requestPath string) (v
 	// Based on the HTTP 1.1 RFC, a `/` should be the minimum path.
 	// https://datatracker.ietf.org/doc/html/rfc2616#section-5.1.2
 	path := "/"
-	if len(matchingGroups[0]) > 1 {
+	if len(matchingGroups[0]) > 2 {
 		path = matchingGroups[0][2]
 	}
 	return dts.Spec, path, nil
 }
 
 func getLocalDatasourceAndPath(dao datasource.DAO, requestPath string) (v1.DatasourceSpec, string, error) {
-	matchingGroups := globalProxyMatcher.FindAllStringSubmatch(requestPath, -1)
+	matchingGroups := localProxyMatcher.FindAllStringSubmatch(requestPath, -1)
 	if len(matchingGroups) > 1 || len(matchingGroups[0]) <= 2 {
 		return v1.DatasourceSpec{}, "", echo.NewHTTPError(http.StatusBadGateway, "unable to forward the request to the datasource, request not properly formatted")
 	}
@@ -115,8 +115,8 @@ func getLocalDatasourceAndPath(dao datasource.DAO, requestPath string) (v1.Datas
 	// Based on the HTTP 1.1 RFC, a `/` should be the minimum path.
 	// https://datatracker.ietf.org/doc/html/rfc2616#section-5.1.2
 	path := "/"
-	if len(matchingGroups[0]) > 1 {
-		path = matchingGroups[0][2]
+	if len(matchingGroups[0]) > 3 {
+		path = matchingGroups[0][3]
 	}
 	return dts.Spec, path, nil
 }

--- a/pkg/client/api/client.go
+++ b/pkg/client/api/client.go
@@ -16,13 +16,14 @@ package api
 import (
 	v1 "github.com/perses/perses/pkg/client/api/v1"
 	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 type ClientInterface interface {
 	RESTClient() *perseshttp.RESTClient
 	V1() v1.ClientInterface
-	Migrate(grafanaDashboard interface{}) (*modelV1.Dashboard, error)
+	Migrate(body *api.Migrate) (*modelV1.Dashboard, error)
 }
 
 type client struct {
@@ -44,12 +45,12 @@ func (c *client) V1() v1.ClientInterface {
 	return v1.NewWithClient(c.restClient)
 }
 
-func (c *client) Migrate(grafanaDashboard interface{}) (*modelV1.Dashboard, error) {
+func (c *client) Migrate(body *api.Migrate) (*modelV1.Dashboard, error) {
 	result := &modelV1.Dashboard{}
 	err := c.restClient.Post().
 		APIVersion("").
 		Resource("migrate").
-		Body(grafanaDashboard).
+		Body(body).
 		Do().
 		Object(result)
 	return result, err

--- a/pkg/model/api/migrate.go
+++ b/pkg/model/api/migrate.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Migrate struct {
+	Input            map[string]string `json:"input,omitempty"`
+	GrafanaDashboard json.RawMessage   `json:"grafana_dashboard"`
+}
+
+func (m *Migrate) UnmarshalJSON(data []byte) error {
+	var tmp Migrate
+	type plain Migrate
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*m = tmp
+	return nil
+}
+
+func (m *Migrate) validate() error {
+	if len(m.GrafanaDashboard) == 0 {
+		return fmt.Errorf("grafana_dashboard cannot be empty")
+	}
+	return nil
+}

--- a/ui/app/src/model/migrate-client.ts
+++ b/ui/app/src/model/migrate-client.ts
@@ -17,17 +17,24 @@ import buildURL from './url-builder';
 
 const resource = 'migrate';
 
+export interface MigrateBodyRequest {
+  input?: Record<string, string>;
+  grafana_dashboard: string;
+}
+
 export function useMigrate() {
-  return useMutation<DashboardResource, Error, string>({
+  return useMutation<DashboardResource, Error, MigrateBodyRequest>({
     mutationKey: [resource],
-    mutationFn: (grafanaDashboard) => {
+    mutationFn: (body) => {
       const url = buildURL({ apiPrefix: '/api', resource: resource });
       return fetchJson<DashboardResource>(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: grafanaDashboard,
+        body: `{"input":${body.input ? JSON.stringify(body.input) : '{}'}, "grafana_dashboard": ${
+          body.grafana_dashboard
+        }}`,
       });
     },
   });


### PR DESCRIPTION
When you want to migrate a dashboard coming from the Grafana marketplace, it can happen there is a list of input like : 

```json
    {
      "name": "DS_PROMETHEUS",
      "label": "prometheus",
      "description": "",
      "type": "datasource",
      "pluginId": "prometheus",
      "pluginName": "Prometheus"
    }
```

This PR is proposing a way to take in consideration. 
1. On API side, the body expected has been changed. It contains now the grafana dashboard (as before) and a map that would represent the values of the inputs.
These values are then used to replace the variable in the whole grafana dashboard. Once it is done, the migration script is running like before.

2. On the UI side, if the Grafana dashboard contains a list of input, it will generate a list of `TextField` that the user can used to enter the different values. 

3. On the CLI side, it is less clever, there is just a new parameters called `input` that can be used in the command.

![image](https://user-images.githubusercontent.com/4548045/203822232-e8d70a04-71ac-4e05-a9a8-be025930f8d7.png)


Signed-off-by: Augustin Husson <husson.augustin@gmail.com>