### PR TITLE
[FEATURE] Add tooltips to icons in panel and panel group header

### DIFF
--- a/ui/components/src/InfoTooltip/InfoTooltip.tsx
+++ b/ui/components/src/InfoTooltip/InfoTooltip.tsx
@@ -33,15 +33,27 @@ interface InfoTooltipProps {
   id?: string;
   title?: string;
   placement?: TooltipPlacement;
+  enterDelay?: number; // default is 500ms
+  enterNextDelay?: number; // default is 500ms
 }
 
-export const InfoTooltip = ({ id, title, description, placement, children }: InfoTooltipProps) => {
+export const InfoTooltip = ({
+  id,
+  title,
+  description,
+  placement,
+  children,
+  enterDelay,
+  enterNextDelay,
+}: InfoTooltipProps) => {
   return (
     <StyledTooltip
       arrow
       id={id}
-      placement={placement}
+      placement={placement ?? TooltipPlacement.Top}
       title={<TooltipContent title={title} description={description} />}
+      enterDelay={enterDelay ?? 500}
+      enterNextDelay={enterNextDelay ?? 500}
     >
       <div>{children}</div>
     </StyledTooltip>

--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -19,6 +19,7 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import ArrowUpIcon from 'mdi-material-ui/ArrowUp';
 import ArrowDownIcon from 'mdi-material-ui/ArrowDown';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import { InfoTooltip } from '@perses-dev/components';
 import { usePanelGroupActions, useEditMode, PanelGroupId, useDeletePanelGroupDialog } from '../../context';
 
 export interface GridTitleProps {
@@ -66,21 +67,38 @@ export function GridTitle(props: GridTitleProps) {
           {text}
           {isEditMode && (
             <Stack direction="row" marginLeft="auto">
-              <IconButton aria-label={`add panel to group ${title}`} onClick={openAddPanel}>
-                <AddPanelIcon />
-              </IconButton>
-              <IconButton aria-label={`edit group ${title}`} onClick={openEditPanelGroup}>
-                <PencilIcon />
-              </IconButton>
-              <IconButton aria-label={`delete group ${title}`} onClick={() => openDeletePanelGroupDialog(panelGroupId)}>
-                <DeleteIcon />
-              </IconButton>
-              <IconButton aria-label={`move group ${title} down`} disabled={moveDown === undefined} onClick={moveDown}>
-                <ArrowDownIcon />
-              </IconButton>
-              <IconButton aria-label={`move group ${title} up`} disabled={moveUp === undefined} onClick={moveUp}>
-                <ArrowUpIcon />
-              </IconButton>
+              <InfoTooltip description={`Add a new panel to ${title}`}>
+                <IconButton aria-label={`add panel to group ${title}`} onClick={openAddPanel}>
+                  <AddPanelIcon />
+                </IconButton>
+              </InfoTooltip>
+              <InfoTooltip description="Edit">
+                <IconButton aria-label={`edit group ${title}`} onClick={openEditPanelGroup}>
+                  <PencilIcon />
+                </IconButton>
+              </InfoTooltip>
+              <InfoTooltip description="Delete">
+                <IconButton
+                  aria-label={`delete group ${title}`}
+                  onClick={() => openDeletePanelGroupDialog(panelGroupId)}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </InfoTooltip>
+              <InfoTooltip description="Move panel group down">
+                <IconButton
+                  aria-label={`move group ${title} down`}
+                  disabled={moveDown === undefined}
+                  onClick={moveDown}
+                >
+                  <ArrowDownIcon />
+                </IconButton>
+              </InfoTooltip>
+              <InfoTooltip description="Move panel group up">
+                <IconButton aria-label={`move group ${title} up`} disabled={moveUp === undefined} onClick={moveUp}>
+                  <ArrowUpIcon />
+                </IconButton>
+              </InfoTooltip>
             </Stack>
           )}
         </>

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -40,21 +40,27 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
     // If there are edit handlers, always just show the edit buttons
     action = (
       <Stack direction="row" spacing={0.5} alignItems="center">
-        <HeaderIconButton aria-label={`edit panel ${title}`} size="small" onClick={editHandlers.onEditPanelClick}>
-          <PencilIcon />
-        </HeaderIconButton>
-        <HeaderIconButton aria-label={`delete panel ${title}`} size="small" onClick={editHandlers.onDeletePanelClick}>
-          <DeleteIcon />
-        </HeaderIconButton>
-        <HeaderIconButton aria-label={`move panel ${title}`} size="small">
-          <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
-        </HeaderIconButton>
+        <InfoTooltip description="Edit">
+          <HeaderIconButton aria-label={`edit panel ${title}`} size="small" onClick={editHandlers.onEditPanelClick}>
+            <PencilIcon />
+          </HeaderIconButton>
+        </InfoTooltip>
+        <InfoTooltip description="Delete">
+          <HeaderIconButton aria-label={`delete panel ${title}`} size="small" onClick={editHandlers.onDeletePanelClick}>
+            <DeleteIcon />
+          </HeaderIconButton>
+        </InfoTooltip>
+        <InfoTooltip description="Drag and drop panel to reorganize">
+          <HeaderIconButton aria-label={`move panel ${title}`} size="small">
+            <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
+          </HeaderIconButton>
+        </InfoTooltip>
       </Stack>
     );
   } else if (description !== undefined && isHovered) {
     // If there aren't edit handlers and we have a description, show a button with a tooltip for the panel description
     action = (
-      <InfoTooltip id={descriptionTooltipId} description={description} placement={TooltipPlacement.Bottom}>
+      <InfoTooltip id={descriptionTooltipId} description={description} enterDelay={100}>
         <HeaderIconButton aria-label="Panel Description">
           <InformationOutlineIcon
             aria-describedby="info-tooltip"

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { CardHeader, Typography, Stack, IconButton, CardHeaderProps, styled } from '@mui/material';
-import { InfoTooltip, TooltipPlacement, combineSx } from '@perses-dev/components';
+import { InfoTooltip, combineSx } from '@perses-dev/components';
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';


### PR DESCRIPTION
These tooltips will show up after 0.5 sec

<img width="520" alt="image" src="https://user-images.githubusercontent.com/9817826/206620787-14cfa87b-fb00-4541-bce5-38fa6132ff1f.png">

<img width="298" alt="image" src="https://user-images.githubusercontent.com/9817826/206621515-93f41aeb-d3ab-4387-9e58-d9d03794bd90.png">
