### PR TITLE
[BREAKINGCHANGE] change legend position values to PascalCase, fix resize glitch

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -119,7 +119,7 @@
                 ],
                 "unit": { "kind": "Decimal" },
                 "legend": {
-                  "position": "right"
+                  "position": "Right"
                 }
               }
             }
@@ -183,7 +183,7 @@
                   }
                 ],
                 "legend": {
-                  "position": "bottom"
+                  "position": "Bottom"
                 },
                 "y_axis": {
                   "show": true,
@@ -219,7 +219,7 @@
                 ],
                 "unit": { "kind": "Decimal", "decimal_places": 2 },
                 "legend": {
-                  "position": "right"
+                  "position": "Right"
                 }
               }
             }
@@ -249,7 +249,7 @@
                   }
                 ],
                 "legend": {
-                  "position": "right"
+                  "position": "Right"
                 },
                 "unit": { "kind": "PercentDecimal", "decimal_places": 1 },
                 "thresholds": {
@@ -301,7 +301,7 @@
                   }
                 },
                 "legend": {
-                  "position": "bottom"
+                  "position": "Bottom"
                 },
                 "thresholds": {
                   "steps": [{ "value": 0.2 }, { "value": 0.35 }]
@@ -920,7 +920,7 @@
                   }
                 ],
                 "legend": {
-                  "position": "bottom"
+                  "position": "Bottom"
                 },
                 "unit": {
                   "kind": "Bytes"
@@ -1009,7 +1009,7 @@
                 ],
                 "unit": { "kind": "PercentDecimal", "decimal_places": 0 },
                 "legend": {
-                  "position": "bottom"
+                  "position": "Bottom"
                 },
                 "thresholds": {
                   "steps": [{ "value": 0.01 }, { "value": 0.02 }]
@@ -1501,7 +1501,7 @@
               }
             }
           }
-        }    
+        }
       },
       "layouts": [
         {
@@ -1556,7 +1556,7 @@
               }
             }
           }
