### PR TITLE
[FEATURE] Add offline mode for the migrate command in the CLI

### DIFF
--- a/internal/api/impl/migrate/migrate.go
+++ b/internal/api/impl/migrate/migrate.go
@@ -16,7 +16,6 @@ package migrate
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/perses/perses/internal/api/shared"
@@ -49,20 +48,11 @@ func (e *Endpoint) Migrate(ctx echo.Context) error {
 	if err := ctx.Bind(body); err != nil {
 		return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
 	}
-	grafanaDashboard := replaceInputValue(body)
+	grafanaDashboard := migrate.ReplaceInputValue(body.Input, string(body.GrafanaDashboard))
 	persesDashboard, err := e.migrationService.Migrate([]byte(grafanaDashboard))
 	if err != nil {
 		return shared.HandleError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, persesDashboard)
-}
-
-func replaceInputValue(body *api.Migrate) string {
-	grafanaDashboard := string(body.GrafanaDashboard)
-	for input, value := range body.Input {
-		grafanaDashboard = strings.Replace(grafanaDashboard, fmt.Sprintf("$%s", input), value, -1)
-		grafanaDashboard = strings.Replace(grafanaDashboard, fmt.Sprintf("${%s}", input), value, -1)
-	}
-	return grafanaDashboard
 }

--- a/internal/api/shared/migrate/migrate.go
+++ b/internal/api/shared/migrate/migrate.go
@@ -64,6 +64,15 @@ const (
 	queryPlaceholderText = "%(conditional_timeserie_queries)"
 )
 
+func ReplaceInputValue(input map[string]string, grafanaDashboard string) string {
+	result := grafanaDashboard
+	for key, value := range input {
+		result = strings.Replace(result, fmt.Sprintf("$%s", key), value, -1)
+		result = strings.Replace(result, fmt.Sprintf("${%s}", key), value, -1)
+	}
+	return result
+}
+
 type Migration interface {
 	Migrate(grafanaDashboard []byte) (*v1.Dashboard, error)
 	BuildMigrationSchemaString()

--- a/internal/cli/cmd/migrate/migrate.go
+++ b/internal/cli/cmd/migrate/migrate.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"regexp"
 
+	apiConfig "github.com/perses/perses/internal/api/config"
+	"github.com/perses/perses/internal/api/shared/migrate"
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/file"
@@ -26,6 +28,7 @@ import (
 	"github.com/perses/perses/internal/cli/output"
 	"github.com/perses/perses/pkg/client/api"
 	modelAPI "github.com/perses/perses/pkg/model/api"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -35,10 +38,15 @@ type option struct {
 	persesCMD.Option
 	opt.FileOption
 	opt.OutputOption
-	writer    io.Writer
-	rowInput  []string
-	input     map[string]string
-	apiClient api.ClientInterface
+	writer           io.Writer
+	rowInput         []string
+	input            map[string]string
+	chartsSchemas    string
+	queriesSchemas   string
+	variablesSchemas string
+	online           bool
+	mig              migrate.Migration
+	apiClient        api.ClientInterface
 }
 
 func (o *option) Complete(args []string) error {
@@ -49,11 +57,25 @@ func (o *option) Complete(args []string) error {
 		return outputErr
 	}
 	o.completeInput()
-	apiClient, err := config.Global.GetAPIClient()
-	if err != nil {
-		return err
+	if (len(o.chartsSchemas) > 0 && len(o.queriesSchemas) > 0) || len(o.variablesSchemas) > 0 {
+		var err error
+		o.mig, err = migrate.New(apiConfig.Schemas{
+			PanelsPath:    o.chartsSchemas,
+			QueriesPath:   o.queriesSchemas,
+			VariablesPath: o.variablesSchemas,
+		})
+		if err != nil {
+			return err
+		}
 	}
-	o.apiClient = apiClient
+	if o.online {
+		// Finally, get the api client we will need later.
+		apiClient, err := config.Global.GetAPIClient()
+		if err != nil {
+			return err
+		}
+		o.apiClient = apiClient
+	}
 	return nil
 }
 
@@ -84,14 +106,29 @@ func (o *option) Execute() error {
 	if err := file.Unmarshal(o.File, &grafanaDashboard); err != nil {
 		return err
 	}
-	persesDashboard, err := o.apiClient.Migrate(&modelAPI.Migrate{
-		Input:            o.input,
-		GrafanaDashboard: grafanaDashboard,
-	})
+	var persesDashboard *modelV1.Dashboard
+	var err error
+	if o.online {
+		persesDashboard, err = o.onlineExecution(grafanaDashboard)
+	} else {
+		persesDashboard, err = o.offlineExecution(grafanaDashboard)
+	}
 	if err != nil {
 		return err
 	}
 	return output.Handle(o.writer, o.Output, persesDashboard)
+}
+
+func (o *option) onlineExecution(grafanaDashboard json.RawMessage) (*modelV1.Dashboard, error) {
+	return o.apiClient.Migrate(&modelAPI.Migrate{
+		Input:            o.input,
+		GrafanaDashboard: grafanaDashboard,
+	})
+}
+
+func (o *option) offlineExecution(grafanaDashboard json.RawMessage) (*modelV1.Dashboard, error) {
+	finalGrafanaDashboard := migrate.ReplaceInputValue(o.input, string(grafanaDashboard))
+	return o.mig.Migrate([]byte(finalGrafanaDashboard))
 }
 
 func (o *option) SetWriter(writer io.Writer) {
@@ -115,5 +152,15 @@ percli migrate -f ./dashboard.json --input=DS_PROMETHEUS=PrometheusDemo
 	opt.AddOutputFlags(cmd, &o.OutputOption)
 	opt.MarkFileFlagAsMandatory(cmd)
 	cmd.Flags().StringArrayVar(&o.rowInput, "input", o.rowInput, "Grafana input values. Syntax supported is InputName=InputValue")
+	cmd.Flags().StringVar(&o.chartsSchemas, "schemas.charts", "", "Path to the CUE schemas for dasbhoard charts.")
+	cmd.Flags().StringVar(&o.queriesSchemas, "schemas.queries", "", "Path to the CUE schemas for chart queries.")
+	cmd.Flags().StringVar(&o.variablesSchemas, "schemas.variables", "", "Path to the CUE schemas for the dashboard variables")
+	cmd.Flags().BoolVar(&o.online, "online", false, "When enable, it can request the API to use it to perform the migration")
+
+	// when online flag is used, the CLI will call the endpoint /migrate that will then use the schema from the server.
+	// So no need to use / load the schemas with the CLI.
+	cmd.MarkFlagsMutuallyExclusive("schemas.charts", "online")
+	cmd.MarkFlagsMutuallyExclusive("schemas.queries", "online")
+	cmd.MarkFlagsMutuallyExclusive("schemas.variables", "online")
 	return cmd
 }


### PR DESCRIPTION
This PR is adding an offline mode on the command `migrate` command in the CLI.

Like the command `lint`, user can choose to use a remote Perses serveror he can choose to use local plugin to perform the command 

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>