### PR TITLE
[IGNORE] Generate Changelog

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Generate endpoints
         run: make generate
       - name: Extract Changelog
-        run: make generate-changelog
+        run: make extract-changelog
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         if: ${{ github.event_name == 'push' && startsWith(github.ref_name, 'v') }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ coverage.txt
 /internal/api/e2e/test/
 /pkg/client/api/v1/test/
 
-GENERATED_CHANGELOG.md
+EXTRACTED_CHANGELOG.md
 
 cue.mod/pkg
 cue.mod/usr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,32 @@ We are using GitHub as our main development and discussion forum.
 If you are unsure about what to do, and you are eager to contribute, you can reach us on the development
 channel [#perses-dev](https://matrix.to/#/#perses-dev:matrix.org) on [Matrix](https://matrix.org/).
 
+## Opening a PR
+
+To help during the release process, we created a script that generates the changelog based on the git history.
+
+To make it works correctly, commit or PR's title should follow the following naming convention:
+
+`[<catalog_entry>] <commit message>`
+
+where `catalog_entry` can be :
+
+- FEATURE
+- ENHANCEMENT
+- BUGFIX
+- BREAKINGCHANGE
+
+This catalog entry will indicate the purpose of your PR.
+
+In the usual workflow, all PRs are squashed. There is two exceptions to this rule:
+
+1. During the release process, the release branch is merge back in the `main` branch. To avoid to lose the commit
+   message that holds the tag, this kind of PR **MUST** be merged and not squashed.
+
+2. In case your PR contains multiple kind of changes (aka, feature, bugfix ..etc.) and you took care about having
+   different commit following the convention described above, then the PR will be merged and not squashed. Like that we
+   are preserving the works you did and the effort you made when creating meaningful commit. 
+
 ## Development
 
 This section explains how to build, launch, and start using Perses.

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,10 @@ generate: assets-compress
 extract-changelog:
 	$(GO) run ./scripts/extract-changelog/extract-changelog.go --version="${VERSION}"
 
+.PHONY: generate-changelog
+generate-changelog:
+	$(GO) run ./scripts/generate-changelog/generate-changelog.go --version="${VERSION}"
+
 .PHONY: clean
 clean:
 	rm -rf ./bin

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ build-cli:
 generate: assets-compress
 	GOARCH=${GOHOSTARCH} GOOS=${GOHOSTOS} $(GO) generate ./internal/api
 
-.PHONY: generate-changelog
-generate-changelog:
-	$(GO) run ./scripts/generate-changelog/generate-changelog.go --version="${VERSION}"
+.PHONY: extract-changelog
+extract-changelog:
+	$(GO) run ./scripts/extract-changelog/extract-changelog.go --version="${VERSION}"
 
 .PHONY: clean
 clean:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,18 +45,19 @@ You should start to create a branch that follows the pattern `release/v<X.Y>`. R
 for any given major or minor release happen in the same release/v<major>.<minor> branch. Do not create release/<version>
 for patch or release candidate releases.
 
-- Update the file `VERSION` with the new version to be created.
-
-- Update the file `CHANGELOG.md` and the different `package.json` with the corresponding version:
-
-```bash
-make bump-version
-```
-
 - Do this in a proper PR pointing to the release branch as this gives others the opportunity to chime in on the release
   in general and on the addition to the changelog in particular.
 
-- Create a proper title for the release following this template : `## <version_number> / <Date>`
+- Update the file `VERSION` with the new version to be created.
+
+- Update the file `CHANGELOG.md` :
+
+```bash
+make generate-changelog
+```
+
+Note: it will generate a first changelog version based on the git history. You should review what has been generated.
+Error can happen ;)
 
 - Entries in the `CHANGELOG.md` are meant to be in this order:
 
@@ -67,6 +68,12 @@ make bump-version
 
 As we have many libraries we publish, it's better if you also put a clear indication about what library is affected by
 these changes.
+
+- Update the different `package.json` with the corresponding version:
+
+```bash
+make bump-version
+```
 
 ### 2. Draft the new release
 
@@ -89,27 +96,39 @@ changelog there. It won't hurt if you check quickly if it does not miss anything
 
 ## How to cut a UI snapshot release
 
-Occasionally, it is helpful to test a packaged version of the UI to validate specific functionality before cutting a real release. Where there are difficulties doing this via tools like `npm link` and `npm pack` because of complexities with workspaces, a maintainer can create a "snapshot" release of the UI.
+Occasionally, it is helpful to test a packaged version of the UI to validate specific functionality before cutting a
+real release. Where there are difficulties doing this via tools like `npm link` and `npm pack` because of complexities
+with workspaces, a maintainer can create a "snapshot" release of the UI.
 
 ### Limits of snapshot releases
 
 - **DO NOT** merge snapshot branches into `main`. They are intended only as a tool for testing.
-- **DO NOT** recommend using snapshot branches in production code. They are intended to be ephemeral for testing purposes.
+- **DO NOT** recommend using snapshot branches in production code. They are intended to be ephemeral for testing
+  purposes.
 
 ### Creating a snapshot branch
 
 The creation of snapshots is automated by Github actions based on branch naming schemes.
 
-- Create a branch following the naming scheme `snapshot/tag-name` (e.g. `snapshot/theme-updates`) with the changes you want to test. The `tag-name` should be short and kebab-case because it will be used as part of a version name and tag name in npm.
-- Github actions will build the UI and release a version named `0.0.0-snapshot-tag-name-SHA` at a tag named `snapshot-tag-name` where `tag-name` comes from your branch name and `SHA` is a short version of the git sha for the latest commit on the branch.
-  - We use `0.0.0` as the version prefix to keep snapshots at the bottom of the npm versions UI to avoid confusion for consumers of the package. This also helps differentiate snapshots from the concept of prereleases, which we do not currently provide, but may add in the future.
+- Create a branch following the naming scheme `snapshot/tag-name` (e.g. `snapshot/theme-updates`) with the changes you
+  want to test. The `tag-name` should be short and kebab-case because it will be used as part of a version name and tag
+  name in npm.
+- Github actions will build the UI and release a version named `0.0.0-snapshot-tag-name-SHA` at a tag
+  named `snapshot-tag-name` where `tag-name` comes from your branch name and `SHA` is a short version of the git sha for
+  the latest commit on the branch.
+    - We use `0.0.0` as the version prefix to keep snapshots at the bottom of the npm versions UI to avoid confusion for
+      consumers of the package. This also helps differentiate snapshots from the concept of prereleases, which we do not
+      currently provide, but may add in the future.
 - Github actions will release a new version with the latest sha each time you push to the snapshot branch.
 
 ### Using a snapshot branch
 
-- Install the snapshot branch for all relevant packages using the `snapshot-NAME` tag (e.g. `npm install  --save-exact @perses-dev/core@snapshot-theme-updates`). Recommend using `--save-exact` to avoid inconsistencies with how snapshot version names may match using `^`.
+- Install the snapshot branch for all relevant packages using the `snapshot-NAME` tag (
+  e.g. `npm install --save-exact @perses-dev/core@snapshot-theme-updates`). Recommend using `--save-exact` to avoid
+  inconsistencies with how snapshot version names may match using `^`.
 
 ### Removing a snapshot
 
 - Delete the branch.
-- Github actions will automatically remove the tag from npm. The version will still show up in the "version history" section of npm.
+- Github actions will automatically remove the tag from npm. The version will still show up in the "version history"
+  section of npm.

--- a/scripts/extract-changelog/extract-changelog.go
+++ b/scripts/extract-changelog/extract-changelog.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This script is extracting the changelog for the current version from the file CHANGELOG.md available at the root of the project.
+// This script must run from the root of the project.
 package main
 
 import (
@@ -33,7 +35,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatalf("unable to get the entry in the changelog for the version %q", *version)
 	}
-	err = os.WriteFile("GENERATED_CHANGELOG.md", []byte(entry.Text), 0600)
+	err = os.WriteFile("EXTRACTED_CHANGELOG.md", []byte(entry.Text), 0600)
 	if err != nil {
 		logrus.WithError(err).Fatal("error when generating the changelog")
 	}

--- a/scripts/generate-changelog/generate-changelog.go
+++ b/scripts/generate-changelog/generate-changelog.go
@@ -1,0 +1,153 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	feature        = "FEATURE"
+	enhancement    = "ENHANCEMENT"
+	bugfix         = "BUGFIX"
+	breakingChange = "BREAKINGCHANGE"
+)
+
+// kind represents the type of change.
+type kind int
+
+const (
+	kindBreakingChange = iota
+	kindFeature
+	kindEnhancement
+	kindBugfix
+	KindToBeIgnored
+)
+
+func getPreviousTag() string {
+	previousVersion, err := exec.Command("git", "describe", "--abbrev=0").Output()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to get the latest tag")
+	}
+	return strings.TrimSpace(string(previousVersion))
+}
+
+func getGitLogs(previousVersion string) []string {
+	gitLogs, err := exec.Command("git", "log", fmt.Sprintf("%s...HEAD", previousVersion), "--pretty=oneline", "--no-decorate").Output()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to get the git logs")
+	}
+	entries := strings.Split(string(gitLogs), "\n")
+	if lastLine := entries[len(entries)-1]; strings.TrimSpace(lastLine) == "" {
+		entries = entries[0 : len(entries)-1]
+	}
+	return entries
+}
+
+func formatChangelogCategory(category string) string {
+	return fmt.Sprintf("[%s]", category)
+}
+
+func removeChangelogCategory(entry string, category string) string {
+	return strings.ReplaceAll(entry, formatChangelogCategory(category), "")
+}
+
+func parseEntry(entry string) (kind, string) {
+	// remove commit ID
+	entryAsRune := []rune(entry)
+	newEntry := entry
+	for i, r := range entryAsRune {
+		if r == ' ' {
+			newEntry = entry[i+1:]
+			break
+		}
+	}
+	// extract catalog entry and remove it to get a cleaner message
+	if strings.Contains(newEntry, formatChangelogCategory(feature)) {
+		newEntry = removeChangelogCategory(newEntry, feature)
+		return kindFeature, newEntry
+	} else if strings.Contains(newEntry, formatChangelogCategory(enhancement)) {
+		newEntry = removeChangelogCategory(newEntry, enhancement)
+		return kindEnhancement, newEntry
+	} else if strings.Contains(newEntry, formatChangelogCategory(bugfix)) {
+		newEntry = removeChangelogCategory(newEntry, bugfix)
+		return kindBugfix, newEntry
+	} else if strings.Contains(newEntry, formatChangelogCategory(breakingChange)) {
+		newEntry = removeChangelogCategory(newEntry, breakingChange)
+		return kindBreakingChange, newEntry
+	}
+	return KindToBeIgnored, ""
+}
+
+type changelog struct {
+	features        []string
+	enhancements    []string
+	bugfixes        []string
+	breakingChanges []string
+}
+
+func newChangelog(entries []string) *changelog {
+	clog := &changelog{}
+	for _, entry := range entries {
+		kindEntry, newEntry := parseEntry(entry)
+		switch kindEntry {
+		case kindFeature:
+			clog.features = append(clog.features, newEntry)
+		case kindEnhancement:
+			clog.enhancements = append(clog.enhancements, newEntry)
+		case kindBugfix:
+			clog.bugfixes = append(clog.bugfixes, newEntry)
+		case kindBreakingChange:
+			clog.breakingChanges = append(clog.breakingChanges, newEntry)
+		}
+	}
+	return clog
+}
+
+func injectEntries(buffer *bytes.Buffer, entries []string, catalogEntry string) {
+	for _, entry := range entries {
+		buffer.WriteString(fmt.Sprintf("- %s %s\n", formatChangelogCategory(catalogEntry), entry))
+	}
+}
+
+func (c *changelog) generateChangelog(version string) string {
+	now := time.Now()
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("## %s / %s\n\n", version, now.Format("2022-12-06")))
+	injectEntries(&buffer, c.features, feature)
+	injectEntries(&buffer, c.enhancements, enhancement)
+	injectEntries(&buffer, c.bugfixes, bugfix)
+	injectEntries(&buffer, c.breakingChanges, breakingChange)
+	return buffer.String()
+}
+
+func (c *changelog) write(version string) {
+	generatedChangelog := c.generateChangelog(version)
+}
+
+func main() {
+	previousVersion := getPreviousTag()
+	entries := getGitLogs(previousVersion)
+	version := flag.String("version", "", "release version")
+	flag.Parse()
+	clog := newChangelog(entries)
+	clog.write(*version)
+}

