### PR TITLE
[ENHANCEMENT] Toolbar uses two rows for small screens

### DIFF
--- a/ui/dashboards/src/components/AddGroupButton/AddGroupButton.tsx
+++ b/ui/dashboards/src/components/AddGroupButton/AddGroupButton.tsx
@@ -11,18 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './AddGroupButton';
-export * from './AddPanelButton';
-export * from './Dashboard';
-export * from './DashboardToolbar';
-export * from './DeletePanelDialog';
-export * from './DeletePanelGroupDialog';
-export * from './DiscardChangesConfirmationDialog';
-export * from './DownloadButton';
-export * from './GridLayout';
-export * from './Panel';
-export * from './PanelDrawer';
-export * from './PanelGroupDialog';
-export * from './TimeRangeControls';
-export * from './ToolbarIconButton';
-export * from './Variables';
+import { Button } from '@mui/material';
+import AddGroupIcon from 'mdi-material-ui/PlusBoxOutline';
+import { InfoTooltip } from '@perses-dev/components';
+import { TOOLTIP_TEXT } from '../../constants';
+import { useDashboardActions } from '../../context';
+
+export const AddGroupButton = () => {
+  const { openAddPanelGroup } = useDashboardActions();
+
+  return (
+    <InfoTooltip description={TOOLTIP_TEXT.addGroup}>
+      <Button startIcon={<AddGroupIcon />} onClick={openAddPanelGroup} aria-label={TOOLTIP_TEXT.addGroup}>
+        Panel Group
+      </Button>
+    </InfoTooltip>
+  );
+};

--- a/ui/dashboards/src/components/AddGroupButton/index.ts
+++ b/ui/dashboards/src/components/AddGroupButton/index.ts
@@ -12,17 +12,3 @@
 // limitations under the License.
 
 export * from './AddGroupButton';
-export * from './AddPanelButton';
-export * from './Dashboard';
-export * from './DashboardToolbar';
-export * from './DeletePanelDialog';
-export * from './DeletePanelGroupDialog';
-export * from './DiscardChangesConfirmationDialog';
-export * from './DownloadButton';
-export * from './GridLayout';
-export * from './Panel';
-export * from './PanelDrawer';
-export * from './PanelGroupDialog';
-export * from './TimeRangeControls';
-export * from './ToolbarIconButton';
-export * from './Variables';

--- a/ui/dashboards/src/components/AddPanelButton/AddPanelButton.tsx
+++ b/ui/dashboards/src/components/AddPanelButton/AddPanelButton.tsx
@@ -11,18 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './AddGroupButton';
-export * from './AddPanelButton';
-export * from './Dashboard';
-export * from './DashboardToolbar';
-export * from './DeletePanelDialog';
-export * from './DeletePanelGroupDialog';
-export * from './DiscardChangesConfirmationDialog';
-export * from './DownloadButton';
-export * from './GridLayout';
-export * from './Panel';
-export * from './PanelDrawer';
-export * from './PanelGroupDialog';
-export * from './TimeRangeControls';
-export * from './ToolbarIconButton';
-export * from './Variables';
+import { Button } from '@mui/material';
+import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
+import { InfoTooltip } from '@perses-dev/components';
+import { TOOLTIP_TEXT } from '../../constants';
+import { useDashboardActions } from '../../context';
+
+export const AddPanelButton = () => {
+  const { openAddPanel } = useDashboardActions();
+
+  return (
+    <InfoTooltip description={TOOLTIP_TEXT.addPanel}>
+      <Button startIcon={<AddPanelIcon />} onClick={openAddPanel} aria-label={TOOLTIP_TEXT.addPanel}>
+        Panel
+      </Button>
+    </InfoTooltip>
+  );
+};

--- a/ui/dashboards/src/components/AddPanelButton/index.ts
+++ b/ui/dashboards/src/components/AddPanelButton/index.ts
@@ -11,18 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './AddGroupButton';
 export * from './AddPanelButton';
-export * from './Dashboard';
-export * from './DashboardToolbar';
-export * from './DeletePanelDialog';
-export * from './DeletePanelGroupDialog';
-export * from './DiscardChangesConfirmationDialog';
-export * from './DownloadButton';
-export * from './GridLayout';
-export * from './Panel';
-export * from './PanelDrawer';
-export * from './PanelGroupDialog';
-export * from './TimeRangeControls';
-export * from './ToolbarIconButton';
-export * from './Variables';

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -11,18 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useState } from 'react';
 import { Typography, Stack, Button, Box, useTheme, useMediaQuery, Alert } from '@mui/material';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
