### PR TITLE
[ENHANCEMENT] Add prop for adjusting the height of the DownloadButton

### DIFF
--- a/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
+++ b/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
@@ -18,10 +18,16 @@ import { TOOLTIP_TEXT } from '../../constants';
 import { useDashboard } from '../../context';
 import { ToolbarIconButton } from '../ToolbarIconButton';
 
-// Button to download the dashboard as a JSON file.
-export function DownloadButton() {
+interface DownloadButtonProps {
+  // The button look best at heights >= 28 pixels
+  heightPx?: number;
+}
+
+// Button that enables downloading the dashboard as a JSON file
+export function DownloadButton({ heightPx }: DownloadButtonProps) {
   const { dashboard } = useDashboard();
   const hiddenLinkRef = useRef<HTMLAnchorElement>(null);
+  const height = heightPx === undefined ? undefined : `${heightPx}px`;
 
   const onDownloadButtonClick = () => {
     if (!hiddenLinkRef || !hiddenLinkRef.current) return;
@@ -41,7 +47,7 @@ export function DownloadButton() {
   return (
     <>
       <InfoTooltip description={TOOLTIP_TEXT.downloadDashboard}>
-        <ToolbarIconButton aria-label={TOOLTIP_TEXT.downloadDashboard} onClick={onDownloadButtonClick}>
+        <ToolbarIconButton aria-label={TOOLTIP_TEXT.downloadDashboard} onClick={onDownloadButtonClick} sx={{ height }}>
           <DownloadIcon />
         </ToolbarIconButton>
       </InfoTooltip>

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -34,9 +34,7 @@ export const TIME_OPTIONS: TimeOption[] = [
 const DEFAULT_HEIGHT = '34px';
 
 interface TimeRangeControlsProps {
-  // Height of the controls in pixels.
-  // The controls look best at heights >= 28 pixels.
-  // You can use values less than 28, but it won't look great.
+  // The controls look best at heights >= 28 pixels
   heightPx?: number;
 }
 
@@ -44,7 +42,7 @@ export function TimeRangeControls({ heightPx }: TimeRangeControlsProps) {
   const { timeRange, setTimeRange, refresh } = useTimeRange();
   const defaultTimeRange = useDefaultTimeRange();
 
-  // Convert height as a number to height as a string, then use this value for styling
+  // Convert height to a string, then use the string for styling
   const height = heightPx === undefined ? DEFAULT_HEIGHT : `${heightPx}px`;
 
   // add time shortcut if one does not match duration from dashboard JSON


### PR DESCRIPTION
Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>

Similar to the `TimeRangeControls`, we want to be able to adjust the height of the `DownloadButton`.

This change will enable us to use the `DownloadButton` from the perses package, instead of using the local version of the `DownloadButton` in our app. 