### PR TITLE
Fix time units display, allow decimal_places to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- [BUGFIX] time series panel edit preview shows stale properties
+- [ENHANCEMENT] Allow `decimal_places` to be used with time units #837
+- [BUGFIX] Time series panel edit preview shows stale properties #835
+- [BUGFIX] Fix time unit value format inconsistencies #837
 
 ## 0.19.0 / 2022-12-02
 

--- a/schemas/common/unit.cue
+++ b/schemas/common/unit.cue
@@ -17,6 +17,7 @@ package common
 
 #timeUnit: {
 	kind: "Milliseconds" | "Seconds" | "Minutes" | "Hours" | "Days" | "Weeks" | "Months" | "Years"
+	decimal_places?: number
 }
 
 #percentUnit: {

--- a/schemas/common/unit.cue
+++ b/schemas/common/unit.cue
@@ -16,7 +16,7 @@ package common
 #unit: #timeUnit | #percentUnit | #decimalUnit | #bytesUnit
 
 #timeUnit: {
-	kind: "Milliseconds" | "Seconds" | "Minutes" | "Hours" | "Days" | "Weeks" | "Months" | "Years"
+	kind:            "Milliseconds" | "Seconds" | "Minutes" | "Hours" | "Days" | "Weeks" | "Months" | "Years"
 	decimal_places?: number
 }
 

--- a/ui/components/src/StatChart/StatChart.test.tsx
+++ b/ui/components/src/StatChart/StatChart.test.tsx
@@ -59,7 +59,7 @@ describe('StatChart', () => {
       kind: 'Seconds',
     };
     renderChart(unit);
-    expect(screen.getByText('7.729 seconds')).toBeInTheDocument();
+    expect(screen.getByText('7.73 seconds')).toBeInTheDocument();
   });
 
   it('show value with time unit formatting', () => {
@@ -67,6 +67,6 @@ describe('StatChart', () => {
       kind: 'Months',
     };
     renderChart(unit);
-    expect(screen.getByText('7.729 months')).toBeInTheDocument();
+    expect(screen.getByText('7.73 months')).toBeInTheDocument();
   });
 });

--- a/ui/components/src/StatChart/StatChart.test.tsx
+++ b/ui/components/src/StatChart/StatChart.test.tsx
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ChartsThemeProvider } from '../context/ChartsThemeProvider';
 import { UnitOptions } from '../model';
