### PR TITLE
[ENHANCEMENT] Make it possible to adjust the height of the time range controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - [ENHANCEMENT] Add ability to specify time zone via TimeZoneProvider #825
 - [ENHANCEMENT] Allow `decimal_places` to be used with time units #837
-- [ENHANCEMENT] Make it possible to adjust the height of time range controls #829
 - [BUGFIX] Time series panel edit preview shows stale properties #835
 - [BUGFIX] Fix time unit value format inconsistencies #837
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [ENHANCEMENT] Add ability to specify time zone via TimeZoneProvider #825
 - [ENHANCEMENT] Allow `decimal_places` to be used with time units #837
+- [ENHANCEMENT] Make it possible to adjust the height of time range controls #829
 - [BUGFIX] Time series panel edit preview shows stale properties #835
 - [BUGFIX] Fix time unit value format inconsistencies #837
 

--- a/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -28,11 +28,11 @@ interface DateTimeRangePickerProps {
   value: TimeRangeValue;
   onChange: (value: TimeRangeValue) => void;
   timeOptions: TimeOption[];
-  size?: 'small' | 'medium' | 'large';
+  height?: string;
 }
 
 export function DateTimeRangePicker(props: DateTimeRangePickerProps) {
-  const { value, onChange, timeOptions, size } = props;
+  const { value, onChange, timeOptions, height } = props;
 
   const [showCustomDateSelector, setShowCustomDateSelector] = useState(false);
   const anchorEl = useRef();
@@ -68,7 +68,7 @@ export function DateTimeRangePicker(props: DateTimeRangePickerProps) {
           <TimeRangeSelector
             timeOptions={timeOptions}
             value={value}
-            size={size}
+            height={height}
             onSelectChange={(event) => {
               const duration = event.target.value;
               const relativeTimeInput: RelativeTimeRange = {

--- a/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -28,10 +28,11 @@ interface DateTimeRangePickerProps {
   value: TimeRangeValue;
   onChange: (value: TimeRangeValue) => void;
   timeOptions: TimeOption[];
+  size?: 'small' | 'medium' | 'large';
 }
 
 export function DateTimeRangePicker(props: DateTimeRangePickerProps) {
-  const { value, onChange, timeOptions } = props;
+  const { value, onChange, timeOptions, size } = props;
 
   const [showCustomDateSelector, setShowCustomDateSelector] = useState(false);
   const anchorEl = useRef();
@@ -67,6 +68,7 @@ export function DateTimeRangePicker(props: DateTimeRangePickerProps) {
           <TimeRangeSelector
             timeOptions={timeOptions}
             value={value}
+            size={size}
             onSelectChange={(event) => {
               const duration = event.target.value;
               const relativeTimeInput: RelativeTimeRange = {

--- a/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -42,7 +42,7 @@ export function DateTimeRangePicker(props: DateTimeRangePickerProps) {
   }, [value]);
 
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={1} height={height}>
       <Popover
         anchorEl={anchorEl.current}
         anchorOrigin={{

--- a/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
+++ b/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
@@ -19,6 +19,12 @@ import { formatAbsoluteRange } from './utils';
 
 const DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
+const SIZE_TO_PADDING_Y = {
+  small: '4px',
+  medium: '6px',
+  large: '10px',
+};
+
 export interface TimeOption {
   value: RelativeTimeRange;
   display: string;
@@ -29,10 +35,11 @@ interface TimeRangeSelectorProps {
   timeOptions: TimeOption[];
   onSelectChange: (event: SelectChangeEvent<string>) => void;
   onCustomClick: () => void;
+  size?: 'small' | 'medium' | 'large';
 }
 
 export function TimeRangeSelector(props: TimeRangeSelectorProps) {
-  const { value, timeOptions, onSelectChange, onCustomClick } = props;
+  const { value, timeOptions, onSelectChange, onCustomClick, size } = props;
   const { timeZone } = useTimeZone();
   const formattedValue = !isRelativeTimeRange(value)
     ? formatAbsoluteRange(value, DATE_TIME_FORMAT, timeZone)
@@ -46,6 +53,7 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
         '.MuiSelect-icon': {
           marginTop: '1px',
         },
+        '.MuiSelect-select': size ? { paddingY: SIZE_TO_PADDING_Y[size] } : {},
       }}
     >
       {timeOptions.map((item, idx) => (

--- a/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
+++ b/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
@@ -19,16 +19,6 @@ import { formatAbsoluteRange } from './utils';
 
 const DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
-function heightToPaddingY(height: string): string {
-  const heightNum = parseFloat(height);
-
-  if (heightNum >= 20) {
-    return `${(heightNum - 20) / 2}px`;
-  } else {
-    return '0px';
-  }
-}
-
 export interface TimeOption {
   value: RelativeTimeRange;
   display: string;
@@ -57,7 +47,7 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
         '.MuiSelect-icon': {
           marginTop: '1px',
         },
-        '.MuiSelect-select': height ? { paddingY: heightToPaddingY(height) } : {},
+        '.MuiSelect-select': height ? { lineHeight: height, paddingY: 0 } : {},
       }}
     >
       {timeOptions.map((item, idx) => (

--- a/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
+++ b/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
@@ -19,11 +19,15 @@ import { formatAbsoluteRange } from './utils';
 
 const DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
-const SIZE_TO_PADDING_Y = {
-  small: '4px',
-  medium: '6px',
-  large: '10px',
-};
+function heightToPaddingY(height: string): string {
+  const heightNum = parseFloat(height);
+
+  if (heightNum >= 20) {
+    return `${(heightNum - 20) / 2}px`;
+  } else {
+    return '0px';
+  }
+}
 
 export interface TimeOption {
   value: RelativeTimeRange;
@@ -35,11 +39,11 @@ interface TimeRangeSelectorProps {
   timeOptions: TimeOption[];
   onSelectChange: (event: SelectChangeEvent<string>) => void;
   onCustomClick: () => void;
-  size?: 'small' | 'medium' | 'large';
+  height?: string;
 }
 
 export function TimeRangeSelector(props: TimeRangeSelectorProps) {
-  const { value, timeOptions, onSelectChange, onCustomClick, size } = props;
+  const { value, timeOptions, onSelectChange, onCustomClick, height } = props;
   const { timeZone } = useTimeZone();
   const formattedValue = !isRelativeTimeRange(value)
     ? formatAbsoluteRange(value, DATE_TIME_FORMAT, timeZone)
@@ -53,7 +57,7 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
         '.MuiSelect-icon': {
           marginTop: '1px',
         },
-        '.MuiSelect-select': size ? { paddingY: SIZE_TO_PADDING_Y[size] } : {},
+        '.MuiSelect-select': height ? { paddingY: heightToPaddingY(height) } : {},
       }}
     >
       {timeOptions.map((item, idx) => (

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -30,17 +30,11 @@ export const TIME_OPTIONS: TimeOption[] = [
   { value: { pastDuration: '14d' }, display: 'Last 14 days' },
 ];
 
-const SIZE_TO_HEIGHT = {
-  small: '28px',
-  medium: '32px',
-  large: '40px',
-};
-
 interface TimeRangeControlsProps {
-  size?: 'small' | 'medium' | 'large';
+  height?: string;
 }
 
-export function TimeRangeControls({ size }: TimeRangeControlsProps) {
+export function TimeRangeControls({ height }: TimeRangeControlsProps) {
   const { timeRange, setTimeRange, refresh } = useTimeRange();
   const defaultTimeRange = useDefaultTimeRange();
 
@@ -56,18 +50,8 @@ export function TimeRangeControls({ size }: TimeRangeControlsProps) {
 
   return (
     <>
-      <DateTimeRangePicker timeOptions={TIME_OPTIONS} value={timeRange} onChange={setTimeRange} size={size} />
-      <RefreshIconButton
-        aria-label="Refresh Dashboard"
-        onClick={refresh}
-        sx={
-          size
-            ? {
-                height: SIZE_TO_HEIGHT[size],
-              }
-            : {}
-        }
-      >
+      <DateTimeRangePicker timeOptions={TIME_OPTIONS} value={timeRange} onChange={setTimeRange} height={height} />
+      <RefreshIconButton aria-label="Refresh Dashboard" onClick={refresh} sx={height ? { height } : {}}>
         <RefreshIcon />
       </RefreshIconButton>
     </>

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -30,6 +30,8 @@ export const TIME_OPTIONS: TimeOption[] = [
   { value: { pastDuration: '14d' }, display: 'Last 14 days' },
 ];
 
+const DEFAULT_HEIGHT = '34px';
+
 interface TimeRangeControlsProps {
   // Height of the controls in pixels.
   // The controls look best at heights >= 28 pixels.
@@ -42,7 +44,7 @@ export function TimeRangeControls({ heightPx }: TimeRangeControlsProps) {
   const defaultTimeRange = useDefaultTimeRange();
 
   // Convert height as a number to height as a string, then use this value for styling
-  const height = heightPx === undefined ? undefined : `${heightPx}px`;
+  const height = heightPx === undefined ? DEFAULT_HEIGHT : `${heightPx}px`;
 
   // add time shortcut if one does not match duration from dashboard JSON
   if (!TIME_OPTIONS.some((option) => option.value.pastDuration === defaultTimeRange.pastDuration)) {

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -31,12 +31,18 @@ export const TIME_OPTIONS: TimeOption[] = [
 ];
 
 interface TimeRangeControlsProps {
-  height?: string;
+  // Height of the controls in pixels.
+  // The controls look best at heights >= 28 pixels.
+  // You can use values less than 28, but it won't look great.
+  heightPx?: number;
 }
 
-export function TimeRangeControls({ height }: TimeRangeControlsProps) {
+export function TimeRangeControls({ heightPx }: TimeRangeControlsProps) {
   const { timeRange, setTimeRange, refresh } = useTimeRange();
   const defaultTimeRange = useDefaultTimeRange();
+
+  // Convert height as a number to height as a string, then use this value for styling
+  const height = heightPx === undefined ? undefined : `${heightPx}px`;
 
   // add time shortcut if one does not match duration from dashboard JSON
   if (!TIME_OPTIONS.some((option) => option.value.pastDuration === defaultTimeRange.pastDuration)) {
@@ -51,7 +57,7 @@ export function TimeRangeControls({ height }: TimeRangeControlsProps) {
   return (
     <>
       <DateTimeRangePicker timeOptions={TIME_OPTIONS} value={timeRange} onChange={setTimeRange} height={height} />
-      <RefreshIconButton aria-label="Refresh Dashboard" onClick={refresh} sx={height ? { height } : {}}>
+      <RefreshIconButton aria-label="Refresh Dashboard" onClick={refresh} sx={{ height }}>
         <RefreshIcon />
       </RefreshIconButton>
     </>

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -30,7 +30,17 @@ export const TIME_OPTIONS: TimeOption[] = [
   { value: { pastDuration: '14d' }, display: 'Last 14 days' },
 ];
 
-export function TimeRangeControls() {
+const SIZE_TO_HEIGHT = {
+  small: '28px',
+  medium: '32px',
+  large: '40px',
+};
+
+interface TimeRangeControlsProps {
+  size?: 'small' | 'medium' | 'large';
+}
+
+export function TimeRangeControls({ size }: TimeRangeControlsProps) {
   const { timeRange, setTimeRange, refresh } = useTimeRange();
   const defaultTimeRange = useDefaultTimeRange();
 
@@ -46,8 +56,18 @@ export function TimeRangeControls() {
 
   return (
     <>
-      <DateTimeRangePicker timeOptions={TIME_OPTIONS} value={timeRange} onChange={setTimeRange} />
-      <RefreshIconButton aria-label="Refresh Dashboard" onClick={refresh}>
+      <DateTimeRangePicker timeOptions={TIME_OPTIONS} value={timeRange} onChange={setTimeRange} size={size} />
+      <RefreshIconButton
+        aria-label="Refresh Dashboard"
+        onClick={refresh}
+        sx={
+          size
+            ? {
+                height: SIZE_TO_HEIGHT[size],
+              }
+            : {}
+        }
+      >
         <RefreshIcon />
       </RefreshIconButton>
     </>


### PR DESCRIPTION
### Problem

In our app, the time range controls (the time range picker and the refresh button) appear next to some buttons, but these controls don't have the same height as the buttons. It looks broken.

<img width="345" alt="Screen Shot 2022-12-01 at 8 24 15 AM" src="https://user-images.githubusercontent.com/2584129/205147831-31a2be08-d101-40eb-b756-d706a2ead8b6.png">

### Updates
Looked into the custom variants idea (julie), the make components grow to fill the container idea (luke), and the pass along specific styles to components idea (luke).

It would be cool to be able to do the fill-the-container idea, but `MUI Select` gave me a hard time on this. I wasn't able to find a way to apply styles to the underlying elements that would make them grow to fill the container. 

So, in the end, changed the external prop to `height` and use the `height` prop to (1) set the `height` of the refresh button and (2) set the vertical padding on the element that represents the time range selector. 

~### Solution~

~In our app, buttons are meant to be one of three heights: small = 28px, medium = 32px (default), and large = 40px.~

~I added a way to adjust the height of the time range controls that matches these values.~

~### Notes~

~I'm not actually going to use the `size` prop in Perses! (Because it looks fine in Perses.) I'll be waiting for integration with cloud to use the `size` prop.~

~### Pitfalls~

~I took a simple approach and didn't make a `type` / `enum` for the `size` prop. I wasn't sure where this `type` / `enum` would live so that it could be accessed by `perses/dashboards` and `perses/components` (though, as I type this, I think the answer is `perses/core`). I also thought I might be getting a little ahead of myself if I enshrined `size` as an idea in wider parts of the codebase.~

~The other pitfall with this approach is that it's hard-coded to 28px/32px/40px, instead of reading values from `theme`. I looked at `theme` and didn't see any fields that seemed appropriate -- MUI theme doesn't seem to have a concept of global `size`.~

Open to ideas on any of this!

