### PR TITLE
[BREAKINGCHANGE] TimeSeries and TimeSeriesValueTuple Iterable type change

### DIFF
--- a/ui/components/src/model/graph.ts
+++ b/ui/components/src/model/graph.ts
@@ -23,7 +23,7 @@ export type GraphSeriesValueTuple = [timestamp: UnixTimeMs, value: number];
 
 export interface GraphSeries {
   name: string;
-  values: Iterable<GraphSeriesValueTuple>;
+  values: GraphSeriesValueTuple[];
 }
 
 export type EChartsValues = number | null | '-';

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -47,7 +47,7 @@ export function GaugeChartPanel(props: GaugeChartPanelProps) {
     for (const timeSeries of data.series) {
       const calculate = CalculationsMap[calculation];
       const series = {
-        value: calculate(Array.from(timeSeries.values)),
+        value: calculate(timeSeries.values),
         label: timeSeries.formattedName ?? '',
       };
       seriesData.push(series);

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -67,9 +67,9 @@ const useChartData = (data: TimeSeriesData | undefined, calculation: Calculation
     };
     if (data === undefined) return loadingData;
 
-    const seriesData = Array.from(data.series)[0];
+    const seriesData = data.series[0];
     const calculate = CalculationsMap[calculation];
-    const calculatedValue = seriesData !== undefined ? calculate(Array.from(seriesData.values)) : undefined;
+    const calculatedValue = seriesData !== undefined ? calculate(seriesData.values) : undefined;
 
     return { calculatedValue, seriesData };
   }, [data, calculation]);

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -128,7 +128,7 @@ describe('TimeSeriesChartPanel', () => {
   it('should toggle selected state when a legend item is clicked', async () => {
     renderPanel();
 
-    const seriesArr = Array.from(MOCK_TIME_SERIES_DATA.series);
+    const seriesArr = MOCK_TIME_SERIES_DATA.series;
     const firstLegend = getLegendByName(seriesArr[0]?.name);
     const secondLegend = getLegendByName(seriesArr[1]?.name);
 
@@ -143,7 +143,7 @@ describe('TimeSeriesChartPanel', () => {
 
   it('should modify selected state when a legend item is clicked with shift key', async () => {
     renderPanel();
-    const seriesArr = Array.from(MOCK_TIME_SERIES_DATA.series);
+    const seriesArr = MOCK_TIME_SERIES_DATA.series;
     const firstLegend = getLegendByName(seriesArr[0]?.name);
     const secondLegend = getLegendByName(seriesArr[1]?.name);
 
@@ -178,7 +178,7 @@ describe('TimeSeriesChartPanel', () => {
 
   it('should modify selected state when a legend item is clicked with meta key', async () => {
     renderPanel();
-    const seriesArr = Array.from(MOCK_TIME_SERIES_DATA.series);
+    const seriesArr = MOCK_TIME_SERIES_DATA.series;
 
     // Falling back to a bogus string if not set to appease typescript.
     const firstName = seriesArr[0]?.name;

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -88,7 +88,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   const queryResults = useTimeSeriesQueries(queries, { suggestedStepMs });
   const fetching = queryResults.some((result) => result.isFetching);
   const loading = queryResults.some((result) => result.isLoading);
-  const hasData = queryResults.some((result) => result.data && Array.from(result.data.series).length > 0);
+  const hasData = queryResults.some((result) => result.data && result.data.series.length > 0);
 
   const { setTimeRange } = useTimeRange();
 

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -48,12 +48,12 @@ export interface TimeSeriesQueryContext {
 export interface TimeSeriesData {
   timeRange?: AbsoluteTimeRange;
   stepMs?: number;
-  series: Iterable<TimeSeries>;
+  series: TimeSeries[];
 }
 
 export interface TimeSeries {
   name: string;
-  values: Iterable<TimeSeriesValueTuple>;
+  values: TimeSeriesValueTuple[];
   formattedName?: string;
 }
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -70,8 +70,6 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
     timeRange: { start: fromUnixTime(start), end: fromUnixTime(end) },
     stepMs: step * 1000,
 
-    // TODO: Maybe do a proper Iterable implementation that defers some of this
-    // processing until its needed
     series: result.map((value) => {
       const { metric, values } = value;
 


### PR DESCRIPTION
Change TimeSeries results types to regular Array instead of Iterable. We had plans to leverage Iterables early on when these types were defined that haven't really materialized. Changing to a regular Array so we can remove `Array.from` calls in many files and makes working with our packages a little easier.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
