### PR TITLE
[ENHANCEMENT ] Fix styling of TimeRangeControls

### DIFF
--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import RefreshIcon from 'mdi-material-ui/Refresh';
+import { Stack } from '@mui/material';
 import { DateTimeRangePicker, InfoTooltip, TimeOption } from '@perses-dev/components';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { isDurationString } from '@perses-dev/core';
@@ -36,10 +37,14 @@ const DEFAULT_HEIGHT = '34px';
 interface TimeRangeControlsProps {
   // The controls look best at heights >= 28 pixels
   heightPx?: number;
+
+  // Whether to show the refresh button or not
+  showRefresh?: boolean;
 }
 
-export function TimeRangeControls({ heightPx }: TimeRangeControlsProps) {
+export function TimeRangeControls({ heightPx, showRefresh = true }: TimeRangeControlsProps) {
   const { timeRange, setTimeRange, refresh } = useTimeRange();
+  // TODO: Remove this since it couples to the dashboard context
   const defaultTimeRange = useDefaultTimeRange();
 
   // Convert height to a string, then use the string for styling
@@ -56,13 +61,15 @@ export function TimeRangeControls({ heightPx }: TimeRangeControlsProps) {
   }
 
   return (
-    <>
+    <Stack direction="row" spacing={1}>
       <DateTimeRangePicker timeOptions={TIME_OPTIONS} value={timeRange} onChange={setTimeRange} height={height} />
-      <InfoTooltip description={TOOLTIP_TEXT.refreshDashboard}>
-        <ToolbarIconButton aria-label={TOOLTIP_TEXT.refreshDashboard} onClick={refresh} sx={{ height }}>
-          <RefreshIcon />
-        </ToolbarIconButton>
-      </InfoTooltip>
-    </>
+      {showRefresh && (
+        <InfoTooltip description={TOOLTIP_TEXT.refreshDashboard}>
+          <ToolbarIconButton aria-label={TOOLTIP_TEXT.refreshDashboard} onClick={refresh} sx={{ height }}>
+            <RefreshIcon />
+          </ToolbarIconButton>
+        </InfoTooltip>
+      )}
+    </Stack>
   );
 }


### PR DESCRIPTION
This fixes the TimeRangeControls to wrap the component in a flex component with a spacing of 1. Without a wrapper, the component did not look great standalone. It also adds the ability to hide the refresh button.

TODO:
There is still some work to make this TimeRangeControls component composable for a majority of usec cases. Some examples:
- ability to pass custom time ranges
- Remove dependency of DashboardContext

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
