### PR TITLE
Wrape codemirror around a box and set a default height

### DIFF
--- a/ui/app/src/views/ViewMigrate.tsx
+++ b/ui/app/src/views/ViewMigrate.tsx
@@ -13,6 +13,7 @@
 
 import {
   Alert,
+  Box,
   Button,
   CircularProgress,
   Container,
@@ -141,7 +142,9 @@ function ViewMigrate() {
         )}
         {migrateMutation.isSuccess && (
           <Stack direction={'row'} spacing={1}>
-            <JSONEditor value={migrateMutation.data} width={'80%'} />
+            <Box width={'80%'}>
+              <JSONEditor value={migrateMutation.data} maxHeight={'50rem'} width={'100%'} />
+            </Box>
             <Stack spacing={1}>
               <TextField
                 required

--- a/ui/app/src/views/ViewMigrate.tsx
+++ b/ui/app/src/views/ViewMigrate.tsx
@@ -141,7 +141,7 @@ function ViewMigrate() {
         )}
         {migrateMutation.isSuccess && (
           <Stack direction={'row'} spacing={1}>
-            <JSONEditor value={migrateMutation.data} />
+            <JSONEditor value={migrateMutation.data} width={'80%'} />
             <Stack spacing={1}>
               <TextField
                 required

--- a/ui/components/src/JSONEditor.tsx
+++ b/ui/components/src/JSONEditor.tsx
@@ -15,20 +15,15 @@ import { useEffect, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { linter, lintGutter } from '@codemirror/lint';
-import { Box, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material';
+import { ReactCodeMirrorProps } from '@uiw/react-codemirror/src';
 
-interface JSONEditorProps<Spec> {
-  value: Spec;
-  onChange?: (next: Spec) => void;
-  maxHeight?: string;
-  height?: string;
-  width?: string;
-  maxWidth?: string;
-}
+type JSONEditorProps<T> = Omit<ReactCodeMirrorProps, 'onBlur' | 'theme' | 'extensions' | 'onChange' | 'value'> & {
+  value: T;
+  onChange?: (next: T) => void;
+};
 
 export function JSONEditor<T>(props: JSONEditorProps<T>) {
-  const { onChange, height, width, maxWidth } = props;
-  const maxHeight = props.maxHeight ?? '50rem';
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
 
@@ -39,29 +34,25 @@ export function JSONEditor<T>(props: JSONEditorProps<T>) {
   }, [props.value]);
 
   return (
-    <Box maxWidth={maxWidth} width={width}>
-      <CodeMirror
-        style={{ border: `1px solid ${theme.palette.divider}` }}
-        theme={isDarkMode ? 'dark' : 'light'}
-        extensions={[json(), linter(jsonParseLinter()), lintGutter()]}
-        value={value}
-        maxHeight={maxHeight}
-        height={height}
-        maxWidth={'100%'}
-        onChange={(newValue) => {
-          setValue(newValue);
-        }}
-        onBlur={() => {
-          try {
-            const json = JSON.parse(value ?? '{}');
-            if (onChange !== undefined) {
-              onChange(json);
-            }
-          } catch (e) {
-            // ignore this error
+    <CodeMirror
+      {...props}
+      style={{ border: `1px solid ${theme.palette.divider}` }}
+      theme={isDarkMode ? 'dark' : 'light'}
+      extensions={[json(), linter(jsonParseLinter()), lintGutter()]}
+      value={value}
+      onChange={(newValue) => {
+        setValue(newValue);
+      }}
+      onBlur={() => {
+        try {
+          const json = JSON.parse(value ?? '{}');
+          if (props.onChange !== undefined) {
+            props.onChange(json);
           }
-        }}
-      />
-    </Box>
+        } catch (e) {
+          // ignore this error
+        }
+      }}
+    />
   );
 }

--- a/ui/components/src/JSONEditor.tsx
+++ b/ui/components/src/JSONEditor.tsx
@@ -15,14 +15,20 @@ import { useEffect, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { linter, lintGutter } from '@codemirror/lint';
-import { useTheme } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 
 interface JSONEditorProps<Spec> {
   value: Spec;
   onChange?: (next: Spec) => void;
+  maxHeight?: string;
+  height?: string;
+  width?: string;
+  maxWidth?: string;
 }
 
 export function JSONEditor<T>(props: JSONEditorProps<T>) {
+  const { onChange, height, width, maxWidth } = props;
+  const maxHeight = props.maxHeight ?? '50rem';
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
 
@@ -33,24 +39,29 @@ export function JSONEditor<T>(props: JSONEditorProps<T>) {
   }, [props.value]);
 
   return (
-    <CodeMirror
-      style={{ border: `1px solid ${theme.palette.divider}` }}
-      theme={isDarkMode ? 'dark' : 'light'}
-      extensions={[json(), linter(jsonParseLinter()), lintGutter()]}
-      value={value}
-      onChange={(newValue) => {
-        setValue(newValue);
-      }}
-      onBlur={() => {
-        try {
-          const json = JSON.parse(value ?? '{}');
-          if (props.onChange !== undefined) {
-            props.onChange(json);
+    <Box maxWidth={maxWidth} width={width}>
+      <CodeMirror
+        style={{ border: `1px solid ${theme.palette.divider}` }}
+        theme={isDarkMode ? 'dark' : 'light'}
+        extensions={[json(), linter(jsonParseLinter()), lintGutter()]}
+        value={value}
+        maxHeight={maxHeight}
+        height={height}
+        maxWidth={'100%'}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        onBlur={() => {
+          try {
+            const json = JSON.parse(value ?? '{}');
+            if (onChange !== undefined) {
+              onChange(json);
+            }
+          } catch (e) {
+            // ignore this error
           }
-        } catch (e) {
-          // ignore this error
-        }
-      }}
-    />
+        }}
+      />
+    </Box>
   );
 }


### PR DESCRIPTION
By default, codemirror doesn't have a maximum height. That can be ok for tiny JSON. It's less ok when you have thousand line (like in the migration page).

Also Codemirror doesn't seem to be well constraint by the width of the container like `Stack`. So I wrapped it around a `Box` and allow user to give a pre-determine `width` if necessary

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>