### PR TITLE
[IGNORE] Use specified playwright viewport

### DIFF
--- a/ui/e2e/src/config/base.playwright.config.ts
+++ b/ui/e2e/src/config/base.playwright.config.ts
@@ -53,11 +53,6 @@ const config: PlaywrightTestConfig = {
      */
     serviceWorkers: 'block',
 
-    // Keep this in sync with the setting in `.happo.js` for consistency for
-    // canvas elements, which are converted into images when run in playwright
-    // and sent to happo.
-    viewport: { width: 1200, height: 800 },
-
     // Use a consistent time zone, so we do not have to worry about flakiness
     // depending on the server.
     timezoneId: 'America/Los_Angeles',
@@ -69,6 +64,10 @@ const config: PlaywrightTestConfig = {
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        // Keep this in sync with the setting in `.happo.js` for consistency for
+        // canvas elements, which are converted into images when run in playwright
+        // and sent to happo.
+        viewport: { width: 1200, height: 800 },
       },
     },
   ],


### PR DESCRIPTION
Previously, a global viewport was set, but would be overridden in the chrome config, so we weren't using the intended value. After this fix, the intended viewport is used.

Signed-off-by: Julie Pagano <julie.pagano@chronosphere.io>

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
