### PR TITLE
[FEATURE] Persist dashboard modification when clicking on save button

### DIFF
--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -14,6 +14,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { DashboardResource, fetchJson } from '@perses-dev/core';
 import buildURL from './url-builder';
+import { HTTPHeader, HTTPMethodPOST, HTTPMethodPUT } from './http';
 
 const resource = 'dashboards';
 
@@ -25,14 +26,31 @@ export function useCreateDashboard(
     mutationFn: (dashboard) => {
       const url = buildURL({ resource: resource, project: dashboard.metadata.project });
       return fetchJson<DashboardResource>(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        method: HTTPMethodPOST,
+        headers: HTTPHeader,
         body: JSON.stringify(dashboard),
       });
     },
     onSuccess: onSuccess,
+  });
+}
+
+export function useUpdateDashboard(
+  onSuccess: (data: DashboardResource) => Promise<unknown> | unknown,
+  onError?: (err: Error) => unknown
+) {
+  return useMutation<DashboardResource, Error, DashboardResource>({
+    mutationKey: [resource],
+    mutationFn: (dashboard) => {
+      const url = buildURL({ resource: resource, project: dashboard.metadata.project, name: dashboard.metadata.name });
+      return fetchJson<DashboardResource>(url, {
+        method: HTTPMethodPUT,
+        headers: HTTPHeader,
+        body: JSON.stringify(dashboard),
+      });
+    },
+    onSuccess: onSuccess,
+    onError: onError,
   });
 }
 

--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -35,22 +35,12 @@ export function useCreateDashboard(
   });
 }
 
