### PR TITLE
[ENHANCEMENT] Hide horizontal scrollbar in Legend

### DIFF
--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -33,6 +33,7 @@ export function Legend({ width, height, options, data }: LegendProps) {
           position: 'absolute',
           top: 0,
           right: 0,
+          overflowX: 'hidden',
           overflowY: 'scroll',
         }}
       >


### PR DESCRIPTION
Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>

When a Mac user has the setting `Show scrollbars: "Always"`, we see a horizontal scrollbar in the legend for a time series chart. The legend text wraps to the next line, so we don't need a horizontal scrollbar. 

This PR hides the horizontal scrollbar.

## Before & After (Note: When this Mac setting is turned off, the vertical scrollbar will not appear unless scrolling)
<img width="616" alt="Screen Shot 2022-12-13 at 11 51 13 AM" src="https://user-images.githubusercontent.com/2584129/207430683-83385398-bb59-4717-b00c-71f668b1116d.png">
<img width="681" alt="Screen Shot 2022-12-13 at 11 50 49 AM" src="https://user-images.githubusercontent.com/2584129/207430679-63ab21b3-5cce-458c-8ee3-a1f5e2e09a20.png">