### PR TITLE
[BUGFIX] Fix empty dashboard spec that wasn't rejected

### DIFF
--- a/internal/api/shared/migrate/testdata/old_format_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_format_perses_dashboard.json
@@ -4,6 +4,7 @@
     "name": "ELftRcK4z",
     "created_at": "0001-01-01T00:00:00Z",
     "updated_at": "0001-01-01T00:00:00Z",
+    "version": 0,
     "project": ""
   },
   "spec": {

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -4,6 +4,7 @@
     "name": "DuJ3dcNVk",
     "created_at": "0001-01-01T00:00:00Z",
     "updated_at": "0001-01-01T00:00:00Z",
+    "version": 0,
     "project": ""
   },
   "spec": {

--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -16,6 +16,7 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/v1/common"
@@ -45,7 +46,7 @@ type DashboardSpec struct {
 	// dashboard
 	Duration  model.Duration       `json:"duration" yaml:"duration"`
 	Variables []dashboard.Variable `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Panels    map[string]*Panel    `json:"panels" yaml:"panels"` // kept as raw json as the validation is done with cuelang
+	Panels    map[string]*Panel    `json:"panels" yaml:"panels"`
 	Layouts   []dashboard.Layout   `json:"layouts" yaml:"layouts"`
 }
 
@@ -147,6 +148,9 @@ func (d *Dashboard) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (d *Dashboard) validate() error {
 	if d.Kind != KindDashboard {
 		return fmt.Errorf("invalid kind: %q for a Dashboard type", d.Kind)
+	}
+	if reflect.DeepEqual(d.Spec, DashboardSpec{}) {
+		return fmt.Errorf("spec cannot be empty")
 	}
 	return d.verifyAndSetJSONReferences()
 }

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -15,6 +15,7 @@ package v1
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -93,6 +94,7 @@ func TestMarshalDashboard(t *testing.T) {
     "name": "SimpleDashboard",
     "created_at": "0001-01-01T00:00:00Z",
     "updated_at": "0001-01-01T00:00:00Z",
+    "version": 0,
     "project": "perses"
   },
   "spec": {
@@ -228,6 +230,7 @@ func TestMarshalDashboard(t *testing.T) {
     "name": "SimpleDashboard",
     "created_at": "0001-01-01T00:00:00Z",
     "updated_at": "0001-01-01T00:00:00Z",
+    "version": 0,
     "project": "perses"
   },
   "spec": {
@@ -488,4 +491,46 @@ func TestUnmarshallDashboard(t *testing.T) {
 	err := json.Unmarshal([]byte(jsonDashboard), result)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
+}
+
+func TestUnmarshalDashboardError(t *testing.T) {
+	testSuite := []struct {
+		title string
+		jason string
+		err   error
+	}{
+		{
+			title: "spec cannot be empty",
+			jason: `
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "test",
+    "project": "perses"
+  }
+}
+`,
+			err: fmt.Errorf("spec cannot be empty"),
+		},
+		{
+			title: "panel list cannot be empty",
+			jason: `
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "test",
+    "project": "perses"
+  },
+  "spec": {}
+}
+`,
+			err: fmt.Errorf("dashboard.spec.panels cannot be empty"),
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := Dashboard{}
+			assert.Equal(t, test.err, json.Unmarshal([]byte(test.jason), &result))
+		})
+	}
 }

--- a/pkg/model/api/v1/datasource.go
+++ b/pkg/model/api/v1/datasource.go
@@ -14,7 +14,9 @@
 package v1
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/v1/common"
@@ -61,6 +63,42 @@ type GlobalDatasource struct {
 	Spec     DatasourceSpec `json:"spec" yaml:"spec"`
 }
 
+func (d *GlobalDatasource) UnmarshalJSON(data []byte) error {
+	var tmp GlobalDatasource
+	type plain GlobalDatasource
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *GlobalDatasource) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp GlobalDatasource
+	type plain GlobalDatasource
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *GlobalDatasource) validate() error {
+	if d.Kind != KindGlobalDatasource {
+		return fmt.Errorf("invalid kind: %q for a GlobalDatasource type", d.Kind)
+	}
+	if reflect.DeepEqual(d.Spec, DatasourceSpec{}) {
+		return fmt.Errorf("spec cannot be empty")
+	}
+	return nil
+}
+
 func (d *GlobalDatasource) GenerateID() string {
 	return GenerateGlobalDatasourceID(d.Metadata.Name)
 }
@@ -88,6 +126,42 @@ type Datasource struct {
 	Kind     Kind            `json:"kind" yaml:"kind"`
 	Metadata ProjectMetadata `json:"metadata" yaml:"metadata"`
 	Spec     DatasourceSpec  `json:"spec" yaml:"spec"`
+}
+
+func (d *Datasource) UnmarshalJSON(data []byte) error {
+	var tmp Datasource
+	type plain Datasource
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *Datasource) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp Datasource
+	type plain Datasource
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *Datasource) validate() error {
+	if d.Kind != KindDatasource {
+		return fmt.Errorf("invalid kind: %q for a Datasource type", d.Kind)
+	}
+	if reflect.DeepEqual(d.Spec, DatasourceSpec{}) {
+		return fmt.Errorf("spec cannot be empty")
+	}
+	return nil
 }
 
 func (d *Datasource) GenerateID() string {

--- a/pkg/model/api/v1/metadata.go
+++ b/pkg/model/api/v1/metadata.go
@@ -30,7 +30,7 @@ type Metadata struct {
 	Name      string    `json:"name" yaml:"name"`
 	CreatedAt time.Time `json:"created_at" yaml:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" yaml:"updated_at"`
-	Version   uint64    `json:"version,omitempty" yaml:"version,omitempty"`
+	Version   uint64    `json:"version" yaml:"version"`
 }
 
 func (m *Metadata) CreateNow() {


### PR DESCRIPTION
Before this PR, this kind of JSON was accepted:

```json
{
  "kind": "Dashboard",
  "metadata": {
    "name": "test",
    "project": "perses"
  }
}
```

that's not something that should be allowed. `Spec` must be defined.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>