### PR TITLE
Fix panel preview shows stale properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [BUGFIX] time series panel edit preview shows stale properties
+
 ## 0.19.0 / 2022-12-02
 
 - [ENHANCEMENT] set abbreviate to true in default Decimal unit #813

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -154,7 +154,7 @@ export function LineChart({
     setPinTooltip(false);
   };
 
-  const option: EChartsCoreOption = useDeepMemo(() => {
+  const option: EChartsCoreOption = useMemo(() => {
     if (data.timeSeries === undefined) return {};
     if (data.timeSeries === null || data.timeSeries.length === 0) return chartsTheme.noDataOption;
 

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { MouseEvent, useMemo, useRef, useState } from 'react';
-import { useDeepMemo } from '@perses-dev/core';
 import { Box } from '@mui/material';
 import type {
   EChartsCoreOption,


### PR DESCRIPTION
This PR removes an unnecessary optimization in LineChart. Now that Christine improved TimeSeriesChart panel performance in #828,  this useDeepMemo is not needed. It also contributes to the unit selector not always updating the panel preview component 