### PR TITLE
[BreakingChange] Remove default value for TextVariable

### DIFF
--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -81,11 +81,8 @@ type VariableDisplay struct {
 }
 
 type CommonVariableSpec struct {
-	Name string `json:"name" yaml:"name"`
-	// TODO default value should be moved to the VariableList and be a string or an array of string
-	// TODO to be aligned with the front end
-	DefaultValue string           `json:"default_value,omitempty" yaml:"default_value,omitempty"`
-	Display      *VariableDisplay `json:"display,omitempty" yaml:"display,omitempty"`
+	Name    string           `json:"name" yaml:"name"`
+	Display *VariableDisplay `json:"display,omitempty" yaml:"display,omitempty"`
 }
 
 type TextVariableSpec struct {
@@ -140,8 +137,11 @@ func (v *TextVariableSpec) validate() error {
 type ListVariableSpec struct {
 	VariableSpec       `json:"-" yaml:"-"`
 	CommonVariableSpec `json:",inline" yaml:",inline"`
-	AllowAllValue      bool `json:"allow_all_value" yaml:"allow_all_value"`
-	AllowMultiple      bool `json:"allow_multiple" yaml:"allow_multiple"`
+	// TODO default value should be a string or an array of string
+	// TODO to be aligned with the front end
+	DefaultValue  string `json:"default_value,omitempty" yaml:"default_value,omitempty"`
+	AllowAllValue bool   `json:"allow_all_value" yaml:"allow_all_value"`
+	AllowMultiple bool   `json:"allow_multiple" yaml:"allow_multiple"`
 	// CustomAllValue is a custom value that will be used if AllowAllValue is true and if then `all` is selected
 	CustomAllValue string `json:"custom_all_value,omitempty" yaml:"custom_all_value,omitempty"`
 	// CapturingRegexp is the regexp used to catch and filter the result of the query.

--- a/ui/core/src/model/variables.ts
+++ b/ui/core/src/model/variables.ts
@@ -23,7 +23,6 @@ interface VariableSpec {
   display?: Display & {
     hidden?: boolean;
   };
-  default_value?: VariableValue;
 }
 
 export interface TextVariableDefinition extends Definition<TextVariableSpec> {
@@ -39,6 +38,7 @@ export interface ListVariableDefinition<PluginSpec = UnknownSpec> extends Defini
 }
 
 export interface ListVariableSpec<PluginSpec> extends VariableSpec {
+  default_value?: VariableValue;
   allow_multiple?: boolean;
   allow_all_value?: boolean;
   custom_all_value?: string;

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -210,22 +210,22 @@ export function TemplateVariableProvider({
 
 /** Helpers */
 
-function hydrateTemplateVariableState(definition: VariableDefinition, initialValue?: VariableValue) {
-  const v = definition;
+function hydrateTemplateVariableState(variable: VariableDefinition, initialValue?: VariableValue) {
   const varState: VariableState = {
-    value: initialValue ?? v.spec.default_value ?? null,
+    value: null,
     loading: false,
   };
-  switch (v.kind) {
+  switch (variable.kind) {
     case 'TextVariable':
-      varState.value = initialValue ?? v.spec.value;
+      varState.value = initialValue ?? variable.spec.value;
       break;
     case 'ListVariable':
       varState.options = [];
+      varState.value = initialValue ?? variable.spec.default_value ?? null;
       if (varState.options.length > 0 && !varState.value) {
         const firstOptionValue = varState.options[0]?.value ?? null;
         if (firstOptionValue !== null) {
-          varState.value = v.spec.allow_multiple ? [firstOptionValue] : firstOptionValue;
+          varState.value = variable.spec.allow_multiple ? [firstOptionValue] : firstOptionValue;
         }
       }
       break;


### PR DESCRIPTION
As talked on matrix sometimes ago, we figured out having a default value doesn't make sense for `TextVariable`. So default value move to be specific to `ListVariable` only

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>