### PR TITLE
[BUGFIX] Toolbar inputs and icons are consistent

### DIFF
--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -130,6 +130,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               {isLaptopSize && (
                 <Button
                   variant="outlined"
+                  color="secondary"
                   startIcon={<PencilIcon />}
                   onClick={onEditButtonClick}
                   sx={{ marginLeft: 'auto' }}

--- a/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
+++ b/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
@@ -13,7 +13,6 @@
 
 import React, { useRef } from 'react';
 import DownloadIcon from 'mdi-material-ui/DownloadOutline';
-import { Button, styled } from '@mui/material';
 import { useDashboard } from '../../context';
 import { ToolbarIconButton } from '../ToolbarIconButton';
 

--- a/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
+++ b/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
@@ -13,8 +13,9 @@
 
 import React, { useRef } from 'react';
 import DownloadIcon from 'mdi-material-ui/DownloadOutline';
-import { IconButton, styled } from '@mui/material';
+import { Button, styled } from '@mui/material';
 import { useDashboard } from '../../context';
+import { ToolbarIconButton } from '../ToolbarIconButton';
 
 // Button to download the dashboard as a JSON file.
 export function DownloadButton() {
@@ -38,9 +39,9 @@ export function DownloadButton() {
 
   return (
     <>
-      <DownloadIconButton title="Download JSON" onClick={onDownloadButtonClick}>
+      <ToolbarIconButton title="Download JSON" onClick={onDownloadButtonClick}>
         <DownloadIcon />
-      </DownloadIconButton>
+      </ToolbarIconButton>
       {/* Hidden link to download the dashboard as a JSON file */}
       {/* eslint-disable jsx-a11y/anchor-has-content */}
       {/* eslint-disable jsx-a11y/anchor-is-valid  */}
@@ -48,10 +49,3 @@ export function DownloadButton() {
     </>
   );
 }
-
-const DownloadIconButton = styled(IconButton)(({ theme }) => ({
-  border: `1px solid ${theme.palette.grey[300]}`,
-  borderRadius: theme.shape.borderRadius,
-  padding: '4px',
-  color: theme.palette.grey[900],
-}));

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import RefreshIcon from 'mdi-material-ui/Refresh';
-import { Button, styled } from '@mui/material';
 import { DateTimeRangePicker, TimeOption } from '@perses-dev/components';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { isDurationString } from '@perses-dev/core';

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -12,11 +12,12 @@
 // limitations under the License.
 
 import RefreshIcon from 'mdi-material-ui/Refresh';
-import { IconButton, styled } from '@mui/material';
+import { Button, styled } from '@mui/material';
 import { DateTimeRangePicker, TimeOption } from '@perses-dev/components';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { isDurationString } from '@perses-dev/core';
 import { useDefaultTimeRange } from '../../context';
+import { ToolbarIconButton } from '../ToolbarIconButton';
 
 export const TIME_OPTIONS: TimeOption[] = [
   { value: { pastDuration: '5m' }, display: 'Last 5 minutes' },
@@ -59,16 +60,9 @@ export function TimeRangeControls({ heightPx }: TimeRangeControlsProps) {
   return (
     <>
       <DateTimeRangePicker timeOptions={TIME_OPTIONS} value={timeRange} onChange={setTimeRange} height={height} />
-      <RefreshIconButton aria-label="Refresh Dashboard" onClick={refresh} sx={{ height }}>
+      <ToolbarIconButton aria-label="Refresh Dashboard" onClick={refresh} sx={{ height }}>
         <RefreshIcon />
-      </RefreshIconButton>
+      </ToolbarIconButton>
     </>
   );
 }
-
-const RefreshIconButton = styled(IconButton)(({ theme }) => ({
-  border: `1px solid ${theme.palette.grey[300]}`,
-  borderRadius: theme.shape.borderRadius,
-  padding: theme.spacing(0.5),
-  color: theme.palette.grey[900],
-}));

--- a/ui/dashboards/src/components/ToolbarIconButton/ToolbarIconButton.tsx
+++ b/ui/dashboards/src/components/ToolbarIconButton/ToolbarIconButton.tsx
@@ -11,16 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './Dashboard';
-export * from './DashboardToolbar';
-export * from './DeletePanelDialog';
-export * from './DeletePanelGroupDialog';
-export * from './DiscardChangesConfirmationDialog';
-export * from './DownloadButton';
-export * from './GridLayout';
-export * from './Panel';
-export * from './PanelDrawer';
-export * from './PanelGroupDialog';
-export * from './TimeRangeControls';
-export * from './ToolbarIconButton';
-export * from './Variables';
+import { Button, styled, ButtonProps } from '@mui/material';
+
+type ToolbarIconButtonProps = ButtonProps;
+
+export function ToolbarIconButton(props: ToolbarIconButtonProps) {
+  return <IconButton variant="outlined" color="secondary" {...props} />;
+}
+
+const IconButton = styled(Button)(({ theme }) => ({
+  // Using a button with some adjusted styles because it is easier to inherit
+  // styling and variants from themes than with an IconButton.
+  padding: theme.spacing(0.5),
+  minWidth: 'auto',
+}));

--- a/ui/dashboards/src/components/ToolbarIconButton/index.ts
+++ b/ui/dashboards/src/components/ToolbarIconButton/index.ts
@@ -11,16 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './Dashboard';
-export * from './DashboardToolbar';
-export * from './DeletePanelDialog';
-export * from './DeletePanelGroupDialog';
-export * from './DiscardChangesConfirmationDialog';
-export * from './DownloadButton';
-export * from './GridLayout';
-export * from './Panel';
-export * from './PanelDrawer';
-export * from './PanelGroupDialog';
-export * from './TimeRangeControls';
 export * from './ToolbarIconButton';
-export * from './Variables';


### PR DESCRIPTION
Addresses some issues around inconsistencies in the dashboard toolbar around inputs, buttons, icon buttons, and MUI theming.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

## Notes for reviewers

- We were doing a little too much hardcoding in some of these components, which meant that things weren't matching up properly moving around between themes in perses and other projects. These changes attempt to simplify those changes, so that they rely more heavily on the MUI theme.

## Screenshots 

### Light mode (perses)

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="994" alt="image" src="https://user-images.githubusercontent.com/396962/207684917-0db3afee-f418-4f58-8b71-afe01c48ab27.png">
</td>
		<td>
<img width="994" alt="image" src="https://user-images.githubusercontent.com/396962/207684387-720a1083-f591-495a-a926-aa5612589afd.png">
</td>
	</tr>
</table>

### Light mode (example in project using perses & MUI theming)

Was able to test this out with snapshots!

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="320" alt="image" src="https://user-images.githubusercontent.com/396962/207696514-a4ad3ab1-a42a-40ac-a58d-db6b28f0b1f3.png">
</td>
		<td>
<img width="320" alt="image" src="https://user-images.githubusercontent.com/396962/207695183-c4bdad58-02e2-46cd-a818-522702d7956a.png">

</td>
	</tr>
</table>

### Dark mode (perses)

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="994" alt="image" src="https://user-images.githubusercontent.com/396962/207684830-1989bea4-b041-4818-8082-0376fe475c93.png">
</td>
		<td>
<img width="994" alt="image" src="https://user-images.githubusercontent.com/396962/207684456-4c65e16d-40d5-467f-921b-356d8375decf.png">
</td>
	</tr>
</table>

### Dark mode (example in project using perses & MUI theming)

Was able to test this out with snapshots!

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="320" alt="image" src="https://user-images.githubusercontent.com/396962/207696465-52be3190-ce8a-497e-8360-be13517a3673.png">
</td>
		<td>
<img width="320" alt="image" src="https://user-images.githubusercontent.com/396962/207695369-92729b83-c93c-43cc-ae2c-3280f06d6bf4.png">


</td>
	</tr>
</table>