### PR TITLE
[IGNORE] ignore google email link with mdox

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -1,0 +1,7 @@
+version: 1
+timeout: '1m'
+
+validators:
+  # randomly it returns the error: status code 403: Forbidden
+  - regex: 'groups\.google\.com'
+    type: 'ignore'

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ fmt:
 .PHONY: fmt-docs
 fmt-docs:
 	@echo ">> format markdown document"
-	$(MDOX) fmt --soft-wraps -l $$(find . -name '*.md' -not -path "./ui/node_modules/*" -not -path "./ui/prometheus-plugin/node_modules/*" -print)
+	$(MDOX) fmt --soft-wraps -l $$(find . -name '*.md' -not -path "./ui/node_modules/*" -not -path "./ui/prometheus-plugin/node_modules/*" -print) --links.validate.config-file=./.mdox.validate.yaml
 
 .PHONY: cue-eval
 cue-eval:


### PR DESCRIPTION
I'm ignoring the link to the google group email.

Randomly it returns an error and it makes the CI failed which is annoying.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>