### PR TITLE
[FEATURE] New `area_shading` toggle in time series panel

### DIFF
--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -24,7 +24,7 @@ import (
 #visual: {
 	line_width?:   number & >=0.25 & <=3
 	point_radius?: number & >=0 & <=6
-	area_opacity?: number & >=0 & <=1
+	area_shading?: bool
 }
 
 #y_axis: {

--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -24,6 +24,7 @@ import (
 #visual: {
 	line_width?:   number & >=0.25 & <=3
 	point_radius?: number & >=0 & <=6
+	area_opacity?: number & >=0 & <=1
 }
 
 #y_axis: {

--- a/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
+++ b/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
@@ -31,7 +31,7 @@ export const OptionsEditorControl = ({ label, control }: OptionsEditorControlPro
     <FormControl>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <FormLabel htmlFor={controlId}>{label}</FormLabel>
-        <Box sx={{ width: '150px', textAlign: 'right' }}> {React.cloneElement(control, controlProps)}</Box>
+        <Box sx={{ width: '160px', textAlign: 'right' }}> {React.cloneElement(control, controlProps)}</Box>
       </Stack>
     </FormControl>
   );

--- a/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
+++ b/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
@@ -31,7 +31,7 @@ export const OptionsEditorControl = ({ label, control }: OptionsEditorControlPro
     <FormControl>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <FormLabel htmlFor={controlId}>{label}</FormLabel>
-        <Box sx={{ width: '160px', textAlign: 'right' }}> {React.cloneElement(control, controlProps)}</Box>
+        <Box sx={{ width: '150px', textAlign: 'right' }}> {React.cloneElement(control, controlProps)}</Box>
       </Stack>
     </FormControl>
   );

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.test.tsx
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import { render, screen, fireEvent } from '@testing-library/react';
-import { VisualOptions, VISUAL_CONFIG } from './time-series-chart-model';
+import userEvent from '@testing-library/user-event';
+import { DEFAULT_VISUAL, VisualOptions, VISUAL_CONFIG } from './time-series-chart-model';
 import { VisualOptionsEditor } from './VisualOptionsEditor';
 
 describe('VisualOptionsEditor', () => {
@@ -22,6 +23,10 @@ describe('VisualOptionsEditor', () => {
 
   const getLineWidthSlider = () => {
     return screen.getByTestId(VISUAL_CONFIG.line_width.testId);
+  };
+
+  const getAreaShadingSwitch = () => {
+    return screen.getByRole('checkbox', { name: VISUAL_CONFIG.area_shading.label });
   };
 
   it('can update the line width visual option', () => {
@@ -51,5 +56,14 @@ describe('VisualOptionsEditor', () => {
     // to move slider and update visual options
     fireEvent.mouseDown(sliderInput, { clientX: 220, clientY: 100 });
     expect(onChange).toHaveBeenCalledWith({ line_width: 1.25, point_radius: 2 });
+  });
+
+  it('can change area shading by clicking', () => {
+    const onChange = jest.fn();
+    renderVisualOptionsEditor(DEFAULT_VISUAL, onChange);
+
+    userEvent.click(getAreaShadingSwitch());
+
+    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_VISUAL, area_shading: !DEFAULT_VISUAL.area_shading });
   });
 });

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Slider } from '@mui/material';
+import { Slider, Switch } from '@mui/material';
 import { OptionsEditorControl, OptionsEditorGroup } from '@perses-dev/components';
 import {
-  DEFAULT_AREA_OPACITY,
+  DEFAULT_AREA_SHADING,
   DEFAULT_LINE_WIDTH,
   DEFAULT_POINT_RADIUS,
   VISUAL_CONFIG,
@@ -84,17 +84,16 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
         }
       />
       <OptionsEditorControl
-        label={VISUAL_CONFIG.area_opacity.label}
+        label={VISUAL_CONFIG.area_shading.label}
         control={
-          <Slider
-            data-testid={VISUAL_CONFIG.area_opacity.testId}
-            value={value.area_opacity ?? DEFAULT_AREA_OPACITY}
-            valueLabelDisplay="auto"
-            step={VISUAL_CONFIG.area_opacity.step}
-            marks
-            min={VISUAL_CONFIG.area_opacity.min}
-            max={VISUAL_CONFIG.area_opacity.max}
-            onChange={handleAreaOpacityChange}
+          <Switch
+            checked={value.area_shading ?? DEFAULT_AREA_SHADING}
+            onChange={(e) => {
+              onChange({
+                ...value,
+                area_shading: e.target.checked,
+              });
+            }}
           />
         }
       />

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -13,7 +13,13 @@
 
 import { Slider } from '@mui/material';
 import { OptionsEditorControl, OptionsEditorGroup } from '@perses-dev/components';
-import { VisualOptions, DEFAULT_LINE_WIDTH, DEFAULT_POINT_RADIUS, VISUAL_CONFIG } from './time-series-chart-model';
+import {
+  DEFAULT_AREA_OPACITY,
+  DEFAULT_LINE_WIDTH,
+  DEFAULT_POINT_RADIUS,
+  VISUAL_CONFIG,
+  VisualOptions,
+} from './time-series-chart-model';
 
 export interface VisualOptionsEditorProps {
   value: VisualOptions;
@@ -34,6 +40,14 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
     onChange({
       ...value,
       line_width: newValue,
+    });
+  };
+
+  const handleAreaOpacityChange = (_: Event, sliderValue: number | number[]) => {
+    const newValue = Array.isArray(sliderValue) ? sliderValue[0] : sliderValue;
+    onChange({
+      ...value,
+      area_opacity: newValue,
     });
   };
 
@@ -66,6 +80,21 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             min={VISUAL_CONFIG.line_width.min}
             max={VISUAL_CONFIG.line_width.max}
             onChange={handleLineWidthChange}
+          />
+        }
+      />
+      <OptionsEditorControl
+        label={VISUAL_CONFIG.area_opacity.label}
+        control={
+          <Slider
+            data-testid={VISUAL_CONFIG.area_opacity.testId}
+            value={value.area_opacity ?? DEFAULT_AREA_OPACITY}
+            valueLabelDisplay="auto"
+            step={VISUAL_CONFIG.area_opacity.step}
+            marks
+            min={VISUAL_CONFIG.area_opacity.min}
+            max={VISUAL_CONFIG.area_opacity.max}
+            onChange={handleAreaOpacityChange}
           />
         }
       />

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -43,14 +43,6 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
     });
   };
 