--- a/scripts/generate-changelog/generate-changelog.go
+++ b/scripts/generate-changelog/generate-changelog.go
@@ -155,7 +155,7 @@ func injectEntries(buffer *bytes.Buffer, entries []string, catalogEntry string) 
 func (c *changelog) generateChangelog(version string) string {
 	now := time.Now()
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("## %s / %s\n\n", version, now.Format("2022-12-06")))
+	buffer.WriteString(fmt.Sprintf("## %s / %s\n\n", version, now.Format("2006-01-02")))
 	injectEntries(&buffer, c.features, feature)
 	injectEntries(&buffer, c.enhancements, enhancement)
 	injectEntries(&buffer, c.bugfixes, bugfix)
@@ -174,9 +174,11 @@ func (c *changelog) write(version string) {
 	i := 0
 	for fileScanner.Scan() {
 		buffer.WriteString(fileScanner.Text())
+		buffer.WriteString("\n")
 		i++
 		if i == 1 {
 			// inject the new changelog entries after the title
+			buffer.WriteString("\n")
 			buffer.WriteString(c.generateChangelog(version))
 		}
 	}

--- a/scripts/generate-changelog/generate-changelog.go
+++ b/scripts/generate-changelog/generate-changelog.go
@@ -67,6 +67,7 @@ func getPreviousTag() string {
 }
 
 func getGitLogs(previousVersion string) []string {
+	// nolint: gosec
 	gitLogs, err := exec.Command("git", "log", fmt.Sprintf("%s...HEAD", previousVersion), "--pretty=oneline", "--no-decorate").Output()
 	if err != nil {
 		logrus.WithError(err).Fatal("unable to get the git logs")
@@ -185,7 +186,7 @@ func (c *changelog) write(version string) {
 	if closeErr := f.Close(); closeErr != nil {
 		logrus.WithError(closeErr).Fatal("unable to close the file CHANGELOG.md")
 	}
-	if writeErr := os.WriteFile("CHANGELOG.md", buffer.Bytes(), 0644); writeErr != nil {
+	if writeErr := os.WriteFile("CHANGELOG.md", buffer.Bytes(), 0600); writeErr != nil {
 		logrus.WithError(writeErr).Fatal("unable to inject the new changelog entries in CHANGELOG.md")
 	}
 }

--- a/scripts/generate-changelog/generate-changelog_test.go
+++ b/scripts/generate-changelog/generate-changelog_test.go
@@ -31,6 +31,12 @@ func TestParseCatalogEntry(t *testing.T) {
 		{
 			title:                "no catalog entry",
 			entry:                "a commit message without a catalog entry",
+			expectedKind:         kindUnknown,
+			expectedCatalogEntry: "",
+		},
+		{
+			title:                "explicit ignore catalog entry",
+			entry:                "[IGNORE] my awesome commit message",
 			expectedKind:         KindToBeIgnored,
 			expectedCatalogEntry: "",
 		},
@@ -94,8 +100,26 @@ func TestParseAndFormatEntry(t *testing.T) {
 		expectedEntry string
 	}{
 		{
-			title:         "commit to be ignored",
+			title:         "unknown catalog",
 			entry:         "b75e042daac589548d85ead05a9ef47fa0e62df0 add a way to generate the changelog entries",
+			expectedKind:  kindUnknown,
+			expectedEntry: "add a way to generate the changelog entries",
+		},
+		{
+			title:         "merge commit is ignored (1)",
+			entry:         "a6918dc9bdfb7e8a50dde0eba2d1ea9f45193086 Merge pull request #843 from perses/release/v0.20",
+			expectedKind:  KindToBeIgnored,
+			expectedEntry: "",
+		},
+		{
+			title:         "merge commit is ignored (2)",
+			entry:         "21771bce89849b46b6dc938e9983e49a3dc9eb07 Merge branch 'main' into release/v0.20",
+			expectedKind:  KindToBeIgnored,
+			expectedEntry: "",
+		},
+		{
+			title:         "release commit is ignored",
+			entry:         "944ef44d198f368e784d6239469a60a9212a4dca Release v0.20.0 (#839)",
 			expectedKind:  KindToBeIgnored,
 			expectedEntry: "",
 		},
@@ -144,6 +168,7 @@ func TestGenerateChangelog(t *testing.T) {
 				},
 				bugfixes:        []string{"Fix time units display, allow decimal_places to be used (#837)"},
 				breakingChanges: []string{"legend.position now required in time series panel (#848)"},
+				unknown:         []string{"Use exact versions for internal npm dependencies (#846)", "Support snapshot UI releases (#844)"},
 			},
 			expected: fmt.Sprintf("%s\n%s", title, `
 - [FEATURE] Discard Changes Confirmation Dialog (#834)
@@ -152,6 +177,11 @@ func TestGenerateChangelog(t *testing.T) {
 - [ENHANCEMENT] Make it possible to adjust the height of the time range controls (#829)
 - [BUGFIX] Fix time units display, allow decimal_places to be used (#837)
 - [BREAKINGCHANGE] legend.position now required in time series panel (#848)
+
+[//]: <UNKNOWN ENTRIES. Release shepherd, please review the following list and categorize them or remove them>
+
+- [UNKNOWN] Use exact versions for internal npm dependencies (#846)
+- [UNKNOWN] Support snapshot UI releases (#844)
 `),
 		},
 	}

--- a/scripts/generate-changelog/generate-changelog_test.go
+++ b/scripts/generate-changelog/generate-changelog_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCatalogEntry(t *testing.T) {
+	testSuite := []struct {
+		title                string
+		entry                string
+		expectedKind         kind
+		expectedCatalogEntry string
+	}{
+		{
+			title:                "no catalog entry",
+			entry:                "a commit message without a catalog entry",
+			expectedKind:         KindToBeIgnored,
+			expectedCatalogEntry: "",
+		},
+		{
+			title:                "feature catalog entry",
+			entry:                "[FEATURE] commit message",
+			expectedKind:         kindFeature,
+			expectedCatalogEntry: "FEATURE",
+		},
+		{
+			title:                "enhancement catalog entry",
+			entry:                "[ENHANCEMENT] another commit message",
+			expectedKind:         kindEnhancement,
+			expectedCatalogEntry: "ENHANCEMENT",
+		},
+		{
+			title:                "breakingChange catalog entry",
+			entry:                "[BREAKINGCHANGE] commit message",
+			expectedKind:         kindBreakingChange,
+			expectedCatalogEntry: "BREAKINGCHANGE",
+		},
+		{
+			title:                "bugFix catalog entry",
+			entry:                "[BUGFIX] commit message",
+			expectedKind:         kindBugfix,
+			expectedCatalogEntry: "BUGFIX",
+		},
+		{
+			title:                "catalog entry with different case (1)",
+			entry:                "[Feature] commit message",
+			expectedKind:         kindFeature,
+			expectedCatalogEntry: "Feature",
+		},
+		{
+			title:                "catalog entry with different case (2)",
+			entry:                "[BugFix] commit message",
+			expectedKind:         kindBugfix,
+			expectedCatalogEntry: "BugFix",
+		},
+		{
+			title:                "catalog entry at the end of the commit",
+			entry:                "commit message [BreakingChange]",
+			expectedKind:         kindBreakingChange,
+			expectedCatalogEntry: "BreakingChange",
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			kindEntry, newEntry := parseCatalogEntry(test.entry)
+			assert.Equal(t, test.expectedKind, kindEntry)
+			assert.Equal(t, test.expectedCatalogEntry, newEntry)
+		})
+	}
+}
+
+func TestParseAndFormatEntry(t *testing.T) {
+	testSuite := []struct {
+		title         string
+		entry         string
+		expectedKind  kind
+		expectedEntry string
+	}{
+		{
+			title:         "commit to be ignored",
+			entry:         "b75e042daac589548d85ead05a9ef47fa0e62df0 add a way to generate the changelog entries",
+			expectedKind:  KindToBeIgnored,
+			expectedEntry: "",
+		},
+		{
+			title:         "commit message extracted and formatted (1)",
+			entry:         "f19355e87558177e6ad77d45bdd070fe99d62db6 [ENHANCEMENT] visual options and reset btn ux feedback (#850)",
+			expectedKind:  kindEnhancement,
+			expectedEntry: "visual options and reset btn ux feedback (#850)",
+		},
+		{
+			title:         "commit message extracted and formatted (2)",
+			entry:         "fa2e023d2bc2e2f5682141026133bcdf4960794f legend.position now required in time series panel [BreakingChange] (#848)",
+			expectedKind:  kindBreakingChange,
+			expectedEntry: "legend.position now required in time series panel  (#848)",
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			kindEntry, newEntry := parseAndFormatEntry(test.entry)
+			assert.Equal(t, test.expectedKind, kindEntry)
+			assert.Equal(t, test.expectedEntry, newEntry)
+		})
+	}
+}
+
+func TestGenerateChangelog(t *testing.T) {
+	now := time.Now()
+	title := fmt.Sprintf("## 0.20.0 / %s", now.Format("2022-12-06"))
+	testSuite := []struct {
+		title    string
+		clog     *changelog
+		expected string
+	}{
+		{
+			title:    "empty changelog",
+			clog:     &changelog{},
+			expected: fmt.Sprintf("%s\n%s\n", title, ""),
+		},
+		{
+			title: "changelog with every entry",
+			clog: &changelog{
+				features: []string{"Discard Changes Confirmation Dialog (#834)"},
+				enhancements: []string{"Variable UX fixes (#842)",
+					"legend options editor UX improvements (#845)",
+					"Make it possible to adjust the height of the time range controls (#829)",
+				},
+				bugfixes:        []string{"Fix time units display, allow decimal_places to be used (#837)"},
+				breakingChanges: []string{"legend.position now required in time series panel (#848)"},
+			},
+			expected: fmt.Sprintf("%s\n%s", title, `
+- [FEATURE] Discard Changes Confirmation Dialog (#834)
+- [ENHANCEMENT] Variable UX fixes (#842)
+- [ENHANCEMENT] legend options editor UX improvements (#845)
+- [ENHANCEMENT] Make it possible to adjust the height of the time range controls (#829)
+- [BUGFIX] Fix time units display, allow decimal_places to be used (#837)
+- [BREAKINGCHANGE] legend.position now required in time series panel (#848)
+`),
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.clog.generateChangelog("0.20.0"))
+		})
+	}
+}

