### PR TITLE
[ENHANCEMENT] Pass headers in Prometheus datasource createClient

### DIFF
--- a/ui/core/src/model/http.ts
+++ b/ui/core/src/model/http.ts
@@ -11,16 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './dashboard';
-export * from './datasource';
-export * from './definitions';
-export * from './display';
-export * from './http';
-export * from './layout';
-export * from './panels';
-export * from './resource';
-export * from './thresholds';
-export * from './time';
-export * from './time-series-queries';
-export * from './variables';
-export * from './display';
+export type RequestHeaders = Record<string, string>;

--- a/ui/prometheus-plugin/src/model/prometheus-client.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-client.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { fetchJson } from '@perses-dev/core';
+import { fetchJson, RequestHeaders } from '@perses-dev/core';
 import {
   InstantQueryRequestParameters,
   InstantQueryResponse,
@@ -25,6 +25,7 @@ import {
 
 interface PrometheusClientOptions {
   datasourceUrl: string;
+  headers?: RequestHeaders;
 }
 
 export interface PrometheusClient {
@@ -37,6 +38,7 @@ export interface PrometheusClient {
 
 export interface QueryOptions {
   datasourceUrl: string;
+  headers?: RequestHeaders;
 }
 
 /**
@@ -81,13 +83,14 @@ function fetchWithGet<T extends RequestParams<T>, TResponse>(apiURI: string, par
 }
 
 function fetchWithPost<T extends RequestParams<T>, TResponse>(apiURI: string, params: T, queryOptions: QueryOptions) {
-  const { datasourceUrl } = queryOptions;
+  const { datasourceUrl, headers } = queryOptions;
 
   const url = `${datasourceUrl}${apiURI}`;
   const init = {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
+      ...headers,
     },
     body: createSearchParams(params),
   };

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.ts
@@ -11,18 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { RequestHeaders } from '@perses-dev/core';
 import { DatasourcePlugin } from '@perses-dev/plugin-system';
 import { instantQuery, rangeQuery, labelNames, labelValues, PrometheusClient } from '../model';
 
 export interface PrometheusDatasourceSpec {
   direct_url?: string;
+  headers?: RequestHeaders;
 }
 
 /**
  * Creates a PrometheusClient for a specific datasource spec.
  */
 const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>['createClient'] = (spec, options) => {
-  const { direct_url } = spec;
+  const { direct_url, headers } = spec;
   const { proxyUrl } = options;
 
   // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
@@ -36,10 +38,10 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
     options: {
       datasourceUrl,
     },
-    instantQuery: (params) => instantQuery(params, { datasourceUrl }),
-    rangeQuery: (params) => rangeQuery(params, { datasourceUrl }),
-    labelNames: (params) => labelNames(params, { datasourceUrl }),
-    labelValues: (params) => labelValues(params, { datasourceUrl }),
+    instantQuery: (params) => instantQuery(params, { datasourceUrl, headers }),
+    rangeQuery: (params) => rangeQuery(params, { datasourceUrl, headers }),
+    labelNames: (params) => labelNames(params, { datasourceUrl, headers }),
+    labelValues: (params) => labelValues(params, { datasourceUrl, headers }),
   };
 };
 


### PR DESCRIPTION
## Overview
As discussed in original datasource proposal, passing custom `headers` are supported. This PR implements this in the context of our PrometheusDatasource. This required updates in createClient as well as the fetchWithPost function.

## Screenshot
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/9369625/221917302-c53a3a4a-da42-4eef-bb3a-5f3aea7493db.png">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