-  const handleAreaOpacityChange = (_: Event, sliderValue: number | number[]) => {
-    const newValue = Array.isArray(sliderValue) ? sliderValue[0] : sliderValue;
-    onChange({
-      ...value,
-      area_opacity: newValue,
-    });
-  };
-
   return (
     <OptionsEditorGroup title="Visual">
       <OptionsEditorControl

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -42,7 +42,7 @@ export type VisualOptions = {
   // type: 'line' | 'bar' | 'scatter'; // TODO: new option to change series type
   point_radius?: number;
   line_width?: number;
-  area_opacity?: number;
+  area_shading?: boolean;
 };
 
 export const DEFAULT_UNIT: UnitOptions = {
@@ -55,12 +55,13 @@ export const DEFAULT_LINE_WIDTH = 1.5;
 
 export const DEFAULT_POINT_RADIUS = 4;
 
-export const DEFAULT_AREA_OPACITY = 0;
+export const DEFAULT_AREA_SHADING = false;
+export const DEFAULT_AREA_OPACITY = 0.4;
 
 export const DEFAULT_VISUAL: VisualOptions = {
   line_width: DEFAULT_LINE_WIDTH,
   point_radius: DEFAULT_POINT_RADIUS,
-  area_opacity: DEFAULT_AREA_OPACITY,
+  area_shading: DEFAULT_AREA_SHADING,
 };
 
 export const VISUAL_CONFIG = {
@@ -78,12 +79,8 @@ export const VISUAL_CONFIG = {
     max: 6,
     step: 0.25,
   },
-  area_opacity: {
-    label: 'Area Opacity',
-    testId: 'slider-area-opacity',
-    min: 0,
-    max: 1,
-    step: 0.1,
+  area_shading: {
+    label: 'Area Shading',
   },
 };
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -42,6 +42,7 @@ export type VisualOptions = {
   // type: 'line' | 'bar' | 'scatter'; // TODO: new option to change series type
   point_radius?: number;
   line_width?: number;
+  area_opacity?: number;
 };
 
 export const DEFAULT_UNIT: UnitOptions = {
@@ -54,9 +55,12 @@ export const DEFAULT_LINE_WIDTH = 1.5;
 
 export const DEFAULT_POINT_RADIUS = 4;
 
+export const DEFAULT_AREA_OPACITY = 0;
+
 export const DEFAULT_VISUAL: VisualOptions = {
   line_width: DEFAULT_LINE_WIDTH,
   point_radius: DEFAULT_POINT_RADIUS,
+  area_opacity: DEFAULT_AREA_OPACITY,
 };
 
 export const VISUAL_CONFIG = {
@@ -73,6 +77,13 @@ export const VISUAL_CONFIG = {
     min: 0,
     max: 6,
     step: 0.25,
+  },
+  area_opacity: {
+    label: 'Area Opacity',
+    testId: 'slider-area-opacity',
+    min: 0,
+    max: 1,
+    step: 0.1,
   },
 };
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -17,7 +17,13 @@ import { EChartsTimeSeries } from '@perses-dev/components';
 import { TimeSeries, useTimeSeriesQueries } from '@perses-dev/plugin-system';
 import { gcd } from '../../../utils/mathjs';
 import { StepOptions } from '../../../model/thresholds';
-import { VisualOptions, DEFAULT_LINE_WIDTH, DEFAULT_POINT_RADIUS } from '../time-series-chart-model';
+import {
+  DEFAULT_AREA_OPACITY,
+  DEFAULT_LINE_WIDTH,
+  DEFAULT_POINT_RADIUS,
+  VisualOptions,
+} from '../time-series-chart-model';
+
 import { getRandomColor } from './palette-gen';
 
 export interface TimeScale {
@@ -149,6 +155,9 @@ export function getLineSeries(
     symbolSize: pointRadius,
     lineStyle: {
       width: lineWidth,
+    },
+    areaStyle: {
+      opacity: visual.area_opacity ?? DEFAULT_AREA_OPACITY,
     },
     emphasis: {
       lineStyle: {

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -157,7 +157,7 @@ export function getLineSeries(
       width: lineWidth,
     },
     areaStyle: {
-      opacity: visual.area_opacity ?? DEFAULT_AREA_OPACITY,
+      opacity: visual.area_shading ? DEFAULT_AREA_OPACITY : 0,
     },
     emphasis: {
       lineStyle: {


### PR DESCRIPTION
## Overview

Add optional `area_shading` boolean to spec for TimeSeriesChart panel. This includes a MUI Switch to customize the ECharts property [series-line.areaStyle.opacity](https://echarts.apache.org/en/option.html#series-line.areaStyle.opacity). Unlike previous PR #962, this branch locks down the option so that we have more control over display.

## Following PRs

- Planning to add visual regression tests after stacked area PR is ready
- [Stacked area](https://echarts.apache.org/examples/en/editor.html?c=area-stack) support by adding new `stacking` visual option
  - schema will most likely be: 
```cue
#visual: {
	line_width?:   number & >=0.25 & <=3
	point_radius?: number & >=0 & <=6
	area_shading?: bool
	stacking?: "Normal" | "Percent"
        // TBD: another option will be needed to control ordering
}
```

## Screenshots

<img width="720" alt="image" src="https://user-images.githubusercontent.com/9369625/219399791-9cb8600b-0847-4cca-94af-05f4862b7c7e.png">

<img width="837" alt="image" src="https://user-images.githubusercontent.com/9369625/219404799-9a21ad8b-71a3-4c63-a596-3c423b49612c.png">

<!--<img width="719" alt="image" src="https://user-images.githubusercontent.com/9369625/219399600-5ab57314-3158-452e-99a9-922c4d83bd7c.png">-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
