### PR TITLE
[BUGFIX] Fix discard changes confirmation dialog showing up even when there is no change

### DIFF
--- a/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
@@ -20,7 +20,7 @@ export const DiscardChangesConfirmationDialog = () => {
   const isOpen = dialog !== undefined;
 
   return (
-    <Dialog open={isOpen} data-testid="discard-changes-confirmation-dialog">
+    <Dialog open={isOpen}>
       {dialog !== undefined && (
         <>
           <DialogTitle>Discard Changes</DialogTitle>

--- a/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
@@ -20,7 +20,7 @@ export const DiscardChangesConfirmationDialog = () => {
   const isOpen = dialog !== undefined;
 
   return (
-    <Dialog open={isOpen}>
+    <Dialog open={isOpen} data-testid="discard-changes-confirmation-dialog">
       {dialog !== undefined && (
         <>
           <DialogTitle>Discard Changes</DialogTitle>

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -17,11 +17,11 @@ import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import shallow from 'zustand/shallow';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { DashboardResource, ProjectMetadata, RelativeTimeRange, UnknownSpec } from '@perses-dev/core';
+import { DashboardResource, ProjectMetadata, RelativeTimeRange } from '@perses-dev/core';
 import { usePlugin, usePluginRegistry } from '@perses-dev/plugin-system';
 import { createPanelGroupEditorSlice, PanelGroupEditorSlice } from './panel-group-editor-slice';
 import { convertLayoutsToPanelGroups, createPanelGroupSlice, PanelGroupSlice } from './panel-group-slice';
-import { createPanelEditorSlice, PanelEditorSlice } from './panel-editor-slice';
+import { createPanelEditorSlice, PanelEditorSlice, PanelEditorValues } from './panel-editor-slice';
 import { createPanelSlice, PanelSlice } from './panel-slice';
 import { createDeletePanelGroupSlice, DeletePanelGroupSlice } from './delete-panel-group-slice';
 import { createDeletePanelSlice, DeletePanelSlice } from './delete-panel-slice';
@@ -85,7 +85,7 @@ export function DashboardProvider(props: DashboardProviderProps) {
   );
 }
 
-function initStore(props: DashboardProviderProps, defaultPanel?: { kind: string; spec: UnknownSpec }) {
+function initStore(props: DashboardProviderProps, defaultPanel?: Pick<PanelEditorValues, 'kind' | 'spec'>) {
   const {
     initialState: { dashboardResource, isEditMode },
   } = props;

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -82,7 +82,7 @@ export interface PanelEditorValues {
 /**
  * Curried function for creating the PanelEditorSlice.
  */
-export function createPanelEditorSlice(defaultPanel?: { kind: string; spec: UnknownSpec }): StateCreator<
+export function createPanelEditorSlice(defaultPanel?: Pick<PanelEditorValues, 'kind' | 'spec'>): StateCreator<
   // Actions in here need to modify both Panels and Panel Groups state
   PanelEditorSlice & PanelSlice & PanelGroupSlice,
   Middleware,

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -82,13 +82,16 @@ export interface PanelEditorValues {
 /**
  * Curried function for creating the PanelEditorSlice.
  */
-export function createPanelEditorSlice(): StateCreator<
+export function createPanelEditorSlice(defaultPanel?: { kind: string; spec: UnknownSpec }): StateCreator<
   // Actions in here need to modify both Panels and Panel Groups state
   PanelEditorSlice & PanelSlice & PanelGroupSlice,
   Middleware,
   [],
   PanelEditorSlice
 > {
+  const defaultKind = defaultPanel?.kind ?? '';
+  const defaultSpec = defaultPanel?.spec ?? {};
+
   // Return the state creator function for Zustand that uses the panels provided as intitial state
   return (set, get) => ({
     panelEditor: undefined,
@@ -190,8 +193,8 @@ export function createPanelEditorSlice(): StateCreator<
           name: '',
           description: '',
           groupId: panelGroupId,
-          kind: '',
-          spec: {},
+          kind: defaultKind,
+          spec: defaultSpec,
         },
         applyChanges: (next) => {
           const panelDef = createPanelDefinitionFromEditorValues(next);

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -31,6 +31,11 @@ import { PanelSlice } from './panel-slice';
  */
 export interface PanelEditorSlice {
   /**
+   * Initial values for add panel if default panel kind is defined
+   */
+  initialValues?: Pick<PanelEditorValues, 'kind' | 'spec'>;
+
+  /**
    * State for the panel editor when its open, otherwise undefined when it's closed.
    */
   panelEditor?: PanelEditorState;
@@ -82,16 +87,13 @@ export interface PanelEditorValues {
 /**
  * Curried function for creating the PanelEditorSlice.
  */
-export function createPanelEditorSlice(defaultPanel?: Pick<PanelEditorValues, 'kind' | 'spec'>): StateCreator<
+export function createPanelEditorSlice(): StateCreator<
   // Actions in here need to modify both Panels and Panel Groups state
   PanelEditorSlice & PanelSlice & PanelGroupSlice,
   Middleware,
   [],
   PanelEditorSlice
 > {
-  const defaultKind = defaultPanel?.kind ?? '';
-  const defaultSpec = defaultPanel?.spec ?? {};
-
   // Return the state creator function for Zustand that uses the panels provided as intitial state
   return (set, get) => ({
     panelEditor: undefined,
@@ -193,8 +195,8 @@ export function createPanelEditorSlice(defaultPanel?: Pick<PanelEditorValues, 'k
           name: '',
           description: '',
           groupId: panelGroupId,
-          kind: defaultKind,
-          spec: defaultSpec,
+          kind: get().initialValues?.kind ?? '',
+          spec: get().initialValues?.spec ?? {},
         },
         applyChanges: (next) => {
           const panelDef = createPanelDefinitionFromEditorValues(next);

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -51,7 +51,6 @@ export class DashboardPage {
 
   readonly panelEditor: Locator;
   readonly variableEditor: Locator;
-  readonly discardChangesConfirmationDialog: Locator;
 
   readonly alert: Locator;
 
@@ -81,7 +80,6 @@ export class DashboardPage {
 
     this.panelEditor = page.getByTestId('panel-editor');
     this.variableEditor = page.getByTestId('variable-editor');
-    this.discardChangesConfirmationDialog = page.getByTestId('discard-changes-confirmation-dialog');
 
     this.alert = page.getByRole('alert');
   }
@@ -101,6 +99,14 @@ export class DashboardPage {
     return this.page.getByRole('dialog', {
       name: name,
     });
+  }
+
+  /**
+   * PANEL EDITOR HELPERS
+   */
+
+  getPanelEditor() {
+    return new PanelEditor(this.panelEditor);
   }
 
   /**

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -51,6 +51,7 @@ export class DashboardPage {
 
   readonly panelEditor: Locator;
   readonly variableEditor: Locator;
+  readonly discardChangesConfirmationDialog: Locator;
 
   readonly alert: Locator;
 
@@ -80,6 +81,7 @@ export class DashboardPage {
 
     this.panelEditor = page.getByTestId('panel-editor');
     this.variableEditor = page.getByTestId('variable-editor');
+    this.discardChangesConfirmationDialog = page.getByTestId('discard-changes-confirmation-dialog');
 
     this.alert = page.getByRole('alert');
   }

--- a/ui/e2e/src/pages/PanelEditor.ts
+++ b/ui/e2e/src/pages/PanelEditor.ts
@@ -22,6 +22,7 @@ export class PanelEditor {
 
   readonly addButton: Locator;
   readonly applyButton: Locator;
+  readonly cancelButton: Locator;
 
   constructor(container: Locator) {
     this.container = container;
@@ -31,6 +32,7 @@ export class PanelEditor {
 
     this.addButton = container.getByRole('button', { name: 'Add', exact: true });
     this.applyButton = container.getByRole('button', { name: 'Apply', exact: true });
+    this.cancelButton = container.getByRole('button', { name: 'Cancel', exact: true });
   }
 
   async isVisible() {

--- a/ui/e2e/src/tests/panelEditor.spec.ts
+++ b/ui/e2e/src/tests/panelEditor.spec.ts
@@ -1,0 +1,43 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test, expect } from '../fixtures/dashboardTest';
+import { PanelEditor } from '../pages/PanelEditor';
+
+test.use({
+  dashboardName: 'Panels',
+});
+
+test.describe('Dashboard: Panel Editor', () => {
+  test('should show discard changes confirmation dialog', async ({ dashboardPage }) => {
+    await dashboardPage.startEditing();
+    await dashboardPage.addPanel();
+    await dashboardPage.panelEditor.isVisible();
+    const panelEditor = new PanelEditor(dashboardPage.panelEditor);
+    await panelEditor.selectType('Markdown');
+    await panelEditor.cancelButton.click();
+
+    await expect(dashboardPage.discardChangesConfirmationDialog).toBeVisible();
+
+    // clicking "Cancel" should do nothing and keep current changes
+    await dashboardPage.discardChangesConfirmationDialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dashboardPage.panelEditor).toBeVisible();
+    await expect(dashboardPage.panelEditor.getByLabel(/^Type/)).toContainText('Markdown');
+
+    // clicking "Discard Changes" should discard changes
+    await panelEditor.cancelButton.click();
+    await dashboardPage.discardChangesConfirmationDialog.getByRole('button', { name: 'Discard Changes' }).click();
+    await expect(dashboardPage.panelEditor).toBeHidden();
+    await expect(dashboardPage.discardChangesConfirmationDialog).toBeHidden();
+  });
+});

--- a/ui/e2e/src/tests/panels.spec.ts
+++ b/ui/e2e/src/tests/panels.spec.ts
@@ -34,6 +34,10 @@ test.describe('Dashboard: Panels', () => {
     await dashboardPage.startEditing();
 
     await dashboardPage.addPanel();
+
+    // verify default panel type is Time Series Chart
+    await expect(dashboardPage.panelEditor.getByLabel(/^Type/)).toContainText('Time Series Chart');
+
     await dashboardPage.addMarkdownPanel('Markdown One');
 
     await expect(dashboardPage.panels).toHaveCount(2);


### PR DESCRIPTION
**BEFORE**
The discard changes confirmation dialog appears even when you don't make any changes 
![BEFORE](https://user-images.githubusercontent.com/9817826/213316920-351375f9-6a58-4a60-95d3-fd8433cec261.gif)


**AFTER** 
![Jan-18-2023 18-15-25](https://user-images.githubusercontent.com/9817826/213316938-0efc3596-1c45-49d5-9814-c05e0e056979.gif)


