### PR TITLE
[BUGFIX] Fix Unmarshal variable display

### DIFF
--- a/internal/api/shared/schemas/schemas_test.go
+++ b/internal/api/shared/schemas/schemas_test.go
@@ -220,11 +220,9 @@ func TestValidateVariables(t *testing.T) {
 								CommonVariableSpec: dashboard.CommonVariableSpec{
 									Name: "my1rstVar",
 									Display: &dashboard.VariableDisplay{
-										Display: common.Display{
-											Name:        "My First Variable",
-											Description: "A simple variable of type FirstVariable",
-										},
-										Hidden: false,
+										Name:        "My First Variable",
+										Description: "A simple variable of type FirstVariable",
+										Hidden:      false,
 									},
 								},
 								AllowAllValue: true,
@@ -238,11 +236,9 @@ func TestValidateVariables(t *testing.T) {
 								CommonVariableSpec: dashboard.CommonVariableSpec{
 									Name: "my2ndVar",
 									Display: &dashboard.VariableDisplay{
-										Display: common.Display{
-											Name:        "My Second Variable",
-											Description: "A simple variable of type SecondVariable",
-										},
-										Hidden: false,
+										Name:        "My Second Variable",
+										Description: "A simple variable of type SecondVariable",
+										Hidden:      false,
 									},
 								},
 								AllowAllValue: true,
@@ -271,11 +267,9 @@ func TestValidateVariables(t *testing.T) {
 								CommonVariableSpec: dashboard.CommonVariableSpec{
 									Name: "myUnknownVar",
 									Display: &dashboard.VariableDisplay{
-										Display: common.Display{
-											Name:        "My Unknown Variable",
-											Description: "A simple variable of type UnknownVariable",
-										},
-										Hidden: false,
+										Name:        "My Unknown Variable",
+										Description: "A simple variable of type UnknownVariable",
+										Hidden:      false,
 									},
 								},
 								AllowAllValue: false,

--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -76,8 +76,42 @@ type VariableSpec interface {
 }
 
 type VariableDisplay struct {
-	common.Display `json:",inline" yaml:",inline"`
-	Hidden         bool `json:"hidden" yaml:"hidden"`
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Hidden      bool   `json:"hidden" yaml:"hidden"`
+}
+
+func (d *VariableDisplay) UnmarshalJSON(data []byte) error {
+	var tmp VariableDisplay
+	type plain VariableDisplay
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *VariableDisplay) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp VariableDisplay
+	type plain VariableDisplay
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *VariableDisplay) validate() error {
+	if len(d.Name) == 0 {
+		return fmt.Errorf("name cannot be empty")
+	}
+	return nil
 }
 
 type CommonVariableSpec struct {

--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -73,9 +73,7 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -113,9 +111,7 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -136,7 +132,8 @@ func TestUnmarshalJSONVariable(t *testing.T) {
   "spec": {
     "name": "MyList",
     "display": {
-      "name": "my awesome variable"
+      "name": "my awesome variable",
+      "hidden": true
     },
     "plugin": {
       "kind": "PrometheusLabelValuesVariable",
@@ -156,10 +153,8 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
-							Hidden: false,
+							Name:   "my awesome variable",
+							Hidden: true,
 						},
 					},
 					Plugin: common.Plugin{
@@ -201,9 +196,7 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -248,9 +241,7 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -317,9 +308,7 @@ spec:
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -349,9 +338,7 @@ spec:
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -372,6 +359,7 @@ spec:
   name: "MyList"
   display:
     name: "my awesome variable"
+    hidden: true
   plugin:
     kind: "PrometheusLabelValuesVariable"
     spec:
@@ -385,10 +373,8 @@ spec:
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
-							Hidden: false,
+							Name:   "my awesome variable",
+							Hidden: true,
 						},
 					},
 					Plugin: common.Plugin{
@@ -423,9 +409,7 @@ spec:
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -465,9 +449,7 @@ spec:
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -585,9 +567,7 @@ func TestMarshalListVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -622,9 +602,7 @@ func TestMarshalListVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -665,9 +643,7 @@ func TestMarshalListVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -710,9 +686,7 @@ func TestMarshalListVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},
@@ -757,9 +731,7 @@ func TestMarshalListVariable(t *testing.T) {
 					CommonVariableSpec: CommonVariableSpec{
 						Name: "MyList",
 						Display: &VariableDisplay{
-							Display: common.Display{
-								Name: "my awesome variable",
-							},
+							Name:   "my awesome variable",
 							Hidden: false,
 						},
 					},


### PR DESCRIPTION
When you inline your a struct in another and both override the json unmarshal method, actually it is used the one coming from the inline struct. So whatever you are putting in addition of the inline struct will be ignored during the unmarshal step.

For the moment, I just copy and past the field coming from the struct `common.Display` to the struct `VariableDisplay`. I don't have better solution for the moment.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>