### PR TITLE
[BUGFIX] Allow editing of time range using inputs

### DIFF
--- a/ui/components/src/DateTimeRangePicker/AbsoluteTimePicker.tsx
+++ b/ui/components/src/DateTimeRangePicker/AbsoluteTimePicker.tsx
@@ -24,13 +24,14 @@ const DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 interface AbsoluteTimeFormProps {
   initialTimeRange: AbsoluteTimeRange;
   onChange: (timeRange: AbsoluteTimeRange) => void;
+  onCancel: () => void;
 }
 
 type AbsoluteTimeRangeInputValue = {
   [Property in keyof AbsoluteTimeRange]: string;
 };
 
-export const AbsoluteTimePicker = ({ initialTimeRange, onChange }: AbsoluteTimeFormProps) => {
+export const AbsoluteTimePicker = ({ initialTimeRange, onChange, onCancel }: AbsoluteTimeFormProps) => {
   const { formatWithUserTimeZone } = useTimeZone();
 
   // Time range values as dates that can be used as a time range.
@@ -199,11 +200,14 @@ export const AbsoluteTimePicker = ({ initialTimeRange, onChange }: AbsoluteTimeF
             type="tel"
           />
         </Stack>
-        <Box sx={{ padding: (theme) => theme.spacing(0, 1) }}>
-          <Button variant="contained" onClick={() => onApply()}>
+        <Stack direction="row" sx={{ padding: (theme) => theme.spacing(0, 1) }} gap={1}>
+          <Button variant="contained" onClick={() => onApply()} fullWidth>
             Apply
           </Button>
-        </Box>
+          <Button variant="outlined" onClick={() => onCancel()} fullWidth>
+            Cancel
+          </Button>
+        </Stack>
       </Stack>
     </LocalizationProvider>
   );

--- a/ui/components/src/DateTimeRangePicker/AbsoluteTimePicker.tsx
+++ b/ui/components/src/DateTimeRangePicker/AbsoluteTimePicker.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useState } from 'react';
-import { Box, Stack, TextField, Typography } from '@mui/material';
+import { Box, Stack, TextField, Typography, Button } from '@mui/material';
 import { LocalizationProvider, StaticDateTimePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { AbsoluteTimeRange } from '@perses-dev/core';
@@ -26,32 +26,74 @@ interface AbsoluteTimeFormProps {
   onChange: (timeRange: AbsoluteTimeRange) => void;
 }
 
+type AbsoluteTimeRangeInputValue = {
+  [Property in keyof AbsoluteTimeRange]: string;
+};
+
 export const AbsoluteTimePicker = ({ initialTimeRange, onChange }: AbsoluteTimeFormProps) => {
-  const [timeRange, setTimeRange] = useState<AbsoluteTimeRange>(initialTimeRange);
-  const [showStartCalendar, setShowStartCalendar] = useState<boolean>(true);
   const { formatWithUserTimeZone } = useTimeZone();
 
-  // validate start and end time, propagate changes
-  const updateDateRange = (input: string, isStartDate: boolean) => {
-    const newDate = new Date(input);
-    if (isStartDate === true) {
-      const isValidDateRange = validateDateRange(newDate, timeRange.end);
-      if (isValidDateRange === true) {
-        setTimeRange((current) => {
-          const updatedRange = { start: newDate, end: current.end };
-          onChange(updatedRange);
-          return updatedRange;
-        });
-      }
-    } else {
-      const isValidDateRange = validateDateRange(timeRange.start, newDate);
-      if (isValidDateRange === true) {
-        setTimeRange((current) => {
-          const updatedRange = { start: current.start, end: newDate };
-          onChange(updatedRange);
-          return updatedRange;
-        });
-      }
+  // Time range values as dates that can be used as a time range.
+  const [timeRange, setTimeRange] = useState<AbsoluteTimeRange>(initialTimeRange);
+
+  // Time range values as strings used to populate the text inputs. May not
+  // be valid as dates when the user is typing.
+  const [timeRangeInputs, setTimeRangeInputs] = useState<AbsoluteTimeRangeInputValue>({
+    start: formatWithUserTimeZone(initialTimeRange.start, DATE_TIME_FORMAT),
+    end: formatWithUserTimeZone(initialTimeRange.end, DATE_TIME_FORMAT),
+  });
+
+  const [showStartCalendar, setShowStartCalendar] = useState<boolean>(true);
+
+  const changeTimeRange = (newTime: string | Date, segment: keyof AbsoluteTimeRange) => {
+    const isInputChange = typeof newTime === 'string';
+    const newInputTime = isInputChange ? newTime : formatWithUserTimeZone(newTime, DATE_TIME_FORMAT);
+
+    setTimeRangeInputs((prevTimeRangeInputs) => {
+      return {
+        ...prevTimeRangeInputs,
+        [segment]: newInputTime,
+      };
+    });
+
+    // When the change is a string from an input, do not try to convert it to
+    // a date because there are likely to be interim stages of editing where it
+    // is not valid as a date. When the change is a Date from the calendar/clock
+    // interface, we can be sure it is a date.
+    if (!isInputChange) {
+      setTimeRange((prevTimeRange) => {
+        return {
+          ...prevTimeRange,
+          [segment]: newTime,
+        };
+      });
+    }
+  };
+
+  const onChangeStartTime = (newStartTime: string | Date) => {
+    changeTimeRange(newStartTime, 'start');
+  };
+
+  const onChangeEndTime = (newEndTime: string | Date) => {
+    changeTimeRange(newEndTime, 'end');
+  };
+
+  const updateDateRange = () => {
+    const newDates = {
+      start: new Date(timeRangeInputs.start),
+      end: new Date(timeRangeInputs.end),
+    };
+    const isValidDateRange = validateDateRange(newDates.start, newDates.end);
+    if (isValidDateRange) {
+      setTimeRange(newDates);
+      return newDates;
+    }
+  };
+
+  const onApply = () => {
+    const newDates = updateDateRange();
+    if (newDates) {
+      onChange(newDates);
     }
   };
 
@@ -88,9 +130,7 @@ export const AbsoluteTimePicker = ({ initialTimeRange, onChange }: AbsoluteTimeF
               value={initialTimeRange.start}
               onChange={(newValue) => {
                 if (newValue === null) return;
-                setTimeRange((current) => {
-                  return { start: newValue, end: current.end };
-                });
+                onChangeStartTime(newValue);
               }}
               onAccept={() => {
                 setShowStartCalendar(false);
@@ -124,13 +164,12 @@ export const AbsoluteTimePicker = ({ initialTimeRange, onChange }: AbsoluteTimeF
               minDateTime={timeRange.start}
               onChange={(newValue) => {
                 if (newValue === null) return;
-                setTimeRange((current) => {
-                  return { start: current.start, end: newValue };
-                });
+                onChangeEndTime(newValue);
               }}
-              onAccept={() => {
+              onAccept={(newValue) => {
+                if (newValue === null) return;
                 setShowStartCalendar(true);
-                onChange(timeRange);
+                onChangeEndTime(newValue);
               }}
               renderInput={(params) => <TextField {...params} />}
             />
@@ -140,24 +179,31 @@ export const AbsoluteTimePicker = ({ initialTimeRange, onChange }: AbsoluteTimeF
           <TextField
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
               // TODO: add helperText, fix validation after we decide on form state solution
-              updateDateRange(event.target.value, true);
+              onChangeStartTime(event.target.value);
             }}
-            value={formatWithUserTimeZone(timeRange.start, DATE_TIME_FORMAT)}
+            onBlur={() => updateDateRange()}
+            value={timeRangeInputs.start}
             label="Start Time"
-            placeholder="mm/dd/yyyy hh:mm"
+            placeholder={DATE_TIME_FORMAT}
             // tel used to match MUI DateTimePicker, may change in future: https://github.com/mui/material-ui/issues/27590
             type="tel"
           />
           <TextField
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              updateDateRange(event.target.value, false);
+              onChangeEndTime(event.target.value);
             }}
-            value={formatWithUserTimeZone(timeRange.end, DATE_TIME_FORMAT)}
+            onBlur={() => updateDateRange()}
+            value={timeRangeInputs.end}
             label="End Time"
-            placeholder="mm/dd/yyyy hh:mm"
+            placeholder={DATE_TIME_FORMAT}
             type="tel"
           />
         </Stack>
+        <Box sx={{ padding: (theme) => theme.spacing(0, 1) }}>
+          <Button variant="contained" onClick={() => onApply()}>
+            Apply
+          </Button>
+        </Box>
       </Stack>
     </LocalizationProvider>
   );

--- a/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/ui/components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -61,6 +61,7 @@ export function DateTimeRangePicker(props: DateTimeRangePickerProps) {
             onChange(value);
             setShowCustomDateSelector(false);
           }}
+          onCancel={() => setShowCustomDateSelector(false)}
         />
       </Popover>
       <FormControl fullWidth>

--- a/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
+++ b/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
@@ -43,6 +43,9 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
       value={formattedValue}
       onChange={onSelectChange}
       IconComponent={Calendar}
+      inputProps={{
+        'aria-label': `Select time range. Currently set to ${formattedValue}`,
+      }}
       sx={{
         '.MuiSelect-icon': {
           marginTop: '1px',

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -50,7 +50,7 @@ describe('TimeRangeControls', () => {
   it('should default to dashboard duration and update selected time option when clicked', async () => {
     renderTimeRangeControls(false);
     expect(screen.getByText('Last 30 minutes')).toBeInTheDocument();
-    const dateButton = screen.getByRole('button', { name: /last/i });
+    const dateButton = screen.getByRole('button', { name: /time range/i });
     userEvent.click(dateButton);
     const firstSelected = screen.getByRole('option', { name: 'Last 5 minutes' });
     userEvent.click(firstSelected);
@@ -59,7 +59,7 @@ describe('TimeRangeControls', () => {
 
   it('should update URL params with correct time range values', () => {
     renderTimeRangeControls(true);
-    const dateButton = screen.getByRole('button', { name: /last/i });
+    const dateButton = screen.getByRole('button', { name: /time range/i });
     userEvent.click(dateButton);
     const firstSelected = screen.getByRole('option', { name: 'Last 5 minutes' });
     userEvent.click(firstSelected);

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -67,6 +67,7 @@ export class DashboardPage {
   readonly themeToggle: Locator;
 
   readonly toolbar: Locator;
+  readonly timePicker: Locator;
   readonly editButton: Locator;
   readonly cancelButton: Locator;
   readonly saveButton: Locator;
@@ -93,6 +94,7 @@ export class DashboardPage {
     this.themeToggle = page.getByRole('checkbox', { name: 'Theme' });
 
     this.toolbar = page.getByTestId('dashboard-toolbar');
+    this.timePicker = page.getByRole('button', { name: 'Select time range' });
     this.editButton = this.toolbar.getByRole('button', { name: 'Edit' });
     this.cancelButton = this.toolbar.getByRole('button', { name: 'Cancel' });
     this.saveButton = this.toolbar.getByRole('button', { name: 'Save' });

--- a/ui/e2e/src/tests/timePicker.spec.ts
+++ b/ui/e2e/src/tests/timePicker.spec.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { test, expect } from '../fixtures/dashboardTest';
+import { parseDateIntoTimeZone } from '../utils';
 
 test.use({
   dashboardName: 'Panels',
@@ -22,7 +23,7 @@ test.use({
 
 test.describe('Time Picker', () => {
   test.describe('can select a custom time range', () => {
-    test('using interactive calendar and clock', async ({ page, dashboardPage }) => {
+    test('using interactive calendar and clock', async ({ page, dashboardPage, timezoneId }) => {
       await dashboardPage.timePicker.click();
 
       await page.getByRole('option', { name: 'Custom time range' }).click();
@@ -75,7 +76,9 @@ test.describe('Time Picker', () => {
 
       await page.getByRole('button', { name: 'Apply' }).click();
 
-      const expectedTimeRange = '2023-02-04 03:15:15 - 2023-02-09 19:55:15';
+      const expectedStart = '2023-02-04 03:15:15';
+      const expectedEnd = '2023-02-09 19:55:15';
+      const expectedTimeRange = `${expectedStart} - ${expectedEnd}`;
 
       // Time picker dropdown shows the new time range
       await expect(page.getByRole('option', { name: expectedTimeRange })).toBeVisible();
@@ -87,9 +90,15 @@ test.describe('Time Picker', () => {
 
       // Time picker shows the new time range.
       await expect(dashboardPage.timePicker).toContainText(expectedTimeRange);
+
+      const expectedStartMs = parseDateIntoTimeZone(expectedStart, timezoneId).valueOf();
+      const expectedEndMs = parseDateIntoTimeZone(expectedEnd, timezoneId).valueOf();
+
+      expect(page.url()).toContain(`start=${expectedStartMs}`);
+      expect(page.url()).toContain(`end=${expectedEndMs}`);
     });
 
-    test('using text input', async ({ page, dashboardPage }) => {
+    test('using text input', async ({ page, dashboardPage, timezoneId }) => {
       await dashboardPage.timePicker.click();
 
       await page.getByRole('option', { name: 'Custom time range' }).click();
@@ -104,7 +113,9 @@ test.describe('Time Picker', () => {
 
       await page.getByRole('button', { name: 'Apply' }).click();
 
-      const expectedTimeRange = '2023-01-15 13:05:00 - 2023-02-01 10:00:00';
+      const expectedStart = '2023-01-15 13:05:00';
+      const expectedEnd = '2023-02-01 10:00:00';
+      const expectedTimeRange = `${expectedStart} - ${expectedEnd}`;
 
       // Time picker dropdown shows the new time range
       await expect(page.getByRole('option', { name: expectedTimeRange })).toBeVisible();
@@ -116,6 +127,12 @@ test.describe('Time Picker', () => {
 
       // Time picker shows the new time range.
       await expect(dashboardPage.timePicker).toContainText(expectedTimeRange);
+
+      const expectedStartMs = parseDateIntoTimeZone(expectedStart, timezoneId).valueOf();
+      const expectedEndMs = parseDateIntoTimeZone(expectedEnd, timezoneId).valueOf();
+
+      expect(page.url()).toContain(`start=${expectedStartMs}`);
+      expect(page.url()).toContain(`end=${expectedEndMs}`);
     });
   });
 });

--- a/ui/e2e/src/tests/timePicker.spec.ts
+++ b/ui/e2e/src/tests/timePicker.spec.ts
@@ -1,0 +1,121 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test, expect } from '../fixtures/dashboardTest';
+
+test.use({
+  dashboardName: 'Panels',
+
+  // Friday, February 10, 2023 12:00:15 PM GMT-08:00
+  mockNow: 1676059215000,
+});
+
+test.describe('Time Picker', () => {
+  test.describe('can select a custom time range', () => {
+    test('using interactive calendar and clock', async ({ page, dashboardPage }) => {
+      await dashboardPage.timePicker.click();
+
+      await page.getByRole('option', { name: 'Custom time range' }).click();
+      await page.getByRole('button', { name: 'Feb 4, 2023' }).click();
+
+      // The a11y markup on this clock face is really hard to work with, so using
+      // a rare forced click here.
+      // eslint-disable-next-line playwright/no-force-option
+      await page
+        .getByRole('option', {
+          name: '3 hours',
+        })
+        .click({
+          force: true,
+        });
+
+      // The a11y markup on this clock face is really hard to work with, so using
+      // a rare forced click here.
+      // eslint-disable-next-line playwright/no-force-option
+      await page
+        .getByRole('option', {
+          name: '15 minutes',
+        })
+        .click({
+          force: true,
+        });
+
+      await page.getByRole('button', { name: 'Feb 9, 2023' }).click();
+      // The a11y markup on this clock face is really hard to work with, so using
+      // a rare forced click here.
+      // eslint-disable-next-line playwright/no-force-option
+      await page
+        .getByRole('option', {
+          name: '7 hours',
+        })
+        .click({
+          force: true,
+        });
+
+      // The a11y markup on this clock face is really hard to work with, so using
+      // a rare forced click here.
+      // eslint-disable-next-line playwright/no-force-option
+      await page
+        .getByRole('option', {
+          name: '55 minutes',
+        })
+        .click({
+          force: true,
+        });
+
+      await page.getByRole('button', { name: 'Apply' }).click();
+
+      const expectedTimeRange = '2023-02-04 03:15:15 - 2023-02-09 19:55:15';
+
+      // Time picker dropdown shows the new time range
+      await expect(page.getByRole('option', { name: expectedTimeRange })).toBeVisible();
+
+      // Dismiss dropdown. This happens automatically when these steps are done
+      // manually, but is required in playwright. Guessing it is something
+      // subtle with the click targets and/or speed of actions.
+      await page.keyboard.press('Escape');
+
+      // Time picker shows the new time range.
+      await expect(dashboardPage.timePicker).toContainText(expectedTimeRange);
+    });
+
+    test('using text input', async ({ page, dashboardPage }) => {
+      await dashboardPage.timePicker.click();
+
+      await page.getByRole('option', { name: 'Custom time range' }).click();
+
+      const startTimeInput = page.getByLabel('Start Time');
+      await startTimeInput.clear();
+      await startTimeInput.type('2023-01-15 13:05:00');
+
+      const endTimeInput = page.getByLabel('End Time');
+      await endTimeInput.clear();
+      await endTimeInput.type('2023-02-01 10:00:00');
+
+      await page.getByRole('button', { name: 'Apply' }).click();
+
+      const expectedTimeRange = '2023-01-15 13:05:00 - 2023-02-01 10:00:00';
+
+      // Time picker dropdown shows the new time range
+      await expect(page.getByRole('option', { name: expectedTimeRange })).toBeVisible();
+
+      // Dismiss dropdown. This happens automatically when these steps are done
+      // manually, but is required in playwright. Guessing it is something
+      // subtle with the click targets and/or speed of actions.
+      await page.keyboard.press('Escape');
+
+      // Time picker shows the new time range.
+      await expect(dashboardPage.timePicker).toContainText(expectedTimeRange);
+    });
+  });
+});

--- a/ui/e2e/src/utils/index.ts
+++ b/ui/e2e/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from './animationUtils';
 export * from './canvasUtils';
 export * from './formUtils';
 export * from './mockTimeSeries';
+export * from './timeUtils';

--- a/ui/e2e/src/utils/timeUtils.ts
+++ b/ui/e2e/src/utils/timeUtils.ts
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { zonedTimeToUtc } from 'date-fns-tz';
 
 /**

--- a/ui/e2e/src/utils/timeUtils.ts
+++ b/ui/e2e/src/utils/timeUtils.ts
@@ -1,0 +1,20 @@
+import { zonedTimeToUtc } from 'date-fns-tz';
+
+/**
+ * Takes a generic date string and converts it to a date at that time in the
+ * specified time zone configured for Playwright. Important to use this when
+ * doing date processing in test code to avoid tests that behave differently
+ * depending on the machine that runs them.
+ *
+ * @param date - String representatino of a date without time zone information (e.g. 2022-01-01 10:01:00)
+ * @param timezoneId - Playwright's configured time zone.
+ */
+export function parseDateIntoTimeZone(date: string, timezoneId?: string): Date {
+  if (!timezoneId) {
+    // Adding this check because the types from Playwright have timezoneId as
+    // optional. In practice, our playwright config always has this value set.
+    throw new Error('Missing time zone');
+  }
+
+  return zonedTimeToUtc(date, timezoneId);
+}


### PR DESCRIPTION
Prior to this fix, the text inputs for setting a custom time range attempted to turn the content of the text input into a `Date` and apply the changes on `change`. This prevented the user from modifying the input to adjust the value and would prematurely complete the time range editing interaction.

After this fix, the text inputs are treated as text while being changed. They are evaluated as dates on blur. This fix also introduces an "apply" button that must be clicked to submit the changes in the text inputs, so that the user has control of when the time range editing interaction completes using text inputs.

This change also fixes a bug where the end time minutes value selected using the clock face interface was not being saved.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Notes for reviewers

- This PR is a little tricky because I'm trying to fix the bugs without doing any major revamping of the time picker UI, which should be done as a more thoughtful effort in collaboration with designers in the future.
- I am not trying to fix a comprehensive set of issues with the time picker (e.g. I'm not adding validation right now because it wasn't in here before) with this PR. I'm primarily focused on un-breaking the custom time range entry.
- ~I'm waiting on feedback from @foxbat07 on some design/UX questions around the placement and behavior of the "apply" button.~ Done! See updated code and screenshots.

# Screenshots 

I did a loom video for this one to show the before and after because it requires a bunch of interaction.
https://www.loom.com/share/566745949347484b98cdf30f81403ee1

This is what the dropdown looks like after syncing up with Mohit.
<img width="561" alt="image" src="https://user-images.githubusercontent.com/396962/219453886-1de487cd-66af-475f-abf0-510627460da5.png">


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# TODO
- [X] Respond to feedback from @foxbat07 about UI/UX.
