### PR TITLE
[BUGFIX] Fix variable collisions with promQL function

### DIFF
--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -16,6 +16,7 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"gopkg.in/yaml.v2"
@@ -127,6 +128,9 @@ func (v *TextVariableSpec) validate() error {
 	if err := common.ValidateID(v.Name); err != nil {
 		return err
 	}
+	if _, err := strconv.Atoi(v.Name); err == nil {
+		return fmt.Errorf("variable name cannot contain only digits. That's not a meaningful name for a variable")
+	}
 	if len(v.Value) == 0 {
 		return fmt.Errorf("value for the variable %q cannot be empty", v.Name)
 	}
@@ -187,7 +191,7 @@ func (v *ListVariableSpec) validate() error {
 }
 
 type Variable struct {
-	// Kind is the type of the variable. Depending of the value of Kind, it will change the content of Spec.
+	// Kind is the type of the variable. Depending on the value of Kind, it will change the content of Spec.
 	Kind VariableKind `json:"kind" yaml:"kind"`
 	Spec VariableSpec `json:"spec" yaml:"spec"`
 }

--- a/pkg/model/api/v1/dashboard/variable_build_order_test.go
+++ b/pkg/model/api/v1/dashboard/variable_build_order_test.go
@@ -262,6 +262,67 @@ func TestBuildVariableDependencies(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "variable with only number is ignored",
+			variables: []Variable{
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						CommonVariableSpec: CommonVariableSpec{
+							Name: "filter_platform",
+						},
+						Value: "myConstant",
+					},
+				},
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						CommonVariableSpec: CommonVariableSpec{
+							Name: "PaaS",
+						},
+						Value: "myConstant",
+					},
+				},
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						CommonVariableSpec: CommonVariableSpec{
+							Name: "filter_kube_sts",
+						},
+						Value: "myConstant",
+					},
+				},
+				{
+					Kind: TextVariable,
+					Spec: &TextVariableSpec{
+						CommonVariableSpec: CommonVariableSpec{
+							Name: "extlabels_prometheus_namespace",
+						},
+						Value: "myConstant",
+					},
+				},
+				{
+					Kind: ListVariable,
+					Spec: &ListVariableSpec{
+						CommonVariableSpec: CommonVariableSpec{
+							Name: "foo",
+						},
+						Plugin: common.Plugin{
+							Kind: "PrometheusPromQLVariable",
+							Spec: map[string]interface{}{
+								"expr":       "group by(prometheus) (label_replace(kube_statefulset_labels{$filter_platform,stack=~\"$PaaS\",$filter_kube_sts,stack=~\"$PaaS\",namespace=~\"$extlabels_prometheus_namespace\"},\"prometheus\",\"$1\",\"label_app_kubernetes_io_instance\",\"([^-]+)-?.*\"))",
+								"label_name": "prometheus",
+							},
+						},
+					},
+				},
+			},
+			result: map[string][]string{
+				"foo": {
+					"filter_platform", "PaaS", "filter_kube_sts", "extlabels_prometheus_namespace",
+				},
+			},
+		},
 	}
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {


### PR DESCRIPTION
This PR fixed #859 

We are going to forbid the possibility to name a variable with just a number. It's not a meaningful name anyway, so it's not that bad to do that.

That should be a way to mitigate the issue #859 and to avoid to detect additional variable coming from different language.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>