### PR TITLE
[ENHANCEMENT] visual options and reset btn ux feedback

### DIFF
--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -22,8 +22,8 @@ import (
 }
 
 #visual: {
-	line_width?:   number & >=0.5 & <=4
-	point_radius?: number & >=0 & <=8
+	line_width?:   number & >=0.25 & <=3
+	point_radius?: number & >=0 & <=6
 }
 
 #y_axis: {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Replay from 'mdi-material-ui/Replay';
 import { Button } from '@mui/material';
 import { produce } from 'immer';
 import {
@@ -78,9 +77,8 @@ export function TimeSeriesChartOptionsEditorSettings(props: TimeSeriesChartOptio
               })
             );
           }}
-          startIcon={<Replay />}
         >
-          Use Default Settings
+          Reset to Default
         </Button>
       </OptionsEditorColumn>
     </OptionsEditorGrid>

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.test.tsx
@@ -50,6 +50,6 @@ describe('VisualOptionsEditor', () => {
 
     // to move slider and update visual options
     fireEvent.mouseDown(sliderInput, { clientX: 220, clientY: 100 });
-    expect(onChange).toHaveBeenCalledWith({ line_width: 2, point_radius: 2 });
+    expect(onChange).toHaveBeenCalledWith({ line_width: 1.25, point_radius: 2 });
   });
 });

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -46,7 +46,7 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             data-testid={VISUAL_CONFIG.point_radius.testId}
             value={value.point_radius ?? DEFAULT_POINT_RADIUS}
             valueLabelDisplay="auto"
-            step={0.5}
+            step={VISUAL_CONFIG.point_radius.step}
             marks
             min={VISUAL_CONFIG.point_radius.min}
             max={VISUAL_CONFIG.point_radius.max}
@@ -61,7 +61,7 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             data-testid={VISUAL_CONFIG.line_width.testId}
             value={value.line_width ?? DEFAULT_LINE_WIDTH}
             valueLabelDisplay="auto"
-            step={0.5}
+            step={VISUAL_CONFIG.line_width.step}
             marks
             min={VISUAL_CONFIG.line_width.min}
             max={VISUAL_CONFIG.line_width.max}

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -60,14 +60,16 @@ export const VISUAL_CONFIG = {
   line_width: {
     label: 'Line Width',
     testId: 'slider-line-width',
-    min: 0.5,
-    max: 4,
+    min: 0.25,
+    max: 3,
+    step: 0.25,
   },
   point_radius: {
     label: 'Point Radius',
     testId: 'slider-point-radius',
     min: 0,
-    max: 8,
+    max: 6,
+    step: 0.25,
   },
 };
 


### PR DESCRIPTION
### Overview

UX feedback from @foxbat07  in time series panel for visual options and reset button text:
- step increment in sliders is now 0.25 instead of 0.5
- max is reduced for both point_radius and line_width
- reset button text now reads "Reset to Default" and icon is removed

### Screenshot

![visual_options_ux_adjustments](https://user-images.githubusercontent.com/9369625/206284646-c4d9bae7-d0f9-4b73-a9b3-938d68df0295.png)

<img width="289" alt="image" src="https://user-images.githubusercontent.com/9369625/206285246-b7ce62a6-c597-42f0-9798-187f3b4bcf37.png">
