### PR TITLE
fix LineChart timeZone warnings, clean up unused props / types

### DIFF
--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -41,8 +41,8 @@ import { EChartsDataFormat } from '../model/graph';
 import { UnitOptions } from '../model/units';
 import { useChartsTheme } from '../context/ChartsThemeProvider';
 import { Tooltip } from '../Tooltip/Tooltip';
-import { enableDataZoom, getDateRange, getFormattedDate, getYAxes, restoreChart, ZoomEventData } from './utils';
 import { useTimeZone } from '../context/TimeZoneProvider';
+import { enableDataZoom, getDateRange, getFormattedDate, getYAxes, restoreChart, ZoomEventData } from './utils';
 
 use([
   EChartsLineChart,
@@ -71,17 +71,7 @@ interface LineChartProps {
   onDoubleClick?: (e: MouseEvent) => void;
 }
 
-export function LineChart({
-  height,
-  data,
-  yAxis,
-  unit,
-  grid,
-  legend,
-  visualMap,
-  onDataZoom,
-  onDoubleClick,
-}: LineChartProps) {
+export function LineChart({ height, data, yAxis, unit, grid, legend, onDataZoom, onDoubleClick }: LineChartProps) {
   const chartsTheme = useChartsTheme();
   const chartRef = useRef<EChartsInstance>();
   const [showTooltip, setShowTooltip] = useState<boolean>(true);
@@ -155,9 +145,12 @@ export function LineChart({
     setPinTooltip(false);
   };
 
+  const yAxisArr = getYAxes(yAxis, unit);
+  const { noDataOption } = chartsTheme;
+
   const option: EChartsCoreOption = useMemo(() => {
     if (data.timeSeries === undefined) return {};
-    if (data.timeSeries === null || data.timeSeries.length === 0) return chartsTheme.noDataOption;
+    if (data.timeSeries === null || data.timeSeries.length === 0) return noDataOption;
 
     const rangeMs = data.rangeMs ?? getDateRange(data.xAxis);
 
@@ -173,7 +166,7 @@ export function LineChart({
           },
         },
       },
-      yAxis: getYAxes(yAxis, unit),
+      yAxis: yAxisArr,
       animation: false,
       tooltip: {
         show: true,
@@ -194,11 +187,10 @@ export function LineChart({
       },
       grid,
       legend,
-      visualMap,
     };
 
     return option;
-  }, [data, yAxis, grid, legend, visualMap, timeZone]);
+  }, [data, yAxisArr, grid, legend, noDataOption, timeZone]);
 
   return (
     <Box

--- a/ui/components/src/Tooltip/TooltipContent.tsx
+++ b/ui/components/src/Tooltip/TooltipContent.tsx
@@ -13,9 +13,9 @@
 
 import { useMemo } from 'react';
 import { Box, Divider, Stack, Typography } from '@mui/material';
+import { useTimeZone } from '../context/TimeZoneProvider';
 import { FocusedSeriesArray } from './focused-series';
 import { SeriesInfo } from './SeriesInfo';
-import { useTimeZone } from '../context/TimeZoneProvider';
 
 interface TooltipContentProps {
   focusedSeries: FocusedSeriesArray | null;

--- a/ui/components/src/model/graph.ts
+++ b/ui/components/src/model/graph.ts
@@ -30,7 +30,7 @@ export type EChartsValues = number | null | '-';
 
 export interface EChartsTimeSeries extends Omit<LineSeriesOption, 'data'> {
   // TODO: support dataset and both category / time xAxis types
-  data: Iterable<GraphSeriesValueTuple> | EChartsValues[];
+  data: EChartsValues[];
 }
 
 export type EChartsDataFormat = {


### PR DESCRIPTION
Seeing some lint warnings for with useTimeZone imports in our LineChart component. While in that file, I cleaned up some unused props / types, and refactored a couple properties in the option mapping dependency array.