### PR TITLE
[FEATURE] Add new endpoints to validate dashboard and datasource

### DIFF
--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/perses/perses/internal/api/impl/v1/globaldatasource"
 	"github.com/perses/perses/internal/api/impl/v1/health"
 	"github.com/perses/perses/internal/api/impl/v1/project"
+	validateendpoint "github.com/perses/perses/internal/api/impl/validate"
 	"github.com/perses/perses/internal/api/shared"
 	"github.com/perses/perses/internal/api/shared/dependency"
 )
@@ -52,6 +53,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, cfg config.Config) e
 	apiEndpoints := []endpoint{
 		configendpoint.New(cfg),
 		migrateendpoint.New(cfg.Schemas),
+		validateendpoint.New(serviceManager.GetSchemas()),
 	}
 	return &api{
 		apiV1Endpoints: apiV1Endpoints,

--- a/internal/api/impl/validate/validate.go
+++ b/internal/api/impl/validate/validate.go
@@ -51,22 +51,18 @@ func (e *Endpoint) ValidateDashboard(ctx echo.Context) error {
 }
 
 func (e *Endpoint) ValidateDatasource(ctx echo.Context) error {
-	entity := &v1.Datasource{}
-	if err := ctx.Bind(entity); err != nil {
-		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
-	}
-	if err := validate.Datasource(entity, nil, e.sch); err != nil {
-		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
-	}
-	return ctx.NoContent(http.StatusOK)
+	return validateDatasource(&v1.Datasource{}, e.sch, ctx)
 }
 
 func (e *Endpoint) ValidateGlobalDatasource(ctx echo.Context) error {
-	entity := &v1.GlobalDatasource{}
+	return validateDatasource(&v1.GlobalDatasource{}, e.sch, ctx)
+}
+
+func validateDatasource[T v1.DatasourceInterface](entity T, sch schemas.Schemas, ctx echo.Context) error {
 	if err := ctx.Bind(entity); err != nil {
 		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
 	}
-	if err := validate.Datasource(entity, nil, e.sch); err != nil {
+	if err := validate.Datasource(entity, nil, sch); err != nil {
 		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
 	}
 	return ctx.NoContent(http.StatusOK)

--- a/internal/api/impl/validate/validate.go
+++ b/internal/api/impl/validate/validate.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/perses/perses/internal/api/shared"
+	"github.com/perses/perses/internal/api/shared/schemas"
+	"github.com/perses/perses/internal/api/shared/validate"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type Endpoint struct {
+	sch schemas.Schemas
+}
+
+func New(sch schemas.Schemas) *Endpoint {
+	return &Endpoint{sch: sch}
+}
+
+func (e *Endpoint) RegisterRoutes(g *echo.Group) {
+	path := "/validate"
+	g.POST(fmt.Sprintf("%s/%s", path, shared.PathDashboard), e.ValidateDashboard)
+	g.POST(fmt.Sprintf("%s/%s", path, shared.PathDatasource), e.ValidateDatasource)
+	g.POST(fmt.Sprintf("%s/%s", path, shared.PathGlobalDatasource), e.ValidateGlobalDatasource)
+}
+
+func (e *Endpoint) ValidateDashboard(ctx echo.Context) error {
+	entity := &v1.Dashboard{}
+	if err := ctx.Bind(entity); err != nil {
+		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
+	}
+	if err := validate.Dashboard(entity, e.sch); err != nil {
+		return fmt.Errorf("%w: %s", shared.BadRequestError, err)
+	}
+	return ctx.NoContent(http.StatusOK)
+}
+
+func (e *Endpoint) ValidateDatasource(ctx echo.Context) error {
+	entity := &v1.Datasource{}
+	if err := ctx.Bind(entity); err != nil {
+		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
+	}
+	if err := validate.Datasource(entity, nil, e.sch); err != nil {
+		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
+	}
+	return ctx.NoContent(http.StatusOK)
+}
+
+func (e *Endpoint) ValidateGlobalDatasource(ctx echo.Context) error {
+	entity := &v1.GlobalDatasource{}
+	if err := ctx.Bind(entity); err != nil {
+		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
+	}
+	if err := validate.Datasource(entity, nil, e.sch); err != nil {
+		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
+	}
+	return ctx.NoContent(http.StatusOK)
+}

--- a/pkg/client/api/client.go
+++ b/pkg/client/api/client.go
@@ -24,6 +24,7 @@ type ClientInterface interface {
 	RESTClient() *perseshttp.RESTClient
 	V1() v1.ClientInterface
 	Migrate(body *api.Migrate) (*modelV1.Dashboard, error)
+	Validate() ValidateInterface
 }
 
 type client struct {
@@ -54,4 +55,8 @@ func (c *client) Migrate(body *api.Migrate) (*modelV1.Dashboard, error) {
 		Do().
 		Object(result)
 	return result, err
+}
+
+func (c *client) Validate() ValidateInterface {
+	return newValidate(c.restClient)
 }

--- a/pkg/client/api/validate.go
+++ b/pkg/client/api/validate.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/perses/perses/pkg/client/perseshttp"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type ValidateInterface interface {
+	Dashboard(entity *v1.Dashboard) error
+	Datasource(entity *v1.Datasource) error
+	GlobalDatasource(entity *v1.GlobalDatasource) error
+}
+
+type validate struct {
+	ValidateInterface
+	client *perseshttp.RESTClient
+}
+
+func newValidate(client *perseshttp.RESTClient) ValidateInterface {
+	return &validate{client: client}
+}
+
+func (c *validate) Dashboard(entity *v1.Dashboard) error {
+	return c.client.Post().
+		APIVersion("").
+		Resource("validate/dashboards").
+		Body(entity).
+		Do().
+		Error()
+}
+func (c *validate) Datasource(entity *v1.Datasource) error {
+	return c.client.Post().
+		APIVersion("").
+		Resource("validate/datasources").
+		Body(entity).
+		Do().
+		Error()
+}
+func (c *validate) GlobalDatasource(entity *v1.GlobalDatasource) error {
+	return c.client.Post().
+		APIVersion("").
+		Resource("validate/globaldatasources").
+		Body(entity).
+		Do().
+		Error()
+}


### PR DESCRIPTION
This PR add three new endpoints : 
- `/api/validate/dashboards`
- `/api/validate/datasources`
- `/api/validate/globaldatasources`

these endpoints are used by the CLI to validate dashboard and datasources using the remote server.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>