### PR TITLE
[BREAKINGCHANGE] remove deprecated top-level `unit` in time series panel

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -44,34 +44,6 @@
           "kind": "Panel",
           "spec": {
             "display": {
-              "name": "1500+ Series",
-              "description": "This is a line chart"
-            },
-            "plugin": {
-              "kind": "TimeSeriesChart",
-              "spec": {
-                "queries": [
-                  {
-                    "kind": "TimeSeriesQuery",
-                    "spec": {
-                      "plugin": {
-                        "kind": "PrometheusTimeSeriesQuery",
-                        "spec": {
-                          "query": "rate(caddy_http_request_duration_seconds_bucket[$interval])"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "unit": { "kind": "Bytes" }
-              }
-            }
-          }
-        },
-        "seriesTestAlt": {
-          "kind": "Panel",
-          "spec": {
-            "display": {
               "name": "~130 Series",
               "description": "This is a line chart"
             },
@@ -91,7 +63,12 @@
                     }
                   }
                 ],
-                "unit": { "kind": "Bytes" }
+                "y_axis": {
+                  "unit": {
+                    "kind": "Bytes",
+                    "abbreviate": true
+                  }
+                }
               }
             }
           }
@@ -117,7 +94,9 @@
                     }
                   }
                 ],
-                "unit": { "kind": "Decimal" },
+                "y_axis": {
+                  "unit": { "kind": "Decimal" }
+                },
                 "legend": {
                   "position": "Right"
                 }
@@ -187,7 +166,10 @@
                 },
                 "y_axis": {
                   "show": true,
-                  "unit": { "kind": "Bytes" }
+                  "unit": {
+                    "kind": "Bytes",
+                    "abbreviate": true
+                  }
                 }
               }
             }
@@ -217,7 +199,9 @@
                     }
                   }
                 ],
-                "unit": { "kind": "Decimal", "decimal_places": 2 },
+                "y_axis": {
+                  "unit": { "kind": "Decimal", "decimal_places": 2 }
+                },
                 "legend": {
                   "position": "Right"
                 }
@@ -251,7 +235,9 @@
                 "legend": {
                   "position": "Right"
                 },
-                "unit": { "kind": "PercentDecimal", "decimal_places": 1 },
+                "y_axis": {
+                  "unit": { "kind": "PercentDecimal", "decimal_places": 1 }
+                },
                 "thresholds": {
                   "steps": [
                     {
@@ -777,36 +763,6 @@
           "kind": "Panel",
           "spec": {
             "display": {
-              "name": "1500+ Series",
-              "description": "This is a line chart"
-            },
-            "plugin": {
-              "kind": "TimeSeriesChart",
-              "spec": {
-                "queries": [
-                  {
-                    "kind": "TimeSeriesQuery",
-                    "spec": {
-                      "plugin": {
-                        "kind": "PrometheusTimeSeriesQuery",
-                        "spec": {
-                          "query": "rate(caddy_http_request_duration_seconds_bucket[$interval])"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "unit": {
-                  "kind": "Bytes"
-                }
-              }
-            }
-          }
-        },
-        "seriesTestAlt": {
-          "kind": "Panel",
-          "spec": {
-            "display": {
               "name": "~130 Series",
               "description": "This is a line chart"
             },
@@ -826,9 +782,11 @@
                     }
                   }
                 ],
-                "unit": {
-                  "kind": "Decimal",
-                  "decimal_places": 4
+                "y_axis": {
+                  "unit": {
+                    "kind": "Decimal",
+                    "decimal_places": 4
+                  }
                 }
               }
             }
@@ -856,9 +814,11 @@
                     }
                   }
                 ],
-                "unit": {
-                  "kind": "PercentDecimal",
-                  "decimal_places": 0
+                "y_axis": {
+                  "unit": {
+                    "kind": "PercentDecimal",
+                    "decimal_places": 0
+                  }
                 }
               }
             }
@@ -922,14 +882,17 @@
                 "legend": {
                   "position": "Bottom"
                 },
-                "unit": {
-                  "kind": "Bytes"
+                "y_axis": {
+                  "unit": {
+                    "kind": "Bytes",
+                    "abbreviate": true
+                  }
                 }
               }
             }
           }
         },
