### PR TITLE
[ENHANCEMENT] Improvements to the migrate feature

### DIFF
--- a/docs/cue.md
+++ b/docs/cue.md
@@ -101,10 +101,10 @@ if #var.type == "custom" || #var.type == "interval" {
             option.value
         }]
     }
-}
+},
 ```
 - The file is named `mig.cuepart`.
-- The file content is made of **one or more conditional block(s)**.
+- The file content is made of **one or more conditional block(s)**, separated by a coma (even if you have only one).
 - Each conditional block defines one or more matches on attributes from the `#var` definition. 
   - `#var` is a variable object from Grafana. You can access the different fields with like `#var.field.subfield`. To know the list of fields available, check the Grafana datamodel for this variable (from Grafana repo, or by inspecting the JSON of the dashboard on the Grafana UI).
   - You most certainly want a check on the `#var.type` value like shown in above example.
@@ -131,10 +131,10 @@ if #panel.type == "timeseries" || #panel.type == "graph" {
             position: #panel.options.legend.placement
         }
     }
-}
+},
 ```
 - The file is named `mig.cuepart`.
-- The file content is made of **one or more conditional block(s)**.
+- The file content is made of **one or more conditional block(s)**, separated by a coma (even if you have only one).
 - Each conditional block defines one or more matches on attributes from the `#panel` definition. 
   - `#panel` is a panel object from Grafana. You can access the different fields with like `#panel.field.subfield`. To know the list of fields available, check the Grafana datamodel for this panel (from Grafana repo, or by inspecting the JSON of the dashboard on the Grafana UI).
   - You most certainly want a check on the `#panel.type` value like shown in above example.
@@ -145,6 +145,13 @@ if #panel.type == "timeseries" || #panel.type == "graph" {
   %(conditional_timeserie_queries)
   ``` 
   the `%(conditional_timeserie_queries)` placeholder will get replaced by conditionals later in the translation process. `#target` is the standard alias expected for the target object, just like `#panel` is for panels.
+
+### Utilities
+
+There are some utilities that you can use in your panel plugin:
+- `#mapping.unit`: mapping table for the unit attribute (key = grafana unit, value = perses equivalent)
+- `#mapping.calc`: mapping table for the calculation attribute (key = grafana unit, value = perses equivalent)
+- `#defaultCalc`: standard default value for the calculation attribute
 
 ## Query
 
@@ -160,10 +167,10 @@ if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" {
         }
         query: #target.expr
     }
-}
+},
 ```
 - The file is named `mig.cuepart`.
-- The file content is made of **one or more conditional block(s)**.
+- The file content is made of **one or more conditional block(s)**, separated by a coma (even if you have only one).
 - Each conditional block defines one or more matches on attributes from the `#target` definition. 
   - `#target` is a target object from Grafana. You can access the different fields with like `#target.field.subfield`. To know the list of fields available, check the Grafana datamodel for the targets (from Grafana repo, or by inspecting the JSON of the dashboard on the Grafana UI).
   - You most certainly want a check on the `#target.datasource.type` value like shown in above example.

--- a/internal/api/impl/migrate/mapping.cuepart
+++ b/internal/api/impl/migrate/mapping.cuepart
@@ -1,13 +1,37 @@
 import (
-	// regexp is not used at the current stage in this file. It is used when merging the different cuepart file together. This is a way to shared the import across the different files
     "regexp"
-    "strings"
+    "strings" 
     "math"
 )
 
+#mapping: {
+    // mapping table for the unit attribute (key = grafana unit, value = perses equivalent)
+    unit: {
+        ms: "Milliseconds"
+        s: "Seconds"
+        m: "Minutes"
+        h: "Hours"
+        d: "Days"
+        percent: "Percent"
+        percentunit: "PercentDecimal"
+        bytes: "Bytes"
+        decbytes: "Bytes"
+    }
+    // mapping table for the calculation attribute (key = grafana unit, value = perses equivalent)
+    calc: {
+        first: "First"
+        firstNotNull: "First"
+        last: "Last"
+        lastNotNull: "LastNumber"
+        mean: "Mean"
+        total: "Sum"
+    }
+}
+#defaultCalc: "Last"
+
 kind: "Dashboard",
 metadata: {
-    name: strings.Replace(#grafanaDashboard.title, " ", "", -1)
+    name: #grafanaDashboard.uid
 },
 spec: {
     duration: "1h" // fixed value, we don't really care translating this one
@@ -23,15 +47,32 @@ spec: {
             }
         }
         if grafanaVar.type != "constant" {
-            kind: "ListVariable",
+            kind: "ListVariable"
             spec: {
-                name: grafanaVar.name,
-                allow_all_value: grafanaVar.includeAll | *false, // the default value tackles the case of variables of type `interval` that don't have such field
-                allow_multiple: grafanaVar.multi | *false,       // the default value tackles the case of variables of type `interval` that don't have such field
-                plugin: {
-                    #var: grafanaVar
-                    %(conditional_variables)
+                name: grafanaVar.name
+                if grafanaVar.label != _|_ || grafanaVar.description != _|_ || grafanaVar.hide > 0 {
+                    display: {
+                        name: [ // switch
+                            if grafanaVar.label != _|_ if grafanaVar.label != "" {
+                                grafanaVar.label
+                            },
+                            grafanaVar.name
+                        ][0]
+                        if grafanaVar.description != _|_ {
+                            description: grafanaVar.description
+                        }
+                        if grafanaVar.hide > 0 {
+                            hidden: true
+                        }
+                    }
                 }
+                allow_all_value: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
+                allow_multiple: *grafanaVar.multi | false       // the default value tackles the case of variables of type `interval` that don't have such field
+                // default_value: nothing to map to this field
+                #var: grafanaVar
+                plugin: [ // switch
+                    %(conditional_variables)
+                ][0]
             }
         }
     }]
@@ -44,13 +85,13 @@ spec: {
                     kind: "Panel"
                     spec: {
                         display: {
-                            name: innerPanel.title
-                            description: innerPanel.description | *""
+                            name: *innerPanel.title | "empty"
+                            description: *innerPanel.description | ""
                         }
-                        plugin: {
-                            #panel: innerPanel
+                        #panel: innerPanel
+                        plugin: [ // switch
                             %(conditional_panels)
-                        }
+                        ][0]
                     }
                 }
             }
@@ -60,13 +101,13 @@ spec: {
                 kind: "Panel"
                 spec: {
                     display: {
-                        name: grafanaPanel.title
-                        description: grafanaPanel.description | *""
+                        name: *grafanaPanel.title | "empty"
+                        description: *grafanaPanel.description | ""
                     }
-                    plugin: {
-                        #panel: grafanaPanel
+                    #panel: grafanaPanel
+                    plugin: [ // switch
                         %(conditional_panels)
-                    }
+                    ][0]
                 }
             }
         }
