### PR TITLE
[ENHANCEMENT] Update query editor collapse/expand chevrons to match the rest of dashboard

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditor.tsx
@@ -18,7 +18,7 @@ import { JSONEditor } from '@perses-dev/components';
 import AddIcon from 'mdi-material-ui/Plus';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import ChevronDown from 'mdi-material-ui/ChevronDown';
-import ChevronUp from 'mdi-material-ui/ChevronUp';
+import ChevronRight from 'mdi-material-ui/ChevronRight';
 import { TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { OptionsEditorProps, TimeSeriesQueryEditor, usePlugin, OptionsEditorTabs } from '@perses-dev/plugin-system';
 import { TimeSeriesChartOptions } from './time-series-chart-model';
@@ -107,7 +107,7 @@ export function TimeSeriesChartOptionsEditor(props: TimeSeriesChartOptionsEditor
                     borderColor={(theme) => theme.palette.divider}
                   >
                     <IconButton size="small" onClick={() => handleQueryCollapseExpand(i)}>
-                      {queriesCollapsed[i] ? <ChevronUp /> : <ChevronDown />}
+                      {queriesCollapsed[i] ? <ChevronRight /> : <ChevronDown />}
                     </IconButton>
                     <Typography variant="overline" component="h4">
                       Query {i + 1}


### PR DESCRIPTION
When opening + closing panel groups, we use "ChevronRight" and "ChevronDown".

This updates the query editor so that we use the same icons when opening and closing queries. 

<img width="475" alt="Screen Shot 2022-12-08 at 5 16 27 PM" src="https://user-images.githubusercontent.com/2584129/206600947-cbf28f7a-8578-44b8-9c4f-4d25bdc4d9df.png">
<img width="482" alt="Screen Shot 2022-12-08 at 5 16 34 PM" src="https://user-images.githubusercontent.com/2584129/206600952-ee5a4f95-eee2-46e4-ad77-1ab2e6d18f49.png">