-        "doubleQueries": {
+        "thresholdsEx": {
           "kind": "Panel",
           "spec": {
             "display": {
@@ -973,11 +936,11 @@
                 "thresholds": {
                   "steps": [
                     {
-                      "value": 0.4,
+                      "value": 1.5,
                       "name": "Alert: Warning condition example"
                     },
                     {
-                      "value": 0.75,
+                      "value": 3,
                       "name": "Alert: Critical condition example"
                     }
                   ]
@@ -1007,7 +970,9 @@
                     }
                   }
                 ],
-                "unit": { "kind": "PercentDecimal", "decimal_places": 0 },
+                "y_axis": {
+                  "unit": { "kind": "PercentDecimal", "decimal_places": 0 }
+                },
                 "legend": {
                   "position": "Bottom"
                 },
@@ -1327,7 +1292,7 @@
                 "width": 12,
                 "height": 6,
                 "content": {
-                  "$ref": "#/spec/panels/doubleQueries"
+                  "$ref": "#/spec/panels/thresholdsEx"
                 }
               },
               {
@@ -1398,7 +1363,7 @@
                 "width": 12,
                 "height": 6,
                 "content": {
-                  "$ref": "#/spec/panels/doubleQueries"
+                  "$ref": "#/spec/panels/thresholdsEx"
                 }
               }
             ]

