### PR TITLE
[ENHANCEMENT] Modify placement of duplicate panels

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -2086,5 +2086,511 @@
         }
       ]
     }
+  },
+  {
+    "kind": "Dashboard",
+    "metadata": {
+      "name": "DuplicatePanels",
+      "created_at": "2022-12-21T00:00:00Z",
+      "updated_at": "2023-02-07T00:28:57.658905Z",
+      "version": 14,
+      "project": "testing"
+    },
+    "spec": {
+      "duration": "6h",
+      "panels": {
+        "markdownEx": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "panel being duplicated",
+              "description": "This panel will be duplicated"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## Duplicate me"
+              }
+            }
+          }
+        },
+        "markdownEx-1": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "panel being duplicated",
+              "description": "This panel will be duplicated"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## Duplicate me"
+              }
+            }
+          }
+        },
+        "markdownEx-10": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 8"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 8"
+              }
+            }
+          }
+        },
+        "markdownEx-11": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "panel being duplicated",
+              "description": "This panel will be duplicated"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## Duplicate me"
+              }
+            }
+          }
+        },
+        "markdownEx-12": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "panel being duplicated",
+              "description": "This panel will be duplicated"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## Duplicate me"
+              }
+            }
+          }
+        },
+        "markdownEx-13": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "panel being duplicated",
+              "description": "This panel will be duplicated"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## Duplicate me"
+              }
+            }
+          }
+        },
+        "markdownEx-14": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 1"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 1"
+              }
+            }
+          }
+        },
+        "markdownEx-15": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "panel being duplicated",
+              "description": "This panel will be duplicated"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## Duplicate me"
+              }
+            }
+          }
+        },
+        "markdownEx-16": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 1"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 1"
+              }
+            }
+          }
+        },
+        "markdownEx-2": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 1"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 1"
+              }
+            }
+          }
+        },
+        "markdownEx-3": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 2"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 2"
+              }
+            }
+          }
+        },
+        "markdownEx-4": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 3"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 3"
+              }
+            }
+          }
+        },
+        "markdownEx-5": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 4"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 4"
+              }
+            }
+          }
+        },
+        "markdownEx-6": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 5"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 5"
+              }
+            }
+          }
+        },
+        "markdownEx-7": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 6"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 6"
+              }
+            }
+          }
+        },
+        "markdownEx-8": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "other panel 7"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## another panel 7"
+              }
+            }
+          }
+        },
+        "markdownEx-9": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "panel being duplicated",
+              "description": "This panel will be duplicated"
+            },
+            "plugin": {
+              "kind": "Markdown",
+              "spec": {
+                "text": "## Duplicate me"
+              }
+            }
+          }
+        }
+      },
+      "layouts": [
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "single panel with space to right",
+              "collapse": {
+                "open": false
+              }
+            },
+            "items": [
+              {
+                "x": 0,
+                "y": 0,
+                "width": 6,
+                "height": 4,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "single panel with space to left",
+              "collapse": {
+                "open": false
+              }
+            },
+            "items": [
+              {
+                "x": 18,
+                "y": 0,
+                "width": 6,
+                "height": 4,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-11"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "single panel with space on both sides",
+              "collapse": {
+                "open": false
+              }
+            },
+            "items": [
+              {
+                "x": 8,
+                "y": 0,
+                "width": 7,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-12"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "single panel without space on same line",
+              "collapse": {
+                "open": false
+              }
+            },
+            "items": [
+              {
+                "x": 4,
+                "y": 0,
+                "width": 14,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-9"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "multiple panels with space next to original",
+              "collapse": {
+                "open": false
+              }
+            },
+            "items": [
+              {
+                "x": 0,
+                "y": 0,
+                "width": 7,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-13"
+                }
+              },
+              {
+                "x": 15,
+                "y": 0,
+                "width": 6,
+                "height": 6,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-14"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "multiple panels with space not next to original",
+              "collapse": {
+                "open": false
+              }
+            },
+            "items": [
+              {
+                "x": 0,
+                "y": 0,
+                "width": 7,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-15"
+                }
+              },
+              {
+                "x": 7,
+                "y": 0,
+                "width": 6,
+                "height": 6,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-16"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "multiple panels w/o space & more panels below",
+              "collapse": {
+                "open": false
+              }
+            },
+            "items": [
+              {
+                "x": 18,
+                "y": 0,
+                "width": 6,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-4"
+                }
+              },
+              {
+                "x": 6,
+                "y": 0,
+                "width": 6,
+                "height": 6,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-1"
+                }
+              },
+              {
+                "x": 0,
+                "y": 0,
+                "width": 6,
+                "height": 6,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-2"
+                }
+              },
+              {
+                "x": 12,
+                "y": 0,
+                "width": 6,
+                "height": 6,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-3"
+                }
+              },
+              {
+                "x": 18,
+                "y": 5,
+                "width": 3,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-8"
+                }
+              },
+              {
+                "x": 21,
+                "y": 5,
+                "width": 3,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-10"
+                }
+              },
+              {
+                "x": 0,
+                "y": 6,
+                "width": 7,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-5"
+                }
+              },
+              {
+                "x": 7,
+                "y": 6,
+                "width": 4,
+                "height": 6,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-6"
+                }
+              },
+              {
+                "x": 11,
+                "y": 6,
+                "width": 7,
+                "height": 5,
+                "content": {
+                  "$ref": "#/spec/panels/markdownEx-7"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/ui/app/src/components/Footer.tsx
+++ b/ui/app/src/components/Footer.tsx
@@ -35,7 +35,7 @@ export default function Footer(): JSX.Element {
             <Github sx={{ verticalAlign: 'bottom' }} />
           </a>
         </li>
-        <li>
+        <li data-happo-hide>
           {isLoading ? (
             <CircularProgress size="1rem" />
           ) : data !== undefined && data.version !== '' ? (

--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -15,6 +15,7 @@ import { Responsive, WidthProvider, Layouts, Layout } from 'react-grid-layout';
 import { Collapse, useTheme } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { useEditMode, usePanelGroup, usePanelGroupActions, PanelGroupId } from '../../context';
+import { GRID_LAYOUT_COLS, GRID_LAYOUT_SMALL_BREAKPOINT } from '../../constants';
 import { GridTitle } from './GridTitle';
 import { GridItemContent } from './GridItemContent';
 import { GridContainer } from './GridContainer';
@@ -24,8 +25,6 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
 export interface GridLayoutProps {
   panelGroupId: PanelGroupId;
 }
-
-const SMALL_LAYOUT_BREAKPOINT = 'sm' as const;
 
 /**
  * Layout component that arranges children in a Grid based on the definition.
@@ -44,7 +43,7 @@ export function GridLayout(props: GridLayoutProps) {
     // a bug in react-layout-grid where `currentLayout` does not adjust properly
     // when going to a smaller breakpoint and then back to a larger breakpoint.
     // https://github.com/react-grid-layout/react-grid-layout/issues/1663
-    const smallLayout = allLayouts[SMALL_LAYOUT_BREAKPOINT];
+    const smallLayout = allLayouts[GRID_LAYOUT_SMALL_BREAKPOINT];
     if (smallLayout) {
       updatePanelGroupLayouts(smallLayout);
     }
@@ -67,14 +66,14 @@ export function GridLayout(props: GridLayoutProps) {
         <ResponsiveGridLayout
           className="layout"
           breakpoints={{ sm: theme.breakpoints.values.sm, xxs: 0 }}
-          cols={{ sm: 24, xxs: 2 }}
+          cols={GRID_LAYOUT_COLS}
           rowHeight={30}
           draggableHandle={'.drag-handle'}
           resizeHandles={['se']}
           isDraggable={isEditMode}
           isResizable={isEditMode}
           containerPadding={[0, 10]}
-          layouts={{ [SMALL_LAYOUT_BREAKPOINT]: groupDefinition.itemLayouts }}
+          layouts={{ [GRID_LAYOUT_SMALL_BREAKPOINT]: groupDefinition.itemLayouts }}
           onLayoutChange={handleLayoutChange}
         >
           {groupDefinition.itemLayouts.map(({ i }) => (

--- a/ui/dashboards/src/constants/grid-layout-config.ts
+++ b/ui/dashboards/src/constants/grid-layout-config.ts
@@ -11,16 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './dashboard-provider-api';
-export * from './DashboardProvider';
-export type {
-  PanelGroupId,
-  PanelGroupDefinition,
-  PanelGroupItemId,
-  PanelGroupItemLayoutId as PanelGroupLayoutId,
-  PanelGroupItemLayout,
-} from './panel-group-slice';
-export type { PanelGroupEditor, PanelGroupEditorValues } from './panel-group-editor-slice';
-export type { DeletePanelDialogState } from './delete-panel-slice';
-export type { DiscardChangesConfirmationDialogState } from './discard-changes-dialog-slice';
-export type { PanelEditorValues } from './panel-editor-slice';
+export const GRID_LAYOUT_COLS = { sm: 24, xxs: 2 } as const;
+
+export const GRID_LAYOUT_SMALL_BREAKPOINT = 'sm' as const;

--- a/ui/dashboards/src/constants/index.ts
+++ b/ui/dashboards/src/constants/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './user-interface-text';
+export * from './grid-layout-config';

--- a/ui/dashboards/src/constants/index.ts
+++ b/ui/dashboards/src/constants/index.ts
@@ -11,5 +11,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './user-interface-text';
 export * from './grid-layout-config';
+export * from './user-interface-text';

--- a/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 import { StateCreator } from 'zustand';
-import { getYForNewRow, getValidPanelKey } from '../../utils/panelUtils';
+import { getValidPanelKey, insertPanelInLayout, PartialPanelGroupItemLayout } from '../../utils/panelUtils';
 import { generateId, Middleware } from './common';
-import { PanelGroupSlice, PanelGroupItemId, PanelGroupItemLayout } from './panel-group-slice';
+import { PanelGroupSlice, PanelGroupItemId } from './panel-group-slice';
 import { PanelSlice } from './panel-slice';
 
 /**
@@ -72,15 +72,15 @@ export function createDuplicatePanelSlice(): StateCreator<
 
         state.panels[dupePanelKey] = panelToDupe;
 
-        const layout: PanelGroupItemLayout = {
+        const duplicateLayout: PartialPanelGroupItemLayout = {
           i: generateId().toString(),
-          x: 0,
-          y: getYForNewRow(group),
           w: matchingLayout.w,
           h: matchingLayout.h,
         };
-        group.itemLayouts.push(layout);
-        group.itemPanelKeys[layout.i] = dupePanelKey;
+
+        group.itemLayouts = insertPanelInLayout(duplicateLayout, matchingLayout, group.itemLayouts);
+
+        group.itemPanelKeys[duplicateLayout.i] = dupePanelKey;
       });
     },
   });

--- a/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { StateCreator } from 'zustand';
-import { getValidPanelKey, insertPanelInLayout, PartialPanelGroupItemLayout } from '../../utils/panelUtils';
+import { getValidPanelKey, insertPanelInLayout, UnpositionedPanelGroupItemLayout } from '../../utils/panelUtils';
 import { generateId, Middleware } from './common';
 import { PanelGroupSlice, PanelGroupItemId } from './panel-group-slice';
 import { PanelSlice } from './panel-slice';
@@ -72,7 +72,7 @@ export function createDuplicatePanelSlice(): StateCreator<
 
         state.panels[dupePanelKey] = panelToDupe;
 
-        const duplicateLayout: PartialPanelGroupItemLayout = {
+        const duplicateLayout: UnpositionedPanelGroupItemLayout = {
           i: generateId().toString(),
           w: matchingLayout.w,
           h: matchingLayout.h,

--- a/ui/dashboards/src/utils/panelUtils.test.ts
+++ b/ui/dashboards/src/utils/panelUtils.test.ts
@@ -13,12 +13,12 @@
 
 import { PanelDefinition } from '@perses-dev/core';
 import { PanelGroupItemLayout } from '../context';
-import { getValidPanelKey, insertPanelInLayout, PartialPanelGroupItemLayout } from './panelUtils';
+import { getValidPanelKey, insertPanelInLayout, UnpositionedPanelGroupItemLayout } from './panelUtils';
 
 describe('insertPanelInLayout', () => {
   describe('inserts the panel to the right when space is available', () => {
     test('with a single panel in that row', () => {
-      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const newLayout: UnpositionedPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
       const referenceLayout: PanelGroupItemLayout = {
         i: 'one',
         x: 0,
@@ -38,7 +38,7 @@ describe('insertPanelInLayout', () => {
     });
 
     test('with multiple panels in that row with space between them', () => {
-      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const newLayout: UnpositionedPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
       const referenceLayout: PanelGroupItemLayout = {
         i: 'one',
         x: 0,
@@ -69,7 +69,7 @@ describe('insertPanelInLayout', () => {
 
   describe('inserts the panel below when space is not available to the right', () => {
     test('with a single panel in the initial layout', () => {
-      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const newLayout: UnpositionedPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
       const referenceLayout: PanelGroupItemLayout = {
         i: 'one',
         x: 1,
@@ -89,7 +89,7 @@ describe('insertPanelInLayout', () => {
     });
 
     test('with a single panel in the same row and additional panels below', () => {
-      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const newLayout: UnpositionedPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
       const referenceLayout: PanelGroupItemLayout = {
         i: 'one',
         x: 0,

--- a/ui/dashboards/src/utils/panelUtils.test.ts
+++ b/ui/dashboards/src/utils/panelUtils.test.ts
@@ -54,9 +54,8 @@ describe('insertPanelInLayout', () => {
         h: 4,
       };
       const layouts: PanelGroupItemLayout[] = [referenceLayout, otherPanelInRow];
-      const result = insertPanelInLayout(newLayout, referenceLayout, layouts);
 
-      expect(result).toEqual([
+      expect(insertPanelInLayout(newLayout, referenceLayout, layouts)).toEqual([
         referenceLayout,
         {
           x: 3,

--- a/ui/dashboards/src/utils/panelUtils.test.ts
+++ b/ui/dashboards/src/utils/panelUtils.test.ts
@@ -12,7 +12,116 @@
 // limitations under the License.
 
 import { PanelDefinition } from '@perses-dev/core';
-import { getValidPanelKey } from './panelUtils';
+import { PanelGroupItemLayout } from '../context';
+import { getValidPanelKey, insertPanelInLayout, PartialPanelGroupItemLayout } from './panelUtils';
+
+describe('insertPanelInLayout', () => {
+  describe('inserts the panel to the right when space is available', () => {
+    test('with a single panel in that row', () => {
+      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const referenceLayout: PanelGroupItemLayout = {
+        i: 'one',
+        x: 0,
+        y: 0,
+        w: 6,
+        h: 6,
+      };
+      const layouts: PanelGroupItemLayout[] = [referenceLayout];
+      expect(insertPanelInLayout(newLayout, referenceLayout, layouts)).toEqual([
+        referenceLayout,
+        {
+          x: 6,
+          y: 0,
+          ...newLayout,
+        },
+      ]);
+    });
+
+    test('with multiple panels in that row with space between them', () => {
+      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const referenceLayout: PanelGroupItemLayout = {
+        i: 'one',
+        x: 0,
+        y: 0,
+        w: 3,
+        h: 4,
+      };
+      const otherPanelInRow: PanelGroupItemLayout = {
+        i: 'two',
+        x: 20,
+        y: 0,
+        w: 4,
+        h: 4,
+      };
+      const layouts: PanelGroupItemLayout[] = [referenceLayout, otherPanelInRow];
+      const result = insertPanelInLayout(newLayout, referenceLayout, layouts);
+
+      expect(result).toEqual([
+        referenceLayout,
+        {
+          x: 3,
+          y: 0,
+          ...newLayout,
+        },
+        otherPanelInRow,
+      ]);
+    });
+  });
+
+  describe('inserts the panel below when space is not available to the right', () => {
+    test('with a single panel in the initial layout', () => {
+      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const referenceLayout: PanelGroupItemLayout = {
+        i: 'one',
+        x: 1,
+        y: 0,
+        w: 18,
+        h: 4,
+      };
+      const layouts: PanelGroupItemLayout[] = [referenceLayout];
+      expect(insertPanelInLayout(newLayout, referenceLayout, layouts)).toEqual([
+        referenceLayout,
+        {
+          x: 1,
+          y: 4,
+          ...newLayout,
+        },
+      ]);
+    });
+
+    test('with a single panel in the same row and additional panels below', () => {
+      const newLayout: PartialPanelGroupItemLayout = { i: 'abc', w: 10, h: 8 };
+      const referenceLayout: PanelGroupItemLayout = {
+        i: 'one',
+        x: 0,
+        y: 0,
+        w: 18,
+        h: 4,
+      };
+      const nextRowItem: PanelGroupItemLayout = {
+        i: 'two',
+        x: 0,
+        y: 4,
+        w: 6,
+        h: 6,
+      };
+      const layouts: PanelGroupItemLayout[] = [referenceLayout, nextRowItem];
+
+      expect(insertPanelInLayout(newLayout, referenceLayout, layouts)).toEqual([
+        referenceLayout,
+        {
+          x: 0,
+          y: 4,
+          ...newLayout,
+        },
+        {
+          ...nextRowItem,
+          y: nextRowItem.y + newLayout.h,
+        },
+      ]);
+    });
+  });
+});
 
 describe('getValidPanelKey', () => {
   test('removes whitespace', () => {

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -81,12 +81,11 @@ export function insertPanelInLayout(
 
   const referenceBounds = getPanelBounds(referenceLayout);
 
+  // Organize layouts based on vertical relation to the item being inserted
+  // after.
   const aboveInsertRow: PanelGroupItemLayout[] = [];
   const insertRow: PanelGroupItemLayout[] = [];
   const belowInsertRow: PanelGroupItemLayout[] = [];
-
-  // Organize layouts based on vertical relation to the item being inserted
-  // after.
   itemLayouts.forEach((itemLayout) => {
     const itemBounds = getPanelBounds(itemLayout);
 

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -135,7 +135,7 @@ export function insertPanelInLayout(
     }
   }
 
-  // Inserted the new item below the original and shift the items below the
+  // Insert the new item below the original and shift the items below the
   // row where the reference is located.
   return [
     ...aboveInsertRow,

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -55,7 +55,7 @@ function getPanelBounds({ x, y, w, h }: PanelGroupItemLayout): PanelGroupItemBou
   };
 }
 
-export type PartialPanelGroupItemLayout = Omit<PanelGroupItemLayout, 'x' | 'y'>;
+export type UnpositionedPanelGroupItemLayout = Omit<PanelGroupItemLayout, 'x' | 'y'>;
 
 /**
  * Inserts a new panel into the layout with placement determined by a specified
@@ -73,7 +73,7 @@ export type PartialPanelGroupItemLayout = Omit<PanelGroupItemLayout, 'x' | 'y'>;
  * @returns - Item layouts modified to insert the new panel.
  */
 export function insertPanelInLayout(
-  newLayout: PartialPanelGroupItemLayout,
+  newLayout: UnpositionedPanelGroupItemLayout,
   referenceLayout: PanelGroupItemLayout,
   itemLayouts: PanelGroupItemLayout[]
 ): PanelGroupItemLayout[] {

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -119,9 +119,7 @@ export function insertPanelInLayout(
         ...belowInsertRow,
       ];
     }
-  }
-
-  if (insertAfterIndex >= 0) {
+  } else if (insertAfterIndex >= 0) {
     const nextItem = insertRow[insertAfterIndex + 1];
 
     if (nextItem && getPanelBounds(nextItem).x1 - referenceBounds.x2 >= newLayout.w) {

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import { PanelDefinition } from '@perses-dev/core';
-import { PanelGroupDefinition } from '../context';
+import { PanelGroupDefinition, PanelGroupItemLayout } from '../context';
+import { GRID_LAYOUT_SMALL_BREAKPOINT, GRID_LAYOUT_COLS } from '../constants';
 
 // Given a PanelGroup, will find the Y coordinate for adding a new row to the grid, taking into account the items present
 export function getYForNewRow(group: PanelGroupDefinition) {
@@ -24,6 +25,133 @@ export function getYForNewRow(group: PanelGroupDefinition) {
     }
   }
   return newRowY;
+}
+
+type PanelGroupItemBounds = {
+  /**
+   * Left horizontal position.
+   */
+  x1: number;
+  /**
+   * Right horizontal position.
+   */
+  x2: number;
+  /**
+   * Top vertical position.
+   */
+  y1: number;
+  /**
+   * Bottom vertical position
+   */
+  y2: number;
+};
+
+function getPanelBounds({ x, y, w, h }: PanelGroupItemLayout): PanelGroupItemBounds {
+  return {
+    x1: x,
+    x2: x + w,
+    y1: y,
+    y2: y + h,
+  };
+}
+
+export type PartialPanelGroupItemLayout = Omit<PanelGroupItemLayout, 'x' | 'y'>;
+
+/**
+ * Inserts a new panel into the layout with placement determined by a specified
+ * reference panel. The new panel is placed:
+ * - To the right of the reference panel if there is space available without
+ *   moving other panels.
+ * - Otherwise, directly below the reference panel. If other panels are below
+ *   this location, they will also shift downward because the grid uses
+ *   vertical-based compacting.
+ *
+ * @param newLayout - Layout for new panel to insert into the grid.
+ * @param referenceLayout - Layout for reference panel used to determine the
+ *   placement of the new panel.
+ * @param itemLayouts - Full grid layout.
+ * @returns - Item layouts modified to insert the new panel.
+ */
+export function insertPanelInLayout(
+  newLayout: PartialPanelGroupItemLayout,
+  referenceLayout: PanelGroupItemLayout,
+  itemLayouts: PanelGroupItemLayout[]
+): PanelGroupItemLayout[] {
+  const MAX_LAYOUT_WIDTH = GRID_LAYOUT_COLS[GRID_LAYOUT_SMALL_BREAKPOINT];
+
+  const referenceBounds = getPanelBounds(referenceLayout);
+
+  const aboveInsertRow: PanelGroupItemLayout[] = [];
+  const insertRow: PanelGroupItemLayout[] = [];
+  const belowInsertRow: PanelGroupItemLayout[] = [];
+
+  // Organize layouts based on vertical relation to the item being inserted
+  // after.
+  itemLayouts.forEach((itemLayout) => {
+    const itemBounds = getPanelBounds(itemLayout);
+
+    if (itemBounds.y2 <= referenceBounds.y1) {
+      aboveInsertRow.push(itemLayout);
+    } else if (itemBounds.y1 >= referenceBounds.y2) {
+      belowInsertRow.push(itemLayout);
+    } else {
+      insertRow.push(itemLayout);
+    }
+  });
+
+  // Cannot safely assume that the order of item layouts array is strictly
+  // left to right. Sorting the row by horizontal position to more easily find
+  // gaps.
+  insertRow.sort((a, b) => a.x - b.x);
+  const insertAfterIndex = insertRow.findIndex((item) => item.i === referenceLayout.i);
+
+  if (insertAfterIndex === insertRow.length - 1) {
+    // Insert to the right when space is available and the reference is the last
+    // item in the row.
+    if (referenceBounds.x2 + newLayout.w <= MAX_LAYOUT_WIDTH) {
+      return [
+        ...aboveInsertRow,
+        ...insertRow,
+        {
+          ...newLayout,
+          x: referenceBounds.x2,
+          y: referenceBounds.y1,
+        },
+        ...belowInsertRow,
+      ];
+    }
+  }
+
+  if (insertAfterIndex >= 0) {
+    const nextItem = insertRow[insertAfterIndex + 1];
+
+    if (nextItem && getPanelBounds(nextItem).x1 - referenceBounds.x2 >= newLayout.w) {
+      // Insert to the right when space is available between the reference and
+      // the next item in the row.
+      insertRow.splice(insertAfterIndex + 1, 0, {
+        ...newLayout,
+        x: referenceBounds.x2,
+        y: referenceBounds.y1,
+      });
+
+      return [...aboveInsertRow, ...insertRow, ...belowInsertRow];
+    }
+  }
+
+  // Inserted the new item below the original and shift the items below the
+  // row where the reference is located.
+  return [
+    ...aboveInsertRow,
+    ...insertRow,
+    { x: referenceBounds.x1, y: referenceBounds.y2, ...newLayout },
+    ...belowInsertRow.map((itemLayout) => {
+      // Note: the grid will not necessarily display all of these items shifted
+      // all the way down because of vertical compacting, but shifing their
+      // y position ensures the new item gets vertical precedence over items
+      // below it in that compacting.
+      return { ...itemLayout, y: itemLayout.y + newLayout.h };
+    }),
+  ];
 }
 
 /**

--- a/ui/e2e/src/pages/AppHomePage.ts
+++ b/ui/e2e/src/pages/AppHomePage.ts
@@ -52,6 +52,7 @@ export class AppHomePage {
   async clickDashboardItem(dashboardName: string) {
     const dashboardButton = this.page.getByRole('button', {
       name: dashboardName,
+      exact: true,
     });
     await dashboardButton.click();
   }

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -77,9 +77,6 @@ export class DashboardPage {
   readonly panelGroups: Locator;
   readonly panelGroupHeadings: Locator;
 
-  // readonly panels: Locator;
-  // readonly panelHeadings: Locator;
-
   readonly variableList: Locator;
   readonly variableListItems: Locator;
 
@@ -109,9 +106,6 @@ export class DashboardPage {
 
     this.panelGroups = page.getByTestId('panel-group');
     this.panelGroupHeadings = this.panelGroups.getByTestId('panel-group-header').getByRole('heading', { level: 2 });
-
-    // this.panels = page.getByTestId('panel');
-    // this.panelHeadings = this.panels.locator('header').getByRole('heading');
 
     this.variableList = page.getByTestId('variable-list');
     this.variableListItems = this.variableList.getByTestId('template-variable');

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -43,6 +43,8 @@ type PanelNameOrPanel = string | Panel;
 export class DashboardPage {
   readonly page: Page;
 
+  readonly root: Locator;
+
   readonly themeToggle: Locator;
 
   readonly toolbar: Locator;
@@ -69,6 +71,8 @@ export class DashboardPage {
 
   constructor(page: Page) {
     this.page = page;
+
+    this.root = page.locator('#root');
 
     this.themeToggle = page.getByRole('checkbox', { name: 'Theme' });
 

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -37,6 +37,25 @@ type ThemeName = 'light' | 'dark';
 
 type PanelNameOrPanel = string | Panel;
 
+type GetPanelOpts = {
+  /**
+   * Name of the panel.
+   */
+  name?: string;
+
+  /**
+   * The parent to look inside for panels. If not specified, defaults to the
+   * page. Useful for filtering panels down to a specific group.
+   */
+  group?: PanelGroup;
+
+  /**
+   * The index of the panel. Useful for locating panels with names that change
+   * or when multiple panels have the same name.
+   */
+  nth?: number;
+};
+
 /**
  * Perses App dashboard page.
  */
@@ -227,17 +246,38 @@ export class DashboardPage {
       return panelNameOrPanel;
     }
 
-    return this.getPanel(panelNameOrPanel);
+    return this.getPanelByName(panelNameOrPanel);
+  }
+
+  getPanels(group?: PanelGroup) {
+    const parent = group ? group.container : this.page;
+
+    return parent.getByTestId('panel');
+  }
+
+  /**
+   * Get a panel based on specified options.
+   */
+  getPanel({ group, name, nth }: GetPanelOpts = {}): Panel {
+    const panels = this.getPanels(group);
+    const panel = panels.filter({
+      has: name ? this.page.getByRole('heading', { name }) : undefined,
+    });
+    if (nth !== undefined) {
+      return new Panel(panel.nth(nth));
+    }
+
+    return new Panel(panel);
   }
 
   /**
    * Get a panel by name.
    */
-  getPanel(panelName: string): Panel {
-    const container = this.panels.filter({
-      has: this.page.getByRole('heading', { name: panelName }),
+  getPanelByName(panelName: Required<GetPanelOpts['name']>, opts: Omit<GetPanelOpts, 'name'> = {}): Panel {
+    return this.getPanel({
+      name: panelName,
+      ...opts,
     });
-    return new Panel(container);
   }
 
   /**

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -77,8 +77,8 @@ export class DashboardPage {
   readonly panelGroups: Locator;
   readonly panelGroupHeadings: Locator;
 
-  readonly panels: Locator;
-  readonly panelHeadings: Locator;
+  // readonly panels: Locator;
+  // readonly panelHeadings: Locator;
 
   readonly variableList: Locator;
   readonly variableListItems: Locator;
@@ -110,8 +110,8 @@ export class DashboardPage {
     this.panelGroups = page.getByTestId('panel-group');
     this.panelGroupHeadings = this.panelGroups.getByTestId('panel-group-header').getByRole('heading', { level: 2 });
 
-    this.panels = page.getByTestId('panel');
-    this.panelHeadings = this.panels.locator('header').getByRole('heading');
+    // this.panels = page.getByTestId('panel');
+    // this.panelHeadings = this.panels.locator('header').getByRole('heading');
 
     this.variableList = page.getByTestId('variable-list');
     this.variableListItems = this.variableList.getByTestId('template-variable');
@@ -280,12 +280,9 @@ export class DashboardPage {
     });
   }
 
-  /**
-   * Look up a panel by its index on the page. Useful for tests when the name
-   * of the panel will change and cannot be relied on as a consistent locator.
-   */
-  getPanelByIndex(i: number) {
-    return new Panel(this.panels.nth(i));
+  getPanelHeadings(group?: PanelGroup): Locator {
+    const panels = this.getPanels(group);
+    return panels.locator('header').getByRole('heading');
   }
 
   /**

--- a/ui/e2e/src/pages/PanelGroup.ts
+++ b/ui/e2e/src/pages/PanelGroup.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { Locator, expect } from '@playwright/test';
+import { waitForAnimations } from '../utils';
 import { Panel } from './Panel';
 
 /**
@@ -84,10 +85,16 @@ export class PanelGroup {
 
   async expand() {
     await this.expandButton.click();
+    // Wait for all animations to complete to avoid misclicking as the panel
+    // group animates open.
+    await waitForAnimations(this.container);
   }
 
   async collapse() {
     await this.collapseButton.click();
+    // Wait for all animations to complete to avoid misclicking as the panel
+    // group animates closed.
+    await waitForAnimations(this.container);
   }
 
   async startEditing() {
@@ -106,8 +113,30 @@ export class PanelGroup {
     await this.deleteButton.click();
   }
 
+  /**
+   * PANEL HELPERS
+   */
+
   async addPanel() {
     await this.addPanelButton.click();
+  }
+
+  /**
+   * Get a panel by name.
+   */
+  getPanel(panelName: string): Panel {
+    const container = this.panels.filter({
+      has: this.container.page().getByRole('heading', { name: panelName }),
+    });
+    return new Panel(container);
+  }
+
+  /**
+   * Look up a panel by its index on the page. Useful for tests when the name
+   * of the panel will change and cannot be relied on as a consistent locator.
+   */
+  getPanelByIndex(i: number) {
+    return new Panel(this.panels.nth(i));
   }
 
   /**

--- a/ui/e2e/src/pages/PanelGroup.ts
+++ b/ui/e2e/src/pages/PanelGroup.ts
@@ -12,8 +12,12 @@
 // limitations under the License.
 
 import { Locator, expect } from '@playwright/test';
-import { waitForAnimations } from '../utils';
+import { waitForAnimations, getPanelByName } from '../utils';
 import { Panel } from './Panel';
+
+type GetPanelByNameOpts = {
+  nth?: number;
+};
 
 /**
  * Panel group on a dashboard page.
@@ -124,10 +128,14 @@ export class PanelGroup {
   /**
    * Get a panel by name.
    */
-  getPanel(panelName: string): Panel {
-    const container = this.panels.filter({
+  getPanel(panelName: string, { nth }: GetPanelByNameOpts = {}): Panel {
+    let container = this.panels.filter({
       has: this.container.page().getByRole('heading', { name: panelName }),
     });
+    if (nth !== undefined) {
+      container = container.nth(nth);
+    }
+
     return new Panel(container);
   }
 

--- a/ui/e2e/src/pages/PanelGroup.ts
+++ b/ui/e2e/src/pages/PanelGroup.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Locator, expect } from '@playwright/test';
-import { waitForAnimations, getPanelByName } from '../utils';
+import { waitForAnimations } from '../utils';
 import { Panel } from './Panel';
 
 type GetPanelByNameOpts = {

--- a/ui/e2e/src/pages/PanelGroup.ts
+++ b/ui/e2e/src/pages/PanelGroup.ts
@@ -117,34 +117,8 @@ export class PanelGroup {
     await this.deleteButton.click();
   }
 
-  /**
-   * PANEL HELPERS
-   */
-
   async addPanel() {
     await this.addPanelButton.click();
-  }
-
-  /**
-   * Get a panel by name.
-   */
-  getPanel(panelName: string, { nth }: GetPanelByNameOpts = {}): Panel {
-    let container = this.panels.filter({
-      has: this.container.page().getByRole('heading', { name: panelName }),
-    });
-    if (nth !== undefined) {
-      container = container.nth(nth);
-    }
-
-    return new Panel(container);
-  }
-
-  /**
-   * Look up a panel by its index on the page. Useful for tests when the name
-   * of the panel will change and cannot be relied on as a consistent locator.
-   */
-  getPanelByIndex(i: number) {
-    return new Panel(this.panels.nth(i));
   }
 
   /**

--- a/ui/e2e/src/pages/PanelGroup.ts
+++ b/ui/e2e/src/pages/PanelGroup.ts
@@ -15,10 +15,6 @@ import { Locator, expect } from '@playwright/test';
 import { waitForAnimations } from '../utils';
 import { Panel } from './Panel';
 
-type GetPanelByNameOpts = {
-  nth?: number;
-};
-
 /**
  * Panel group on a dashboard page.
  */
@@ -27,8 +23,6 @@ export class PanelGroup {
 
   readonly header: Locator;
   readonly content: Locator;
-  readonly panels: Locator;
-  readonly panelHeadings: Locator;
 
   readonly editButton: Locator;
   readonly expandButton: Locator;
@@ -68,9 +62,6 @@ export class PanelGroup {
     this.addPanelButton = this.header.getByRole('button', {
       name: 'add panel to group',
     });
-
-    this.panels = this.container.getByTestId('panel');
-    this.panelHeadings = this.panels.locator('header').getByRole('heading');
   }
 
   isOpen() {

--- a/ui/e2e/src/tests/duplicatePanels.spec.ts
+++ b/ui/e2e/src/tests/duplicatePanels.spec.ts
@@ -45,8 +45,8 @@ test.describe('Dashboard: Panels can be duplicated', () => {
     await duplicateOne.duplicateButton.click();
     const duplicateTwo = dashboardPage.getPanel({ group: panelGroup, nth: 2 });
 
-    await expect(panelGroup.panels).toHaveCount(3);
-    await expect(panelGroup.panelHeadings).toContainText([
+    await expect(dashboardPage.getPanels(panelGroup)).toHaveCount(3);
+    await expect(dashboardPage.getPanelHeadings(panelGroup)).toContainText([
       'panel being duplicated',
       'panel being duplicated',
       'panel being duplicated',
@@ -79,7 +79,7 @@ test.describe('Dashboard: Panels can be duplicated', () => {
     }
 
     // Ensure that editing the duplicates does not modify the original panel.
-    await expect(dashboardPage.panelHeadings).toContainText([
+    await expect(dashboardPage.getPanelHeadings(panelGroup)).toContainText([
       'panel being duplicated',
       'Duplicate panel 1',
       'Duplicate panel 2',
@@ -105,13 +105,13 @@ test.describe('Dashboard: Panels can be duplicated', () => {
 
       const originalPanel = dashboardPage.getPanel({ group: panelGroup, name: 'panel being duplicated' });
       await expect(originalPanel.container).toBeVisible();
-      const orignalPanelCount = await panelGroup.panels.count();
+      const orignalPanelCount = await dashboardPage.getPanels(panelGroup).count();
 
       // Duplicate the original panel
       await originalPanel.duplicateButton.click();
 
       // Wait for new panel to be added and loaded.
-      await expect(panelGroup.panels).toHaveCount(orignalPanelCount + 1);
+      await expect(dashboardPage.getPanels(panelGroup)).toHaveCount(orignalPanelCount + 1);
       const newPanel = dashboardPage.getPanel({ group: panelGroup, name: 'panel being duplicated', nth: 1 });
       await newPanel.container.scrollIntoViewIfNeeded();
       await newPanel.isLoaded();

--- a/ui/e2e/src/tests/duplicatePanels.spec.ts
+++ b/ui/e2e/src/tests/duplicatePanels.spec.ts
@@ -1,0 +1,122 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import happoPlaywright from 'happo-playwright';
+import { test, expect } from '../fixtures/dashboardTest';
+
+test.use({
+  dashboardName: 'DuplicatePanels',
+  modifiesDashboard: true,
+});
+
+test.describe('Dashboard: Panels can be duplicated', () => {
+  test.beforeEach(async ({ context }) => {
+    await happoPlaywright.init(context);
+  });
+
+  test.afterEach(async () => {
+    await happoPlaywright.finish();
+  });
+
+  test('multiple times', async ({ dashboardPage }) => {
+    await dashboardPage.startEditing();
+    const panelGroup = dashboardPage.getPanelGroup('single panel with space to right');
+    await panelGroup.expand();
+    const originalPanel = panelGroup.getPanelByIndex(0);
+
+    // Duplicate the original panel
+    await originalPanel.duplicateButton.click();
+    // Panels are referenced by index in this test because they will be renamed
+    // later, so their names are not durable locators.
+    const duplicateOne = panelGroup.getPanelByIndex(1);
+
+    // Duplicate the duplicate. Intentionally testing multiple duplicates to
+    // catch some edge cases.
+    await duplicateOne.duplicateButton.click();
+    const duplicateTwo = panelGroup.getPanelByIndex(2);
+
+    await expect(panelGroup.panels).toHaveCount(3);
+    await expect(panelGroup.panelHeadings).toContainText([
+      'panel being duplicated',
+      'panel being duplicated',
+      'panel being duplicated',
+    ]);
+
+    const duplicatePanels = [duplicateOne, duplicateTwo];
+
+    for (const duplicatePanel of duplicatePanels) {
+      await expect(duplicatePanel.container).toBeVisible();
+
+      // Duplicate panel should have the same dimensions.
+      const originalBounds = await originalPanel.getBounds();
+      const duplicateBounds = await duplicatePanel.getBounds();
+      expect(originalBounds.height).toEqual(duplicateBounds.height);
+      expect(originalBounds.width).toEqual(duplicateBounds.width);
+
+      // Duplicate panel should have the same content.
+      const originalContent = await originalPanel.figure.innerHTML();
+      const duplicateContent = await duplicatePanel.figure.innerHTML();
+      expect(originalContent).toEqual(duplicateContent);
+    }
+
+    // Modify duplicate panels to ensure they are now being treated as distinct
+    // from the panels they were duplicated from.
+    for (const [i, duplicatePanel] of duplicatePanels.entries()) {
+      await dashboardPage.editPanel(duplicatePanel, async (panelEditor) => {
+        await panelEditor.nameInput.clear();
+        await panelEditor.nameInput.type(`Duplicate panel ${i + 1}`);
+      });
+    }
+
+    // Ensure that editing the duplicates does not modify the original panel.
+    await expect(dashboardPage.panelHeadings).toContainText([
+      'panel being duplicated',
+      'Duplicate panel 1',
+      'Duplicate panel 2',
+    ]);
+
+    await dashboardPage.saveChanges();
+  });
+
+  [
+    'single panel with space to right',
+    'single panel with space to left',
+    'single panel with space on both sides',
+    'single panel without space on same line',
+    'multiple panels with space next to original',
+    'multiple panels with space not next to original',
+    'multiple panels w/o space & more panels below',
+  ].forEach((panelGroupName) => {
+    test(`with ${panelGroupName}`, async ({ dashboardPage, page }) => {
+      await dashboardPage.startEditing();
+      const panelGroup = dashboardPage.getPanelGroup(panelGroupName);
+      await panelGroup.expand();
+      await panelGroup.container.scrollIntoViewIfNeeded();
+
+      const originalPanel = panelGroup.getPanel('panel being duplicated');
+      await expect(originalPanel.container).toBeVisible();
+
+      // Duplicate the original panel
+      await originalPanel.duplicateButton.click();
+
+      // Take a screenshot of each duplicate case because it's easier to look
+      // at than to try to write a bunch of complex assertions about placement.
+      // Take a picture of the root instead of the individual group because the
+      // background color and placement are dependent on it to render.
+      await happoPlaywright.screenshot(page, dashboardPage.root, {
+        component: 'Duplicate panel',
+        variant: panelGroupName,
+      });
+    });
+  });
+});

--- a/ui/e2e/src/tests/duplicatePanels.spec.ts
+++ b/ui/e2e/src/tests/duplicatePanels.spec.ts
@@ -105,9 +105,16 @@ test.describe('Dashboard: Panels can be duplicated', () => {
 
       const originalPanel = panelGroup.getPanel('panel being duplicated');
       await expect(originalPanel.container).toBeVisible();
+      const orignalPanelCount = await panelGroup.panels.count();
 
       // Duplicate the original panel
       await originalPanel.duplicateButton.click();
+
+      // Wait for new panel to be added and loaded.
+      await expect(panelGroup.panels).toHaveCount(orignalPanelCount + 1);
+      const newPanel = panelGroup.getPanel('panel being duplicated', { nth: 1 });
+      await newPanel.container.scrollIntoViewIfNeeded();
+      await newPanel.isLoaded();
 
       // Take a screenshot of each duplicate case because it's easier to look
       // at than to try to write a bunch of complex assertions about placement.

--- a/ui/e2e/src/tests/duplicatePanels.spec.ts
+++ b/ui/e2e/src/tests/duplicatePanels.spec.ts
@@ -32,18 +32,18 @@ test.describe('Dashboard: Panels can be duplicated', () => {
     await dashboardPage.startEditing();
     const panelGroup = dashboardPage.getPanelGroup('single panel with space to right');
     await panelGroup.expand();
-    const originalPanel = panelGroup.getPanelByIndex(0);
+    const originalPanel = dashboardPage.getPanel({ group: panelGroup, nth: 0 });
 
     // Duplicate the original panel
     await originalPanel.duplicateButton.click();
     // Panels are referenced by index in this test because they will be renamed
     // later, so their names are not durable locators.
-    const duplicateOne = panelGroup.getPanelByIndex(1);
+    const duplicateOne = dashboardPage.getPanel({ group: panelGroup, nth: 1 });
 
     // Duplicate the duplicate. Intentionally testing multiple duplicates to
     // catch some edge cases.
     await duplicateOne.duplicateButton.click();
-    const duplicateTwo = panelGroup.getPanelByIndex(2);
+    const duplicateTwo = dashboardPage.getPanel({ group: panelGroup, nth: 2 });
 
     await expect(panelGroup.panels).toHaveCount(3);
     await expect(panelGroup.panelHeadings).toContainText([
@@ -103,7 +103,7 @@ test.describe('Dashboard: Panels can be duplicated', () => {
       await panelGroup.expand();
       await panelGroup.container.scrollIntoViewIfNeeded();
 
-      const originalPanel = panelGroup.getPanel('panel being duplicated');
+      const originalPanel = dashboardPage.getPanel({ group: panelGroup, name: 'panel being duplicated' });
       await expect(originalPanel.container).toBeVisible();
       const orignalPanelCount = await panelGroup.panels.count();
 
@@ -112,7 +112,7 @@ test.describe('Dashboard: Panels can be duplicated', () => {
 
       // Wait for new panel to be added and loaded.
       await expect(panelGroup.panels).toHaveCount(orignalPanelCount + 1);
-      const newPanel = panelGroup.getPanel('panel being duplicated', { nth: 1 });
+      const newPanel = dashboardPage.getPanel({ group: panelGroup, name: 'panel being duplicated', nth: 1 });
       await newPanel.container.scrollIntoViewIfNeeded();
       await newPanel.isLoaded();
 

--- a/ui/e2e/src/tests/gaugeChartPanel.spec.ts
+++ b/ui/e2e/src/tests/gaugeChartPanel.spec.ts
@@ -60,7 +60,7 @@ test.describe('Dashboard: Gauge Chart Panel', () => {
     });
 
     await dashboardPage.forEachTheme(async (themeName) => {
-      const panel = dashboardPage.getPanel('Single Gauge');
+      const panel = dashboardPage.getPanelByName('Single Gauge');
       await panel.isLoaded();
       // Wait for gauge animation to finish before taking a screenshot.
       await waitForStableCanvas(panel.canvas);

--- a/ui/e2e/src/tests/markdownPanel.spec.ts
+++ b/ui/e2e/src/tests/markdownPanel.spec.ts
@@ -30,7 +30,7 @@ test.describe('Dashboard: Markdown Panel', () => {
   ['Headings', 'Text', 'Links', 'Code', 'Lists', 'Tables'].forEach((panelName) => {
     test(`displays ${panelName} as expected`, async ({ page, dashboardPage }) => {
       await dashboardPage.forEachTheme(async (themeName) => {
-        const markdownPanel = dashboardPage.getPanel(panelName);
+        const markdownPanel = dashboardPage.getPanelByName(panelName);
         await markdownPanel.container.scrollIntoViewIfNeeded();
         await markdownPanel.isLoaded();
 

--- a/ui/e2e/src/tests/panels.spec.ts
+++ b/ui/e2e/src/tests/panels.spec.ts
@@ -24,7 +24,7 @@ test.describe('Dashboard: Panels', () => {
     await dashboardPage.addMarkdownPanel('Markdown One');
 
     await expect(dashboardPage.panels).toHaveCount(2);
-    const newPanel = dashboardPage.getPanel('Markdown One');
+    const newPanel = dashboardPage.getPanelByName('Markdown One');
     await expect(newPanel.container).toBeVisible();
 
     await expect(dashboardPage.panelHeadings).toContainText(['Markdown Example Zero', 'Markdown One']);
@@ -41,7 +41,7 @@ test.describe('Dashboard: Panels', () => {
     await dashboardPage.addMarkdownPanel('Markdown One');
 
     await expect(dashboardPage.panels).toHaveCount(2);
-    const newPanel = dashboardPage.getPanel('Markdown One');
+    const newPanel = dashboardPage.getPanelByName('Markdown One');
     await expect(newPanel.container).toBeVisible();
 
     await expect(dashboardPage.panelHeadings).toContainText(['Markdown Example Zero', 'Markdown One']);
@@ -83,7 +83,7 @@ test.describe('Dashboard: Panels', () => {
   test('can be resized', async ({ dashboardPage }) => {
     await dashboardPage.startEditing();
 
-    const panel = dashboardPage.getPanel('Markdown Example Zero');
+    const panel = dashboardPage.getPanelByName('Markdown Example Zero');
 
     const originalSize = await panel.getBounds();
 
@@ -111,7 +111,7 @@ test.describe('Dashboard: Panels', () => {
   // There was previously a bug related to going to a smaller screen and back to
   // a larger screen. This test will help avoid a regression.
   test('can resize responsively', async ({ dashboardPage, page }) => {
-    const panel = dashboardPage.getPanel('Markdown Example Zero');
+    const panel = dashboardPage.getPanelByName('Markdown Example Zero');
     const panelGroup = dashboardPage.getPanelGroup('Row 1');
 
     // Save original panel size.
@@ -140,61 +140,5 @@ test.describe('Dashboard: Panels', () => {
       expect(largePanelPercentSize).toEqual(originalPanelPercentSize);
       expect(largePanelPercentSize.width).toBeCloseTo(0.25, 1);
     }
-  });
-
-  test('can be duplicated', async ({ dashboardPage }) => {
-    await dashboardPage.startEditing();
-    const originalPanel = dashboardPage.getPanelByIndex(0);
-
-    // Duplicate the original panel
-    await originalPanel.duplicateButton.click();
-    // Panels are referenced by index in this test because they will be renamed
-    // later, so their names are not durable locators.
-    const duplicateOne = dashboardPage.getPanelByIndex(1);
-
-    // Duplicate the duplicate. Intentionally testing multiple duplicates to
-    // catch some edge cases.
-    await duplicateOne.duplicateButton.click();
-    const duplicateTwo = dashboardPage.getPanelByIndex(2);
-
-    await expect(dashboardPage.panels).toHaveCount(3);
-    await expect(dashboardPage.panelHeadings).toContainText([
-      'Markdown Example Zero',
-      'Markdown Example Zero',
-      'Markdown Example Zero',
-    ]);
-
-    const duplicatePanels = [duplicateOne, duplicateTwo];
-
-    for (const duplicatePanel of duplicatePanels) {
-      await expect(duplicatePanel.container).toBeVisible();
-
-      // Duplicate panel should have the same dimensions.
-      const originalBounds = await originalPanel.getBounds();
-      const duplicateBounds = await duplicatePanel.getBounds();
-      expect(originalBounds.height).toEqual(duplicateBounds.height);
-      expect(originalBounds.width).toEqual(duplicateBounds.width);
-
-      // Duplicate panel should have the same content.
-      const originalContent = await originalPanel.figure.innerHTML();
-      const duplicateContent = await duplicatePanel.figure.innerHTML();
-      expect(originalContent).toEqual(duplicateContent);
-    }
-
-    // Modify duplicate panels to ensure they are now being treated as distinct
-    // from the panels they were duplicated from.
-    for (const [i, duplicatePanel] of duplicatePanels.entries()) {
-      await dashboardPage.editPanel(duplicatePanel, async (panelEditor) => {
-        await panelEditor.nameInput.clear();
-        await panelEditor.nameInput.type(`Duplicate panel ${i + 1}`);
-      });
-    }
-
-    // Ensure that editing the duplicates does not modify the original panel.
-    await expect(dashboardPage.panelHeadings).toContainText([
-      'Markdown Example Zero',
-      'Duplicate panel 1',
-      'Duplicate panel 2',
-    ]);
   });
 });

--- a/ui/e2e/src/tests/panels.spec.ts
+++ b/ui/e2e/src/tests/panels.spec.ts
@@ -23,11 +23,11 @@ test.describe('Dashboard: Panels', () => {
     await dashboardPage.addPanelToGroup('Row 1');
     await dashboardPage.addMarkdownPanel('Markdown One');
 
-    await expect(dashboardPage.panels).toHaveCount(2);
+    await expect(dashboardPage.getPanels()).toHaveCount(2);
     const newPanel = dashboardPage.getPanelByName('Markdown One');
     await expect(newPanel.container).toBeVisible();
 
-    await expect(dashboardPage.panelHeadings).toContainText(['Markdown Example Zero', 'Markdown One']);
+    await expect(dashboardPage.getPanelHeadings()).toContainText(['Markdown Example Zero', 'Markdown One']);
   });
 
   test('can be added to the dashboard', async ({ dashboardPage }) => {
@@ -40,33 +40,33 @@ test.describe('Dashboard: Panels', () => {
 
     await dashboardPage.addMarkdownPanel('Markdown One');
 
-    await expect(dashboardPage.panels).toHaveCount(2);
+    await expect(dashboardPage.getPanels()).toHaveCount(2);
     const newPanel = dashboardPage.getPanelByName('Markdown One');
     await expect(newPanel.container).toBeVisible();
 
-    await expect(dashboardPage.panelHeadings).toContainText(['Markdown Example Zero', 'Markdown One']);
+    await expect(dashboardPage.getPanelHeadings()).toContainText(['Markdown Example Zero', 'Markdown One']);
   });
 
   test('can be removed', async ({ dashboardPage }) => {
     await dashboardPage.startEditing();
     await dashboardPage.removePanel('Markdown Example Zero');
-    await expect(dashboardPage.panels).toHaveCount(0);
+    await expect(dashboardPage.getPanels()).toHaveCount(0);
   });
 
   test('can be moved to a different panel group', async ({ dashboardPage }) => {
     const panelGroupOne = dashboardPage.getPanelGroup('Row 1');
     const panelGroupTwo = dashboardPage.getPanelGroup('Row 2');
 
-    await expect(panelGroupOne.panelHeadings).toContainText(['Markdown Example Zero']);
-    await expect(panelGroupTwo.panelHeadings).toContainText([]);
+    await expect(dashboardPage.getPanelHeadings(panelGroupOne)).toContainText(['Markdown Example Zero']);
+    await expect(dashboardPage.getPanelHeadings(panelGroupTwo)).toContainText([]);
 
     await dashboardPage.startEditing();
     await dashboardPage.editPanel('Markdown Example Zero', async (panelEditor) => {
       await panelEditor.selectGroup('Row 2');
     });
 
-    await expect(panelGroupOne.panelHeadings).toContainText([]);
-    await expect(panelGroupTwo.panelHeadings).toContainText(['Markdown Example Zero']);
+    await expect(dashboardPage.getPanelHeadings(panelGroupOne)).toContainText([]);
+    await expect(dashboardPage.getPanelHeadings(panelGroupTwo)).toContainText(['Markdown Example Zero']);
   });
 
   test('can be renamed', async ({ dashboardPage }) => {
@@ -77,7 +77,7 @@ test.describe('Dashboard: Panels', () => {
       await panelEditor.nameInput.type('Markdown With a New Name');
     });
 
-    await expect(dashboardPage.panelHeadings).toContainText(['Markdown With a New Name']);
+    await expect(dashboardPage.getPanelHeadings()).toContainText(['Markdown With a New Name']);
   });
 
   test('can be resized', async ({ dashboardPage }) => {

--- a/ui/e2e/src/tests/statChartPanel.spec.ts
+++ b/ui/e2e/src/tests/statChartPanel.spec.ts
@@ -59,7 +59,7 @@ test.describe('Dashboard: Stat Chart Panel', () => {
     });
 
     await dashboardPage.forEachTheme(async (themeName) => {
-      const panel = dashboardPage.getPanel('Simple Stat');
+      const panel = dashboardPage.getPanelByName('Simple Stat');
       await panel.isLoaded();
       await waitForStableCanvas(panel.canvas);
 

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -59,7 +59,7 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
     });
 
     await dashboardPage.forEachTheme(async (themeName) => {
-      const panel = dashboardPage.getPanel('Single Line');
+      const panel = dashboardPage.getPanelByName('Single Line');
       await panel.isLoaded();
       await waitForStableCanvas(panel.canvas);
 


### PR DESCRIPTION
Prior to this change, duplicate panels would always be placed on the
far left in a new row at the bottom of the dashboard.

After this change, duplicate panels are placed as follows:
- If there is space directly to the right of the panel being duplicated,
  the duplicate will be placed there.
- Otherwise, the duplicate panel is placed directly below the panel
  being duplicated, pushing down any panels below it.

This approach to placement of duplicate panels balances the following
considerations:
- Making it easy for the user to find a duplicate by initially placing
  it close to the original panel.
- Minimizing rework for the user that may be caused if we move other
  panels to make place for the duplicate panel. The grid compacts
  vertically, so moving other panels downward while retaining their
  horizontal positioning is less disruptive than changing horizontal
  positioning.


<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# Screenshots

See [added examples in Happo screenshots](https://happo.io/a/1009/p/1488/compare/d22943c5c7cab3726bcf00f4b6b8174c0ba9a2e7/04987906de88563ba5534e6448e5e53a44357f25?t=added).
