### PR TITLE
[BUGFIX] Decrease size of icons in panel headers

### DIFF
--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -35,36 +35,37 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
   const titleElementId = `${id}-title`;
   const descriptionTooltipId = `${id}-description`;
 
-  let action: CardHeaderProps['action'] = undefined;
+  let actions: CardHeaderProps['action'] = undefined;
   if (editHandlers !== undefined) {
     // If there are edit handlers, always just show the edit buttons
-    action = (
-      <Stack direction="row" spacing={0.5} alignItems="center">
+    actions = (
+      <>
         <InfoTooltip description="Edit">
           <HeaderIconButton aria-label={`edit panel ${title}`} size="small" onClick={editHandlers.onEditPanelClick}>
-            <PencilIcon />
+            <PencilIcon fontSize="inherit" />
           </HeaderIconButton>
         </InfoTooltip>
         <InfoTooltip description="Delete">
           <HeaderIconButton aria-label={`delete panel ${title}`} size="small" onClick={editHandlers.onDeletePanelClick}>
-            <DeleteIcon />
+            <DeleteIcon fontSize="inherit" />
           </HeaderIconButton>
         </InfoTooltip>
         <InfoTooltip description="Drag and drop panel to reorganize">
           <HeaderIconButton aria-label={`move panel ${title}`} size="small">
-            <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} />
+            <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} fontSize="inherit" />
           </HeaderIconButton>
         </InfoTooltip>
-      </Stack>
+      </>
     );
   } else if (description !== undefined && isHovered) {
     // If there aren't edit handlers and we have a description, show a button with a tooltip for the panel description
-    action = (
+    actions = (
       <InfoTooltip id={descriptionTooltipId} description={description} enterDelay={100}>
-        <HeaderIconButton aria-label="Panel Description">
+        <HeaderIconButton aria-label="Panel Description" size="small">
           <InformationOutlineIcon
             aria-describedby="info-tooltip"
             aria-hidden={false}
+            fontSize="inherit"
             sx={{ color: (theme) => theme.palette.grey[700] }}
           />
         </HeaderIconButton>
@@ -96,13 +97,24 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
           {title}
         </Typography>
       }
-      action={action}
+      action={
+        <HeaderActionWrapper direction="row" spacing={0.25} alignItems="center">
+          {actions}
+        </HeaderActionWrapper>
+      }
       sx={combineSx(
         (theme) => ({
           padding: theme.spacing(1),
           borderBottom: `solid 1px ${theme.palette.divider}`,
           '.MuiCardHeader-content': {
             overflow: 'hidden',
+          },
+          '.MuiCardHeader-action': {
+            // Overriding the negative margins from MUI's defaults, so we
+            // can vertically center the icons. Moving these values to a wrapper
+            // inside the action in `HeaderActionWrapper` below.
+            // https://github.com/mui/material-ui/blob/master/packages/mui-material/src/CardHeader/CardHeader.js#L56-L58
+            margin: 'auto',
           },
         }),
         sx
@@ -115,4 +127,13 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
 const HeaderIconButton = styled(IconButton)(({ theme }) => ({
   borderRadius: theme.shape.borderRadius,
   padding: '4px',
+}));
+
+const HeaderActionWrapper = styled(Stack)(() => ({
+  // Adding back the negative margins from MUI's defaults for actions, so we
+  // avoid increasing the header size when actions are present while also being
+  // able to vertically center the actions.
+  // https://github.com/mui/material-ui/blob/master/packages/mui-material/src/CardHeader/CardHeader.js#L56-L58
+  marginTop: -4,
+  marginBottom: -4,
 }));


### PR DESCRIPTION
This brings the panels in line with the mocks and provides more screen real estate for panel titles.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Screenshots

## Edit

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td><img width="1264" alt="image" src="https://user-images.githubusercontent.com/396962/206779075-d53ffb3d-1012-4904-90a5-1108420f0966.png"></td>
		<td>
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/396962/206778610-961f7cb7-af5c-4d66-83a5-ed228cd1b67b.png">
</td>
	</tr>
</table>

## View

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/396962/206779225-9c67ab12-194b-4926-b750-fe226836b77f.png">

</td>
		<td>
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/396962/206778841-dbb87613-4aa3-4c3f-bce0-83c25e5a52e0.png">
</td>
	</tr>
</table>