### PR TITLE
[BUGFIX] default_value is accepted by the backend to be a string or an array

### DIFF
--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -165,6 +165,20 @@ func (v *DefaultVariableValue) UnmarshalYAML(unmarshal func(interface{}) error) 
 	return nil
 }
 
+func (v *DefaultVariableValue) MarshalJSON() ([]byte, error) {
+	if len(v.SingleValue) > 0 {
+		return json.Marshal(v.SingleValue)
+	}
+	return json.Marshal(v.SliceValues)
+}
+
+func (v *DefaultVariableValue) MarshalYAML() (interface{}, error) {
+	if len(v.SingleValue) > 0 {
+		return v.SingleValue, nil
+	}
+	return v.SliceValues, nil
+}
+
 type ListVariableSpec struct {
 	VariableSpec       `json:"-" yaml:"-"`
 	CommonVariableSpec `json:",inline" yaml:",inline"`

--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -213,13 +213,11 @@ func (v *ListVariableSpec) validate() error {
 	if err := common.ValidateID(v.Name); err != nil {
 		return err
 	}
-	if !v.AllowAllValue {
-		if len(v.CustomAllValue) > 0 {
-			return fmt.Errorf("custom_all_value cannot be set if allow_all_value is not set to true")
-		}
-		if v.DefaultValue != nil && len(v.DefaultValue.SliceValues) > 0 {
-			return fmt.Errorf("you can not use a list of default values if allow_multiple is set to false")
-		}
+	if len(v.CustomAllValue) > 0 && !v.AllowAllValue {
+		return fmt.Errorf("custom_all_value cannot be set if allow_all_value is not set to true")
+	}
+	if v.DefaultValue != nil && len(v.DefaultValue.SliceValues) > 0 && !v.AllowMultiple {
+		return fmt.Errorf("you can not use a list of default values if allow_multiple is set to false")
 	}
 
 	return nil

--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -172,6 +172,100 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "default value as a single string",
+			jason: `
+{
+  "kind": "ListVariable",
+  "spec": {
+    "name": "MyList",
+    "display": {
+      "name": "my awesome variable"
+    },
+    "default_value": "default",
+    "plugin": {
+      "kind": "PrometheusLabelValuesVariable",
+      "spec": {
+        "label_name": "instance",
+        "matchers": [
+          "up"
+        ]
+      }
+    }
+  }
+}
+`,
+			result: &Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					DefaultValue: &DefaultVariableValue{SingleValue: "default"},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelValuesVariable",
+						Spec: map[string]interface{}{
+							"label_name": "instance",
+							"matchers":   []interface{}{"up"},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "default list of values",
+			jason: `
+{
+  "kind": "ListVariable",
+  "spec": {
+    "name": "MyList",
+    "display": {
+      "name": "my awesome variable"
+    },
+    "allow_multiple" : true,
+    "default_value": ["default1", "default2"],
+    "plugin": {
+      "kind": "PrometheusLabelValuesVariable",
+      "spec": {
+        "label_name": "instance",
+        "matchers": [
+          "up"
+        ]
+      }
+    }
+  }
+}
+`,
+			result: &Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					AllowMultiple: true,
+					DefaultValue:  &DefaultVariableValue{SliceValues: []string{"default1", "default2"}},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelValuesVariable",
+						Spec: map[string]interface{}{
+							"label_name": "instance",
+							"matchers":   []interface{}{"up"},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
@@ -297,6 +391,88 @@ spec:
 							Hidden: false,
 						},
 					},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelValuesVariable",
+						Spec: map[interface{}]interface{}{
+							"label_name": "instance",
+							"matchers":   []interface{}{"up"},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "default value as a single string",
+			yamele: `
+kind: "ListVariable"
+spec:
+  name: "MyList"
+  display:
+    name: "my awesome variable"
+  default_value: "default"
+  plugin:
+    kind: "PrometheusLabelValuesVariable"
+    spec:
+      label_name: "instance"
+      matchers:
+        - "up"
+`,
+			result: &Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					DefaultValue: &DefaultVariableValue{SingleValue: "default"},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelValuesVariable",
+						Spec: map[interface{}]interface{}{
+							"label_name": "instance",
+							"matchers":   []interface{}{"up"},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "default list of values",
+			yamele: `
+kind: "ListVariable"
+spec:
+  name: "MyList"
+  display:
+    name: "my awesome variable"
+  allow_multiple: true
+  default_value:
+    - "default1"
+    - "default2"
+  plugin:
+    kind: "PrometheusLabelValuesVariable"
+    spec:
+      label_name: "instance"
+      matchers:
+        - "up"
+`,
+			result: &Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					AllowMultiple: true,
+					DefaultValue:  &DefaultVariableValue{SliceValues: []string{"default1", "default2"}},
 					Plugin: common.Plugin{
 						Kind: "PrometheusLabelValuesVariable",
 						Spec: map[interface{}]interface{}{

--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -551,3 +551,261 @@ func TestUnmarshalVariableError(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalListVariable(t *testing.T) {
+	testSuite := []struct {
+		title    string
+		variable Variable
+		result   string
+	}{
+		{
+			title: "simple TextVariable",
+			variable: Variable{
+				Kind: TextVariable,
+				Spec: &TextVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "SimpleText",
+					},
+					Value: "value",
+				},
+			},
+			result: `{
+  "kind": "TextVariable",
+  "spec": {
+    "name": "SimpleText",
+    "value": "value"
+  }
+}`,
+		},
+		{
+			title: "query variable by label_names",
+			variable: Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelNamesVariable",
+						Spec: map[string]interface{}{},
+					},
+				},
+			},
+			result: `{
+  "kind": "ListVariable",
+  "spec": {
+    "name": "MyList",
+    "display": {
+      "name": "my awesome variable",
+      "hidden": false
+    },
+    "allow_all_value": false,
+    "allow_multiple": false,
+    "plugin": {
+      "kind": "PrometheusLabelNamesVariable",
+      "spec": {}
+    }
+  }
+}`,
+		},
+		{
+			title: "query variable by label_names with matcher",
+			variable: Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelNamesVariable",
+						Spec: map[string]interface{}{
+							"matchers": []interface{}{"up"},
+						},
+					},
+				},
+			},
+			result: `{
+  "kind": "ListVariable",
+  "spec": {
+    "name": "MyList",
+    "display": {
+      "name": "my awesome variable",
+      "hidden": false
+    },
+    "allow_all_value": false,
+    "allow_multiple": false,
+    "plugin": {
+      "kind": "PrometheusLabelNamesVariable",
+      "spec": {
+        "matchers": [
+          "up"
+        ]
+      }
+    }
+  }
+}`,
+		},
+		{
+			title: "query variable with label_values and matcher",
+			variable: Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelValuesVariable",
+						Spec: map[string]interface{}{
+							"label_name": "instance",
+							"matchers":   []interface{}{"up"},
+						},
+					},
+				},
+			},
+			result: `{
+  "kind": "ListVariable",
+  "spec": {
+    "name": "MyList",
+    "display": {
+      "name": "my awesome variable",
+      "hidden": false
+    },
+    "allow_all_value": false,
+    "allow_multiple": false,
+    "plugin": {
+      "kind": "PrometheusLabelValuesVariable",
+      "spec": {
+        "label_name": "instance",
+        "matchers": [
+          "up"
+        ]
+      }
+    }
+  }
+}`,
+		},
+		{
+			title: "default value as a single string",
+			variable: Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					DefaultValue: &DefaultVariableValue{SingleValue: "default"},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelValuesVariable",
+						Spec: map[string]interface{}{
+							"label_name": "instance",
+							"matchers":   []interface{}{"up"},
+						},
+					},
+				},
+			},
+			result: `{
+  "kind": "ListVariable",
+  "spec": {
+    "name": "MyList",
+    "display": {
+      "name": "my awesome variable",
+      "hidden": false
+    },
+    "default_value": "default",
+    "allow_all_value": false,
+    "allow_multiple": false,
+    "plugin": {
+      "kind": "PrometheusLabelValuesVariable",
+      "spec": {
+        "label_name": "instance",
+        "matchers": [
+          "up"
+        ]
+      }
+    }
+  }
+}`,
+		},
+		{
+			title: "default list of values",
+			variable: Variable{
+				Kind: ListVariable,
+				Spec: &ListVariableSpec{
+					CommonVariableSpec: CommonVariableSpec{
+						Name: "MyList",
+						Display: &VariableDisplay{
+							Display: common.Display{
+								Name: "my awesome variable",
+							},
+							Hidden: false,
+						},
+					},
+					AllowMultiple: true,
+					DefaultValue:  &DefaultVariableValue{SliceValues: []string{"default1", "default2"}},
+					Plugin: common.Plugin{
+						Kind: "PrometheusLabelValuesVariable",
+						Spec: map[string]interface{}{
+							"label_name": "instance",
+							"matchers":   []interface{}{"up"},
+						},
+					},
+				},
+			},
+			result: `{
+  "kind": "ListVariable",
+  "spec": {
+    "name": "MyList",
+    "display": {
+      "name": "my awesome variable",
+      "hidden": false
+    },
+    "default_value": [
+      "default1",
+      "default2"
+    ],
+    "allow_all_value": false,
+    "allow_multiple": true,
+    "plugin": {
+      "kind": "PrometheusLabelValuesVariable",
+      "spec": {
+        "label_name": "instance",
+        "matchers": [
+          "up"
+        ]
+      }
+    }
+  }
+}`,
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			data, err := json.MarshalIndent(test.variable, "", "  ")
+			assert.NoError(t, err)
+			assert.Equal(t, test.result, string(data))
+		})
+	}
+}


### PR DESCRIPTION
Regarding the field `default_value` available in the `ListVariable` It was possible to use an array of string or a string in the frontend, but the backend would have blocked that.

This PR aligned the type of `default_value` between the frontend and the backend.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>