### PR TITLE
fix the permission on the workdir perses in the docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [BUGFIX] Fix button wrapping when too many vars #803
 - [BUGFIX] Fix pressing back button removes query param individually #811
 - [BUGFIX] Fix dashboard.name when migrating from a Grafana dashboard #812
+- [BUGFIX] Fix the permission on the workdir `perses` in the docker images #817
 - [BREAKINGCHANGE] bump peer-dependencies @mui/material to v5.10.0 #782
 - [BREAKINGCHANGE] useTimeRange now returns timeRange and absoluteTimeRange #777
 - [BREAKINGCHANGE] Remove empty chart #809

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+FROM alpine AS build-env
+RUN mkdir /perses
+
 FROM gcr.io/distroless/static-debian11
 
 LABEL maintainer="The Perses Authors <perses-team@googlegroups.com>"
@@ -10,9 +13,9 @@ COPY --chown=nobody:nobody LICENSE                           /LICENSE
 COPY --chown=nobody:nobody schemas/                          /etc/perses/schemas/
 COPY --chown=nobody:nobody cue.mod/                          /etc/perses/cue.mod/
 COPY --chown=nobody:nobody docs/examples/config.docker.yaml  /etc/perses/config.yaml
+COPY --from=build-env --chown=nobody:nobody                  /perses /perses
 
 WORKDIR /perses
-RUN chown -R nobody:nobody /perses
 
 EXPOSE     8080
 VOLUME     ["/perses"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY --chown=nobody:nobody cue.mod/                          /etc/perses/cue.mod
 COPY --chown=nobody:nobody docs/examples/config.docker.yaml  /etc/perses/config.yaml
 
 WORKDIR /perses
+RUN chown -R nobody:nobody /perses
+
 EXPOSE     8080
 VOLUME     ["/perses"]
 ENTRYPOINT [ "/bin/perses" ]

--- a/distroless-debug.Dockerfile
+++ b/distroless-debug.Dockerfile
@@ -1,3 +1,6 @@
+FROM alpine AS build-env
+RUN mkdir /perses
+
 FROM gcr.io/distroless/static-debian11:debug
 
 LABEL maintainer="The Perses Authors <perses-team@googlegroups.com>"
@@ -10,9 +13,9 @@ COPY --chown=nobody:nobody LICENSE                           /LICENSE
 COPY --chown=nobody:nobody schemas/                          /etc/perses/schemas/
 COPY --chown=nobody:nobody cue.mod/                          /etc/perses/cue.mod/
 COPY --chown=nobody:nobody docs/examples/config.docker.yaml  /etc/perses/config.yaml
+COPY --from=build-env --chown=nobody:nobody                  /perses /perses
 
 WORKDIR /perses
-RUN chown -R nobody:nobody /perses
 
 EXPOSE     8080
 VOLUME     ["/perses"]

--- a/distroless-debug.Dockerfile
+++ b/distroless-debug.Dockerfile
@@ -12,6 +12,8 @@ COPY --chown=nobody:nobody cue.mod/                          /etc/perses/cue.mod
 COPY --chown=nobody:nobody docs/examples/config.docker.yaml  /etc/perses/config.yaml
 
 WORKDIR /perses
+RUN chown -R nobody:nobody /perses
+
 EXPOSE     8080
 VOLUME     ["/perses"]
 ENTRYPOINT [ "/bin/perses" ]


### PR DESCRIPTION
When using the docker image, it appears that the workdir `/perses` doesn't have the right usergroup which ends up by not being able to use it.

This PR is hopefully fixing this issue.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>