### PR TITLE
[BUGFIX] reset btn dark mode font color

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
@@ -67,6 +67,7 @@ export function TimeSeriesChartOptionsEditorSettings(props: TimeSeriesChartOptio
       <OptionsEditorColumn>
         <Button
           variant="outlined"
+          color="secondary"
           onClick={() => {
             onChange(
               produce(value, (draft: TimeSeriesChartOptions) => {


### PR DESCRIPTION
Fixes time series panel reset button in dark mode when Perses is embedded, see example of bug:

<img width="258" alt="image" src="https://user-images.githubusercontent.com/9369625/206732901-5ec63655-1a8a-44f8-bcdb-b62a8736769c.png">
