### PR TITLE
[ENHANCEMENT] Update markdown library

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -809,7 +809,7 @@
             "plugin": {
               "kind": "Markdown",
               "spec": {
-                "text": "## Dashboard Team!\nOn this page, you'll find charts used by the dashboard team.\n\nHere is `some inline code`.\n\n```\n{ look: 'at this code' }\n```\n\n1. One\n2. Two\n3. Three\n\n* two bullet\n* points\n\nDo you want to [visit the google](https://www.google.com)?\n| Dashboard | Link |\n| :----------- | :----------- |\n| Dashboard 1 | [link](www.google.com) |\n| Dashboard 2 | [link](www.google.com) | \n\n<script>alert('xss');</script>\n> Will this <a \n> href='javascript:alert()'>block-quote attack work?</a>\n\n<h1>When inlining HTML, will this header be here?</h1><a href='www.google.com'>Will this regular link be here?</a> <a href='javascript:alert('xss')>Will this javascript link be here?</a>\n\n"
+                "text": "# First header\n\nFirst header\n=========\n\n## Second header\n\nSecond header\n---------\n\n### Third header\n\n#### Fourth header\n\n*Italic*\n\n_Italic_\n\n**Bold**\n\n__Bold__\n\n[Link](http://a.com)\n\n[Link][1]\n\n[1]: http://b.org\n\n> Blockquote\n\n* List\n* List\n* List\n\n- List\n- List\n- List\n\n1. One\n2. Two\n3. Three\n\n1) One\n2) Two\n3) Three\n\n---\n\n***\n\n`Inline code` with backticks\n\n```\n# code block\nprint '3 backticks or'\nprint 'indent 4 spaces'\n```\n\n| Name | Data |\n| -- | -- |\n| Row 1 | Hi |\n| Row 2 | Hi |\n\n## Attempts at XSS\n\n<script>alert('xss');</script>\n> Will this <a \n> href='javascript:alert()'>block-quote attack work?</a>\n\n<h3>When inlining HTML, will this header be here?</h3><a href='www.google.com'>Will this regular link be here?</a><br/><a href='javascript:alert('xss')>Will this javascript link be here?</a>\n\n"
               }
             }
           }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10891,9 +10891,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -14726,7 +14726,7 @@
         "echarts": "^5.3.3",
         "immer": "^9.0.15",
         "lodash-es": "^4.17.21",
-        "marked": "^4.1.0",
+        "marked": "^4.2.12",
         "mathjs": "^10.6.4"
       },
       "devDependencies": {
@@ -17158,7 +17158,7 @@
         "echarts": "^5.3.3",
         "immer": "^9.0.15",
         "lodash-es": "^4.17.21",
-        "marked": "^4.1.0",
+        "marked": "*",
         "mathjs": "^10.6.4"
       }
     },
@@ -22788,9 +22788,9 @@
       }
     },
     "marked": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
     },
     "mathjs": {
       "version": "10.6.4",

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -36,7 +36,7 @@
     "echarts": "^5.3.3",
     "immer": "^9.0.15",
     "lodash-es": "^4.17.21",
-    "marked": "^4.1.0",
+    "marked": "^4.2.12",
     "mathjs": "^10.6.4"
   },
   "peerDependencies": {

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -25,9 +25,13 @@ function createMarkdownPanelStyles(theme: Theme) {
     // Make the content scrollable
     height: '100%',
     overflowY: 'auto',
-    // Ignore first margin
+    // Ignore top margin on the first element (TODO: Remove when we can set padding for each panel type)
     '& :first-child': {
       marginTop: 0,
+    },
+    // Styles for headers
+    '& h1': {
+      fontSize: '2em',
     },
     // Styles for <code>
     '& code': { fontSize: '0.85em' },
@@ -58,12 +62,13 @@ function createMarkdownPanelStyles(theme: Theme) {
   };
 }
 
-// Convert markdown text to HTML, with support for original markdown and Github Flavored Markdown
-function convertTextToHTML(text: string): string {
+// Convert markdown to HTML
+// Supports original markdown and GitHub Flavored markdown
+function markdownToHTML(text: string): string {
   return marked.parse(text, { gfm: true });
 }
 
-// Sanitize HTML (i.e. prevent XSS attacks by removing the vectors for these attacks)
+// Prevent XSS attacks by removing the vectors for attacks
 function sanitizeHTML(html: string): string {
   return DOMPurify.sanitize(html);
 }
@@ -73,7 +78,7 @@ export function MarkdownPanel(props: MarkdownPanelProps) {
     spec: { text },
   } = props;
 
-  const html = useMemo(() => convertTextToHTML(text), [text]);
+  const html = useMemo(() => markdownToHTML(text), [text]);
   const sanitizedHTML = useMemo(() => sanitizeHTML(html), [html]);
 
   return <Box sx={createMarkdownPanelStyles} dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />;

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanelOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanelOptionsEditor.tsx
@@ -18,7 +18,7 @@ import { MarkdownPanelOptions } from './markdown-panel-model';
 
 export type MarkdownPanelOptionsEditorProps = OptionsEditorProps<MarkdownPanelOptions>;
 
-const MARKDOWN_GUIDE_URL = 'https://www.markdownguide.org/cheat-sheet';
+const MARKDOWN_GUIDE_URL = 'https://commonmark.org/help/';
 const TEXT_INPUT_NUM_ROWS = 20;
 
 export function MarkdownPanelOptionsEditor(props: MarkdownPanelOptionsEditorProps) {


### PR DESCRIPTION
## Changes
* Change markdown reference from https://www.markdownguide.org/cheat-sheet/ to https://commonmark.org/help/
* Update test data to have more overlap with https://commonmark.org/help/
* Update `marked` library
* Fix bug where h2 was bigger than h1

<img width="1512" alt="Screen Shot 2023-01-20 at 12 36 16 PM" src="https://user-images.githubusercontent.com/2584129/213802398-a00770a5-fc1e-4906-80a7-799111cecad6.png">
<img width="1512" alt="Screen Shot 2023-01-20 at 12 36 27 PM" src="https://user-images.githubusercontent.com/2584129/213802400-baeaf6c8-cd12-4d3d-8886-9b2aa32d63d3.png">

## Checklist
- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

Signed-off-by: Christine Donovan <christine.donovan@chronosphere.io>