### PR TITLE
[BUGFIX] remove semicolon below legend

### DIFF
--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -51,7 +51,7 @@ export function Legend({ width, height, options, data }: LegendProps) {
         bottom: 0,
       }}
     >
-      <CompactLegend items={data} height={height} />;
+      <CompactLegend items={data} height={height} />
     </Box>
   );
 }


### PR DESCRIPTION
Shan found a bug where a random semicolon shows below our legend when inspecting the DOM or in certain cases like shown here:

![semi-colon-bug](https://user-images.githubusercontent.com/9369625/220438211-882826a3-7535-4291-adb9-9fa5cdee2778.png)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