-import AddPanelGroupIcon from 'mdi-material-ui/PlusBoxOutline';
-import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
-import { ErrorBoundary, ErrorAlert, InfoTooltip } from '@perses-dev/components';
+import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
-import { useState } from 'react';
-import { TOOLTIP_TEXT } from '../../constants';
-import { useDashboard, useDashboardActions, useEditMode } from '../../context';
-import { TemplateVariableList, EditVariablesButton } from '../Variables';
-import { TimeRangeControls } from '../TimeRangeControls';
+import { useDashboard, useEditMode } from '../../context';
+import { AddPanelButton } from '../AddPanelButton';
+import { AddGroupButton } from '../AddGroupButton';
 import { DownloadButton } from '../DownloadButton';
+import { TimeRangeControls } from '../TimeRangeControls';
+import { TemplateVariableList, EditVariablesButton } from '../Variables';
 
 export interface DashboardToolbarProps {
   dashboardName: string;
@@ -45,11 +44,14 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
     onSave,
   } = props;
 
-  const { isEditMode, setEditMode } = useEditMode();
-  const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
   const dashboard = useDashboard();
-  const { openAddPanelGroup, openAddPanel } = useDashboardActions();
-  const isLaptopSize = useMediaQuery(useTheme().breakpoints.up('sm'));
+  const { isEditMode, setEditMode } = useEditMode();
+
+  const isBiggerThanMd = useMediaQuery(useTheme().breakpoints.up('md'));
+  const isBiggerThanSm = useMediaQuery(useTheme().breakpoints.up('sm'));
+
+  const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
+
   const dashboardTitle = dashboardTitleComponent ? (
     dashboardTitleComponent
   ) : (
@@ -109,25 +111,29 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
                 }}
               />
             </ErrorBoundary>
-            <Stack direction="row" spacing={1} marginLeft="auto" sx={{ whiteSpace: 'nowrap' }}>
-              <EditVariablesButton />
-              <InfoTooltip description={TOOLTIP_TEXT.addPanel}>
-                <Button startIcon={<AddPanelIcon />} onClick={openAddPanel} aria-label={TOOLTIP_TEXT.addPanel}>
-                  Panel
-                </Button>
-              </InfoTooltip>
-              <InfoTooltip description={TOOLTIP_TEXT.addGroup}>
-                <Button
-                  startIcon={<AddPanelGroupIcon />}
-                  onClick={openAddPanelGroup}
-                  aria-label={TOOLTIP_TEXT.addGroup}
-                >
-                  Panel Group
-                </Button>
-              </InfoTooltip>
-              <TimeRangeControls />
-              <DownloadButton />
-            </Stack>
+            {isBiggerThanMd ? (
+              // On bigger screens, make it one row
+              <Stack direction="row" spacing={1} marginLeft="auto" sx={{ whiteSpace: 'nowrap' }}>
+                <EditVariablesButton />
+                <AddPanelButton />
+                <AddGroupButton />
+                <TimeRangeControls />
+                <DownloadButton />
+              </Stack>
+            ) : (
+              // On smaller screens, make it two rows
+              <Stack spacing={1}>
+                <Stack direction="row" spacing={1} marginLeft="auto" sx={{ whiteSpace: 'nowrap' }}>
+                  <TimeRangeControls />
+                  <DownloadButton />
+                </Stack>
+                <Stack direction="row" spacing={1} marginLeft="auto" sx={{ whiteSpace: 'nowrap' }}>
+                  <EditVariablesButton />
+                  <AddPanelButton />
+                  <AddGroupButton />
+                </Stack>
+              </Stack>
+            )}
           </Box>
         </Stack>
       ) : (
@@ -137,7 +143,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             <Stack direction="row" spacing={1} marginLeft="auto">
               <TimeRangeControls />
               <DownloadButton />
-              {isLaptopSize && (
+              {isBiggerThanSm && (
                 <Button
                   variant="outlined"
                   color="secondary"


### PR DESCRIPTION
Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>

With this PR: 
* When the screen size is tablet or bigger, the toolbar buttons will take up one row (existing behavior). 
* When the screen size is smaller, the toolbar buttons will be split into two rows to save space


## Tablet or bigger screens
<img width="1003" alt="Screen Shot 2023-01-06 at 11 08 38 AM" src="https://user-images.githubusercontent.com/2584129/211084863-288dabea-7916-4612-bb5f-72098321abbb.png">

## Small screens
<img width="656" alt="Screen Shot 2023-01-06 at 11 08 10 AM" src="https://user-images.githubusercontent.com/2584129/211084861-4307561c-5016-45c9-88bb-d41620209a47.png">