@@ -19,14 +18,16 @@ import { testChartsTheme } from '../test-utils';
 import { StatChart, StatChartData } from './StatChart';
 
 describe('StatChart', () => {
-  const contentDimensions = {
-    width: 200,
-    height: 200,
-  };
-
-  const unit: UnitOptions = {
-    kind: 'Decimal',
-    decimal_places: 2,
+  const renderChart = (unit: UnitOptions) => {
+    const contentDimensions = {
+      width: 200,
+      height: 200,
+    };
+    render(
+      <ChartsThemeProvider chartsTheme={testChartsTheme}>
+        <StatChart width={contentDimensions.width} height={contentDimensions.height} data={mockStatData} unit={unit} />
+      </ChartsThemeProvider>
+    );
   };
 
   const mockStatData: StatChartData = {
@@ -44,19 +45,28 @@ describe('StatChart', () => {
     },
   };
 
-  describe('Render default options (no sparkline)', () => {
-    it('should render', () => {
-      render(
-        <ChartsThemeProvider chartsTheme={testChartsTheme}>
-          <StatChart
-            width={contentDimensions.width}
-            height={contentDimensions.height}
-            data={mockStatData}
-            unit={unit}
-          />
-        </ChartsThemeProvider>
-      );
-      expect(screen.getByText('7.73')).toBeInTheDocument();
-    });
+  it('render default options (no sparkline)', () => {
+    const unit: UnitOptions = {
+      kind: 'Decimal',
+      decimal_places: 2,
+    };
+    renderChart(unit);
+    expect(screen.getByText('7.73')).toBeInTheDocument();
+  });
+
+  it('show value with time unit formatting', () => {
+    const unit: UnitOptions = {
+      kind: 'Seconds',
+    };
+    renderChart(unit);
+    expect(screen.getByText('7.729 seconds')).toBeInTheDocument();
+  });
+
+  it('show value with time unit formatting', () => {
+    const unit: UnitOptions = {
+      kind: 'Months',
+    };
+    renderChart(unit);
+    expect(screen.getByText('7.729 months')).toBeInTheDocument();
   });
 });

--- a/ui/components/src/UnitSelector/UnitSelector.test.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.test.tsx
@@ -144,11 +144,6 @@ describe('UnitSelector', () => {
   });
 
   describe('with a time unit selected', () => {
-    it('does not allow the user to modify the decimal places', () => {
-      renderUnitSelector({ kind: 'Hours' });
-      expect(getDecimalSelector()).toBeDisabled();
-    });
-
     it('does not allow the user to set abbreviate', () => {
       renderUnitSelector({ kind: 'Minutes' });
       expect(getAbbreviateSwitch()).toBeDisabled();

--- a/ui/components/src/model/units/time.ts
+++ b/ui/components/src/model/units/time.ts
@@ -11,16 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { DEFAULT_DECIMAL_PLACES } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
 
 const timeUnitKinds = ['Milliseconds', 'Seconds', 'Minutes', 'Hours', 'Days', 'Weeks', 'Months', 'Years'] as const;
 type TimeUnitKind = typeof timeUnitKinds[number];
 export type TimeUnitOptions = {
   kind: TimeUnitKind;
+  decimal_places?: number;
 };
 const TIME_GROUP = 'Time';
 export const TIME_GROUP_CONFIG: UnitGroupConfig = {
   label: 'Time',
+  decimal_places: true,
 };
 export const TIME_UNIT_CONFIG: Readonly<Record<TimeUnitKind, UnitConfig>> = {
   Milliseconds: {
@@ -71,11 +74,14 @@ export enum TimeIntlDuration {
 }
 
 export function formatTime(value: number, unitOptions: TimeUnitOptions): string {
+  const decimals = unitOptions.decimal_places ?? DEFAULT_DECIMAL_PLACES;
   const timeUnit: string = TimeIntlDuration[unitOptions.kind];
   const formatter = new Intl.NumberFormat('en', {
     style: 'unit',
     unit: timeUnit,
     unitDisplay: 'long',
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
   });
   return formatter.format(value);
 }

--- a/ui/components/src/model/units/time.ts
+++ b/ui/components/src/model/units/time.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Duration, milliseconds } from 'date-fns';
 import { UnitGroupConfig, UnitConfig } from './types';
 
 const timeUnitKinds = ['Milliseconds', 'Seconds', 'Minutes', 'Hours', 'Days', 'Weeks', 'Months', 'Years'] as const;
@@ -58,71 +57,25 @@ export const TIME_UNIT_CONFIG: Readonly<Record<TimeUnitKind, UnitConfig>> = {
   },
 };
 
+// Mapping of time units to what Intl.NumberFormat formatter expects
+// https://v8.dev/features/intl-numberformat#units
+export enum TimeIntlDuration {
+  Milliseconds = 'millisecond',
+  Seconds = 'second',
+  Minutes = 'minute',
+  Hours = 'hour',
+  Days = 'day',
+  Weeks = 'week',
+  Months = 'month',
+  Years = 'year',
+}
+
 export function formatTime(value: number, unitOptions: TimeUnitOptions): string {
-  // Create a Duration from the value based on what time unit it is
-  const duration: Duration = {};
-  switch (unitOptions.kind) {
-    case 'Milliseconds':
-      duration.seconds = value / 1000;
-      break;
-    case 'Seconds':
-      duration.seconds = value;
-      break;
-    case 'Minutes':
-      duration.minutes = value;
-      break;
-    case 'Hours':
-      duration.hours = value;
-      break;
-    case 'Days':
-      duration.days = value;
-      break;
-    case 'Weeks':
-      duration.weeks = value;
-      break;
-    case 'Months':
-      duration.months = value;
-      break;
-    case 'Years':
-      duration.years = value;
-      break;
-    default: {
-      const exhaustive: never = unitOptions.kind;
-      throw new Error(`Unknown time unit type ${exhaustive}`);
-    }
-  }
-
-  // Find the largest whole time unit we can display the value in and use it
-  const ms = milliseconds(duration);
-  const seconds = ms / 1000;
-  if (seconds < 1) {
-    return `${ms.toFixed()} milliseconds`;
-  }
-
-  const minutes = seconds / 60;
-  if (minutes < 1) {
-    return `${seconds.toFixed()} seconds`;
-  }
-
-  const hours = minutes / 60;
-  if (hours < 1) {
-    return `${minutes.toFixed()} minutes`;
-  }
-
-  const days = hours / 24;
-  if (days < 1) {
-    return `${hours.toFixed()} hours`;
-  }
-
-  const weeks = days / 7;
-  if (weeks < 1) {
-    return `${days.toFixed()} days`;
-  }
-
-  const years = weeks / 52;
-  if (years < 1) {
-    return `${weeks.toFixed()} weeks`;
-  }
-
-  return `${years.toFixed()} years`;
+  const timeUnit: string = TimeIntlDuration[unitOptions.kind];
+  const formatter = new Intl.NumberFormat('en', {
+    style: 'unit',
+    unit: timeUnit,
+    unitDisplay: 'long',
+  });
+  return formatter.format(value);
 }


### PR DESCRIPTION
### Overview

This PR improves time unit display, before the formatTime function found the largest whole time unit that could be shown. This was counterintuitive when switching between units, especially when applied to y axis formatting.  Commits include:

- Fix time units inconsistencies--instead of a custom function, [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) is now used ([more info](https://dev.to/jordanfinners/never-use-a-number-or-currency-formatting-library-again-mhb))
  - _Existing properties include: 'Milliseconds', 'Seconds', 'Minutes', 'Hours', 'Days', 'Weeks', 'Months', 'Years'_
- allow `decimal_places` to be used with time units

### Screenshot

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/9369625/205673715-8e60828d-3db6-4070-bbd8-c4c956ef7ddb.png">
