### PR TITLE
[BUGFIX] time series migration add unit inside y_axis

### DIFF
--- a/schemas/panels/time-series/mig.cuepart
+++ b/schemas/panels/time-series/mig.cuepart
@@ -26,8 +26,10 @@ if #panel.type == "timeseries" || #panel.type == "graph" {
         }
         #unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
         if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
-            unit: {
-                kind: #mapping.unit[#unitPath]
+            y_axis: {
+                unit: {
+                  kind: #mapping.unit[#unitPath]
+                }
             }
         }
         if #panel.fieldConfig.defaults.thresholds != _|_ {


### PR DESCRIPTION
Follow up to unit breaking changes in #920. This PR fixes TimeSeriesChart migration by updating mig.cuepart file so unit is added inside `y_axis`. Now importing migrated dashboard into a project does not throw errors.

## Screenshot

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/9369625/216998172-ebfd4082-0512-4fc8-a00e-e297bda35d75.png">


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
