### PR TITLE
replace encoding/json by jsoniter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [BUGFIX] Fix `dashboard.name` when migrating from a Grafana dashboard #812
 - [BUGFIX] Fix the permission on the workdir `perses` in the docker images #817
 - [BUGFIX] Fix the backend proxy that wasn't working when using a datasource from a project. #816
+- [BUGFIX] Fix issue when translating a Perses dashboard from YAML to JSON. #822
 - [BREAKINGCHANGE] Bump peer-dependencies @mui/material to v5.10.0 #782
 - [BREAKINGCHANGE] useTimeRange now returns timeRange and absoluteTimeRange #777
 - [BREAKINGCHANGE] Remove empty chart #809

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cuelang.org/go v0.4.2
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gavv/httpexpect/v2 v2.6.1
+	github.com/json-iterator/go v1.1.12
 	github.com/labstack/echo/v4 v4.9.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/perses/common v0.16.0
@@ -48,6 +49,8 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/nexucis/lamenv v0.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,7 @@ github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -275,9 +276,11 @@ github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQ
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -16,7 +16,6 @@
 package e2eframework
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/perses/perses/internal/api/shared/dependency"
 	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
@@ -112,6 +112,7 @@ func newDatasourceSpec(t *testing.T) v1.DatasourceSpec {
 	if err != nil {
 		t.Fatal(err)
 	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	pluginSpec := &datasource.Prometheus{
 		Proxy: datasourceHTTP.Proxy{
 			Kind: "HTTPProxy",
@@ -191,6 +192,7 @@ func NewGlobalDatasource(t *testing.T, name string) *v1.GlobalDatasource {
 }
 
 func NewDashboard(t *testing.T, projectName string, name string) *v1.Dashboard {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	// Creating a full dashboard is quite long and to ensure the changes are still matching the dev environment,
 	// it's better to use the dashboard written in the dev/data/dashboard.json
 	persesRepositoryPath := getRepositoryPath(t)

--- a/internal/cli/file/file.go
+++ b/internal/cli/file/file.go
@@ -14,9 +14,9 @@
 package file
 
 import (
-	"encoding/json"
 	"fmt"
 
+	jsoniter "github.com/json-iterator/go"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
@@ -24,6 +24,7 @@ import (
 )
 
 func Unmarshal(file string, obj interface{}) error {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	data, isJSON, err := readAndDetect(file)
 	if err != nil {
 		return err
@@ -59,6 +60,7 @@ func (u *unmarshaller) unmarshal(file string) ([]modelAPI.Entity, error) {
 }
 
 func (u *unmarshaller) read(file string) error {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	data, isJSON, err := readAndDetect(file)
 	if err != nil {
 		return err
@@ -92,6 +94,7 @@ func (u *unmarshaller) unmarshalEntities() ([]modelAPI.Entity, error) {
 		return nil, fmt.Errorf("unable to unmarshall data, data is empty")
 	}
 	var result []modelAPI.Entity
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	for i, object := range u.objects {
 		if _, ok := object["kind"]; !ok {
 			return nil, fmt.Errorf("objects[%d] unable to find 'kind' field", i)
@@ -125,6 +128,7 @@ func (u *unmarshaller) unmarshalEntities() ([]modelAPI.Entity, error) {
 }
 
 func (u *unmarshaller) unmarshalEntity(data []byte, entity modelAPI.Entity) error {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var unmarshalErr error
 	if u.isJSON {
 		unmarshalErr = json.Unmarshal(data, entity)

--- a/pkg/client/perseshttp/request.go
+++ b/pkg/client/perseshttp/request.go
@@ -16,13 +16,14 @@ package perseshttp
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 const (
@@ -122,6 +123,7 @@ func (r *Request) Query(query QueryInterface) *Request {
 // Body defines the body in the HTTP request.
 // The body shall be json compatible
 func (r *Request) Body(obj interface{}) *Request {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	data, err := json.Marshal(obj)
 	if err != nil {
 		r.err = err
@@ -321,6 +323,7 @@ type errorResponse struct {
 
 // Error returns the error executing the request, nil if no error occurred.
 func (r *Response) Error() error {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	e := &RequestError{Err: r.err}
 	// check code result
 	if r.statusCode < http.StatusOK || r.statusCode > http.StatusPartialContent {
@@ -352,6 +355,7 @@ func (r *Response) Error() error {
 
 // Object stores the result into respObj.
 func (r *Response) Object(respObj interface{}) error {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := r.Error()
 
 	if err != nil {


### PR DESCRIPTION
This PR proposed to use [jsoniter](https://github.com/json-iterator/go) instead of using `encoding/json` to marshal / unmarshal data.

Using this lib is fixing the issue that you can have when using the CLI to migrate a dashboard in a yaml format.
The conversion between yaml and json doesn't work with the standard library (`encoding/json`) and result with the following error : 

```bash
Error: json: unsupported type: map[interface {}]interface {}
```

This new lib is able to manage this kind of type and as a side effect it seems more optimised. 
Let's see if in a long term we encounter some issues with this new lib.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>