-export function useUpdateDashboard(
-  onSuccess: (data: DashboardResource) => Promise<unknown> | unknown,
-  onError?: (err: Error) => unknown
-) {
-  return useMutation<DashboardResource, Error, DashboardResource>({
-    mutationKey: [resource],
-    mutationFn: (dashboard) => {
-      const url = buildURL({ resource: resource, project: dashboard.metadata.project, name: dashboard.metadata.name });
-      return fetchJson<DashboardResource>(url, {
-        method: HTTPMethodPUT,
-        headers: HTTPHeader,
-        body: JSON.stringify(dashboard),
-      });
-    },
-    onSuccess: onSuccess,
-    onError: onError,
+export function updateDashboard(entity: DashboardResource) {
+  const url = buildURL({ resource: resource, project: entity.metadata.project, name: entity.metadata.name });
+  return fetchJson<DashboardResource>(url, {
+    method: HTTPMethodPUT,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
   });
 }
 

--- a/ui/app/src/model/http.ts
+++ b/ui/app/src/model/http.ts
@@ -1,0 +1,19 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const HTTPMethodPOST = 'POST';
+export const HTTPMethodPUT = 'PUT';
+export const HTTPHeader: Record<string, string> = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};

--- a/ui/app/src/model/migrate-client.ts
+++ b/ui/app/src/model/migrate-client.ts
@@ -14,6 +14,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { DashboardResource, fetchJson } from '@perses-dev/core';
 import buildURL from './url-builder';
+import { HTTPHeader, HTTPMethodPOST } from './http';
 
 const resource = 'migrate';
 
@@ -28,10 +29,8 @@ export function useMigrate() {
     mutationFn: (body) => {
       const url = buildURL({ apiPrefix: '/api', resource: resource });
       return fetchJson<DashboardResource>(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        method: HTTPMethodPOST,
+        headers: HTTPHeader,
         body: `{"input":${body.input ? JSON.stringify(body.input) : '{}'}, "grafana_dashboard": ${
           body.grafana_dashboard
         }}`,

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -40,7 +40,7 @@ function ViewDashboard() {
   const dashboardUpdatePromise = (data: DashboardResource) => {
     return updateDashboard(data)
       .then((updatedDashboard) => {
-        successSnackbar(`dashboard ${updatedDashboard.metadata.name} has been successfully updated`);
+        successSnackbar(`dashboard ${updatedDashboard.metadata.name} is successfully updated`);
         return updatedDashboard;
       })
       .catch((err) => {

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -17,10 +17,12 @@ import { Box } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../model/bundled-plugins';
-import { useDashboard } from '../model/dashboard-client';
+import { useDashboard, useUpdateDashboard } from '../model/dashboard-client';
 import { useDatasourceApi } from '../model/datasource-api';
 import DashboardBreadcrumbs from '../components/DashboardBreadcrumbs';
 import { useIsReadonly } from '../model/config-client';
+import { useSnackbar } from '../context/SnackbarProvider';
+import { DashboardResource } from '@perses-dev/core';
 
 /**
  * The View for viewing a Dashboard.
@@ -34,6 +36,10 @@ function ViewDashboard() {
 
   const datasourceApi = useDatasourceApi();
   const { data, isLoading } = useDashboard(projectName, dashboardName);
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const dashboardUpdateMutation = useUpdateDashboard((data: DashboardResource) => {
+    successSnackbar(`dashboard ${data.metadata.name} has been successfully updated`);
+  }, exceptionSnackbar);
   const isReadonly = useIsReadonly();
   if (isLoading) return null;
 
@@ -64,6 +70,7 @@ function ViewDashboard() {
                   dashboardProject={data.metadata.project}
                 />
               }
+              dashboardMutation={dashboardUpdateMutation}
               initialVariableIsSticky={true}
               isReadonly={isReadonly}
             />

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -39,9 +39,9 @@ function ViewDashboard() {
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
   const dashboardUpdatePromise = (data: DashboardResource) => {
     return updateDashboard(data)
-      .then((data) => {
-        successSnackbar(`dashboard ${data.metadata.name} has been successfully updated`);
-        return data;
+      .then((updatedDashboard) => {
+        successSnackbar(`dashboard ${updatedDashboard.metadata.name} has been successfully updated`);
+        return updatedDashboard;
       })
       .catch((err) => {
         exceptionSnackbar(err);

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -45,7 +45,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   } = props;
 
   const { isEditMode, setEditMode } = useEditMode();
-  const [isSaveDashboard, setSaveDashboard] = useState<boolean>(false);
+  const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
   const dashboard = useDashboard();
   const { openAddPanelGroup, openAddPanel } = useDashboardActions();
   const isLaptopSize = useMediaQuery(useTheme().breakpoints.up('sm'));
@@ -56,15 +56,15 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   );
 
   const onSaveButtonClick = () => {
-    if (onSave != undefined) {
-      setSaveDashboard(true);
+    if (onSave !== undefined) {
+      setSavingDashboard(true);
       onSave(dashboard.dashboard)
         .then(() => {
-          setSaveDashboard(false);
+          setSavingDashboard(false);
           setEditMode(false);
         })
         .catch(() => {
-          setSaveDashboard(false);
+          setSavingDashboard(false);
         });
     } else {
       setEditMode(false);
@@ -83,7 +83,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
                   Dashboard managed via code only. Download JSON and commit changes to save.
                 </Alert>
               )}
-              <Button variant="contained" onClick={onSaveButtonClick} disabled={isReadonly || isSaveDashboard}>
+              <Button variant="contained" onClick={onSaveButtonClick} disabled={isReadonly || isSavingDashboard}>
                 Save
               </Button>
               <Button variant="outlined" onClick={onCancelButtonClick}>

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -18,7 +18,7 @@ import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 import { UseMutationResult } from '@tanstack/react-query';
 import { DashboardResource } from '@perses-dev/core';
-import { useDashboardActions, useEditMode } from '../../context';
+import { useDashboard, useDashboardActions, useEditMode } from '../../context';
 import { TemplateVariableList } from '../Variables';
 import { TimeRangeControls } from '../TimeRangeControls';
 import { DownloadButton } from '../DownloadButton';
@@ -45,6 +45,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   } = props;
 
   const { isEditMode, setEditMode } = useEditMode();
+  const dashboard = useDashboard();
   const { openAddPanelGroup, openAddPanel } = useDashboardActions();
   const isLaptopSize = useMediaQuery(useTheme().breakpoints.up('sm'));
   const dashboardTitle = dashboardTitleComponent ? (
@@ -54,7 +55,14 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   );
 
   const onSave = () => {
-    setEditMode(false);
+    dashboardMutation?.mutate(dashboard.dashboard);
+    if (dashboardMutation !== undefined) {
+      if (dashboardMutation.isSuccess) {
+        setEditMode(false);
+      }
+    } else {
+      setEditMode(false);
+    }
   };
 
   return (

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -17,11 +17,11 @@ import AddPanelGroupIcon from 'mdi-material-ui/PlusBoxOutline';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
+import { useState } from 'react';
 import { useDashboard, useDashboardActions, useEditMode } from '../../context';
 import { TemplateVariableList } from '../Variables';
 import { TimeRangeControls } from '../TimeRangeControls';
 import { DownloadButton } from '../DownloadButton';
-import { useState } from 'react';
 
 export interface DashboardToolbarProps {
   dashboardName: string;

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -16,6 +16,8 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import AddPanelGroupIcon from 'mdi-material-ui/PlusBoxOutline';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
+import { UseMutationResult } from '@tanstack/react-query';
+import { DashboardResource } from '@perses-dev/core';
 import { useDashboardActions, useEditMode } from '../../context';
 import { TemplateVariableList } from '../Variables';
 import { TimeRangeControls } from '../TimeRangeControls';
@@ -24,6 +26,7 @@ import { DownloadButton } from '../DownloadButton';
 export interface DashboardToolbarProps {
   dashboardName: string;
   dashboardTitleComponent?: JSX.Element;
+  dashboardMutation?: UseMutationResult<DashboardResource, Error, DashboardResource>;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;
   onEditButtonClick: () => void;
@@ -34,6 +37,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   const {
     dashboardName,
     dashboardTitleComponent,
+    dashboardMutation,
     initialVariableIsSticky,
     isReadonly,
     onEditButtonClick,
@@ -65,7 +69,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
                   Dashboard managed via code only. Download JSON and commit changes to save.
                 </Alert>
               )}
-              <Button variant="contained" onClick={onSave} disabled={isReadonly}>
+              <Button variant="contained" onClick={onSave} disabled={isReadonly || dashboardMutation?.isLoading}>
                 Save
               </Button>
               <Button variant="outlined" onClick={onCancelButtonClick}>

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -15,7 +15,6 @@ import { useState } from 'react';
 import { Box } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
-import { UseMutationResult } from '@tanstack/react-query';
 import {
   PanelDrawer,
   Dashboard,

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { Box } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
+import { UseMutationResult } from '@tanstack/react-query';
 import {
   PanelDrawer,
   Dashboard,
@@ -29,12 +30,13 @@ import { useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '
 export interface DashboardAppProps {
   dashboardResource: DashboardResource;
   dashboardTitleComponent?: JSX.Element;
+  dashboardMutation?: UseMutationResult<DashboardResource, Error, DashboardResource>;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;
 }
 
 export const DashboardApp = (props: DashboardAppProps) => {
-  const { dashboardResource, dashboardTitleComponent, initialVariableIsSticky, isReadonly } = props;
+  const { dashboardResource, dashboardTitleComponent, dashboardMutation, initialVariableIsSticky, isReadonly } = props;
   const { setEditMode } = useEditMode();
   const { dashboard, setDashboard } = useDashboard();
   const [originalDashboard, setOriginalDashboard] = useState<DashboardResource | undefined>(undefined);
@@ -86,6 +88,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
         dashboardName={dashboardResource.metadata.name}
         dashboardTitleComponent={dashboardTitleComponent}
         initialVariableIsSticky={initialVariableIsSticky}
+        dashboardMutation={dashboardMutation}
         isReadonly={isReadonly}
         onEditButtonClick={onEditButtonClick}
         onCancelButtonClick={onCancelButtonClick}

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -30,13 +30,13 @@ import { useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '
 export interface DashboardAppProps {
   dashboardResource: DashboardResource;
   dashboardTitleComponent?: JSX.Element;
-  dashboardMutation?: UseMutationResult<DashboardResource, Error, DashboardResource>;
+  onSave?: (entity: DashboardResource) => Promise<DashboardResource>;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;
 }
 
 export const DashboardApp = (props: DashboardAppProps) => {
-  const { dashboardResource, dashboardTitleComponent, dashboardMutation, initialVariableIsSticky, isReadonly } = props;
+  const { dashboardResource, dashboardTitleComponent, onSave, initialVariableIsSticky, isReadonly } = props;
   const { setEditMode } = useEditMode();
   const { dashboard, setDashboard } = useDashboard();
   const [originalDashboard, setOriginalDashboard] = useState<DashboardResource | undefined>(undefined);
@@ -88,7 +88,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
         dashboardName={dashboardResource.metadata.name}
         dashboardTitleComponent={dashboardTitleComponent}
         initialVariableIsSticky={initialVariableIsSticky}
-        dashboardMutation={dashboardMutation}
+        onSave={onSave}
         isReadonly={isReadonly}
         onEditButtonClick={onEditButtonClick}
         onCancelButtonClick={onCancelButtonClick}

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -15,7 +15,6 @@ import { Box, BoxProps } from '@mui/material';
 import { DashboardResource } from '@perses-dev/core';
 import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import { TimeRangeProvider, useInitialTimeRange } from '@perses-dev/plugin-system';
-import { UseMutationResult } from '@tanstack/react-query';
 import {
   TemplateVariableProvider,
   DashboardProvider,
@@ -28,7 +27,7 @@ export interface ViewDashboardProps extends Omit<BoxProps, 'children'> {
   dashboardResource: DashboardResource;
   datasourceApi: DatasourceStoreProviderProps['datasourceApi'];
   dashboardTitleComponent?: JSX.Element;
-  dashboardMutation?: UseMutationResult<DashboardResource, Error, DashboardResource>;
+  onSave?: (entity: DashboardResource) => Promise<DashboardResource>;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;
 }
@@ -41,7 +40,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
     dashboardResource,
     datasourceApi,
     dashboardTitleComponent,
-    dashboardMutation,
+    onSave,
     initialVariableIsSticky,
     isReadonly,
     sx,
@@ -73,7 +72,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
                 <DashboardApp
                   dashboardResource={dashboardResource}
                   dashboardTitleComponent={dashboardTitleComponent}
-                  dashboardMutation={dashboardMutation}
+                  onSave={onSave}
                   initialVariableIsSticky={initialVariableIsSticky}
                   isReadonly={isReadonly}
                 />

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -15,6 +15,7 @@ import { Box, BoxProps } from '@mui/material';
 import { DashboardResource } from '@perses-dev/core';
 import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import { TimeRangeProvider, useInitialTimeRange } from '@perses-dev/plugin-system';
+import { UseMutationResult } from '@tanstack/react-query';
 import {
   TemplateVariableProvider,
   DashboardProvider,
@@ -27,6 +28,7 @@ export interface ViewDashboardProps extends Omit<BoxProps, 'children'> {
   dashboardResource: DashboardResource;
   datasourceApi: DatasourceStoreProviderProps['datasourceApi'];
   dashboardTitleComponent?: JSX.Element;
+  dashboardMutation?: UseMutationResult<DashboardResource, Error, DashboardResource>;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;
 }
@@ -39,6 +41,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
     dashboardResource,
     datasourceApi,
     dashboardTitleComponent,
+    dashboardMutation,
     initialVariableIsSticky,
     isReadonly,
     sx,
@@ -70,6 +73,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
                 <DashboardApp
                   dashboardResource={dashboardResource}
                   dashboardTitleComponent={dashboardTitleComponent}
+                  dashboardMutation={dashboardMutation}
                   initialVariableIsSticky={initialVariableIsSticky}
                   isReadonly={isReadonly}
                 />


### PR DESCRIPTION
This PR allowed the UI to send a request to the backend to persist the modified dashboard.

Success or error message are displayed using the `Snackbar`

This PR fixes #807 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>