### PR TITLE
[FEATURE] Generic Dialog Components

### DIFF
--- a/ui/components/src/Dialog/Dialog.tsx
+++ b/ui/components/src/Dialog/Dialog.tsx
@@ -14,13 +14,16 @@
 import React from 'react';
 import {
   Button,
+  ButtonProps,
   Dialog as MuiDialog,
   DialogActions,
   DialogContent,
   DialogContentProps as MuiDialogContentProps,
+  DialogProps,
   DialogTitle,
   DialogTitleProps,
   IconButton,
+  Theme,
 } from '@mui/material';
 import CloseIcon from 'mdi-material-ui/Close';
 import { combineSx } from '../utils';
@@ -32,7 +35,7 @@ export interface DialogHeaderProps extends DialogTitleProps {
   onClose?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
-export interface DialogButtonProps {
+export interface DialogButtonProps extends Omit<ButtonProps, 'variant' | 'color'> {
   children: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   /**
@@ -54,15 +57,7 @@ const Header = ({ children, onClose, ...props }: DialogHeaderProps) => {
     <>
       <DialogTitle {...props}>{children}</DialogTitle>
       {onClose && (
-        <IconButton
-          aria-label="Close"
-          onClick={onClose}
-          sx={(theme) => ({
-            position: 'absolute',
-            top: theme.spacing(0.5),
-            right: theme.spacing(0.5),
-          })}
-        >
+        <IconButton aria-label="Close" onClick={onClose} sx={dialogCloseIconButtonStyle}>
           <CloseIcon />
         </IconButton>
       )}
@@ -76,23 +71,30 @@ const Content = ({ children, width = 500, sx, ...props }: DialogContentProps) =>
   </DialogContent>
 );
 
-const PrimaryButton = ({ children, form, onClick }: DialogButtonProps) => (
-  <Button variant="contained" type="submit" form={form} onClick={onClick}>
+const PrimaryButton = ({ children, form, onClick, ...props }: DialogButtonProps) => (
+  <Button variant="contained" type="submit" form={form} onClick={onClick} {...props}>
     {children}
   </Button>
 );
 
-const SecondaryButton = ({ children, onClick }: DialogButtonProps) => (
-  <Button variant="outlined" color="secondary" onClick={onClick}>
+const SecondaryButton = ({ children, onClick, ...props }: DialogButtonProps) => (
+  <Button variant="outlined" color="secondary" onClick={onClick} {...props}>
     {children}
   </Button>
 );
 
-export const Dialog = {
-  Dialog: MuiDialog,
-  Header,
-  Content,
-  PrimaryButton,
-  SecondaryButton,
-  Actions: DialogActions,
+/**
+ * Render the CSS of the dialog's close button, according to the given material theme.
+ * @param theme material theme
+ */
+const dialogCloseIconButtonStyle = (theme: Theme) => {
+  return { position: 'absolute', top: theme.spacing(0.5), right: theme.spacing(0.5) };
 };
+
+export const Dialog = ({ children, ...props }: DialogProps) => <MuiDialog {...props}>{children}</MuiDialog>;
+
+Dialog.Header = Header;
+Dialog.Content = Content;
+Dialog.PrimaryButton = PrimaryButton;
+Dialog.SecondaryButton = SecondaryButton;
+Dialog.Actions = DialogActions;

--- a/ui/components/src/Dialog/Dialog.tsx
+++ b/ui/components/src/Dialog/Dialog.tsx
@@ -26,6 +26,9 @@ import CloseIcon from 'mdi-material-ui/Close';
 import { combineSx } from '../utils';
 
 export interface DialogHeaderProps extends DialogTitleProps {
+  /**
+   * Callback fired when close button is clicked. If undefined, close button will not appear in header.
+   */
   onClose?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -40,6 +43,9 @@ export interface DialogButtonProps {
 }
 
 export interface DialogContentProps extends MuiDialogContentProps {
+  /**
+   * @default 500
+   */
   width?: number;
 }
 

--- a/ui/components/src/Dialog/Dialog.tsx
+++ b/ui/components/src/Dialog/Dialog.tsx
@@ -1,0 +1,92 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import {
+  Button,
+  Dialog as MuiDialog,
+  DialogActions,
+  DialogContent,
+  DialogContentProps as MuiDialogContentProps,
+  DialogTitle,
+  DialogTitleProps,
+  IconButton,
+} from '@mui/material';
+import CloseIcon from 'mdi-material-ui/Close';
+import { combineSx } from '../utils';
+
+export interface DialogHeaderProps extends DialogTitleProps {
+  onClose?: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+export interface DialogButtonProps {
+  children: React.ReactNode;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  /**
+   * This specifies the form the button belongs to.
+   * The value of this prop must be equal to the id attribute of a form element.
+   */
+  form?: string;
+}
+
+export interface DialogContentProps extends MuiDialogContentProps {
+  width?: number;
+}
+
+const Header = ({ children, onClose, ...props }: DialogHeaderProps) => {
+  return (
+    <>
+      <DialogTitle {...props}>{children}</DialogTitle>
+      {onClose && (
+        <IconButton
+          aria-label="Close"
+          onClick={onClose}
+          sx={(theme) => ({
+            position: 'absolute',
+            top: theme.spacing(0.5),
+            right: theme.spacing(0.5),
+          })}
+        >
+          <CloseIcon />
+        </IconButton>
+      )}
+    </>
+  );
+};
+
+const Content = ({ children, width = 500, sx, ...props }: DialogContentProps) => (
+  <DialogContent dividers {...props} sx={combineSx({ width: `${width}px` }, sx)}>
+    {children}
+  </DialogContent>
+);
+
+const PrimaryButton = ({ children, form, onClick }: DialogButtonProps) => (
+  <Button variant="contained" type="submit" form={form} onClick={onClick}>
+    {children}
+  </Button>
+);
+
+const SecondaryButton = ({ children, onClick }: DialogButtonProps) => (
+  <Button variant="outlined" color="secondary" onClick={onClick}>
+    {children}
+  </Button>
+);
+
+export const Dialog = {
+  Dialog: MuiDialog,
+  Header,
+  Content,
+  PrimaryButton,
+  SecondaryButton,
+  Actions: DialogActions,
+};

--- a/ui/components/src/Dialog/Dialog.tsx
+++ b/ui/components/src/Dialog/Dialog.tsx
@@ -35,15 +35,7 @@ export interface DialogHeaderProps extends DialogTitleProps {
   onClose?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
-export interface DialogButtonProps extends Omit<ButtonProps, 'variant' | 'color'> {
-  children: React.ReactNode;
-  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
-  /**
-   * This specifies the form the button belongs to.
-   * The value of this prop must be equal to the id attribute of a form element.
-   */
-  form?: string;
-}
+export type DialogButtonProps = Omit<ButtonProps, 'variant' | 'color' | 'type'>;
 
 export interface DialogContentProps extends MuiDialogContentProps {
   /**
@@ -71,14 +63,14 @@ const Content = ({ children, width = 500, sx, ...props }: DialogContentProps) =>
   </DialogContent>
 );
 
-const PrimaryButton = ({ children, form, onClick, ...props }: DialogButtonProps) => (
-  <Button variant="contained" type="submit" form={form} onClick={onClick} {...props}>
+const PrimaryButton = ({ children, ...props }: DialogButtonProps) => (
+  <Button variant="contained" type="submit" {...props}>
     {children}
   </Button>
 );
 
-const SecondaryButton = ({ children, onClick, ...props }: DialogButtonProps) => (
-  <Button variant="outlined" color="secondary" onClick={onClick} {...props}>
+const SecondaryButton = ({ children, ...props }: DialogButtonProps) => (
+  <Button variant="outlined" color="secondary" {...props}>
     {children}
   </Button>
 );

--- a/ui/components/src/Dialog/index.tsx
+++ b/ui/components/src/Dialog/index.tsx
@@ -1,0 +1,14 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './Dialog';

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 export * from './DateTimeRangePicker';
+export * from './Dialog';
 export * from './Drawer';
 export * from './EChart';
 export * from './ErrorAlert';

--- a/ui/dashboards/src/components/DeletePanelDialog/DeletePanelDialog.tsx
+++ b/ui/dashboards/src/components/DeletePanelDialog/DeletePanelDialog.tsx
@@ -12,29 +12,17 @@
 // limitations under the License.
 
 import { FormEvent } from 'react';
-import { IconButton, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
-import CloseIcon from 'mdi-material-ui/Close';
+import { Dialog } from '@perses-dev/components';
 import { useDeletePanelDialog, DeletePanelDialogState } from '../../context';
 
 export const DeletePanelDialog = () => {
   const { deletePanelDialog, closeDeletePanelDialog } = useDeletePanelDialog();
 
   return (
-    <Dialog open={deletePanelDialog !== undefined}>
-      <DialogTitle>Delete Panel</DialogTitle>
-      <IconButton
-        aria-label="Close"
-        onClick={() => closeDeletePanelDialog()}
-        sx={(theme) => ({
-          position: 'absolute',
-          top: theme.spacing(0.5),
-          right: theme.spacing(0.5),
-        })}
-      >
-        <CloseIcon />
-      </IconButton>
+    <Dialog.Dialog open={deletePanelDialog !== undefined}>
+      <Dialog.Header onClose={() => closeDeletePanelDialog()}>Delete Panel</Dialog.Header>
       {deletePanelDialog && <DeletePanelForm deletePanelDialog={deletePanelDialog} />}
-    </Dialog>
+    </Dialog.Dialog>
   );
 };
 
@@ -53,18 +41,14 @@ const DeletePanelForm = ({ deletePanelDialog }: DeletePanelFormProps) => {
   };
   return (
     <form onSubmit={handleDelete}>
-      <DialogContent dividers sx={{ width: '500px' }}>
+      <Dialog.Content>
         Are you sure you want to delete {deletePanelDialog.panelName} from {deletePanelDialog.panelGroupName}? This
         action cannot be undone.
-      </DialogContent>
-      <DialogActions>
-        <Button variant="contained" type="submit">
-          Delete
-        </Button>
-        <Button variant="outlined" color="secondary" onClick={() => closeDeletePanelDialog()}>
-          Cancel
-        </Button>
-      </DialogActions>
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Dialog.PrimaryButton>Delete</Dialog.PrimaryButton>
+        <Dialog.SecondaryButton onClick={() => closeDeletePanelDialog()}>Cancel</Dialog.SecondaryButton>
+      </Dialog.Actions>
     </form>
   );
 };

--- a/ui/dashboards/src/components/DeletePanelDialog/DeletePanelDialog.tsx
+++ b/ui/dashboards/src/components/DeletePanelDialog/DeletePanelDialog.tsx
@@ -19,10 +19,10 @@ export const DeletePanelDialog = () => {
   const { deletePanelDialog, closeDeletePanelDialog } = useDeletePanelDialog();
 
   return (
-    <Dialog.Dialog open={deletePanelDialog !== undefined}>
+    <Dialog open={deletePanelDialog !== undefined}>
       <Dialog.Header onClose={() => closeDeletePanelDialog()}>Delete Panel</Dialog.Header>
       {deletePanelDialog && <DeletePanelForm deletePanelDialog={deletePanelDialog} />}
-    </Dialog.Dialog>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
https://github.com/perses/perses/discussions/935

Based on the discussion, we want generic dialog components that include common UX patterns:

1. Close icon button at the top right corner
2. Dividers for dialog content
3. For dialog actions, we always want primary button with contained variant on the left and secondary button (usually Cancel) with outlined variant on the right