### PR TITLE
[IGNORE] Bump go to v1.20.x

### DIFF
--- a/.github/actions/setup_environment/action.yaml
+++ b/.github/actions/setup_environment/action.yaml
@@ -14,7 +14,7 @@ runs:
       uses: actions/setup-go@v3
       if: inputs.enable_go == 'true'
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
     - uses: actions/cache@v3.0.8
       if: inputs.enable_go == 'true'
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -99,7 +99,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.49.0
+          version: v1.51.2
           args: --timeout 5m
   cue-eval:
     name: cue


### PR DESCRIPTION
I'm just bumping the Golang version to the last one
