### PR TITLE
[IGNORE] add visual options test for time series panel

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -1917,7 +1917,7 @@
           "spec": {
             "display": {
               "name": "Line Visual Options",
-              "description": "Time series chart with custom visual options and unformatted legend"
+              "description": "Time series chart with custom visual options"
             },
             "plugin": {
               "kind": "TimeSeriesChart",
@@ -1940,7 +1940,7 @@
                   }
                 ],
                 "visual": {
-                  "area_opacity": 0.4,
+                  "area_opacity": 0.5,
                   "point_radius": 6,
                   "line_width": 3
                 }

--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -1916,7 +1916,7 @@
           "kind": "Panel",
           "spec": {
             "display": {
-              "name": "Line Visual Options",
+              "name": "Custom Visual Options",
               "description": "Time series chart with custom visual options"
             },
             "plugin": {

--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -1911,6 +1911,42 @@
               }
             }
           }
+        },
+        "LineVisualOptions": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "Line Visual Options",
+              "description": "Time series chart with custom visual options and unformatted legend"
+            },
+            "plugin": {
+              "kind": "TimeSeriesChart",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "TimeSeriesQuery",
+                    "spec": {
+                      "plugin": {
+                        "kind": "PrometheusTimeSeriesQuery",
+                        "spec": {
+                          "datasource": {
+                            "kind": "PrometheusDatasource",
+                            "name": "PrometheusDemo"
+                          },
+                          "query": "up{job=\"grafana\",instance=\"demo.do.prometheus.io:3000\"}"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "visual": {
+                  "area_opacity": 0.4,
+                  "point_radius": 6,
+                  "line_width": 3
+                }
+              }
+            }
+          }
         }
       },
       "layouts": [
@@ -1931,6 +1967,15 @@
                 "height": 7,
                 "content": {
                   "$ref": "#/spec/panels/SingleLine"
+                }
+              },
+              {
+                "x": 9,
+                "y": 0,
+                "width": 9,
+                "height": 7,
+                "content": {
+                  "$ref": "#/spec/panels/LineVisualOptions"
                 }
               }
             ]

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -63,22 +63,22 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
     });
 
     await dashboardPage.forEachTheme(async (themeName) => {
-      const panelFirst = dashboardPage.getPanelByName('Single Line');
-      await panelFirst.isLoaded();
-      await waitForStableCanvas(panelFirst.canvas);
+      const firstPanel = dashboardPage.getPanelByName('Single Line');
+      await firstPanel.isLoaded();
+      await waitForStableCanvas(firstPanel.canvas);
 
-      await happoPlaywright.screenshot(page, panelFirst.parent, {
+      await happoPlaywright.screenshot(page, firstPanel.parent, {
         component: 'Time Series Chart Panel',
         variant: `Single Line [${themeName}]`,
       });
 
-      const panelSecond = dashboardPage.getPanelByName('Line Visual Options');
-      await panelSecond.isLoaded();
-      await waitForStableCanvas(panelSecond.canvas);
+      const secondPanel = dashboardPage.getPanelByName('Custom Visual Options');
+      await secondPanel.isLoaded();
+      await waitForStableCanvas(secondPanel.canvas);
 
-      await happoPlaywright.screenshot(page, panelSecond.parent, {
+      await happoPlaywright.screenshot(page, secondPanel.parent, {
         component: 'Time Series Chart Panel',
-        variant: `Line Visual Options [${themeName}]`,
+        variant: `Custom Visual Options [${themeName}]`,
       });
     });
   });

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -29,7 +29,11 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
     await happoPlaywright.finish();
   });
 
