### PR TITLE
Fix panel editor crash by reducing number of expensive loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [ENHANCEMENT] set abbreviate to true in default Decimal unit #813
 - [ENHANCEMENT] show axisPointer line on hover in time series panel #821
+- [BUGFIX] Fix browser crash when opening panel editor #828
 
 ## 0.18.0 / 2022-11-29
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -11,8 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { merge } from 'lodash-es';
+import { useDeepMemo } from '@perses-dev/core';
 import { PanelProps, useTimeSeriesQueries, useTimeRange } from '@perses-dev/plugin-system';
 import type { GridComponentOption } from 'echarts';
 import { Box, Skeleton } from '@mui/material';
@@ -70,6 +71,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);
   const queryResults = useTimeSeriesQueries(queries, { suggestedStepMs });
+  const fetching = queryResults.some((result) => result.isFetching);
   const loading = queryResults.some((result) => result.isLoading);
   const hasData = queryResults.some((result) => result.data && Array.from(result.data.series).length > 0);
 
@@ -103,7 +105,15 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   };
 
   // Populate series data based on query results
-  const { graphData } = useMemo(() => {
+  const { graphData } = useDeepMemo(() => {
+    // If loading or fetching, we display a loading indicator.
+    // We skip the expensive loops below until we are done loading or fetching.
+    if (loading || fetching) {
+      return {
+        graphData: EMPTY_GRAPH_DATA,
+      };
+    }
+
     const timeScale = getCommonTimeScale(queryResults);
     if (timeScale === undefined) {
       return {
@@ -120,8 +130,8 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     const xAxisData = [...getXValues(timeScale)];
 
     for (const result of queryResults) {
-      // Skip queries that are still loading and don't have data
-      if (result.isLoading || result.data === undefined) continue;
+      // Skip queries that are still loading or don't have data
+      if (result.isLoading || result.isFetching || result.data === undefined) continue;
 
       for (const timeSeries of result.data.series) {
         const formattedSeriesName = timeSeries.formattedName ?? timeSeries.name;
@@ -165,13 +175,13 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     return {
       graphData,
     };
-  }, [queryResults, thresholds, selectedSeriesNames, legend, visual]);
+  }, [queryResults, thresholds, selectedSeriesNames, legend, visual, fetching, loading]);
 
   if (contentDimensions === undefined) {
     return null;
   }
 
-  if (loading === true) {
+  if (loading === true || fetching == true) {
     return (
       <Box
         sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}


### PR DESCRIPTION
This gets us to a better place (no crashes), but there are probably ways to improve.

## Issue
We we have been seeing that the browser can freeze/crash when we open the panel editor AND the panel has multiple queries: https://github.com/perses/perses/issues/819

## What's going on?
When we render a time series chart, we load data from the backend, then we use this data to compute `graphData`, and then pass `graphData` into `LineChart` for rendering. But computing `graphData` involves looping over every data point -- so this is the part where we can cause the browser to freeze.

The computation of `graphData` is memoized, with the main dependency being the results from the backend. 

When we open the editor, it looks like we trigger fetching data, which changes the `fetchStatus` of each query result. When there are multiple queries, this can lead to `graphData` being recomputed each time any of the query results changes from `fetchStatus: fetching` to `fetchStatus: idle`. On top of this, it also looks like `stepMs` can go through changes when we're in this fetching stage, which also causes `graphData` to be recomputed too.

## Fix
For now, I was able to stop browser crashes by simply not running the loops if we are either loading or fetching data.

The downside is that we'll render the loading indicator when we're fetching new data, instead of rendering the old data until we're ready to render the new data. It would be nicer to render the old data until we're ready, but I figure this is a good step for now (better than a browser crash). 