### PR TITLE
[IGNORE] Wait for stable canvas in tests

### DIFF
--- a/ui/e2e/src/tests/statChartPanel.spec.ts
+++ b/ui/e2e/src/tests/statChartPanel.spec.ts
@@ -13,7 +13,7 @@
 
 import happoPlaywright from 'happo-playwright';
 import { test } from '../fixtures/dashboardTest';
-import { mockTimeSeriesResponseWithStableValue } from '../utils';
+import { mockTimeSeriesResponseWithStableValue, waitForStableCanvas } from '../utils';
 
 test.use({
   dashboardName: 'StatChartPanel',
@@ -61,6 +61,7 @@ test.describe('Dashboard: Stat Chart Panel', () => {
     await dashboardPage.forEachTheme(async (themeName) => {
       const panel = dashboardPage.getPanel('Simple Stat');
       await panel.isLoaded();
+      await waitForStableCanvas(panel.canvas);
 
       await happoPlaywright.screenshot(page, panel.parent, {
         component: 'Stat Chart Panel',

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -13,7 +13,7 @@
 
 import happoPlaywright from 'happo-playwright';
 import { test } from '../fixtures/dashboardTest';
-import { mockTimeSeriesResponseWithStableValue } from '../utils';
+import { mockTimeSeriesResponseWithStableValue, waitForStableCanvas } from '../utils';
 
 test.use({
   dashboardName: 'TimeSeriesChartPanel',
@@ -61,6 +61,7 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
     await dashboardPage.forEachTheme(async (themeName) => {
       const panel = dashboardPage.getPanel('Single Line');
       await panel.isLoaded();
+      await waitForStableCanvas(panel.canvas);
 
       await happoPlaywright.screenshot(page, panel.parent, {
         component: 'Time Series Chart Panel',


### PR DESCRIPTION
Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

Occasionally noticing some flakiness with the loading state around echarts-based visual tests. Adding the wait for a stable canvas to all of them to see if that helps.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
