### PR TITLE
[BUGFIX] Fix API error EOF that happens when decoding multiple times the body from a middleware

### DIFF
--- a/internal/api/core/middleware/verification.go
+++ b/internal/api/core/middleware/verification.go
@@ -14,8 +14,11 @@
 package middleware
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -38,7 +41,8 @@ func CheckProject(svc project.Service) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			// we don't need to verify if a project exists in case we are in a PUT / GET / DELETE request since if the project doesn't exist, then the dashboard won't exist either.
 			// Also, we avoid an additional query to the DB like that.
-			if c.Request().Method != http.MethodPost {
+			// In case the body is nil, then there is nothing to do about it as well
+			if c.Request().Method != http.MethodPost || c.Request().Body == nil {
 				return next(c)
 			}
 			projectName := shared.GetProjectParameter(c)
@@ -49,9 +53,24 @@ func CheckProject(svc project.Service) echo.MiddlewareFunc {
 				// And just to avoid a non-necessary deserialization, we will ensure we are managing a resource that is part of a project by checking the HTTP Path.
 				for _, path := range shared.ProjectResourcePathList {
 					if strings.HasPrefix(c.Path(), fmt.Sprintf("%s/%s", shared.APIV1Prefix, path)) {
+						// Parsing the body in an Echo middleware may cause the error code=400, message=EOF.
+						//
+						// Context.Bind only can be called only once in the life of the request as it read the body which can only be read once.
+						// The request data reader is running out, Context.Bind() function read request body data from the socket buffer, once you took it out, it is just gone
+						// That’s why it returns EOF error.
+						//
+						// In this middleware we need to partially decode the body to see if the project is set.
+						// So we read the body, and then we re-inject it in the request.
+						bodyBytes, err := io.ReadAll(c.Request().Body)
+						if err != nil {
+							return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, err))
+						}
+						// write back to request body
+						c.Request().Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+						// now we can safely partially decode the body
 						o := &partialObject{}
-						if err := c.Bind(o); err != nil {
-							return err
+						if unmarshalErr := json.Unmarshal(bodyBytes, o); unmarshalErr != nil {
+							return shared.HandleError(fmt.Errorf("%w: %s", shared.BadRequestError, unmarshalErr))
 						}
 						if len(o.Metadata.Project) == 0 {
 							return shared.HandleError(fmt.Errorf("%w: metadata.project cannot be empty", shared.BadRequestError))

--- a/internal/api/e2e/framework/scenario.go
+++ b/internal/api/e2e/framework/scenario.go
@@ -172,6 +172,20 @@ func MainTestScenarioWithProject(t *testing.T, path string, creator func(project
 			parent, entity := creator("myProject", "myResource")
 			CreateAndWaitUntilEntityExists(t, manager, parent)
 
+			expect.POST(fmt.Sprintf("%s/%s", shared.APIV1Prefix, path)).
+				WithJSON(entity).
+				Expect().
+				Status(http.StatusOK)
+
+			return []api.Entity{parent, entity}
+		})
+	})
+
+	t.Run("Creation with project path", func(t *testing.T) {
+		WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+			parent, entity := creator("myProject", "myResource")
+			CreateAndWaitUntilEntityExists(t, manager, parent)
+
 			expect.POST(fmt.Sprintf("%s/%s/%s/%s", shared.APIV1Prefix, shared.PathProject, parent.GetMetadata().GetName(), path)).
 				WithJSON(entity).
 				Expect().

--- a/internal/api/shared/utils.go
+++ b/internal/api/shared/utils.go
@@ -32,7 +32,6 @@ const (
 	PathFolder           = "folders"
 	PathGlobalDatasource = "globaldatasources"
 	PathProject          = "projects"
-	PathUser             = "users"
 )
 
 // ProjectResourcePathList is containing the list of the resource path that are part of a project.


### PR DESCRIPTION
When calling the endpoint `/api/v1/dashboards`, it will trigger a middleware that is decoding the body to find the what project shall be used to perform the request.

It appears it's not possible to decode multiple times the body when we are using the method `bind` from the framework `echo`.

This PR is fixing that, assuring we don't modify the request body so it can be decoded later by the business code.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>