### PR TITLE
[BUGFIX] GaugeChart do not ignore unit decimal_places and abbreviate

### DIFF
--- a/ui/components/src/GaugeChart/GaugeChart.tsx
+++ b/ui/components/src/GaugeChart/GaugeChart.tsx
@@ -152,10 +152,7 @@ export function GaugeChart(props: GaugeChartProps) {
             color: 'inherit', // allows value color to match active threshold color
             fontSize: valueSizeClamp,
             formatter: (value: number) => {
-              return formatValue(value, {
-                kind: unit.kind,
-                decimal_places: 0,
-              });
+              return formatValue(value, unit);
             },
           },
           data: [
@@ -199,10 +196,7 @@ export function getResponsiveValueSize(value: number, unit: UnitOptions, width: 
   const MIN_SIZE = 3;
   const MAX_SIZE = 24;
   const SIZE_MULTIPLIER = 0.7;
-  const formattedValue = formatValue(value, {
-    kind: unit.kind,
-    decimal_places: 0,
-  });
+  const formattedValue = formatValue(value, unit);
   const valueCharacters = formattedValue.length ?? 2;
   const valueSize = (Math.min(width, height) / valueCharacters) * SIZE_MULTIPLIER;
   return `clamp(${MIN_SIZE}px, ${valueSize}px, ${MAX_SIZE}px)`;

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { merge } from 'lodash-es';
 import { CalculationSelector, CalculationSelectorProps } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
 import { DEFAULT_CALCULATION } from '@perses-dev/plugin-system';
@@ -43,11 +44,14 @@ export function GaugeChartOptionsEditorSettings(props: GaugeChartOptionsEditorPr
     );
   };
 
+  // ensures decimal_places defaults to correct value
+  const unit = merge({}, DEFAULT_UNIT, value.unit);
+
   return (
     <OptionsEditorGrid>
       <OptionsEditorColumn>
         <OptionsEditorGroup title="Misc">
-          <UnitSelector value={value.unit ?? DEFAULT_UNIT} onChange={handleUnitChange} />
+          <UnitSelector value={unit} onChange={handleUnitChange} />
           <CalculationSelector value={value.calculation ?? DEFAULT_CALCULATION} onChange={handleCalculationChange} />
         </OptionsEditorGroup>
       </OptionsEditorColumn>

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import type { GaugeSeriesOption } from 'echarts';
+import { merge } from 'lodash-es';
 import { useTimeSeriesQuery, PanelProps, CalculationsMap } from '@perses-dev/plugin-system';
 import { GaugeChart, GaugeSeries } from '@perses-dev/components';
 import { Box, Skeleton, Stack } from '@mui/material';
@@ -30,7 +31,9 @@ export function GaugeChartPanel(props: GaugeChartPanelProps) {
   const { spec: pluginSpec, contentDimensions } = props;
   const { query, calculation, max } = pluginSpec;
 
-  const unit = pluginSpec.unit ?? DEFAULT_UNIT;
+  // ensures decimal_places gets set if undef
+  const unit = merge({}, DEFAULT_UNIT, pluginSpec.unit);
+
   const thresholds = pluginSpec.thresholds ?? defaultThresholdInput;
 
   const suggestedStepMs = useSuggestedStepMs(contentDimensions?.width);

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -31,7 +31,7 @@ export function GaugeChartPanel(props: GaugeChartPanelProps) {
   const { spec: pluginSpec, contentDimensions } = props;
   const { query, calculation, max } = pluginSpec;
 
-  // ensures decimal_places gets set if undef
+  // ensures all default unit properties set if undef
   const unit = merge({}, DEFAULT_UNIT, pluginSpec.unit);
 
   const thresholds = pluginSpec.thresholds ?? defaultThresholdInput;

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -47,14 +47,14 @@ export function createInitialGaugeChartOptions(): GaugeChartOptions {
       },
     },
     calculation: 'LastNumber',
-    unit: { kind: 'Percent' },
+    unit: DEFAULT_UNIT,
     thresholds: {
       steps: [
         {
-          value: 80,
+          value: 0.8,
         },
         {
-          value: 90,
+          value: 0.9,
         },
       ],
     },


### PR DESCRIPTION
## Overview

Currently, `decimal_places` in GaugeChart is hard-coded to 0 and abbreviate is not respected. This PR ensures the full `unit` object is passed into the formatValue function. 

DEFAULT_UNIT is also updated so when adding a new GaugeChart panel to PercentDecimal is used instead of Percent (I've noticed that PercentDecimal gets used more often, but I'm open to reverting this change based on feedback).

Note: this is a follow up to PR #891 

## Screenshot

<img width="817" alt="image" src="https://user-images.githubusercontent.com/9369625/208933435-2522b0b4-77e5-47bc-b487-90173061c390.png">
