### PR TITLE
[IGNORE] Short-term fix for visual test fonts

### DIFF
--- a/ui/e2e/package.json
+++ b/ui/e2e/package.json
@@ -9,7 +9,7 @@
     "e2e:debug": "npm run e2e:local -- --debug",
     "e2e:report": "playwright show-report",
     "e2e:watch": "chokidar src/tests/**/**.ts -c 'playwright test {path}'",
-    "e2e:ci": "npx happo-e2e -- playwright test --config=src/config/ci.playwright.config.ts",
+    "e2e:ci": "HAPPO_DOWNLOAD_ALL=true npx happo-e2e -- playwright test --config=src/config/ci.playwright.config.ts",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "npm run lint -- --fix"
   },


### PR DESCRIPTION
Prior to this fix, the visual tests were not using the correct font because the happo asset uploader only caught relative asset links and our fonts use a full link including localhost.

The addition of the `HAPPO_DOWNLOAD_ALL=true` env var forces the happo asset uploader to grab all assets, which will grab the fonts. This is the easiest short-term fix. Their support team will take a look at adjusting the script to support non-relative asset links with localhost in them, and we can hopefully pull down and get a fix in the near future. We have very few external assets, so the side effects of using this env var should be minimal even if we need it for a longer period of time.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
