### PR TITLE
[BREAKINGCHANGE] Move panel padding to plugins

### DIFF
--- a/ui/components/src/GaugeChart/GaugeChart.tsx
+++ b/ui/components/src/GaugeChart/GaugeChart.tsx
@@ -181,6 +181,7 @@ export function GaugeChart(props: GaugeChartProps) {
       sx={{
         width: width,
         height: height,
+        padding: (theme) => theme.spacing(1.5),
       }}
       option={option}
       theme={chartsTheme.echartsTheme}

--- a/ui/components/src/GaugeChart/GaugeChart.tsx
+++ b/ui/components/src/GaugeChart/GaugeChart.tsx
@@ -181,7 +181,7 @@ export function GaugeChart(props: GaugeChartProps) {
       sx={{
         width: width,
         height: height,
-        padding: (theme) => theme.spacing(1.5),
+        padding: `${chartsTheme.container.padding.default}px`,
       }}
       option={option}
       theme={chartsTheme.echartsTheme}

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import React, { useMemo } from 'react';
-import { Box, Typography, Stack } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { merge } from 'lodash-es';
 import { use, EChartsCoreOption } from 'echarts/core';
 import { GaugeChart as EChartsGaugeChart, GaugeSeriesOption } from 'echarts/charts';
@@ -115,13 +115,13 @@ export function StatChart(props: StatChartProps) {
   const containerPadding = `${chartsTheme.container.padding.default}px`;
 
   return (
-    <Stack sx={{ height: '100%', width: '100%' }} spacing={0}>
+    <Box sx={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'column' }}>
       <Typography
         variant="h3"
         sx={(theme) => ({
           color: theme.palette.text.primary,
           fontSize: `clamp(${MIN_VALUE_SIZE}px, ${valueSize}px, ${MAX_VALUE_SIZE}px)`,
-          padding: [containerPadding, containerPadding, 0, containerPadding],
+          padding: `${containerPadding} ${containerPadding} 0 ${containerPadding}`,
         })}
       >
         {formattedValue}
@@ -139,6 +139,6 @@ export function StatChart(props: StatChartProps) {
           />
         </Box>
       )}
-    </Stack>
+    </Box>
   );
 }

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -112,6 +112,8 @@ export function StatChart(props: StatChartProps) {
   const charactersAdjust = formattedValue.length;
   const valueSize = isLargePanel === true ? MAX_VALUE_SIZE : Math.min(width, height) / charactersAdjust;
 
+  const containerPadding = `${chartsTheme.container.padding.default}px`;
+
   return (
     <Stack sx={{ height: '100%', width: '100%' }} spacing={0}>
       <Typography
@@ -119,7 +121,7 @@ export function StatChart(props: StatChartProps) {
         sx={(theme) => ({
           color: theme.palette.text.primary,
           fontSize: `clamp(${MIN_VALUE_SIZE}px, ${valueSize}px, ${MAX_VALUE_SIZE}px)`,
-          padding: (theme) => theme.spacing(1.5, 1.5, 0, 1.5),
+          padding: [containerPadding, containerPadding, 0, containerPadding],
         })}
       >
         {formattedValue}

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import React, { useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Stack } from '@mui/material';
 import { merge } from 'lodash-es';
 import { use, EChartsCoreOption } from 'echarts/core';
 import { GaugeChart as EChartsGaugeChart, GaugeSeriesOption } from 'echarts/charts';
@@ -34,7 +34,6 @@ use([
   CanvasRenderer,
 ]);
 
-const PANEL_PADDING = 32;
 const MIN_VALUE_SIZE = 12;
 const MAX_VALUE_SIZE = 36;
 
@@ -114,30 +113,30 @@ export function StatChart(props: StatChartProps) {
   const valueSize = isLargePanel === true ? MAX_VALUE_SIZE : Math.min(width, height) / charactersAdjust;
 
   return (
-    <Box>
+    <Stack sx={{ height: '100%', width: '100%' }} spacing={0}>
       <Typography
         variant="h3"
         sx={(theme) => ({
           color: theme.palette.text.primary,
           fontSize: `clamp(${MIN_VALUE_SIZE}px, ${valueSize}px, ${MAX_VALUE_SIZE}px)`,
+          padding: (theme) => theme.spacing(1.5, 1.5, 0, 1.5),
         })}
       >
         {formattedValue}
       </Typography>
       {sparkline !== undefined && (
-        <EChart
-          sx={{
-            width: width + PANEL_PADDING, // allows sparkline to extend to edge of panel
-            height: height,
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-          }}
-          option={option}
-          theme={chartsTheme.echartsTheme}
-          renderer="svg"
-        />
+        <Box sx={{ flex: 1 }}>
+          <EChart
+            sx={{
+              width: '100%',
+              height: '100%',
+            }}
+            option={option}
+            theme={chartsTheme.echartsTheme}
+            renderer="svg"
+          />
+        </Box>
       )}
-    </Box>
+    </Stack>
   );
 }

--- a/ui/components/src/model/theme.ts
+++ b/ui/components/src/model/theme.ts
@@ -20,6 +20,17 @@ export interface PersesChartsTheme {
     width: number;
     color: string;
   };
+  /**
+   * Theming for the container that wraps a chart.
+   */
+  container: {
+    /**
+     * Padding in pixels.
+     */
+    padding: {
+      default: number;
+    };
+  };
 }
 
 // https://github.com/apache/echarts/issues/12489#issuecomment-643185207

--- a/ui/components/src/test-utils/theme.ts
+++ b/ui/components/src/test-utils/theme.ts
@@ -20,4 +20,9 @@ export const testChartsTheme: PersesChartsTheme = {
     width: 1,
     color: '#000000',
   },
+  container: {
+    padding: {
+      default: 12,
+    },
+  },
 };

--- a/ui/components/src/utils/theme-gen.test.ts
+++ b/ui/components/src/utils/theme-gen.test.ts
@@ -33,6 +33,11 @@ describe('generateChartsTheme', () => {
   it('should return perses specific charts theme from converted MUI theme', () => {
     expect(chartsTheme).toMatchInlineSnapshot(`
       Object {
+        "container": Object {
+          "padding": Object {
+            "default": 12,
+          },
+        },
         "echartsTheme": Object {
           "bar": Object {
             "barMaxWidth": 150,

--- a/ui/components/src/utils/theme-gen.ts
+++ b/ui/components/src/utils/theme-gen.ts
@@ -176,6 +176,11 @@ export function generateChartsTheme(muiTheme: MuiTheme, echartsTheme: EChartsThe
       width: 2,
       color: '#1976d2',
     },
+    container: {
+      padding: {
+        default: parseInt(muiTheme.spacing(1.5), 10),
+      },
+    },
     // TODO: add thresholdColors to theme
   };
 }

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -14,7 +14,7 @@
 import { useState, useMemo } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import { useInView } from 'react-intersection-observer';
-import { ErrorBoundary, ErrorAlert, combineSx, useId } from '@perses-dev/components';
+import { ErrorBoundary, ErrorAlert, combineSx, useId, useChartsTheme } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
 import { Card, CardProps, CardContent } from '@mui/material';
 import { PanelHeader, PanelHeaderProps } from './PanelHeader';
@@ -51,8 +51,7 @@ export function Panel(props: PanelProps) {
     triggerOnce: true,
   });
 
-  // TODO: adjust padding for small panels, consistent way to determine isLargePanel here and in StatChart
-  const panelPadding = 1.5;
+  const chartsTheme = useChartsTheme();
 
   const handleMouseEnter: CardProps['onMouseEnter'] = (e) => {
     setIsHovered(true);
@@ -91,7 +90,7 @@ export function Panel(props: PanelProps) {
         description={definition.spec.display.description}
         editHandlers={editHandlers}
         isHovered={isHovered}
-        sx={{ paddingX: (theme) => theme.spacing(panelPadding) }}
+        sx={{ paddingX: `${chartsTheme.container.padding.default}px` }}
       />
       <CardContent
         component="figure"

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -100,10 +100,10 @@ export function Panel(props: PanelProps) {
           overflow: 'hidden',
           flexGrow: 1,
           margin: 0,
-          padding: (theme) => theme.spacing(panelPadding),
+          padding: 0,
           // Override MUI default style for last-child
           ':last-child': {
-            padding: (theme) => theme.spacing(panelPadding),
+            padding: 0,
           },
         }}
         ref={setContentElement}

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -110,11 +110,13 @@ export function GaugeChartPanel(props: GaugeChartPanelProps) {
     chartWidth = GAUGE_MIN_WIDTH;
   }
 
+  const hasMultipleCharts = gaugeData.length > 1;
+
   return (
     <Stack
       direction="row"
-      spacing={2}
-      justifyContent="left"
+      spacing={hasMultipleCharts ? 2 : 0}
+      justifyContent={hasMultipleCharts ? 'left' : 'center'}
       alignItems="center"
       sx={{
         // so scrollbar only shows when necessary

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -16,13 +16,14 @@ import * as DOMPurify from 'dompurify';
 import { marked } from 'marked';
 import { Box, Theme } from '@mui/material';
 import { PanelProps } from '@perses-dev/plugin-system';
+import { PersesChartsTheme, useChartsTheme } from '@perses-dev/components';
 import { MarkdownPanelOptions } from './markdown-panel-model';
 
 export type MarkdownPanelProps = PanelProps<MarkdownPanelOptions>;
 
-function createMarkdownPanelStyles(theme: Theme) {
+function createMarkdownPanelStyles(theme: Theme, chartsTheme: PersesChartsTheme) {
   return {
-    padding: theme.spacing(1.5),
+    padding: `${chartsTheme.container.padding.default}px`,
     // Make the content scrollable
     height: '100%',
     overflowY: 'auto',
@@ -78,9 +79,15 @@ export function MarkdownPanel(props: MarkdownPanelProps) {
   const {
     spec: { text },
   } = props;
+  const chartsTheme = useChartsTheme();
 
   const html = useMemo(() => markdownToHTML(text), [text]);
   const sanitizedHTML = useMemo(() => sanitizeHTML(html), [html]);
 
-  return <Box sx={createMarkdownPanelStyles} dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />;
+  return (
+    <Box
+      sx={(theme) => createMarkdownPanelStyles(theme, chartsTheme)}
+      dangerouslySetInnerHTML={{ __html: sanitizedHTML }}
+    />
+  );
 }

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -22,6 +22,7 @@ export type MarkdownPanelProps = PanelProps<MarkdownPanelOptions>;
 
 function createMarkdownPanelStyles(theme: Theme) {
   return {
+    padding: theme.spacing(1.5),
     // Make the content scrollable
     height: '100%',
     overflowY: 'auto',

--- a/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
+++ b/ui/panels-plugin/src/plugins/markdown/MarkdownPanel.tsx
@@ -27,7 +27,7 @@ function createMarkdownPanelStyles(theme: Theme, chartsTheme: PersesChartsTheme)
     // Make the content scrollable
     height: '100%',
     overflowY: 'auto',
-    // Ignore top margin on the first element (TODO: Remove when we can set padding for each panel type)
+    // Ignore top margin on the first element.
     '& :first-child': {
       marginTop: 0,
     },

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -16,7 +16,7 @@ import { merge } from 'lodash-es';
 import { useDeepMemo } from '@perses-dev/core';
 import { PanelProps, useTimeSeriesQueries, useTimeRange } from '@perses-dev/plugin-system';
 import type { GridComponentOption } from 'echarts';
-import { Box, Skeleton, useTheme } from '@mui/material';
+import { Box, Skeleton } from '@mui/material';
 import {
   DEFAULT_LEGEND,
   EChartsDataFormat,
@@ -25,6 +25,7 @@ import {
   LineChart,
   YAxisLabel,
   ZoomEventData,
+  useChartsTheme,
 } from '@perses-dev/components';
 import { useSuggestedStepMs } from '../../model/time';
 import { StepOptions, ThresholdColors, ThresholdColorsPalette } from '../../model/thresholds';
@@ -46,12 +47,12 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     spec: { queries, thresholds, y_axis },
     contentDimensions,
   } = props;
-  const theme = useTheme();
+  const chartsTheme = useChartsTheme();
 
   // TODO: consider refactoring how the layout/spacing/alignment are calculated
   // the next time significant changes are made the the time series panel (e.g.
   // when making improvements to the legend to more closely match designs).
-  const contentPadding = parseInt(theme.spacing(1.5), 10);
+  const contentPadding = chartsTheme.container.padding.default;
   const adjustedContentDimensions: typeof contentDimensions = contentDimensions
     ? {
         width: contentDimensions.width - contentPadding * 2,
@@ -238,7 +239,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   };
 
   return (
-    <Box sx={{ padding: (theme) => theme.spacing(1.5), position: 'relative' }}>
+    <Box sx={{ padding: `${contentPadding}px`, position: 'relative' }}>
       {y_axis && y_axis.show && y_axis.label && (
         <YAxisLabel name={y_axis.label} height={adjustedContentDimensions.height} />
       )}

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -50,7 +50,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   const chartsTheme = useChartsTheme();
 
   // TODO: consider refactoring how the layout/spacing/alignment are calculated
-  // the next time significant changes are made the the time series panel (e.g.
+  // the next time significant changes are made to the time series panel (e.g.
   // when making improvements to the legend to more closely match designs).
   const contentPadding = chartsTheme.container.padding.default;
   const adjustedContentDimensions: typeof contentDimensions = contentDimensions

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -52,6 +52,8 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   // TODO: consider refactoring how the layout/spacing/alignment are calculated
   // the next time significant changes are made to the time series panel (e.g.
   // when making improvements to the legend to more closely match designs).
+  // This may also want to include moving some of this logic down to the shared,
+  // embeddable components.
   const contentPadding = chartsTheme.container.padding.default;
   const adjustedContentDimensions: typeof contentDimensions = contentDimensions
     ? {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -48,6 +48,9 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   } = props;
   const theme = useTheme();
 
+  // TODO: consider refactoring how the layout/spacing/alignment are calculated
+  // the next time significant changes are made the the time series panel (e.g.
+  // when making improvements to the legend to more closely match designs).
   const contentPadding = parseInt(theme.spacing(1.5), 10);
   const adjustedContentDimensions: typeof contentDimensions = contentDimensions
     ? {


### PR DESCRIPTION
Previously, the panel content always added padding. This would lead to some annoying workarounds in plugins where the visualization wanted to have less or no padding.

After this fix, the panel content adds no padding and any spacing needs have moved down into the individual plugins.

This commit also adjusts some minor spacing and alignment issues in the plugins.

BREAKINGCHANGE: Panel plugins external to the perses repository can no longer depend on the container providing padding and will likely need to make some styling adjustments after this change.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# Screenshots

Click the "details" link for happo in the status checks to see our visual tests in action! Note that there are some issues related to font loading that are being addressed in https://github.com/perses/perses/pull/943.
<img width="846" alt="image" src="https://user-images.githubusercontent.com/396962/215225274-8794a4a0-35f7-4061-be59-9f53de15af78.png">


## Time series chart panel

Should look and behave identically to before.

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="638" alt="image" src="https://user-images.githubusercontent.com/396962/215222777-8afd9126-b66f-4e44-9daf-7487eed0ca11.png">
</td>
		<td>
<img width="638" alt="image" src="https://user-images.githubusercontent.com/396962/215222795-5b3679f0-f36f-43cd-97f1-c7913afd5db2.png">
</td>
	</tr>
</table>

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="643" alt="image" src="https://user-images.githubusercontent.com/396962/215225679-192092f8-c6dd-4a3f-94b7-5f81e4fb712e.png">
</td>
		<td>
<img width="643" alt="image" src="https://user-images.githubusercontent.com/396962/215225693-4813691f-e6c9-46a6-ae7c-0a8e73904fa6.png">
</td>
	</tr>
</table>

## Gauge chart panel

I left off the padding in the gauge chart and rely on the underlying padding in stack. This is mostly noticeable in the "multiple gauges" because the single gauge is center aligned.

### Single gauge

While in here, I made some adjustments to the use case with a single gauge to center it, which looked nicer in that use case (to my eyes, anyways -- let me know if you think it was better the other way).

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="426" alt="image" src="https://user-images.githubusercontent.com/396962/215223055-fb8ff91c-0ac3-489e-b531-01a7b63560cf.png">
</td>
		<td>
<img width="426" alt="image" src="https://user-images.githubusercontent.com/396962/215223069-8aa3812d-a204-4d6f-a55f-40d0ff603bfa.png">
</td>
	</tr>
</table>

### Multiple gauges

Note a slight spacing difference here based on the adjustments to padding.

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/396962/215223874-6d14ab45-6594-4fd9-bbbc-913c94362d1b.png">
</td>
		<td>
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/396962/215223884-ada5b5c4-4d38-4636-810e-ed1ce4caa9e5.png">
</td>
	</tr>
</table>

## Start chart panel

Note that the stat chart is a teeny bit lower than previously. This is intentional to avoid the chart potentially overlapping with the text value above when refactoring some of the styling.

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="853" alt="image" src="https://user-images.githubusercontent.com/396962/215222916-467b25b1-3fd0-412f-8ff3-943a3431732f.png">
</td>
		<td>
<img width="853" alt="image" src="https://user-images.githubusercontent.com/396962/215222902-ea7e5d83-739d-47ae-8d5a-65f9f961ed53.png">
</td>
	</tr>
</table>

## Markdown panel

Should look and behave identically to before. 

Note that the diffs for markdown in the happo output are the result of a font loading issue that is being resolved in https://github.com/perses/perses/pull/943.

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/396962/215224310-619e0fee-b44c-4512-9be6-1eeb3044c599.png">
</td>
		<td>
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/396962/215224322-d3bbde0f-5fad-4bfc-b827-169b8cec71c5.png">
</td>
	</tr>
</table>