-  test(`displays single line as expected`, async ({ page, dashboardPage, mockNow }) => {
+  test(`displays default single line and custom visual options as expected`, async ({
+    page,
+    dashboardPage,
+    mockNow,
+  }) => {
     // Mock data response, so we can make assertions on consistent response data.
     await dashboardPage.mockQueryRangeRequests({
       queries: [
@@ -59,63 +63,20 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
     });
 
     await dashboardPage.forEachTheme(async (themeName) => {
-      const panel = dashboardPage.getPanelByName('Single Line');
-      await panel.isLoaded();
-      await waitForStableCanvas(panel.canvas);
+      const panelFirst = dashboardPage.getPanelByName('Single Line');
+      await panelFirst.isLoaded();
+      await waitForStableCanvas(panelFirst.canvas);
 
-      await happoPlaywright.screenshot(page, panel.parent, {
+      await happoPlaywright.screenshot(page, panelFirst.parent, {
         component: 'Time Series Chart Panel',
         variant: `Single Line [${themeName}]`,
       });
-    });
-  });
 
-  test(`displays time series with custom visual options`, async ({ page, dashboardPage, mockNow }) => {
-    // Mock data response, so we can make assertions on consistent response data.
-    await dashboardPage.mockQueryRangeRequests({
-      queries: [
-        {
-          query: 'up{job="grafana",instance="demo.do.prometheus.io:3000"}',
-          response: {
-            status: 200,
-            body: JSON.stringify(
-              mockTimeSeriesResponseWithStableValue({
-                metrics: [
-                  {
-                    metric: {
-                      __name__: 'up',
-                      instance: 'demo.do.prometheus.io:3000',
-                      job: 'grafana',
-                    },
-                    value: '1',
-                  },
-                ],
-                startTimeMs: mockNow - 6 * 60 * 60 * 1000,
-                endTimeMs: mockNow,
-              })
-            ),
-          },
-        },
-      ],
-    });
+      const panelSecond = dashboardPage.getPanelByName('Line Visual Options');
+      await panelSecond.isLoaded();
+      await waitForStableCanvas(panelSecond.canvas);
 
-    await dashboardPage.forEachTheme(async (themeName) => {
-      const panel = dashboardPage.getPanelByName('Single Line');
-      await panel.isLoaded();
-      await waitForStableCanvas(panel.canvas);
-
-      await happoPlaywright.screenshot(page, panel.parent, {
-        component: 'Time Series Chart Panel',
-        variant: `Single Line [${themeName}]`,
-      });
-    });
-
-    await dashboardPage.forEachTheme(async (themeName) => {
-      const panel = dashboardPage.getPanelByName('Line Visual Options');
-      await panel.isLoaded();
-      await waitForStableCanvas(panel.canvas);
-
-      await happoPlaywright.screenshot(page, panel.parent, {
+      await happoPlaywright.screenshot(page, panelSecond.parent, {
         component: 'Time Series Chart Panel',
         variant: `Line Visual Options [${themeName}]`,
       });

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -69,4 +69,56 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
       });
     });
   });
+
+  test(`displays time series with custom visual options`, async ({ page, dashboardPage, mockNow }) => {
+    // Mock data response, so we can make assertions on consistent response data.
+    await dashboardPage.mockQueryRangeRequests({
+      queries: [
+        {
+          query: 'up{job="grafana",instance="demo.do.prometheus.io:3000"}',
+          response: {
+            status: 200,
+            body: JSON.stringify(
+              mockTimeSeriesResponseWithStableValue({
+                metrics: [
+                  {
+                    metric: {
+                      __name__: 'up',
+                      instance: 'demo.do.prometheus.io:3000',
+                      job: 'grafana',
+                    },
+                    value: '1',
+                  },
+                ],
+                startTimeMs: mockNow - 6 * 60 * 60 * 1000,
+                endTimeMs: mockNow,
+              })
+            ),
+          },
+        },
+      ],
+    });
+
+    await dashboardPage.forEachTheme(async (themeName) => {
+      const panel = dashboardPage.getPanelByName('Single Line');
+      await panel.isLoaded();
+      await waitForStableCanvas(panel.canvas);
+
+      await happoPlaywright.screenshot(page, panel.parent, {
+        component: 'Time Series Chart Panel',
+        variant: `Single Line [${themeName}]`,
+      });
+    });
+
+    await dashboardPage.forEachTheme(async (themeName) => {
+      const panel = dashboardPage.getPanelByName('Line Visual Options');
+      await panel.isLoaded();
+      await waitForStableCanvas(panel.canvas);
+
+      await happoPlaywright.screenshot(page, panel.parent, {
+        component: 'Time Series Chart Panel',
+        variant: `Line Visual Options [${themeName}]`,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Follow up to `area_opacity` PR #962 with visual regression tests for the new TimeSeriesChart panel option.

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
