### PR TITLE
[ENHANCEMENT] Move edit variables button and make variables wrap to next line

### DIFF
--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -15,13 +15,16 @@ import { Typography, Stack, Button, Box, useTheme, useMediaQuery, Alert } from '
 import PencilIcon from 'mdi-material-ui/PencilOutline';
 import AddPanelGroupIcon from 'mdi-material-ui/PlusBoxOutline';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
-import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
+import { ErrorBoundary, ErrorAlert, InfoTooltip, TooltipPlacement } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
 import { useState } from 'react';
 import { useDashboard, useDashboardActions, useEditMode } from '../../context';
-import { TemplateVariableList } from '../Variables';
+import { TemplateVariableList, VariableEditButton } from '../Variables';
 import { TimeRangeControls } from '../TimeRangeControls';
 import { DownloadButton } from '../DownloadButton';
+
+const ADD_PANEL_BUTTON_DESCRIPTION = 'Add panel';
+const ADD_PANEL_GROUP_BUTTON_DESCRIPTION = 'Add panel group';
 
 export interface DashboardToolbarProps {
   dashboardName: string;
@@ -95,8 +98,8 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             sx={{
               display: 'flex',
               width: '100%',
-              alignItems: 'flex-start',
-              padding: (theme) => theme.spacing(0, 2, 2, 2),
+              alignItems: 'start',
+              padding: (theme) => theme.spacing(1, 2, 2, 2),
             }}
           >
             <ErrorBoundary FallbackComponent={ErrorAlert}>
@@ -109,12 +112,21 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               />
             </ErrorBoundary>
             <Stack direction="row" spacing={1} marginLeft="auto" sx={{ whiteSpace: 'nowrap' }}>
-              <Button startIcon={<AddPanelGroupIcon />} onClick={openAddPanelGroup}>
-                Add Panel Group
-              </Button>
-              <Button startIcon={<AddPanelIcon />} onClick={openAddPanel}>
-                Add Panel
-              </Button>
+              <VariableEditButton />
+              <InfoTooltip description={ADD_PANEL_BUTTON_DESCRIPTION} placement={TooltipPlacement.Bottom}>
+                <Button startIcon={<AddPanelIcon />} onClick={openAddPanel} aria-label={ADD_PANEL_BUTTON_DESCRIPTION}>
+                  Panel
+                </Button>
+              </InfoTooltip>
+              <InfoTooltip description={ADD_PANEL_GROUP_BUTTON_DESCRIPTION} placement={TooltipPlacement.Bottom}>
+                <Button
+                  startIcon={<AddPanelGroupIcon />}
+                  onClick={openAddPanelGroup}
+                  aria-label={ADD_PANEL_GROUP_BUTTON_DESCRIPTION}
+                >
+                  Panel group
+                </Button>
+              </InfoTooltip>
               <TimeRangeControls />
               <DownloadButton />
             </Stack>

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -19,7 +19,7 @@ import { ErrorBoundary, ErrorAlert, InfoTooltip, TooltipPlacement } from '@perse
 import { DashboardResource } from '@perses-dev/core';
 import { useState } from 'react';
 import { useDashboard, useDashboardActions, useEditMode } from '../../context';
-import { TemplateVariableList, VariableEditButton } from '../Variables';
+import { TemplateVariableList, EditVariablesButton } from '../Variables';
 import { TimeRangeControls } from '../TimeRangeControls';
 import { DownloadButton } from '../DownloadButton';
 
@@ -112,7 +112,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               />
             </ErrorBoundary>
             <Stack direction="row" spacing={1} marginLeft="auto" sx={{ whiteSpace: 'nowrap' }}>
-              <VariableEditButton />
+              <EditVariablesButton />
               <InfoTooltip description={ADD_PANEL_BUTTON_DESCRIPTION} placement={TooltipPlacement.Bottom}>
                 <Button startIcon={<AddPanelIcon />} onClick={openAddPanel} aria-label={ADD_PANEL_BUTTON_DESCRIPTION}>
                   Panel

--- a/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
+++ b/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
@@ -22,9 +22,9 @@ import { VariableEditor } from './VariableEditor';
 
 const EDIT_VARIABLES_BUTTON_DESCRIPTION = 'Edit variables';
 
-export function VariableEditButton() {
+export function EditVariablesButton() {
   const [isVariableEditorOpen, setIsVariableEditorOpen] = useState(false);
-  const variableDefinitions = useTemplateVariableDefinitions();
+  const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
   const { setVariableDefinitions } = useTemplateVariableActions();
 
   const openVariableEditor = () => {

--- a/ui/dashboards/src/components/Variables/VariableEditButton.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditButton.tsx
@@ -1,0 +1,57 @@
+// Copyright 2022 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react';
+import { Button } from '@mui/material';
+import PencilIcon from 'mdi-material-ui/PencilOutline';
+import { Drawer, InfoTooltip, TooltipPlacement } from '@perses-dev/components';
+import { VariableDefinition } from '@perses-dev/core';
+
+import { useTemplateVariableDefinitions, useTemplateVariableActions } from '../../context';
+import { VariableEditor } from './VariableEditor';
+
+const EDIT_VARIABLES_BUTTON_DESCRIPTION = 'Edit variables';
+
+export function VariableEditButton() {
+  const [isVariableEditorOpen, setIsVariableEditorOpen] = useState(false);
+  const variableDefinitions = useTemplateVariableDefinitions();
+  const { setVariableDefinitions } = useTemplateVariableActions();
+
+  const openVariableEditor = () => {
+    setIsVariableEditorOpen(true);
+  };
+
+  const closeVariableEditor = () => {
+    setIsVariableEditorOpen(false);
+  };
+
+  return (
+    <>
+      <InfoTooltip description={EDIT_VARIABLES_BUTTON_DESCRIPTION} placement={TooltipPlacement.Bottom}>
+        <Button startIcon={<PencilIcon />} onClick={openVariableEditor} aria-label={EDIT_VARIABLES_BUTTON_DESCRIPTION}>
+          Variables
+        </Button>
+      </InfoTooltip>
+      <Drawer isOpen={isVariableEditorOpen} onClose={closeVariableEditor} PaperProps={{ sx: { width: '50%' } }}>
+        <VariableEditor
+          variableDefinitions={variableDefinitions}
+          onCancel={closeVariableEditor}
+          onChange={(variables: VariableDefinition[]) => {
+            setVariableDefinitions(variables);
+            setIsVariableEditorOpen(false);
+          }}
+        />
+      </Drawer>
+    </>
+  );
+}

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { AppBar, Box, IconButton, SxProps, Theme, useScrollTrigger } from '@mui/material';
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
+import { VariableDefinition } from '@perses-dev/core';
 import { useTemplateVariableDefinitions } from '../../context';
 import { TemplateVariable } from './Variable';
 
@@ -28,7 +29,7 @@ interface TemplateVariableListProps {
 
 export function TemplateVariableList(props: TemplateVariableListProps) {
   const [isPin, setIsPin] = useState(props.initialVariableIsSticky);
-  const variableDefinitions = useTemplateVariableDefinitions();
+  const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
 
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
   const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -11,15 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useState } from 'react';
-import { Button, Stack, Box, AppBar, useScrollTrigger, IconButton, SxProps, Theme } from '@mui/material';
-import PencilIcon from 'mdi-material-ui/Pencil';
+import { useState } from 'react';
+import { AppBar, Box, IconButton, SxProps, Theme, useScrollTrigger } from '@mui/material';
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
-import { Drawer } from '@perses-dev/components';
-import { useTemplateVariableDefinitions, useEditMode, useTemplateVariableActions } from '../../context';
+import { useTemplateVariableDefinitions } from '../../context';
 import { TemplateVariable } from './Variable';
-import { VariableEditor } from './VariableEditor';
+
+const VARIABLE_INPUT_MIN_WIDTH = '120px';
+const VARIABLE_INPUT_MAX_WIDTH = '240px';
 
 interface TemplateVariableListProps {
   initialVariableIsSticky?: boolean;
@@ -27,52 +27,33 @@ interface TemplateVariableListProps {
 }
 
 export function TemplateVariableList(props: TemplateVariableListProps) {
-  const [isEditing, setIsEditing] = useState(false);
   const [isPin, setIsPin] = useState(props.initialVariableIsSticky);
   const variableDefinitions = useTemplateVariableDefinitions();
-  const { isEditMode } = useEditMode();
-  const { setVariableDefinitions } = useTemplateVariableActions();
+
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
   const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
 
-  const onClose = () => {
-    setIsEditing(false);
-  };
-
   return (
     <Box>
-      <Drawer isOpen={isEditing} onClose={onClose} PaperProps={{ sx: { width: '50%' } }}>
-        <VariableEditor
-          variableDefinitions={variableDefinitions}
-          onCancel={onClose}
-          onChange={(v) => {
-            setVariableDefinitions(v);
-            setIsEditing(false);
-          }}
-        />
-      </Drawer>
-      {isEditMode && (
-        <Box pb={2}>
-          <Button onClick={() => setIsEditing(true)} startIcon={<PencilIcon />}>
-            Edit Variables
-          </Button>
-        </Box>
-      )}
-
       <AppBar
-        color={'inherit'}
+        color="inherit"
         position={isSticky ? 'fixed' : 'static'}
         elevation={isSticky ? 4 : 0}
         sx={{ ...props.sx }}
       >
-        <Box display={'flex'} justifyContent="space-between" my={isSticky ? 2 : 0} ml={isSticky ? 2 : 0}>
-          <Stack direction="row" spacing={1}>
-            {variableDefinitions.map((v) => (
-              <Box key={v.spec.name} display={v.spec.display?.hidden ? 'none' : undefined}>
-                <TemplateVariable key={v.spec.name} name={v.spec.name} />
-              </Box>
-            ))}
-          </Stack>
+        <Box display="flex" flexWrap="wrap" alignItems="start" my={isSticky ? 2 : 0} ml={isSticky ? 2 : 0}>
+          {variableDefinitions.map((v) => (
+            <Box
+              key={v.spec.name}
+              display={v.spec.display?.hidden ? 'none' : undefined}
+              minWidth={VARIABLE_INPUT_MIN_WIDTH}
+              maxWidth={VARIABLE_INPUT_MAX_WIDTH}
+              marginBottom={1}
+              marginRight={1}
+            >
+              <TemplateVariable key={v.spec.name} name={v.spec.name} />
+            </Box>
+          ))}
           {props.initialVariableIsSticky && (
             <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
           )}

--- a/ui/dashboards/src/components/Variables/index.tsx
+++ b/ui/dashboards/src/components/Variables/index.tsx
@@ -12,5 +12,7 @@
 // limitations under the License.
 
 export * from './Variable';
-export * from './VariableList';
+export * from './VariableEditButton';
+export * from './VariableEditor';
 export * from './VariableEditorForm';
+export * from './VariableList';

--- a/ui/dashboards/src/components/Variables/index.tsx
+++ b/ui/dashboards/src/components/Variables/index.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export * from './EditVariablesButton';
 export * from './Variable';
-export * from './VariableEditButton';
 export * from './VariableEditor';
 export * from './VariableEditorForm';
 export * from './VariableList';


### PR DESCRIPTION
## Changes
* Created the `EditVariablesButton` component, so that it's possible to move the button to a different location, as designs call for.  `EditVariablesButton` contains both the button itself and the drawer for editing variables. 

## Other changes
* When we have many variables, they will stack on top of each other nicely (and the margins will be correct)
* The buttons saying "Add panel" and "Add panel group" are shortened to "Panel" and "Panel group" to save space (the icon and tooltip still tell the user that these buttons are for adding things). 

<img width="1502" alt="Screen Shot 2023-01-03 at 1 21 05 PM" src="https://user-images.githubusercontent.com/2584129/210443355-a79d6753-5340-4b1c-ab74-f48770fa00f5.png">
<img width="1502" alt="Screen Shot 2023-01-03 at 1 20 44 PM" src="https://user-images.githubusercontent.com/2584129/210443378-b3b978c8-cfc7-4427-90f3-00e679e56021.png">

Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>