### PR TITLE
[IGNORE] Reduce duplicate github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
 name: ci
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -8,6 +7,7 @@ on:
       - snapshot/*
     tags:
       - v*
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,12 @@ name: ci
 on:
   pull_request:
   push:
+    branches:
+      - main
+      - release/*
+      - snapshot/*
+    tags:
+      - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+      - release/*
+      - snapshot/*
+    tags:
+      - v*
   pull_request:
 
 concurrency:
@@ -22,59 +26,58 @@ jobs:
     name: "check code format"
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v3
-    - uses: ./.github/actions/setup_environment
-      with:
-        enable_go: true
-    - name: install cue
-      run: go install cuelang.org/go/cmd/cue@v0.4.2
-    - name: check format
-      run: make checkformat
-    - name: check go.mod
-      run: make checkunused
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_environment
+        with:
+          enable_go: true
+      - name: install cue
+        run: go install cuelang.org/go/cmd/cue@v0.4.2
+      - name: check format
+        run: make checkformat
+      - name: check go.mod
+        run: make checkunused
   test:
     name: "unit and integration tests"
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v3
-    - uses: ./.github/actions/setup_environment
-      with:
-        enable_go: true
-    - name: test
-      run: make integration-test
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_environment
+        with:
+          enable_go: true
+      - name: test
+        run: make integration-test
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v3
-    - uses: ./.github/actions/setup_environment
-      with:
-        enable_go: true
-        enable_npm: false
-    - name: generate files
-      run: make generate
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3.3.1
-      with:
-        # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.49.0
-        args: --timeout 5m
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_environment
+        with:
+          enable_go: true
+          enable_npm: false
+      - name: generate files
+        run: make generate
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.3.1
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.49.0
+          args: --timeout 5m
   cue-eval:
     name: cue
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v3
-    - uses: ./.github/actions/setup_environment
-      with:
-        enable_go: true
-    - name: install cue
-      run: go install cuelang.org/go/cmd/cue@latest
-    - name: eval cue schema
-      run: make cue-eval
-    - name: test cue schema
-      run: make cue-test
-
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_environment
+        with:
+          enable_go: true
+      - name: install cue
+        run: go install cuelang.org/go/cmd/cue@latest
+      - name: eval cue schema
+        run: make cue-eval
+      - name: test cue schema
+        run: make cue-test

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+      - release/*
+      - snapshot/*
+    tags:
+      - v*
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Prior to this change, the github actions in `ci.yaml` would run on pull request and push events. This means that when maintainers work in branches, they trigger these actions twice when working in pull requests. This is an unnecessary use of actions resources and can slow down getting work done (e.g. slowed down getting #868 done to unblock a release).

After this change, the github actions in `ci.yaml` will continue to run on pull request events. It will modify the behavior to only run on push events when they match one of the following:
- `main` branch: default project branch
- `release/*` branch: branches used to prepare releases
- `snapshot/*` branch: branches used to release one-off snapshots for testing
- `v*` tag: release tags.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>