### PR TITLE
[BUGFIX] Fix the text color for buttons with outlined variant

### DIFF
--- a/ui/dashboards/src/components/DeletePanelDialog/DeletePanelDialog.tsx
+++ b/ui/dashboards/src/components/DeletePanelDialog/DeletePanelDialog.tsx
@@ -61,7 +61,7 @@ const DeletePanelForm = ({ deletePanelDialog }: DeletePanelFormProps) => {
         <Button variant="contained" type="submit">
           Delete
         </Button>
-        <Button variant="outlined" onClick={() => closeDeletePanelDialog()}>
+        <Button variant="outlined" color="secondary" onClick={() => closeDeletePanelDialog()}>
           Cancel
         </Button>
       </DialogActions>

--- a/ui/dashboards/src/components/DeletePanelGroupDialog/DeletePanelGroupDialog.tsx
+++ b/ui/dashboards/src/components/DeletePanelGroupDialog/DeletePanelGroupDialog.tsx
@@ -53,7 +53,7 @@ export const DeletePanelGroupDialog = () => {
           <Button variant="contained" type="submit">
             Delete
           </Button>
-          <Button variant="outlined" onClick={() => closeDeletePanelGroupDialog()}>
+          <Button variant="outlined" color="secondary" onClick={() => closeDeletePanelGroupDialog()}>
             Cancel
           </Button>
         </DialogActions>

--- a/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
@@ -43,7 +43,7 @@ export const DiscardChangesConfirmationDialog = () => {
             <Button variant="contained" onClick={dialog.onDiscardChanges}>
               Discard Changes
             </Button>
-            <Button variant="outlined" onClick={dialog.onCancel}>
+            <Button variant="outlined" color="secondary" onClick={dialog.onCancel}>
               Cancel
             </Button>
           </DialogActions>

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.tsx
@@ -68,7 +68,7 @@ export function PanelGroupDialog() {
             <Button variant="contained" type="submit" form={panelGroupEditorFormId}>
               {panelGroupEditor.mode === 'Edit' ? 'Apply' : 'Add'}
             </Button>
-            <Button variant="outlined" onClick={panelGroupEditor.close}>
+            <Button variant="outlined" color="secondary" onClick={panelGroupEditor.close}>
               Cancel
             </Button>
           </DialogActions>


### PR DESCRIPTION
For time being, we need to make sure that any Button with `variant=outlined` also has `color=secondary`

## Before
<img width="560" alt="Screen Shot 2023-01-10 at 12 00 29 PM" src="https://user-images.githubusercontent.com/2584129/211650332-699f92d4-7d55-4966-acb4-81fbbd10fabb.png">

## After
<img width="568" alt="Screen Shot 2023-01-10 at 11 59 27 AM" src="https://user-images.githubusercontent.com/2584129/211650350-a1c4076d-c6f2-458f-9526-20ed5703cb8d.png">