-        }    
+        }
       },
       "layouts": [
         {

--- a/internal/api/shared/migrate/testdata/old_format_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_format_perses_dashboard.json
@@ -74,7 +74,7 @@
             "kind": "TimeSeriesChart",
             "spec": {
               "legend": {
-                "position": "bottom"
+                "position": "Bottom"
               },
               "queries": [{
                 "kind": "TimeSeriesQuery",

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -310,7 +310,7 @@
             "kind": "TimeSeriesChart",
             "spec": {
               "legend": {
-                "position": "bottom"
+                "position": "Bottom"
               },
               "queries": [{
                 "kind": "TimeSeriesQuery",
@@ -353,7 +353,7 @@
             "kind": "TimeSeriesChart",
             "spec": {
               "legend": {
-                "position": "bottom"
+                "position": "Bottom"
               },
               "queries": [{
                 "kind": "TimeSeriesQuery",

--- a/schemas/panels/time-series/mig.cuepart
+++ b/schemas/panels/time-series/mig.cuepart
@@ -16,8 +16,8 @@ if #panel.type == "timeseries" || #panel.type == "graph" {
             }
             if #panel.type == "graph" {
                 position: [ // switch
-                    if #panel.legend.rightSide != _|_ if #panel.legend.rightSide { "right" },
-                    { "bottom" }
+                    if #panel.legend.rightSide != _|_ if #panel.legend.rightSide { "Right" },
+                    { "Bottom" }
                 ][0]
             }
         }

--- a/schemas/panels/time-series/mig.cuepart
+++ b/schemas/panels/time-series/mig.cuepart
@@ -12,7 +12,10 @@ if #panel.type == "timeseries" || #panel.type == "graph" {
         }]
         legend: {
             if #panel.type == "timeseries" {
-                position: #panel.options.legend.placement
+            	  position: [
+            	  	if #panel.options.legend.placement == "bottom" { "Bottom" },
+            	  	if #panel.options.legend.placement == "right" { "Right" },
+            	  ][0]
             }
             if #panel.type == "graph" {
                 position: [ // switch

--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -18,7 +18,7 @@ import (
 )
 
 #legend: {
-	position: "bottom" | "right"
+	position: "Bottom" | "Right"
 }
 
 #visual: {

--- a/schemas/panels/time-series/time-series.json
+++ b/schemas/panels/time-series/time-series.json
@@ -29,7 +29,7 @@
       }
     },
     "legend": {
-      "position": "bottom"
+      "position": "Bottom"
     },
     "thresholds": {
       "steps": [

--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -24,7 +24,7 @@ interface LegendProps {
 }
 
 export function Legend({ width, height, options, data }: LegendProps) {
-  if (options.position === 'right') {
+  if (options.position === 'Right') {
     return (
       <Box
         sx={{
@@ -42,5 +42,16 @@ export function Legend({ width, height, options, data }: LegendProps) {
     );
   }
 
-  return <CompactLegend items={data} height={height} />;
+  return (
+    <Box
+      sx={{
+        width: width,
+        height: height,
+        position: 'absolute',
+        bottom: 0,
+      }}
+    >
+      <CompactLegend items={data} height={height} />;
+    </Box>
+  );
 }

--- a/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.test.tsx
+++ b/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.test.tsx
@@ -29,10 +29,27 @@ describe('LegendOptionsEditor', () => {
     return screen.getByRole('checkbox', { name: 'Show' });
   };
 
+  const getLegendPositionSelector = () => {
+    return screen.getByRole('combobox', { name: 'Position' });
+  };
+
   it('can change legend visibility by clicking', () => {
     const onChange = jest.fn();
     renderLegendOptionsEditor(undefined, onChange);
+    expect(getLegendPositionSelector()).toBeDisabled();
     userEvent.click(getLegendShowSwitch());
-    expect(onChange).toHaveBeenCalledWith({ position: 'bottom' });
+    expect(onChange).toHaveBeenCalledWith({ position: 'Bottom' });
+  });
+
+  it('should allow changing legend position', () => {
+    const onChange = jest.fn();
+    renderLegendOptionsEditor({ position: 'Bottom' }, onChange);
+    expect(getLegendPositionSelector()).toBeEnabled();
+    userEvent.click(getLegendPositionSelector());
+    const positionRightOption = screen.getByRole('option', {
+      name: 'Right',
+    });
+    userEvent.click(positionRightOption);
+    expect(onChange).toHaveBeenCalledWith({ position: 'Right' });
   });
 });

--- a/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -56,7 +56,6 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
   const legendConfig = LEGEND_POSITIONS_CONFIG[currentPosition];
   return (
     <>
-      {/* TODO: how to fix in light mode, styleOverrides needed in theme? */}
       {!isValidLegend && <ErrorAlert error={{ name: 'invalid-legend', message: 'Invalid legend spec' }} />}
       <OptionsEditorControl
         label="Show"

--- a/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -51,18 +51,16 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
     });
   };
 
-  const currentPosition = getLegendPosition(value?.position);
-
-  const legendConfig = LEGEND_POSITIONS_CONFIG[currentPosition];
-
   const isValidLegend = validateLegendSpec(value);
-
+  const currentPosition = getLegendPosition(value?.position);
+  const legendConfig = LEGEND_POSITIONS_CONFIG[currentPosition];
   return (
     <>
+      {/* TODO: how to fix in light mode, styleOverrides needed in theme? */}
       {!isValidLegend && <ErrorAlert error={{ name: 'invalid-legend', message: 'Invalid legend spec' }} />}
       <OptionsEditorControl
         label="Show"
-        control={<Switch checked={isValidLegend} onChange={handleLegendShowChange} />}
+        control={<Switch checked={value !== undefined} onChange={handleLegendShowChange} />}
       />
       <OptionsEditorControl
         label="Position"
@@ -76,7 +74,7 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
             isOptionEqualToValue={(option, value) => option.id === value.id}
             renderInput={(params) => <TextField {...params} />}
             onChange={handleLegendPositionChange}
-            disabled={!isValidLegend}
+            disabled={value === undefined}
             disableClearable
           ></Autocomplete>
         }

--- a/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/components/src/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -12,21 +12,16 @@
 // limitations under the License.
 
 import { Autocomplete, Switch, SwitchProps, TextField } from '@mui/material';
-import { DEFAULT_LEGEND, LegendOptions } from '../model';
+import { ErrorAlert } from '../ErrorAlert';
+import {
+  DEFAULT_LEGEND,
+  getLegendPosition,
+  validateLegendSpec,
+  LEGEND_POSITIONS_CONFIG,
+  LegendOptions,
+  LegendPositionConfig,
+} from '../model';
 import { OptionsEditorControl } from '../OptionsEditorLayout';
-
-type LegendPositionConfig = {
-  label: string;
-};
-
-const LEGEND_POSITIONS = ['bottom', 'right'] as const;
-
-type LegendPositions = typeof LEGEND_POSITIONS[number];
-
-const LEGEND_POSITIONS_CONFIG: Readonly<Record<LegendPositions, LegendPositionConfig>> = {
-  bottom: { label: 'Bottom' },
-  right: { label: 'Right' },
-};
 
 type LegendPositionOption = LegendPositionConfig & { id: LegendOptions['position'] };
 
@@ -56,13 +51,18 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
     });
   };
 
-  const legendConfig = LEGEND_POSITIONS_CONFIG[value?.position ?? DEFAULT_LEGEND.position];
+  const currentPosition = getLegendPosition(value?.position);
+
+  const legendConfig = LEGEND_POSITIONS_CONFIG[currentPosition];
+
+  const isValidLegend = validateLegendSpec(value);
 
   return (
     <>
+      {!isValidLegend && <ErrorAlert error={{ name: 'invalid-legend', message: 'Invalid legend spec' }} />}
       <OptionsEditorControl
         label="Show"
-        control={<Switch checked={value !== undefined} onChange={handleLegendShowChange} />}
+        control={<Switch checked={isValidLegend} onChange={handleLegendShowChange} />}
       />
       <OptionsEditorControl
         label="Position"
@@ -70,13 +70,13 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
           <Autocomplete
             value={{
               ...legendConfig,
-              id: value?.position ?? DEFAULT_LEGEND.position,
+              id: currentPosition,
             }}
             options={POSITION_OPTIONS}
             isOptionEqualToValue={(option, value) => option.id === value.id}
             renderInput={(params) => <TextField {...params} />}
             onChange={handleLegendPositionChange}
-            disabled={value === undefined}
+            disabled={!isValidLegend}
             disableClearable
           ></Autocomplete>
         }

--- a/ui/components/src/model/graph.ts
+++ b/ui/components/src/model/graph.ts
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { MouseEventHandler } from 'react';
 import { LineSeriesOption } from 'echarts/charts';
+import { LegendItem } from './legend';
 
 // adjust display when there are many time series to help with performance
 export const OPTIMIZED_MODE_SERIES_LIMIT = 1000;
@@ -39,25 +39,4 @@ export type EChartsDataFormat = {
   legendItems?: LegendItem[];
   xAxisMax?: number | string;
   rangeMs?: number;
-};
-
-/**
- * Supported legend options
- */
-export interface LegendOptions {
-  position: 'bottom' | 'right';
-}
-
-export interface LegendItem {
-  id: string;
-  label: string;
-  isSelected: boolean;
-  color: string;
-  onClick: MouseEventHandler<HTMLLIElement>;
-}
-
-export const DEFAULT_LEGEND_POSITION = 'bottom';
-
-export const DEFAULT_LEGEND: LegendOptions = {
-  position: DEFAULT_LEGEND_POSITION,
 };

--- a/ui/components/src/model/legend.test.ts
+++ b/ui/components/src/model/legend.test.ts
@@ -11,7 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph';
-export * from './legend';
-export * from './theme';
-export * from './units';
+import { validateLegendSpec } from './legend';
+
+describe('validateLegendSpec', () => {
+  it('should check if a legend spec is valid', () => {
+    expect(validateLegendSpec({ position: 'bottom' })).toEqual(false);
+    expect(validateLegendSpec({ position: 'Bottom' })).toEqual(true);
+  });
+});

--- a/ui/components/src/model/legend.test.ts
+++ b/ui/components/src/model/legend.test.ts
@@ -17,5 +17,6 @@ describe('validateLegendSpec', () => {
   it('should check if a legend spec is valid', () => {
     expect(validateLegendSpec({ position: 'bottom' })).toEqual(false);
     expect(validateLegendSpec({ position: 'Bottom' })).toEqual(true);
+    expect(validateLegendSpec(undefined)).toEqual(true);
   });
 });

--- a/ui/components/src/model/legend.test.ts
+++ b/ui/components/src/model/legend.test.ts
@@ -11,11 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { validateLegendSpec } from './legend';
+import { LegendOptions, validateLegendSpec } from './legend';
 
 describe('validateLegendSpec', () => {
   it('should check if a legend spec is valid', () => {
-    expect(validateLegendSpec({ position: 'bottom' })).toEqual(false);
+    const invalidLegend = { position: 'bottom' };
+    expect(validateLegendSpec(invalidLegend as LegendOptions)).toEqual(false);
     expect(validateLegendSpec({ position: 'Bottom' })).toEqual(true);
     expect(validateLegendSpec(undefined)).toEqual(true);
   });

--- a/ui/components/src/model/legend.ts
+++ b/ui/components/src/model/legend.ts
@@ -56,9 +56,7 @@ export function isValidLegendPosition(position: LegendPositions) {
   return (legendPositions as readonly string[]).includes(position);
 }
 
-// TODO: how to not use any, try unknown
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function validateLegendSpec(legend?: any) {
+export function validateLegendSpec(legend?: LegendOptions) {
   if (legend === undefined) {
     // undefined is valid since this is how legend is hidden by default
     return true;

--- a/ui/components/src/model/legend.ts
+++ b/ui/components/src/model/legend.ts
@@ -56,10 +56,12 @@ export function isValidLegendPosition(position: LegendPositions) {
   return (legendPositions as readonly string[]).includes(position);
 }
 
+// TODO: how to not use any, try unknown
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function validateLegendSpec(legend?: any) {
-  if (!legend) {
-    return false;
+  if (legend === undefined) {
+    // undefined is valid since this is how legend is hidden by default
+    return true;
   }
   if (!isValidLegendPosition(legend.position)) {
     return false;

--- a/ui/components/src/model/legend.ts
+++ b/ui/components/src/model/legend.ts
@@ -1,0 +1,68 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { MouseEventHandler } from 'react';
+
+export const legendPositions = ['Bottom', 'Right'] as const;
+
+export type LegendPositions = typeof legendPositions[number];
+
+export interface LegendOptions {
+  position: LegendPositions;
+}
+
+export interface LegendItem {
+  id: string;
+  label: string;
+  isSelected: boolean;
+  color: string;
+  onClick: MouseEventHandler<HTMLLIElement>;
+}
+
+export type LegendPositionConfig = {
+  label: string;
+};
+
+export const LEGEND_POSITIONS_CONFIG: Readonly<Record<LegendPositions, LegendPositionConfig>> = {
+  Bottom: { label: 'Bottom' },
+  Right: { label: 'Right' },
+};
+
+export const DEFAULT_LEGEND: LegendOptions = {
+  position: 'Bottom',
+};
+
+export function getLegendPosition(position?: LegendPositions) {
+  if (position === undefined) {
+    return DEFAULT_LEGEND.position;
+  }
+  if (isValidLegendPosition(position)) {
+    return position;
+  }
+  return DEFAULT_LEGEND.position;
+}
+
+export function isValidLegendPosition(position: LegendPositions) {
+  return (legendPositions as readonly string[]).includes(position);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function validateLegendSpec(legend?: any) {
+  if (!legend) {
+    return false;
+  }
+  if (!isValidLegendPosition(legend.position)) {
+    return false;
+  }
+  return true;
+}

--- a/ui/components/src/theme/theme.ts
+++ b/ui/components/src/theme/theme.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createTheme, PaletteMode, ThemeOptions, Theme } from '@mui/material';
+import { createTheme, PaletteMode, ThemeOptions, Theme, alertClasses } from '@mui/material';
 import { getPaletteOptions } from './palette/palette-options';
 import { typography } from './typography';
 
@@ -68,6 +68,17 @@ const components: ThemeOptions['components'] = {
   MuiDialog: {
     styleOverrides: {
       paper: getModalBackgroundStyle,
+    },
+  },
+  MuiAlert: {
+    styleOverrides: {
+      standardError: ({ theme }) => ({
+        backgroundColor: theme.palette.designSystem.red[500],
+        color: theme.palette.common.white,
+        [`&	.${alertClasses.icon}`]: {
+          color: theme.palette.common.white,
+        },
+      }),
     },
   },
 };

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -72,7 +72,7 @@ const TEST_TIME_SERIES_PANEL: TimeSeriesChartProps = {
     ],
     unit: { kind: 'Decimal', decimal_places: 2 },
     legend: {
-      position: 'right',
+      position: 'Right',
     },
   },
 };

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -19,11 +19,12 @@ import type { GridComponentOption } from 'echarts';
 import { Box, Skeleton } from '@mui/material';
 import {
   DEFAULT_LEGEND,
-  LineChart,
   EChartsDataFormat,
-  ZoomEventData,
+  validateLegendSpec,
   Legend,
+  LineChart,
   YAxisLabel,
+  ZoomEventData,
 } from '@perses-dev/components';
 import { useSuggestedStepMs } from '../../model/time';
 import { StepOptions, ThresholdColors, ThresholdColorsPalette } from '../../model/thresholds';
@@ -47,7 +48,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   } = props;
 
   // popuate default 'position' and other future properties
-  const legend = props.spec.legend ? merge({}, DEFAULT_LEGEND, props.spec.legend) : undefined;
+  const legend = validateLegendSpec(props.spec.legend) ? merge({}, DEFAULT_LEGEND, props.spec.legend) : undefined;
 
   // TODO: eventually remove props.spec.unit, add support for y_axis_alt.unit
   let unit = DEFAULT_UNIT;
@@ -205,20 +206,16 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     }
   }
 
-  const legendWidth = legend && legend.position === 'right' ? 200 : contentDimensions.width;
-  const legendHeight = legend && legend.position === 'right' ? contentDimensions.height : 35;
+  const legendWidth = legend && legend.position === 'Right' ? 200 : contentDimensions.width;
+  const legendHeight = legend && legend.position === 'Right' ? contentDimensions.height : 40;
 
   // override default spacing, see: https://echarts.apache.org/en/option.html#grid
   const gridLeft = y_axis && y_axis.label ? 30 : 20;
   const gridOverrides: GridComponentOption = {
     left: !yAxis.show ? 0 : gridLeft,
-    right: legend && legend.position === 'right' ? legendWidth : 20,
+    right: legend && legend.position === 'Right' ? legendWidth : 20,
+    bottom: legend && legend.position === 'Bottom' ? legendHeight : 0,
   };
-
-  const lineChartHeight =
-    legend && legend.position === 'bottom' && graphData.legendItems && graphData.legendItems.length > 0
-      ? contentDimensions.height - legendHeight
-      : contentDimensions.height;
 
   const handleDataZoom = (event: ZoomEventData) => {
     // TODO: add ECharts transition animation on zoom
@@ -229,7 +226,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     <>
       {y_axis && y_axis.show && y_axis.label && <YAxisLabel name={y_axis.label} height={contentDimensions.height} />}
       <LineChart
-        height={lineChartHeight}
+        height={contentDimensions.height}
         data={graphData}
         yAxis={yAxis}
         unit={unit}

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -47,7 +47,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     contentDimensions,
   } = props;
 
-  // popuate default 'position' and other future properties
+  // populate default 'position' and other future properties
   const legend =
     props.spec.legend && validateLegendSpec(props.spec.legend)
       ? merge({}, DEFAULT_LEGEND, props.spec.legend)

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -48,7 +48,10 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   } = props;
 
   // popuate default 'position' and other future properties
-  const legend = validateLegendSpec(props.spec.legend) ? merge({}, DEFAULT_LEGEND, props.spec.legend) : undefined;
+  const legend =
+    props.spec.legend && validateLegendSpec(props.spec.legend)
+      ? merge({}, DEFAULT_LEGEND, props.spec.legend)
+      : undefined;
 
   // TODO: eventually remove props.spec.unit, add support for y_axis_alt.unit
   let unit = DEFAULT_UNIT;


### PR DESCRIPTION
This PR includes:
- [BREAKINGCHANGE] change legend position values to PascalCase
- [BUGFIX] chart resize glitch when changing legend position 

The `legend.position` change to use PascalCase for dashboard values that are string unions/enums was made for consistency with other properties like `kind` and `calculation`. I also took a quick stab at FE validation for the legend spec when inside the panel edit drawer, but this isn't meant to be a long term solution.

See Matrix chat discussion about snake_case for keys in dashboard JSON and PascalCase for values: 
https://matrix.to/#/!XNmgYIAndZOkEvQAbb:matrix.org/$1yAfafCLxONIoBfj83jN0ul2v8AhHBPXpG2QZfwHJUk?via=matrix.org&via=herail.net