--- a/scripts/generate-changelog/generate-changelog_test.go
+++ b/scripts/generate-changelog/generate-changelog_test.go
@@ -123,7 +123,7 @@ func TestParseAndFormatEntry(t *testing.T) {
 
 func TestGenerateChangelog(t *testing.T) {
 	now := time.Now()
-	title := fmt.Sprintf("## 0.20.0 / %s", now.Format("2022-12-06"))
+	title := fmt.Sprintf("## 0.20.0 / %s", now.Format("2006-01-02"))
 	testSuite := []struct {
 		title    string
 		clog     *changelog


### PR DESCRIPTION
This PR is going to tackle the points raised in #838

It provides a new Go script called `generate-changelog` that create a first list of changelog entries in the file `CHANGELOG.md` based on the git history.

The script will select any logs in the git history that contains the pattern `[<catalog_entry>]` where `catalog_entry` can be `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`.

The catalog entry can be placed anywhere in the commit message and it's not case sensitive. For example: 

`legend.position now required in time series panel [BreakingChange] (#848)` will be selected

`Support snaphost UI releases (#844)` wont be selected by the script.

As a side note, if a PR contains multiple different clean commit containing a catalog entry, this PR should be merged and not squashed to preserve these clean commit in the git history.

Excepting this case, every PR should be squashed ;)