--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -40,6 +40,30 @@
         }
       ],
       "panels": {
+        "defaultTimeSeriesChart": {
+          "kind": "Panel",
+          "spec": {
+            "display": { "name": "Default Time Series Panel" },
+            "plugin": {
+              "kind": "TimeSeriesChart",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "TimeSeriesQuery",
+                    "spec": {
+                      "plugin": {
+                        "kind": "PrometheusTimeSeriesQuery",
+                        "spec": {
+                          "query": "up"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
         "seriesTest": {
           "kind": "Panel",
           "spec": {
@@ -677,9 +701,16 @@
               {
                 "x": 0,
                 "y": 6,
-                "width": 24,
+                "width": 12,
                 "height": 8,
                 "content": { "$ref": "#/spec/panels/cpuLine" }
+              },
+              {
+                "x": 12,
+                "y": 0,
+                "width": 12,
+                "height": 8,
+                "content": { "$ref": "#/spec/panels/defaultTimeSeriesChart" }
               }
             ]
           }
@@ -744,6 +775,30 @@
         }
       ],
       "panels": {
+        "defaultTimeSeriesChart": {
+          "kind": "Panel",
+          "spec": {
+            "display": { "name": "Default Time Series Panel" },
+            "plugin": {
+              "kind": "TimeSeriesChart",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "TimeSeriesQuery",
+                    "spec": {
+                      "plugin": {
+                        "kind": "PrometheusTimeSeriesQuery",
+                        "spec": {
+                          "query": "up"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
         "markdownEx": {
           "kind": "Panel",
           "spec": {
@@ -827,9 +882,7 @@
         "legendEx": {
           "kind": "Panel",
           "spec": {
-            "display": {
-              "name": "Legend Example"
-            },
+            "display": { "name": "Legend Example" },
             "plugin": {
               "kind": "TimeSeriesChart",
               "spec": {
@@ -840,7 +893,8 @@
                       "plugin": {
                         "kind": "PrometheusTimeSeriesQuery",
                         "spec": {
-                          "query": "node_memory_MemTotal_bytes{job=\"node\",instance=\"$instance\"} - node_memory_MemFree_bytes{job=\"node\",instance=\"$instance\"} - node_memory_Buffers_bytes{job=\"node\",instance=\"$instance\"} - node_memory_Cached_bytes{job=\"node\",instance=\"$instance\"}"
+                          "series_name_format": "Node memory total",
+                          "query": "node_memory_MemTotal_bytes{job='$job',instance=~'$instance'} - node_memory_MemFree_bytes{job='$job',instance=~'$instance'} - node_memory_Buffers_bytes{job='$job',instance=~'$instance'} - node_memory_Cached_bytes{job='$job',instance=~'$instance'}"
                         }
                       }
                     }
@@ -851,7 +905,8 @@
                       "plugin": {
                         "kind": "PrometheusTimeSeriesQuery",
                         "spec": {
-                          "query": "node_memory_Buffers_bytes{job=\"node\",instance=\"$instance\"}"
+                          "series_name_format": "Memory (buffers) - {{instance}}",
+                          "query": "node_memory_Buffers_bytes{job='$job',instance=~'$instance'}"
                         }
                       }
                     }
@@ -862,7 +917,8 @@
                       "plugin": {
                         "kind": "PrometheusTimeSeriesQuery",
                         "spec": {
-                          "query": "node_memory_Cached_bytes{job=\"node\",instance=\"$instance\"}"
+                          "series_name_format": "Cached Bytes",
+                          "query": "node_memory_Cached_bytes{job='$job',instance=~'$instance'}"
                         }
                       }
                     }
@@ -873,7 +929,8 @@
                       "plugin": {
                         "kind": "PrometheusTimeSeriesQuery",
                         "spec": {
-                          "query": "node_memory_MemFree_bytes{job=\"node\",instance=\"$instance\"}"
+                          "series_name_format": "MemFree Bytes",
+                          "query": "node_memory_MemFree_bytes{job='$job',instance=~'$instance'}"
                         }
                       }
                     }
@@ -883,6 +940,7 @@
                   "position": "Bottom"
                 },
                 "y_axis": {
+                  "show": true,
                   "unit": {
                     "kind": "Bytes",
                     "abbreviate": true
@@ -1320,19 +1378,28 @@
               {
                 "x": 0,
                 "y": 0,
-                "width": 12,
+                "width": 8,
                 "height": 6,
                 "content": {
-                  "$ref": "#/spec/panels/legendEx"
+                  "$ref": "#/spec/panels/cpu"
                 }
               },
               {
-                "x": 12,
+                "x": 8,
                 "y": 0,
-                "width": 12,
+                "width": 8,
                 "height": 6,
                 "content": {
                   "$ref": "#/spec/panels/basicEx"
+                }
+              },
+              {
+                "x": 16,
+                "y": 0,
+                "width": 8,
+                "height": 6,
+                "content": {
+                  "$ref": "#/spec/panels/defaultTimeSeriesChart"
                 }
               }
             ]
@@ -1354,7 +1421,7 @@
                 "width": 12,
                 "height": 6,
                 "content": {
-                  "$ref": "#/spec/panels/cpu"
+                  "$ref": "#/spec/panels/legendEx"
                 }
               },
               {

--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -39,7 +39,6 @@ spec: close({
 	queries: [...#ts_query]
 	legend?:     #legend
 	y_axis?:     #y_axis
-	unit?:       common.#unit
 	thresholds?: common.#thresholds
 	visual?:     #visual
 })

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -53,12 +53,10 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
       ? merge({}, DEFAULT_LEGEND, props.spec.legend)
       : undefined;
 
-  // TODO: eventually remove props.spec.unit, add support for y_axis_alt.unit
+  // TODO: add support for y_axis_alt.unit
   let unit = DEFAULT_UNIT;
   if (props.spec.y_axis?.unit) {
     unit = props.spec.y_axis.unit;
-  } else if (props.spec.unit) {
-    unit = props.spec.unit;
   }
 
   // ensures there are fallbacks for unset properties since most

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -54,10 +54,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
       : undefined;
 
   // TODO: add support for y_axis_alt.unit
-  let unit = DEFAULT_UNIT;
-  if (props.spec.y_axis?.unit) {
-    unit = props.spec.y_axis.unit;
-  }
+  const unit = props.spec.y_axis?.unit ?? DEFAULT_UNIT;
 
   // ensures there are fallbacks for unset properties since most
   // users should not need to customize visual display


### PR DESCRIPTION
## Overview

Follow up to #767 (see [comments here](https://github.com/perses/perses/pull/767#issuecomment-1316307642)), in that PR we essentially deprecated the top level `unit` in TimeSeriesChart panels. Now that most dashboards have been converted to using the preferred `y_axis.unit`, I'm removing the top level unit completely (see CUE schema update). This also makes visual editing more intuitive, because sometimes the unit you would see in our panel edit form controls would not always match what was set in the JSON (since there was no way to edit the top level unit). 

Example Demo and Benchmark dashboards are updated to pass BE validation, as well as some minor changes to options / layout as I was testing locally.

## Screenshots
Panel editing of `y_axis.unit`
<img width="906" alt="image" src="https://user-images.githubusercontent.com/9369625/212359251-7e5d6a54-e086-4f1c-98f4-17dd61c911f9.png">

Ensure schema validation works when setting top level `unit`
![unit_schema_change_validation_test](https://user-images.githubusercontent.com/9369625/212359456-874bdbd6-d67b-4f81-b2c2-3b4d1642524e.png)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