@@ -93,14 +134,14 @@ spec: {
         // go through the top-level panels a 3rd time & match only the rows, to create the corresponding grids
         for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels if grafanaPanel.panels != _|_ { // if the panel is a row
             #row: grafanaPanel
-            kind: "Grid",
+            kind: "Grid"
             spec: {
                 display: {
                     title: #row.title,
                     collapse: {
                         open: !#row.collapsed
                     }
-                },
+                }
                 // go through the children panels of the current row
                 items: [ for innerPanelId, innnerPanel in #row.panels {
                     // it may happen that a grafana panel coordinate has a decimal

--- a/internal/api/impl/migrate/testdata/old_format_grafana_dashboard.json
+++ b/internal/api/impl/migrate/testdata/old_format_grafana_dashboard.json
@@ -1,366 +1,347 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
-          "type": "dashboard"
-        }
-      ]
-    },
-    "description": "This dashboard provides informatiomn about message queues.",
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 1,
-    "id": 34726,
-    "links": [
-      {
-        "asDropdown": true,
-        "icon": "external link",
-        "includeVars": true,
-        "keepTime": true,
-        "tags": [
-          "ACS",
-          "standard",
-          "otf"
-        ],
-        "targetBlank": true,
-        "title": "OTF links",
-        "type": "dashboards",
-        "url": ""
+  "annotations": {
+    "list": [{
+      "builtIn": 1,
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
       },
-      {
-        "asDropdown": true,
-        "icon": "external link",
-        "includeVars": true,
-        "keepTime": true,
-        "tags": [
-          "standard",
-          "pods"
-        ],
-        "targetBlank": true,
-        "title": "System links",
-        "type": "dashboards",
-        "url": ""
+      "enable": true,
+      "hide": true,
+      "iconColor": "rgba(0, 211, 255, 1)",
+      "name": "Annotations & Alerts",
+      "target": {
+        "limit": 100,
+        "matchAny": false,
+        "tags": [],
+        "type": "dashboard"
       },
-      {
-        "asDropdown": true,
-        "icon": "external link",
-        "includeVars": true,
-        "keepTime": true,
-        "tags": [
-          "standard",
-          "process",
-          "application",
-          "AACS"
-        ],
-        "targetBlank": true,
-        "title": "Process links",
-        "type": "dashboards",
-        "url": ""
-      }
-    ],
-    "liveNow": false,
-    "panels": [
-      {
-        "collapse": true,
-        "collapsed": true,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "argos-world"
-        },
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 2,
-        "panels": [
-          {
-            "content": "<p>This dashboard provides information on OTF Front-End queues.<br/>Minimum OTF FE version required: 18.0.0.68 / 19.0.0.29<br/>\nMore information on FE metrics used here: <a href=\"https://rndwww.nce.amadeus.net/confluence/display/OTFTeam/OTF+Monitoring+-+FE+metrics\">Confluence link</a>\n</p>",
-            "datasource": {
-              "type": "prometheus",
-              "uid": "argos-world"
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 0
-            },
-            "id": 3,
-            "mode": "html",
-            "title": "Purpose of the Dashboard",
-            "type": "text"
-          },
-          {
-            "content": "<p>In case of issue with the dashboard, please contact the OTF team<br/><old><ol><li>Chorus Team: TPE-OTP-AFC-CPF</li><li>Win@proach Group: DAOTF</li><li>MS Teams: <a href=\"https://teams.microsoft.com/l/channel/19%3ac3e958d9e7ca4ff2b46b7e19fe971d48%40thread.skype/OTF%2520Monitoring%2520-%2520Prometheus?groupId=a690f775-792a-44f1-9b9b-35763376cf50&tenantId=b3f4f7c2-72ce-4192-aba4-d6c7719b5766\">Channel Link</a></li></ol></p>",
-            "datasource": {
-              "type": "prometheus",
-              "uid": "argos-world"
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 12,
-              "y": 0
-            },
-            "id": 4,
-            "mode": "html",
-            "title": "Point of Contact",
-            "type": "text"
-          }
-        ],
-        "showTitle": true,
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "argos-world"
-            },
-            "refId": "A"
-          }
-        ],
-        "title": "Dashboard Info",
-        "titleSize": "h6",
-        "type": "row"
-      },
-      {
-        "collapse": true,
-        "collapsed": true,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "argos-world"
-        },
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 5,
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "description": "Messages Enqueued-Dequeued per second.\n\n - Queueing rate: Rate of messages enqueued (no BE instance ready)\n - Dequeueing rate (negative): Rate of messages dequeued (a BE instance became available)",
-            "fieldConfig": {
-              "defaults": {
-                "unit": "msg/s"
-              },
-              "overrides": []
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 2
-            },
-            "hiddenSeries": false,
-            "id": 6,
-            "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": false,
-              "max": true,
-              "min": true,
-              "rightSide": false,
-              "show": true,
-              "sort": "avg",
-              "sortDesc": true,
-              "total": false,
-              "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "null",
-            "options": {
-              "alertThreshold": true
-            },
-            "paceLength": 10,
-            "percentage": false,
-            "pluginVersion": "9.2.6",
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "Queueing rate",
-                "color": "#F2CC0C",
-                "fill": 1,
-                "zindex": "-1"
-              },
-              {
-                "alias": "Dequeueing rate (negative)",
-                "color": "#56A64B",
-                "fill": 1,
-                "zindex": "0"
-              },
-              {
-                "alias": "Queue growing rate",
-                "color": "#FF780A",
-                "fill": 1,
-                "zindex": "1"
-              }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "editorMode": "code",
-                "exemplar": false,
-                "expr": "sum (rate(otf_fe_queue_be_messages_enqueued_total[$__rate_interval]))",
-                "format": "time_series",
-                "hide": false,
-                "instant": false,
-                "interval": "2m",
-                "intervalFactor": 1,
-                "legendFormat": "Queueing rate",
-                "refId": "queue"
-              }
-            ],
-            "thresholds": [],
-            "timeRegions": [],
-            "title": "Queueing rate",
-            "tooltip": {
-              "msResolution": true,
-              "shared": true,
-              "sort": 2,
-              "value_type": "individual"
-            },
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {},
-                  "indexByName": {},
-                  "renameByName": {}
-                }
-              }
-            ],
-            "type": "graph",
-            "xaxis": {
-              "mode": "time",
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "msg/s",
-                "logBase": 1,
-                "show": true
-              },
-              {
-                "format": "short",
-                "logBase": 1,
-                "show": false
-              }
-            ],
-            "yaxis": {
-              "align": false
-            }
-          }
-        ],
-        "showTitle": true,
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "argos-world"
-            },
-            "refId": "A"
-          }
-        ],
-        "title": "Overview",
-        "titleSize": "h6",
-        "type": "row"
-      }
-    ],
-    "refresh": "",
-    "schemaVersion": 37,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "current": {
-            "selected": false,
-            "text": "argos-world",
-            "value": "argos-world"
-          },
-          "hide": 2,
-          "includeAll": false,
-          "label": "PaaS",
-          "multi": false,
-          "name": "datasource",
-          "options": [],
-          "query": "prometheus",
-          "refresh": 1,
-          "regex": "/^argos-.+/",
-          "skipUrlSync": false,
-          "type": "datasource"
-        }
-      ]
-    },
-    "time": {
-      "from": "now-6h",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
+      "type": "dashboard"
+    }]
+  },
+  "description": "This dashboard provides informatiomn about message queues.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 34726,
+  "links": [{
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "ACS",
+        "standard",
+        "otf"
       ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
+      "targetBlank": true,
+      "title": "OTF links",
+      "type": "dashboards",
+      "url": ""
     },
-    "timezone": "utc",
-    "title": "queues-test",
-    "uid": "ELftRcK4z",
-    "version": 5,
-    "weekStart": ""
-  }
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "standard",
+        "pods"
+      ],
+      "targetBlank": true,
+      "title": "System links",
+      "type": "dashboards",
+      "url": ""
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "standard",
+        "process",
+        "application",
+        "AACS"
+      ],
+      "targetBlank": true,
+      "title": "Process links",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "liveNow": false,
+  "panels": [{
+      "collapse": true,
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "argos-world"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": [{
+          "content": "<p>This dashboard provides information on OTF Front-End queues.<br/>Minimum OTF FE version required: 18.0.0.68 / 19.0.0.29<br/>\nMore information on FE metrics used here: <a href=\"https://rndwww.nce.amadeus.net/confluence/display/OTFTeam/OTF+Monitoring+-+FE+metrics\">Confluence link</a>\n</p>",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "argos-world"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 3,
+          "mode": "html",
+          "title": "Purpose of the Dashboard",
+          "type": "text"
+        },
+        {
+          "content": "<p>In case of issue with the dashboard, please contact the OTF team<br/><old><ol><li>Chorus Team: TPE-OTP-AFC-CPF</li><li>Win@proach Group: DAOTF</li><li>MS Teams: <a href=\"https://teams.microsoft.com/l/channel/19%3ac3e958d9e7ca4ff2b46b7e19fe971d48%40thread.skype/OTF%2520Monitoring%2520-%2520Prometheus?groupId=a690f775-792a-44f1-9b9b-35763376cf50&tenantId=b3f4f7c2-72ce-4192-aba4-d6c7719b5766\">Channel Link</a></li></ol></p>",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "argos-world"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 4,
+          "mode": "html",
+          "title": "Point of Contact",
+          "type": "text"
+        }
+      ],
+      "showTitle": true,
+      "targets": [{
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "refId": "A"
+      }],
+      "title": "Dashboard Info",
+      "titleSize": "h6",
+      "type": "row"
+    },
+    {
+      "collapse": true,
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "argos-world"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 5,
+      "panels": [{
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "description": "Messages Enqueued-Dequeued per second.\n\n - Queueing rate: Rate of messages enqueued (no BE instance ready)\n - Dequeueing rate (negative): Rate of messages dequeued (a BE instance became available)",
+        "fieldConfig": {
+          "defaults": {
+            "unit": "msg/s"
+          },
+          "overrides": []
+        },
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 0,
+          "y": 2
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": false,
+          "max": true,
+          "min": true,
+          "rightSide": false,
+          "show": true,
+          "sort": "avg",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "paceLength": 10,
+        "percentage": false,
+        "pluginVersion": "9.2.6",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [{
+            "alias": "Queueing rate",
+            "color": "#F2CC0C",
+            "fill": 1,
+            "zindex": "-1"
+          },
+          {
+            "alias": "Dequeueing rate (negative)",
+            "color": "#56A64B",
+            "fill": 1,
+            "zindex": "0"
+          },
+          {
+            "alias": "Queue growing rate",
+            "color": "#FF780A",
+            "fill": 1,
+            "zindex": "1"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [{
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum (rate(otf_fe_queue_be_messages_enqueued_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "2m",
+          "intervalFactor": 1,
+          "legendFormat": "Queueing rate",
+          "refId": "queue"
+        }],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Queueing rate",
+        "tooltip": {
+          "msResolution": true,
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "transformations": [{
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }],
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [{
+            "format": "msg/s",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      }],
+      "showTitle": true,
+      "targets": [{
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "refId": "A"
+      }],
+      "title": "Overview",
+      "titleSize": "h6",
+      "type": "row"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [{
+      "current": {
+        "selected": false,
+        "text": "argos-world",
+        "value": "argos-world"
+      },
+      "hide": 2,
+      "includeAll": false,
+      "label": "PaaS",
+      "multi": false,
+      "name": "datasource",
+      "options": [],
+      "query": "prometheus",
+      "refresh": 1,
+      "regex": "/^argos-.+/",
+      "skipUrlSync": false,
+      "type": "datasource"
+    }]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "queues-test",
+  "uid": "ELftRcK4z",
+  "version": 5,
+  "weekStart": ""
+}

--- a/internal/api/impl/migrate/testdata/old_format_perses_dashboard.json
+++ b/internal/api/impl/migrate/testdata/old_format_perses_dashboard.json
@@ -1,160 +1,157 @@
 {
-    "kind": "Dashboard",
-    "metadata": {
-      "name": "queues-test",
-      "created_at": "0001-01-01T00:00:00Z",
-      "updated_at": "0001-01-01T00:00:00Z",
-      "project": ""
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ELftRcK4z",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "queues-test"
     },
-    "spec": {
-      "display": {
-        "name": "queues-test"
-      },
-      "duration": "1h",
-      "variables": [
-        {
-          "kind": "ListVariable",
+    "duration": "1h",
+    "variables": [{
+      "kind": "ListVariable",
+      "spec": {
+        "name": "datasource",
+        "display": {
+          "name": "PaaS",
+          "hidden": true
+        },
+        "allow_all_value": false,
+        "allow_multiple": false,
+        "plugin": {
+          "kind": "StaticListVariable",
           "spec": {
-            "name": "datasource",
-            "allow_all_value": false,
-            "allow_multiple": false,
-            "plugin": {
-              "kind": "StaticListVariable",
-              "spec": {
-                "values": [
-                  "grafana",
-                  "migration",
-                  "not",
-                  "supported"
-                ]
-              }
+            "values": [
+              "grafana",
+              "migration",
+              "not",
+              "supported"
+            ]
+          }
+        }
+      }
+    }],
+    "panels": {
+      "0_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Purpose of the Dashboard"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "<p>This dashboard provides information on OTF Front-End queues.<br/>Minimum OTF FE version required: 18.0.0.68 / 19.0.0.29<br/>\nMore information on FE metrics used here: <a href=\"https://rndwww.nce.amadeus.net/confluence/display/OTFTeam/OTF+Monitoring+-+FE+metrics\">Confluence link</a>\n</p>"
             }
           }
         }
-      ],
-      "panels": {
-        "0_0": {
-          "kind": "Panel",
-          "spec": {
-            "display": {
-              "name": "Purpose of the Dashboard"
-            },
-            "plugin": {
-              "kind": "Markdown",
-              "spec": {
-                "text": "<p>This dashboard provides information on OTF Front-End queues.<br/>Minimum OTF FE version required: 18.0.0.68 / 19.0.0.29<br/>\nMore information on FE metrics used here: <a href=\"https://rndwww.nce.amadeus.net/confluence/display/OTFTeam/OTF+Monitoring+-+FE+metrics\">Confluence link</a>\n</p>"
-              }
+      },
+      "0_1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Point of Contact"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "<p>In case of issue with the dashboard, please contact the OTF team<br/><old><ol><li>Chorus Team: TPE-OTP-AFC-CPF</li><li>Win@proach Group: DAOTF</li><li>MS Teams: <a href=\"https://teams.microsoft.com/l/channel/19%3ac3e958d9e7ca4ff2b46b7e19fe971d48%40thread.skype/OTF%2520Monitoring%2520-%2520Prometheus?groupId=a690f775-792a-44f1-9b9b-35763376cf50&tenantId=b3f4f7c2-72ce-4192-aba4-d6c7719b5766\">Channel Link</a></li></ol></p>"
             }
           }
-        },
-        "0_1": {
-          "kind": "Panel",
-          "spec": {
-            "display": {
-              "name": "Point of Contact"
-            },
-            "plugin": {
-              "kind": "Markdown",
-              "spec": {
-                "text": "<p>In case of issue with the dashboard, please contact the OTF team<br/><old><ol><li>Chorus Team: TPE-OTP-AFC-CPF</li><li>Win@proach Group: DAOTF</li><li>MS Teams: <a href=\"https://teams.microsoft.com/l/channel/19%3ac3e958d9e7ca4ff2b46b7e19fe971d48%40thread.skype/OTF%2520Monitoring%2520-%2520Prometheus?groupId=a690f775-792a-44f1-9b9b-35763376cf50&tenantId=b3f4f7c2-72ce-4192-aba4-d6c7719b5766\">Channel Link</a></li></ol></p>"
-              }
-            }
-          }
-        },
-        "1_0": {
-          "kind": "Panel",
-          "spec": {
-            "display": {
-              "name": "Queueing rate"
-            },
-            "plugin": {
-              "kind": "TimeSeriesChart",
-              "spec": {
-                "legend": {
-                  "position": "bottom"
-                },
-                "queries": [
-                  {
-                    "kind": "TimeSeriesQuery",
+        }
+      },
+      "1_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Queueing rate",
+            "description": "Messages Enqueued-Dequeued per second.\n\n - Queueing rate: Rate of messages enqueued (no BE instance ready)\n - Dequeueing rate (negative): Rate of messages dequeued (a BE instance became available)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              },
+              "queries": [{
+                "kind": "TimeSeriesQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "PrometheusTimeSeriesQuery",
                     "spec": {
-                      "plugin": {
-                        "kind": "PrometheusTimeSeriesQuery",
-                        "spec": {
-                          "datasource": {
-                            "kind": "PrometheusDatasource",
-                            "name": "MigrationFromGrafanaNotSupported"
-                          },
-                          "query": "migration_from_grafana_not_supported"
-                        }
-                      }
+                      "datasource": {
+                        "kind": "PrometheusDatasource",
+                        "name": "MigrationFromGrafanaNotSupported"
+                      },
+                      "query": "migration_from_grafana_not_supported"
                     }
                   }
-                ]
-              }
+                }
+              }]
             }
           }
         }
-      },
-      "layouts": [
-        {
-          "kind": "Grid",
-          "spec": {
-            "items": []
-          }
-        },
-        {
-          "kind": "Grid",
-          "spec": {
-            "display": {
-              "title": "Dashboard Info",
-              "collapse": {
-                "open": false
-              }
-            },
-            "items": [
-              {
-                "x": 0,
-                "y": 0,
-                "width": 12,
-                "height": 8,
-                "content": {
-                  "$ref": "#/spec/panels/0_0"
-                }
-              },
-              {
-                "x": 12,
-                "y": 0,
-                "width": 12,
-                "height": 8,
-                "content": {
-                  "$ref": "#/spec/panels/0_1"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "kind": "Grid",
-          "spec": {
-            "display": {
-              "title": "Overview",
-              "collapse": {
-                "open": false
-              }
-            },
-            "items": [
-              {
-                "x": 0,
-                "y": 2,
-                "width": 12,
-                "height": 10,
-                "content": {
-                  "$ref": "#/spec/panels/1_0"
-                }
-              }
-            ]
-          }
+      }
+    },
+    "layouts": [{
+        "kind": "Grid",
+        "spec": {
+          "items": []
         }
-      ]
-    }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Dashboard Info",
+            "collapse": {
+              "open": false
+            }
+          },
+          "items": [{
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/0_0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/0_1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Overview",
+            "collapse": {
+              "open": false
+            }
+          },
+          "items": [{
+            "x": 0,
+            "y": 2,
+            "width": 12,
+            "height": 10,
+            "content": {
+              "$ref": "#/spec/panels/1_0"
+            }
+          }]
+        }
+      }
+    ]
   }
+}

--- a/internal/api/impl/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/impl/migrate/testdata/simple_grafana_dashboard.json
@@ -1,696 +1,753 @@
 {
-    "annotations": {
-        "list": [
-            {
-                "builtIn": 1,
-                "datasource": {
-                    "type": "grafana",
-                    "uid": "-- Grafana --"
-                },
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "target": {
-                    "limit": 100,
-                    "matchAny": false,
-                    "tags": [],
-                    "type": "dashboard"
-                },
-                "type": "dashboard"
-            }
-        ]
+  "annotations": {
+    "list": [{
+      "builtIn": 1,
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
+      },
+      "enable": true,
+      "hide": true,
+      "iconColor": "rgba(0, 211, 255, 1)",
+      "name": "Annotations & Alerts",
+      "target": {
+        "limit": 100,
+        "matchAny": false,
+        "tags": [],
+        "type": "dashboard"
+      },
+      "type": "dashboard"
+    }]
+  },
+  "description": " A simple grafana dashboard to be converted to perses format",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 34819,
+  "links": [],
+  "liveNow": false,
+  "panels": [{
+      "datasource": {
+        "type": "prometheus",
+        "uid": "argos-world"
+      },
+      "description": "a stat chart that is basically showing stats as a chart",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "pressurekbar"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.6",
+      "targets": [{
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "editorMode": "code",
+        "expr": "vector(4)",
+        "legendFormat": "__auto",
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "My Stat chart",
+      "type": "stat"
     },
-    "description": " A simple grafana dashboard to be converted to perses format",
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 34342,
-    "links": [],
-    "liveNow": false,
-    "panels": [
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "argos-world"
-            },
-            "description": "a stat chart that is basically showing stats as a chart",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 5
-                            }
-                        ]
-                    },
-                    "unit": "pressurekbar"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 0,
-                "y": 0
-            },
-            "id": 13,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.2.3",
-            "targets": [
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "argos-world"
-                    },
-                    "editorMode": "code",
-                    "expr": "vector(4)",
-                    "legendFormat": "__auto",
-                    "range": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "My Stat chart",
-            "type": "stat"
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "argos-world"
+      },
+      "description": "my second panel is a gauge",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
         },
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "argos-world"
-            },
-            "description": "my second panel is a gauge",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    },
-                    "unit": "h"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 12,
-                "y": 0
-            },
-            "id": 5,
-            "options": {
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "showThresholdLabels": false,
-                "showThresholdMarkers": true
-            },
-            "pluginVersion": "9.2.3",
-            "targets": [
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "argos-world"
-                    },
-                    "editorMode": "code",
-                    "expr": "vector(2)",
-                    "legendFormat": "__auto",
-                    "range": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "My 2nd panel",
-            "type": "gauge"
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "argos-world"
-            },
-            "description": "my first panel is a timeseries",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    },
-                    "custom": {
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                            "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "spanNulls": false,
-                        "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                            "mode": "off"
-                        }
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 0,
-                "y": 8
-            },
-            "id": 2,
-            "options": {
-                "legend": {
-                    "calcs": [],
-                    "displayMode": "list",
-                    "placement": "bottom",
-                    "showLegend": true
-                },
-                "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
-                }
-            },
-            "targets": [
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "argos-world"
-                    },
-                    "editorMode": "code",
-                    "expr": "vector(1)",
-                    "legendFormat": "__auto",
-                    "range": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "My 1rst panel",
-            "type": "timeseries"
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "9.2.6",
+      "targets": [{
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
         },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 16
+        "editorMode": "code",
+        "expr": "vector(2)",
+        "legendFormat": "__auto",
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "My 2nd panel",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "argos-world"
+      },
+      "description": "my first panel is a timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "id": 11,
-            "panels": [
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "argos-world"
-                    },
-                    "description": "my third panel is a timeseries",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "custom": {
-                                "axisCenteredZero": false,
-                                "axisColorMode": "text",
-                                "axisLabel": "",
-                                "axisPlacement": "auto",
-                                "barAlignment": 0,
-                                "drawStyle": "line",
-                                "fillOpacity": 0,
-                                "gradientMode": "none",
-                                "hideFrom": {
-                                    "legend": false,
-                                    "tooltip": false,
-                                    "viz": false
-                                },
-                                "lineInterpolation": "linear",
-                                "lineWidth": 1,
-                                "pointSize": 5,
-                                "scaleDistribution": {
-                                    "type": "linear"
-                                },
-                                "showPoints": "auto",
-                                "spanNulls": false,
-                                "stacking": {
-                                    "group": "A",
-                                    "mode": "none"
-                                },
-                                "thresholdsStyle": {
-                                    "mode": "off"
-                                }
-                            },
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 17
-                    },
-                    "id": 3,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom",
-                            "showLegend": true
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "datasource": {
-                                "type": "prometheus",
-                                "uid": "argos-world"
-                            },
-                            "editorMode": "code",
-                            "expr": "vector(3)",
-                            "legendFormat": "__auto",
-                            "range": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "My 3rd panel",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "argos-world"
-                    },
-                    "fieldConfig": {
-                        "defaults": {
-                            "custom": {
-                                "hideFrom": {
-                                    "legend": false,
-                                    "tooltip": false,
-                                    "viz": false
-                                },
-                                "scaleDistribution": {
-                                    "type": "linear"
-                                }
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 5,
-                        "w": 6,
-                        "x": 12,
-                        "y": 17
-                    },
-                    "id": 7,
-                    "options": {
-                        "calculate": false,
-                        "cellGap": 1,
-                        "color": {
-                            "exponent": 0.5,
-                            "fill": "dark-orange",
-                            "mode": "scheme",
-                            "reverse": false,
-                            "scale": "exponential",
-                            "scheme": "Oranges",
-                            "steps": 64
-                        },
-                        "exemplars": {
-                            "color": "rgba(255,0,255,0.7)"
-                        },
-                        "filterValues": {
-                            "le": 1e-9
-                        },
-                        "legend": {
-                            "show": true
-                        },
-                        "rowsFrame": {
-                            "layout": "auto"
-                        },
-                        "tooltip": {
-                            "show": true,
-                            "yHistogram": false
-                        },
-                        "yAxis": {
-                            "axisPlacement": "left",
-                            "reverse": false
-                        }
-                    },
-                    "pluginVersion": "9.2.3",
-                    "title": "Empty heatmap",
-                    "type": "heatmap"
-                },
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "argos-world"
-                    },
-                    "description": "",
-                    "gridPos": {
-                        "h": 8,
-                        "w": 6,
-                        "x": 18,
-                        "y": 17
-                    },
-                    "id": 9,
-                    "options": {
-                        "code": {
-                            "language": "plaintext",
-                            "showLineNumbers": false,
-                            "showMiniMap": false
-                        },
-                        "content": "# Title\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)",
-                        "mode": "markdown"
-                    },
-                    "pluginVersion": "9.2.3",
-                    "title": "My Text panel",
-                    "type": "text"
-                }
-            ],
-            "title": "My row title",
-            "type": "row"
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
-    ],
-    "schemaVersion": 37,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-        "list": [
-            {
-                "current": {
-                    "selected": false,
-                    "text": "one",
-                    "value": "one"
+      },
+      "targets": [{
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "editorMode": "code",
+        "expr": "vector(1)",
+        "legendFormat": "__auto",
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "My 1rst panel",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 11,
+      "panels": [{
+          "datasource": {
+            "type": "prometheus",
+            "uid": "argos-world"
+          },
+          "description": "my third panel is a timeseries",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
                 },
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "listVar",
-                "options": [
-                    {
-                        "selected": true,
-                        "text": "one",
-                        "value": "one"
-                    },
-                    {
-                        "selected": false,
-                        "text": "two",
-                        "value": "two"
-                    },
-                    {
-                        "selected": false,
-                        "text": "three",
-                        "value": "three"
-                    }
-                ],
-                "query": "one,two,three",
-                "skipUrlSync": false,
-                "type": "custom"
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [{
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
             },
-            {
-                "hide": 2,
-                "name": "myConst",
-                "query": "HelloWorld",
-                "skipUrlSync": false,
-                "type": "constant"
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            {
-                "current": {
-                    "selected": false,
-                    "text": "alice",
-                    "value": "alice"
-                },
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "firstNames",
-                "options": [
-                    {
-                        "selected": true,
-                        "text": "alice",
-                        "value": "alice"
-                    },
-                    {
-                        "selected": false,
-                        "text": "bob",
-                        "value": "bob"
-                    },
-                    {
-                        "selected": false,
-                        "text": "chris",
-                        "value": "chris"
-                    }
-                ],
-                "query": "alice,bob,chris",
-                "skipUrlSync": false,
-                "type": "custom"
-            },
-            {
-                "current": {
-                    "selected": false,
-                    "text": "net6",
-                    "value": "net6"
-                },
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "argos-world"
-                },
-                "definition": "label_values(stack)",
-                "hide": 0,
-                "includeAll": true,
-                "multi": false,
-                "name": "Stack",
-                "options": [],
-                "query": {
-                    "query": "label_values(stack)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "type": "query"
-            },
-            {
-                "current": {
-                    "selected": false,
-                    "text": "net6",
-                    "value": "net6"
-                },
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "argos-world"
-                },
-                "definition": "label_values(thanos_build_info, stack)",
-                "hide": 0,
-                "includeAll": true,
-                "multi": false,
-                "name": "stack_with_metric",
-                "options": [],
-                "query": {
-                    "query": "label_values(thanos_build_info, stack)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "type": "query"
-            },
-            {
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                    "selected": false,
-                    "text": "1m",
-                    "value": "1m"
-                },
-                "description": "ad hoc filter",
-                "hide": 0,
-                "name": "interval",
-                "options": [
-                    {
-                        "selected": true,
-                        "text": "1m",
-                        "value": "1m"
-                    },
-                    {
-                        "selected": false,
-                        "text": "10m",
-                        "value": "10m"
-                    },
-                    {
-                        "selected": false,
-                        "text": "30m",
-                        "value": "30m"
-                    },
-                    {
-                        "selected": false,
-                        "text": "1h",
-                        "value": "1h"
-                    },
-                    {
-                        "selected": false,
-                        "text": "6h",
-                        "value": "6h"
-                    },
-                    {
-                        "selected": false,
-                        "text": "12h",
-                        "value": "12h"
-                    },
-                    {
-                        "selected": false,
-                        "text": "1d",
-                        "value": "1d"
-                    },
-                    {
-                        "selected": false,
-                        "text": "7d",
-                        "value": "7d"
-                    },
-                    {
-                        "selected": false,
-                        "text": "14d",
-                        "value": "14d"
-                    },
-                    {
-                        "selected": false,
-                        "text": "30d",
-                        "value": "30d"
-                    }
-                ],
-                "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-                "refresh": 2,
-                "skipUrlSync": false,
-                "type": "interval"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "argos-world"
-                },
-                "description": "adHocFilter",
-                "filters": [],
-                "hide": 0,
-                "name": "AHF",
-                "skipUrlSync": false,
-                "type": "adhoc"
-            },
-            {
-                "current": {
-                    "selected": false,
-                    "text": "API",
-                    "value": "API"
-                },
-                "definition": "label_names()",
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "LabelNamesTest",
-                "options": [],
-                "query": {
-                    "query": "label_names()",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "type": "query"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
             }
-        ]
-    },
-    "time": {
-        "from": "now-6h",
-        "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "",
-    "title": "Simple grafana dashboard",
-    "uid": "DuJ3dcNVk",
-    "version": 13,
-    "weekStart": ""
+          },
+          "targets": [{
+            "datasource": {
+              "type": "prometheus",
+              "uid": "argos-world"
+            },
+            "editorMode": "code",
+            "expr": "vector(3)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }],
+          "title": "My 3rd panel",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "argos-world"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 17
+          },
+          "id": 7,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false
+            }
+          },
+          "pluginVersion": "9.2.3",
+          "title": "Empty heatmap",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "argos-world"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 17
+          },
+          "id": 9,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "# Title\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)",
+            "mode": "markdown"
+          },
+          "pluginVersion": "9.2.3",
+          "title": "My Text panel",
+          "type": "text"
+        }
+      ],
+      "title": "My row title",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [{
+        "current": {
+          "selected": false,
+          "text": "one",
+          "value": "one"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "listVar",
+        "options": [{
+            "selected": true,
+            "text": "one",
+            "value": "one"
+          },
+          {
+            "selected": false,
+            "text": "two",
+            "value": "two"
+          },
+          {
+            "selected": false,
+            "text": "three",
+            "value": "three"
+          }
+        ],
+        "query": "one,two,three",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "hide": 2,
+        "name": "myConst",
+        "query": "HelloWorld",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "alice",
+          "value": "alice"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "firstNames",
+        "options": [{
+            "selected": true,
+            "text": "alice",
+            "value": "alice"
+          },
+          {
+            "selected": false,
+            "text": "bob",
+            "value": "bob"
+          },
+          {
+            "selected": false,
+            "text": "chris",
+            "value": "chris"
+          }
+        ],
+        "query": "alice,bob,chris",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "net6",
+          "value": "net6"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "definition": "label_values(stack)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "Stack",
+        "options": [],
+        "query": {
+          "query": "label_values(stack)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "net6",
+          "value": "net6"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "definition": "label_values(thanos_build_info, stack)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "stack_with_metric",
+        "options": [],
+        "query": {
+          "query": "label_values(thanos_build_info, stack)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "1m",
+          "value": "1m"
+        },
+        "description": "ad hoc filter",
+        "hide": 0,
+        "name": "interval",
+        "options": [{
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "description": "adHocFilter",
+        "filters": [],
+        "hide": 0,
+        "name": "AHF",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "API",
+          "value": "API"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "definition": "label_names()",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "LabelNamesTest",
+        "options": [],
+        "query": {
+          "query": "label_names()",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Azure",
+          "value": "Azure"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "argos-world"
+        },
+        "definition": "query_result(group by(type) (up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}))",
+        "description": "variable using query_result clause",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Query Result Variable",
+        "multi": false,
+        "name": "queryResVar",
+        "options": [],
+        "query": {
+          "query": "query_result(group by(type) (up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": ".*type=\\\"(.*)\\\".*",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "{type=\"Azure\"} 1 1670489608000",
+          "value": "{type=\"Azure\"} 1 1670489608000"
+        },
+        "definition": "query_result(group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range])))",
+        "description": "query result var for volatile series (relies $__range global var)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "queryResVarVolatile",
+        "options": [],
+        "query": {
+          "query": "query_result(group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range])))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "{app_part_of=\"1ASMTP\",application=\"1ASMTP\",applicationdetailed=\"1ASMTP\",componentmodel=\"UNDEFINED\",componentname=\"UNDEFINED\",firecell=\"UNDEFINED\",hostname=\"mrelay-dev-vm-01\",instance=\"10.56.163.36:50700\",job=\"cmdbrtu-custom-sd\",nodename=\"mrelay-dev-vm-01\",osname=\"Linux\",owner=\"UNDEFINED\",partition=\"-\",phase=\"DEV\",prometheus=\"system\",prometheus_instance=\"iaasvms\",prometheus_namespace=\"argos-external\",region=\"azure\",role=\"UNDEFINED\",serversite=\"rnd-we\",stack=\"external\",type=\"Azure\",virtual=\"yes\"} 1 1670489615000",
+          "value": "{app_part_of=\"1ASMTP\",application=\"1ASMTP\",applicationdetailed=\"1ASMTP\",componentmodel=\"UNDEFINED\",componentname=\"UNDEFINED\",firecell=\"UNDEFINED\",hostname=\"mrelay-dev-vm-01\",instance=\"10.56.163.36:50700\",job=\"cmdbrtu-custom-sd\",nodename=\"mrelay-dev-vm-01\",osname=\"Linux\",owner=\"UNDEFINED\",partition=\"-\",phase=\"DEV\",prometheus=\"system\",prometheus_instance=\"iaasvms\",prometheus_namespace=\"argos-external\",region=\"azure\",role=\"UNDEFINED\",serversite=\"rnd-we\",stack=\"external\",type=\"Azure\",virtual=\"yes\"} 1 1670489615000"
+        },
+        "definition": "query_result(present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range]))",
+        "description": "query result var with no <aggr> by clause",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "queryResVarOther",
+        "options": [],
+        "query": {
+          "query": "query_result(present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range]))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Simple grafana dashboard",
+  "uid": "DuJ3dcNVk",
+  "version": 1,
+  "weekStart": ""
 }

--- a/internal/api/impl/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/impl/migrate/testdata/simple_perses_dashboard.json
@@ -1,429 +1,486 @@
 {
-    "kind": "Dashboard",
-    "metadata": {
-        "name": "Simplegrafanadashboard",
-        "created_at": "0001-01-01T00:00:00Z",
-        "updated_at": "0001-01-01T00:00:00Z",
-        "project": ""
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "DuJ3dcNVk",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "Simple grafana dashboard"
     },
-    "spec": {
-        "duration": "1h",
-        "display": {
-            "name": "Simple grafana dashboard"
-        },
-        "variables": [
-            {
-                "kind": "ListVariable",
-                "spec": {
-                    "name": "listVar",
-                    "allow_all_value": false,
-                    "allow_multiple": false,
-                    "plugin": {
-                        "kind": "StaticListVariable",
-                        "spec": {
-                            "values": [
-                                "one",
-                                "two",
-                                "three"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "kind": "TextVariable",
-                "spec": {
-                    "name": "myConst",
-                    "value": "HelloWorld"
-                }
-            },
-            {
-                "kind": "ListVariable",
-                "spec": {
-                    "name": "firstNames",
-                    "allow_all_value": false,
-                    "allow_multiple": false,
-                    "plugin": {
-                        "kind": "StaticListVariable",
-                        "spec": {
-                            "values": [
-                                "alice",
-                                "bob",
-                                "chris"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "kind": "ListVariable",
-                "spec": {
-                    "name": "Stack",
-                    "allow_all_value": false,
-                    "allow_multiple": false,
-                    "plugin": {
-                        "kind": "PrometheusLabelValuesVariable",
-                        "spec": {
-                            "label_name": "stack",
-                            "matchers": []
-                        }
-                    }
-                }
-            },
-            {
-                "kind": "ListVariable",
-                "spec": {
-                    "name": "stack_with_metric",
-                    "allow_all_value": false,
-                    "allow_multiple": false,
-                    "plugin": {
-                        "kind": "PrometheusLabelValuesVariable",
-                        "spec": {
-                            "label_name": "stack",
-                            "matchers": []
-                        }
-                    }
-                }
-            },
-            {
-                "kind": "ListVariable",
-                "spec": {
-                    "name": "interval",
-                    "allow_all_value": false,
-                    "allow_multiple": false,
-                    "plugin": {
-                        "kind": "StaticListVariable",
-                        "spec": {
-                            "values": [
-                                "1m",
-                                "10m",
-                                "30m",
-                                "1h",
-                                "6h",
-                                "12h",
-                                "1d",
-                                "7d",
-                                "14d",
-                                "30d"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "kind": "ListVariable",
-                "spec": {
-                    "name": "AHF",
-                    "allow_all_value": false,
-                    "allow_multiple": false,
-                    "plugin": {
-                        "kind": "StaticListVariable",
-                        "spec": {
-                            "values": [
-                                "grafana",
-                                "migration",
-                                "not",
-                                "supported"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "kind": "ListVariable",
-                "spec": {
-                    "name": "LabelNamesTest",
-                    "allow_all_value": false,
-                    "allow_multiple": false,
-                    "plugin": {
-                        "kind": "PrometheusLabelNamesVariable",
-                        "spec": {
-                            "matchers": []
-                        }
-                    }
-                }
+    "duration": "1h",
+    "variables": [{
+        "kind": "ListVariable",
+        "spec": {
+          "name": "listVar",
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "one",
+                "two",
+                "three"
+              ]
             }
-        ],
-        "panels": {
-            "0": {
-                "kind": "Panel",
-                "spec": {
-                    "display": {
-                        "name": "My Stat chart"
-                    },
-                    "plugin": {
-                        "kind": "StatChart",
-                        "spec": {
-                            "calculation": "LastNumber",
-                            "query": {
-                                "kind": "TimeSeriesQuery",
-                                "spec": {
-                                    "plugin": {
-                                        "kind": "PrometheusTimeSeriesQuery",
-                                        "spec": {
-                                            "datasource": {
-                                                "kind": "PrometheusDatasource",
-                                                "name": "argos-world"
-                                            },
-                                            "query": "vector(4)"
-                                        }
-                                    }
-                                }
-                            },
-                            "thresholds": {
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 5
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            },
-            "1": {
-                "kind": "Panel",
-                "spec": {
-                    "display": {
-                        "name": "My 2nd panel"
-                    },
-                    "plugin": {
-                        "kind": "GaugeChart",
-                        "spec": {
-                            "calculation": "LastNumber",
-                            "query": {
-                                "kind": "TimeSeriesQuery",
-                                "spec": {
-                                    "plugin": {
-                                        "kind": "PrometheusTimeSeriesQuery",
-                                        "spec": {
-                                            "datasource": {
-                                                "kind": "PrometheusDatasource",
-                                                "name": "argos-world"
-                                            },
-                                            "query": "vector(2)"
-                                        }
-                                    }
-                                }
-                            },
-                            "thresholds": {
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            },
-                            "unit": {
-                                "kind": "Hours"
-                            }
-                        }
-                    }
-                }
-            },
-            "2": {
-                "kind": "Panel",
-                "spec": {
-                    "display": {
-                        "name": "My 1rst panel"
-                    },
-                    "plugin": {
-                        "kind": "TimeSeriesChart",
-                        "spec": {
-                            "legend": {
-                                "position": "bottom"
-                            },
-                            "queries": [
-                                {
-                                    "kind": "TimeSeriesQuery",
-                                    "spec": {
-                                        "plugin": {
-                                            "kind": "PrometheusTimeSeriesQuery",
-                                            "spec": {
-                                                "datasource": {
-                                                    "kind": "PrometheusDatasource",
-                                                    "name": "argos-world"
-                                                },
-                                                "query": "vector(1)"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            },
-            "3_0": {
-                "kind": "Panel",
-                "spec": {
-                    "display": {
-                        "name": "My 3rd panel"
-                    },
-                    "plugin": {
-                        "kind": "TimeSeriesChart",
-                        "spec": {
-                            "legend": {
-                                "position": "bottom"
-                            },
-                            "queries": [
-                                {
-                                    "kind": "TimeSeriesQuery",
-                                    "spec": {
-                                        "plugin": {
-                                            "kind": "PrometheusTimeSeriesQuery",
-                                            "spec": {
-                                                "datasource": {
-                                                    "kind": "PrometheusDatasource",
-                                                    "name": "argos-world"
-                                                },
-                                                "query": "vector(3)"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            },
-            "3_1": {
-                "kind": "Panel",
-                "spec": {
-                    "display": {
-                        "name": "Empty heatmap"
-                    },
-                    "plugin": {
-                        "kind": "Markdown",
-                        "spec": {
-                            "text": "**Migration from Grafana not supported !**"
-                        }
-                    }
-                }
-            },
-            "3_2": {
-                "kind": "Panel",
-                "spec": {
-                    "display": {
-                        "name": "My Text panel"
-                    },
-                    "plugin": {
-                        "kind": "Markdown",
-                        "spec": {
-                            "text": "# Title\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)"
-                        }
-                    }
-                }
+          }
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "name": "myConst",
+          "value": "HelloWorld"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "firstNames",
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "alice",
+                "bob",
+                "chris"
+              ]
             }
-        },
-        "layouts": [
-            {
-                "kind": "Grid",
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "Stack",
+          "allow_all_value": true,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "label_name": "stack",
+              "matchers": []
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "stack_with_metric",
+          "allow_all_value": true,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "label_name": "stack",
+              "matchers": []
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "interval",
+          "display": {
+            "name": "interval",
+            "description": "ad hoc filter",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "1m",
+                "10m",
+                "30m",
+                "1h",
+                "6h",
+                "12h",
+                "1d",
+                "7d",
+                "14d",
+                "30d"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "AHF",
+          "display": {
+            "name": "AHF",
+            "description": "adHocFilter",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "grafana",
+                "migration",
+                "not",
+                "supported"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "LabelNamesTest",
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusLabelNamesVariable",
+            "spec": {
+              "matchers": []
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "queryResVar",
+          "display": {
+            "name": "Query Result Variable",
+            "description": "variable using query_result clause",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "group by(type) (up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"})",
+              "label_name": "type"
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "queryResVarVolatile",
+          "display": {
+            "name": "queryResVarVolatile",
+            "description": "query result var for volatile series (relies $__range global var)",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[placeholder]))",
+              "label_name": "type"
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "queryResVarOther",
+          "display": {
+            "name": "queryResVarOther",
+            "description": "query result var with no <aggr> by clause",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "query_result(present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[placeholder]))",
+              "label_name": "migration_from_grafana_not_supported"
+            }
+          }
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My Stat chart",
+            "description": "a stat chart that is basically showing stats as a chart"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "LastNumber",
+              "query": {
+                "kind": "TimeSeriesQuery",
                 "spec": {
-                    "items": [
-                        {
-                            "x": 0,
-                            "y": 0,
-                            "width": 12,
-                            "height": 8,
-                            "content": {
-                                "$ref": "#/spec/panels/0"
-                            }
-                        },
-                        {
-                            "x": 12,
-                            "y": 0,
-                            "width": 12,
-                            "height": 8,
-                            "content": {
-                                "$ref": "#/spec/panels/1"
-                            }
-                        },
-                        {
-                            "x": 0,
-                            "y": 8,
-                            "width": 12,
-                            "height": 8,
-                            "content": {
-                                "$ref": "#/spec/panels/2"
-                            }
-                        }
-                    ]
+                  "plugin": {
+                    "kind": "PrometheusTimeSeriesQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "PrometheusDatasource",
+                        "name": "argos-world"
+                      },
+                      "query": "vector(4)"
+                    }
+                  }
                 }
+              },
+              "thresholds": {
+                "steps": [{
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My 2nd panel",
+            "description": "my second panel is a gauge"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "LastNumber",
+              "query": {
+                "kind": "TimeSeriesQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "PrometheusTimeSeriesQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "PrometheusDatasource",
+                        "name": "argos-world"
+                      },
+                      "query": "vector(2)"
+                    }
+                  }
+                }
+              },
+              "thresholds": {
+                "steps": [{
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": {
+                "kind": "Hours"
+              }
+            }
+          }
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My 1rst panel",
+            "description": "my first panel is a timeseries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              },
+              "queries": [{
+                "kind": "TimeSeriesQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "PrometheusTimeSeriesQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "PrometheusDatasource",
+                        "name": "argos-world"
+                      },
+                      "query": "vector(1)"
+                    }
+                  }
+                }
+              }],
+              "thresholds": {
+                "steps": [{
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "3_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My 3rd panel",
+            "description": "my third panel is a timeseries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              },
+              "queries": [{
+                "kind": "TimeSeriesQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "PrometheusTimeSeriesQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "PrometheusDatasource",
+                        "name": "argos-world"
+                      },
+                      "query": "vector(3)"
+                    }
+                  }
+                }
+              }],
+              "thresholds": {
+                "steps": [{
+                  "color": "red",
+                  "value": 80
+                }]
+              }
+            }
+          }
+        }
+      },
+      "3_1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Empty heatmap"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "**Migration from Grafana not supported !**"
+            }
+          }
+        }
+      },
+      "3_2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My Text panel"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "# Title\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)"
+            }
+          }
+        }
+      }
+    },
+    "layouts": [{
+        "kind": "Grid",
+        "spec": {
+          "items": [{
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
             },
             {
-                "kind": "Grid",
-                "spec": {
-                    "display": {
-                        "title": "My row title",
-                        "collapse": {
-                            "open": false
-                        }
-                    },
-                    "items": [
-                        {
-                            "x": 0,
-                            "y": 17,
-                            "width": 12,
-                            "height": 8,
-                            "content": {
-                                "$ref": "#/spec/panels/3_0"
-                            }
-                        },
-                        {
-                            "x": 12,
-                            "y": 17,
-                            "width": 6,
-                            "height": 5,
-                            "content": {
-                                "$ref": "#/spec/panels/3_1"
-                            }
-                        },
-                        {
-                            "x": 18,
-                            "y": 17,
-                            "width": 6,
-                            "height": 8,
-                            "content": {
-                                "$ref": "#/spec/panels/3_2"
-                            }
-                        }
-                    ]
-                }
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
             }
-        ]
-    }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "My row title",
+            "collapse": {
+              "open": false
+            }
+          },
+          "items": [{
+              "x": 0,
+              "y": 17,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3_0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 17,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/3_1"
+              }
+            },
+            {
+              "x": 18,
+              "y": 17,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3_2"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
 }

--- a/schemas/panels/gauge/mig.cuepart
+++ b/schemas/panels/gauge/mig.cuepart
@@ -4,58 +4,31 @@ if #panel.type == "gauge" {
         query: {
             kind: "TimeSeriesQuery"
             spec: {
-                plugin: {
-                    #target: #panel.targets[0] // Perses's GaugeChart doesn't support multi queries
+                #target: #panel.targets[0] // Perses's GaugeChart doesn't support multi queries
+                plugin: [ // switch
                     %(conditional_timeserie_queries)
-                }
+                ][0]
             }
         }
-        // mapping table for the `calculation` attribute
-        // TODO: factorize this for all panels?
-        #calcMapping: {
-            first: "First"
-            firstNotNull: "First"
-            last: "Last"
-            lastNotNull: "LastNumber"
-            mean: "Mean"
-            total: "Sum"
-        }
-        #defaultCalc: "Last"
-        // TODO manage full calcs array?
-        if #calcMapping["\(#panel.options.reduceOptions.calcs[0])"] != _|_ {
-            calculation: #calcMapping["\(#panel.options.reduceOptions.calcs[0])"]
-        }
-        if #calcMapping["\(#panel.options.reduceOptions.calcs[0])"] == _|_ {
-            calculation: #defaultCalc
-        }
-        // mapping table for the `unit` attribute
-        // TODO: factorize this for all panels?
-        #unitMapping: {
-            ms: "Milliseconds"
-            s: "Seconds"
-            m: "Minutes"
-            h: "Hours"
-            d: "Days"
-            percent: "Percent"
-            percentunit: "PercentDecimal"
-            bytes: "Bytes"
-            decbytes: "Bytes"
-        }
-        if #panel.fieldConfig.defaults.unit != _|_ if #unitMapping["\(#panel.fieldConfig.defaults.unit)"] != _|_ {
+        #calcName: "\(#panel.options.reduceOptions.calcs[0])" // only consider [0] here as Perses's GaugeChart doesn't support multi queries
+        calculation: [ // switch
+            if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
+            { #defaultCalc }
+        ][0]
+        #unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
+        if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
             unit: {
-                kind: #unitMapping["\(#panel.fieldConfig.defaults.unit)"]
+                kind: #mapping.unit[#unitPath]
             }
         }
         if #panel.fieldConfig.defaults.thresholds != _|_ {
             thresholds: {
-                // default_color:                                                      // TODO how to fill this field?
-                steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps { // TODO how to manage the overrides part? 
-                    if step.value == null {
-                        value: 0
-                    }
-                    if step.value != null {
-                        value: step.value
-                    }
+                // default_color: TODO how to fill this one?
+                steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part? 
+                    value: [ // switch
+                        if step.value == null { 0 },
+                        { step.value }
+                    ][0]
                     color: step.color
                 }]
             }
@@ -64,4 +37,4 @@ if #panel.type == "gauge" {
             max: #panel.fieldConfig.defaults.max
         }
     }
-}
+},

--- a/schemas/panels/markdown/mig.cuepart
+++ b/schemas/panels/markdown/mig.cuepart
@@ -1,17 +1,16 @@
 
 // NB: Convert text panels with mode=html as markdown panels as best effort while we dont provide a proper panel type for this
-// NB: We cannot factorize the first part of the condition (`#panel.type == "text"`) in a wrapping if, otherwise the default condition `if kind == _|_` from the
-// migration feature gets wrongly applied, because in this case the assignations done here live in a nested scope, thus `if kind == _|_` always evaluates to true.
-
-if #panel.type == "text" if #panel.mode != _|_ {
-    kind: "Markdown"
-    spec: {
-        text: #panel.content
+if #panel.type == "text" {
+    if #panel.mode != _|_ {
+        kind: "Markdown"
+        spec: {
+            text: #panel.content
+        }
     }
-}
-if #panel.type == "text" if #panel.options != _|_ {
-    kind: "Markdown"
-    spec: {
-        text: #panel.options.content
+    if #panel.options != _|_ {
+        kind: "Markdown"
+        spec: {
+            text: #panel.options.content
+        }
     }
-}
+},

--- a/schemas/panels/stat/mig.cuepart
+++ b/schemas/panels/stat/mig.cuepart
@@ -4,62 +4,35 @@ if #panel.type == "stat" {
         query: {
             kind: "TimeSeriesQuery"
             spec: {
-                plugin: {
-                    #target: #panel.targets[0] // Perses's StatChart doesn't support multi queries
+                #target: #panel.targets[0] // Perses's StatChart doesn't support multi queries
+                plugin: [ // switch
                     %(conditional_timeserie_queries)
-                }
+                ][0]
             }
         }
-        // mapping table for the `calculation` attribute
-        // TODO: factorize this for all panels?
-        #calcMapping: {
-            first: "First"
-            firstNotNull: "First"
-            last: "Last"
-            lastNotNull: "LastNumber"
-            mean: "Mean"
-            total: "Sum"
-        }
-        #defaultCalc: "Last"
-        // TODO manage full calcs array?
-        if #calcMapping["\(#panel.options.reduceOptions.calcs[0])"] != _|_ {
-            calculation: #calcMapping["\(#panel.options.reduceOptions.calcs[0])"]
-        }
-        if #calcMapping["\(#panel.options.reduceOptions.calcs[0])"] == _|_ {
-            calculation: #defaultCalc
-        }
-        // mapping table for the `unit` attribute
-        // TODO: factorize this for all panels?
-        #unitMapping: {
-            ms: "Milliseconds"
-            s: "Seconds"
-            m: "Minutes"
-            h: "Hours"
-            d: "Days"
-            percent: "Percent"
-            percentunit: "PercentDecimal"
-            bytes: "Bytes"
-            decbytes: "Bytes"
-        }
-        if #panel.fieldConfig.defaults.unit != _|_ if #unitMapping["\(#panel.fieldConfig.defaults.unit)"] != _|_ {
+        #calcPath: "\(#panel.options.reduceOptions.calcs[0])" // only consider [0] here as Perses's StatChart doesn't support multi queries
+        calculation: [ // switch
+            if #mapping.calc[#calcPath] != _|_ { #mapping.calc[#calcPath] },
+            { #defaultCalc }
+        ][0]
+        #unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
+        if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
             unit: {
-                kind: #unitMapping["\(#panel.fieldConfig.defaults.unit)"]
+                kind: #mapping.unit[#unitPath]
             }
         }
         if #panel.fieldConfig.defaults.thresholds != _|_ {
             thresholds: {
-                // default_color                                                       // TODO how to fill this field?
-                steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps { // TODO how to manage the overrides part? 
-                    if step.value == null {
-                        value: 0
-                    }
-                    if step.value != null {
-                        value: step.value
-                    }
+                //default_color: TODO how to fill this one?
+                steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part? 
+                    value: [ // switch
+                        if step.value == null { 0 },
+                        { step.value }
+                    ][0]
                     color: step.color
                 }]
             }
         }
         // nothing to map to the `sparkline` field yet
     }
-}
+},

--- a/schemas/panels/time-series/mig.cuepart
+++ b/schemas/panels/time-series/mig.cuepart
@@ -4,10 +4,10 @@ if #panel.type == "timeseries" || #panel.type == "graph" {
         queries: [ for _, target in #panel.targets {
             kind: "TimeSeriesQuery"
             spec: {
-                plugin: {
-                    #target: target
+                #target: target
+                plugin: [ // switch
                     %(conditional_timeserie_queries)
-                }
+                ][0]
             }
         }]
         legend: {
@@ -15,45 +15,29 @@ if #panel.type == "timeseries" || #panel.type == "graph" {
                 position: #panel.options.legend.placement
             }
             if #panel.type == "graph" {
-                if #panel.legend.rightSide {
-                    position: "right"
-                }
-                if !#panel.legend.rightSide {
-                    position: "bottom"
-                }
+                position: [ // switch
+                    if #panel.legend.rightSide != _|_ if #panel.legend.rightSide { "right" },
+                    { "bottom" }
+                ][0]
             }
         }
-        // mapping table for the `unit` attribute
-        // TODO: factorize this for all panels?
-        #unitMapping: {
-            ms: "Milliseconds"
-            s: "Seconds"
-            m: "Minutes"
-            h: "Hours"
-            d: "Days"
-            percent: "Percent"
-            percentunit: "PercentDecimal"
-            bytes: "Bytes"
-            decbytes: "Bytes"
-        }
-        if #panel.fieldConfig.defaults.unit != _|_ if #unitMapping["\(#panel.fieldConfig.defaults.unit)"] != _|_ {
+        #unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
+        if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
             unit: {
-                kind: #unitMapping["\(#panel.fieldConfig.defaults.unit)"]
+                kind: #mapping.unit[#unitPath]
             }
         }
         if #panel.fieldConfig.defaults.thresholds != _|_ {
             thresholds: {
-                //default_color:                                                       // TODO how to fill this field?
+                //default_color: TODO how to fill this one?
                 steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part?
-                    if step.value == null {
-                        value: 0
-                    }
-                    if step.value != null {
-                        value: step.value
-                    }
+                    value: [ // switch
+                        if step.value == null { 0 },
+                        { step.value }
+                    ][0]
                     color: step.color
                 }]
             }
         }
     }
