### PR TITLE
[IGNORE] Include retry in dashboard name for tests

### DIFF
--- a/ui/e2e/src/fixtures/dashboardTest.ts
+++ b/ui/e2e/src/fixtures/dashboardTest.ts
@@ -80,10 +80,12 @@ async function deleteDashboard(projectName: string, dashboardName: string) {
  * Generates a dashboard name to use when duplicating a dashboard for a given
  * test.
  */
-function generateDuplicateDashboardName(dashboardName: string, testTitle: string) {
+function generateDuplicateDashboardName(dashboardName: string, testTitle: string, retry: number) {
   // Replaces any characters that are not allowed in dashboard names with
   // underscores.
-  return dashboardName + '__' + testTitle.replace(/[^a-zA-Z0-9_.:-]+/g, '_');
+  const normalizedTitle = testTitle.replace(/[^a-zA-Z0-9_.:-]+/g, '_');
+
+  return [dashboardName, normalizedTitle, retry].join('__');
 }
 
 /**
@@ -97,7 +99,7 @@ export const test = testBase.extend<DashboardTestOptions & DashboardTestFixtures
     let testDashboardName: string = dashboardName;
 
     if (modifiesDashboard) {
-      testDashboardName = generateDuplicateDashboardName(dashboardName, testInfo.title);
+      testDashboardName = generateDuplicateDashboardName(dashboardName, testInfo.title, testInfo.retry);
       await duplicateDashboard(projectName, dashboardName, testDashboardName);
     }
 


### PR DESCRIPTION
I noticed a rare flaky test run related to this in another PR ([example failure](https://github.com/perses/perses/actions/runs/4027288537/jobs/6922828092)). We have retry logic set up to catch a rare issue in a test and try again. When a retry runs on a test set that mutates dashboards, we can hit a case where the backend throws an error because we try to create a duplicate dashboard name.

This fix includes the `retry` number in the dashboard name to ensure it is unique.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
