### PR TITLE
[ENHANCEMENT] Remove variable list background color

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -35,12 +35,14 @@ export function TemplateVariableList(props: TemplateVariableListProps) {
   const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
 
   return (
-    <Box>
+    // marginBottom={-1} counteracts the marginBottom={1} on every variable input.
+    // The margin on the inputs is for spacing between inputs, but is not meant to add space to bottom of the container.
+    <Box marginBottom={-1}>
       <AppBar
         color="inherit"
         position={isSticky ? 'fixed' : 'static'}
         elevation={isSticky ? 4 : 0}
-        sx={{ ...props.sx }}
+        sx={{ backgroundColor: 'inherit', ...props.sx }}
       >
         <Box display="flex" flexWrap="wrap" alignItems="start" my={isSticky ? 2 : 0} ml={isSticky ? 2 : 0}>
           {variableDefinitions.map((v) => (


### PR DESCRIPTION
Two style tweaks:

* AppBar has a background color that shows up in dark mode. It's subtle, but different from the other background color (see screenshot).
* Added a negative margin to make sure the variables don't have unnecessary padding (I added the margins in previous PR so that the variables will have margins when they wrap to next line). 

## Background color (see the division between variables and buttons)
![Screen Shot 2023-01-09 at 3 17 45 PM](https://user-images.githubusercontent.com/2584129/211427673-5828fd3b-3015-4de5-9d4c-5790aca1bd74.png)