-}
+},

--- a/schemas/queries/prometheus/mig.cuepart
+++ b/schemas/queries/prometheus/mig.cuepart
@@ -7,4 +7,4 @@ if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" { /
         }
         query: #target.expr
     }
-}
+},

--- a/schemas/variables/prometheus-label-names/mig.cuepart
+++ b/schemas/variables/prometheus-label-names/mig.cuepart
@@ -3,4 +3,4 @@ if #var.type == "query" if #var.query.query =~ "^label_names\\(\\)$" {
     spec: {
         matchers: []
     }
-}
+},

--- a/schemas/variables/prometheus-label-values/mig.cuepart
+++ b/schemas/variables/prometheus-label-values/mig.cuepart
@@ -4,4 +4,4 @@ if #var.type == "query" if #var.query.query =~ "^label_values\\(.*\\)$" {
         label_name: regexp.FindSubmatch("^label_values\\(.*?,?([a-zA-Z0-9-_]+)\\)$", #var.query.query)[1] // TODO manage the 2 different kinds of label_values 
         matchers: []
     }
-}
+},

--- a/schemas/variables/prometheus-promql/mig.cuepart
+++ b/schemas/variables/prometheus-promql/mig.cuepart
@@ -1,0 +1,21 @@
+if #var.type == "query" {
+    #qResRegexp: "^query_result\\((.*by\\s*\\((\\w+).*)\\)$"
+    #cleanedQuery: strings.Replace(#var.query.query, "$__range", "placeholder", -1) // this removes the grafana global vars that'd be causing validation issues later (e.g "__range is used but not defined")
+    // TODO replace above assignation by below one once we'll rely on cue > v0.5 (regexp.ReplaceAll was added in v0.4.3)
+    // #cleanedQuery: regexp.ReplaceAll("\\$__\\w+", #var.query.query, "placeholder") // this removes the grafana global vars that'd be causing validation issues later (e.g "__range is used but not defined")
+
+    if #var.query.query =~ #qResRegexp {
+        kind:          "PrometheusPromQLVariable"
+        spec: {
+            expr:       regexp.FindSubmatch(#qResRegexp, #cleanedQuery)[1]
+            label_name: regexp.FindSubmatch(#qResRegexp, #cleanedQuery)[2]
+        }
+    }
+    if #var.query.query !~ #qResRegexp {
+        kind:          "PrometheusPromQLVariable"
+        spec: {
+            expr:       #cleanedQuery
+            label_name: "migration_from_grafana_not_supported"
+        }
+    }
+},

--- a/schemas/variables/static-list/mig.cuepart
+++ b/schemas/variables/static-list/mig.cuepart
@@ -5,4 +5,4 @@ if #var.type == "custom" || #var.type == "interval" {
             option.value
         }]
     }
-}
+},


### PR DESCRIPTION
This PR brings several improvements to the migrate feature.
- Preload the mapping engine instead of building it at each and every request. -> /!\\ refresh on plugin changes (filewatch) is required due to this change, missing at the moment.
- Move the different mappings used for unit, calc.. conversion to the common file + document these, as they are now available to any plugin.
- Added migration file for PrometheusPromQLVariable.
- Support more attributes in the conversion: variable show/hide, description...
- Fix several default values that were wrongly taking the priority.
- Fix several cases where the migration was failing because of missing expected attribute.
- Fix an issue with the Hidden attribute that was getting ignored by the default json unmarshal.

Signed-off-by: AntoineThebaud <antoine.thebaud@yahoo.fr>