### PR TITLE
[BUGFIX] round small decimal values when abbreviate is set

### DIFF
--- a/ui/components/src/model/units/decimal.ts
+++ b/ui/components/src/model/units/decimal.ts
@@ -36,7 +36,7 @@ export const DECIMAL_UNIT_CONFIG: Readonly<Record<DecimalUnitKind, UnitConfig>> 
 export function formatDecimal(value: number, unitOptions: DecimalUnitOptions): string {
   const decimals = unitOptions.decimal_places ?? DEFAULT_DECIMAL_PLACES;
 
-  if (unitOptions.abbreviate === true) {
+  if (unitOptions.abbreviate === true && value >= 1000) {
     return abbreviateLargeNumber(value, decimals);
   }
 

--- a/ui/components/src/model/units/decimal.ts
+++ b/ui/components/src/model/units/decimal.ts
@@ -36,7 +36,11 @@ export const DECIMAL_UNIT_CONFIG: Readonly<Record<DecimalUnitKind, UnitConfig>> 
 export function formatDecimal(value: number, unitOptions: DecimalUnitOptions): string {
   const decimals = unitOptions.decimal_places ?? DEFAULT_DECIMAL_PLACES;
 
-  if (unitOptions.abbreviate === true && value >= 1000) {
+  if (value === 0) {
+    return value.toString();
+  }
+
+  if (unitOptions.abbreviate && value >= 1000) {
     return abbreviateLargeNumber(value, decimals);
   }
 

--- a/ui/components/src/model/units/units.test.ts
+++ b/ui/components/src/model/units/units.test.ts
@@ -32,6 +32,26 @@ describe('formatValue', () => {
       expected: '155,900.0000',
     },
     {
+      value: 1000,
+      unit: { kind: 'Decimal', decimal_places: 2, abbreviate: true },
+      expected: '1K',
+    },
+    {
+      value: 1590.878787,
+      unit: { kind: 'Decimal', decimal_places: 3, abbreviate: true },
+      expected: '1.591K',
+    },
+    {
+      value: 0.123456789,
+      unit: { kind: 'Decimal', decimal_places: 2, abbreviate: true },
+      expected: '0.12',
+    },
+    {
+      value: 0.123456789,
+      unit: { kind: 'Decimal', decimal_places: 4, abbreviate: false },
+      expected: '0.1235',
+    },
+    {
       value: 10,
       unit: { kind: 'Percent' },
       expected: '10.00%',

--- a/ui/components/src/model/units/units.test.ts
+++ b/ui/components/src/model/units/units.test.ts
@@ -52,6 +52,16 @@ describe('formatValue', () => {
       expected: '0.1235',
     },
     {
+      value: -0.123456789,
+      unit: { kind: 'Decimal', decimal_places: 3, abbreviate: true },
+      expected: '-0.123',
+    },
+    {
+      value: 0,
+      unit: { kind: 'Decimal', decimal_places: 2, abbreviate: true },
+      expected: '0',
+    },
+    {
       value: 10,
       unit: { kind: 'Percent' },
       expected: '10.00%',


### PR DESCRIPTION
## Overview

In certain cases, when a custom unit such as `"unit": { "kind": "Decimal", "decimal_places": 2, "abbreviate": true }` is used, the value is not rounded. This is most noticeable for smaller values in the tooltip. Now the abbreviateLargeNumber function is only called when a value is 1000 or greater, otherwise decimalFormatter.format is called like normal.

## Before Screenshot
![tooltip_rounding_bug_before](https://user-images.githubusercontent.com/9369625/215516975-2765858e-fb4a-462f-9824-1c1c94472733.png)

## After Screenshot
![tooltip_rounding_bug_after_fixed](https://user-images.githubusercontent.com/9369625/215521627-a649767a-cfe3-4afc-93fa-558c7e4c8b0f.png)

<!--![tooltip_rounding_bug_after](https://user-images.githubusercontent.com/9369625/215517004-47a71ad3-15d5-400b-b520-dd98ab165492.png)-->


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
