### PR TITLE
[ENHANCEMENT] Legend height increased for tall panels

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -1917,7 +1917,7 @@
           "spec": {
             "display": {
               "name": "Legend Position Bottom",
-              "description": "Time series chart with a single line"
+              "description": "Time series chart with a default legend"
             },
             "plugin": {
               "kind": "TimeSeriesChart",
@@ -1969,7 +1969,7 @@
                             "name": "PrometheusDemo"
                           },
                           "query": "up{job=\"grafana\",instance=\"demo.do.prometheus.io:3000\"}",
-                          "series_name_format": "formatted series example - {{job}} job - {{instance}}"
+                          "series_name_format": "formatted series name example - {{job}} job - instance {{instance}}"
                         }
                       }
                     }

--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -1946,6 +1946,40 @@
             }
           }
         },
+        "LegendRight": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "Legend Position Right",
+              "description": "Time series chart with a legend positioned to the right"
+            },
+            "plugin": {
+              "kind": "TimeSeriesChart",
+              "spec": {
+                "legend": {
+                  "position": "Right"
+                },
+                "queries": [
+                  {
+                    "kind": "TimeSeriesQuery",
+                    "spec": {
+                      "plugin": {
+                        "kind": "PrometheusTimeSeriesQuery",
+                        "spec": {
+                          "datasource": {
+                            "kind": "PrometheusDatasource",
+                            "name": "PrometheusDemo"
+                          },
+                          "query": "up{job=\"grafana\",instance=\"demo.do.prometheus.io:3000\"}"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
         "LegendTallFormatted": {
           "kind": "Panel",
           "spec": {
@@ -2101,6 +2135,13 @@
               },
               {
                 "x": 8,
+                "y": 7,
+                "width": 8,
+                "height": 7,
+                "content": { "$ref": "#/spec/panels/LegendRight" }
+              },
+              {
+                "x": 16,
                 "y": 7,
                 "width": 8,
                 "height": 10,

--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -1912,6 +1912,73 @@
             }
           }
         },
+        "LegendBottom": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "Legend Position Bottom",
+              "description": "Time series chart with a single line"
+            },
+            "plugin": {
+              "kind": "TimeSeriesChart",
+              "spec": {
+                "legend": {
+                  "position": "Bottom"
+                },
+                "queries": [
+                  {
+                    "kind": "TimeSeriesQuery",
+                    "spec": {
+                      "plugin": {
+                        "kind": "PrometheusTimeSeriesQuery",
+                        "spec": {
+                          "datasource": {
+                            "kind": "PrometheusDatasource",
+                            "name": "PrometheusDemo"
+                          },
+                          "query": "up{job=\"grafana\",instance=\"demo.do.prometheus.io:3000\"}"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "LegendTallFormatted": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "Legend Tall Formatted",
+              "description": "Time series chart with large legend and formatted series names"
+            },
+            "plugin": {
+              "kind": "TimeSeriesChart",
+              "spec": {
+                "legend": { "position": "Bottom" },
+                "queries": [
+                  {
+                    "kind": "TimeSeriesQuery",
+                    "spec": {
+                      "plugin": {
+                        "kind": "PrometheusTimeSeriesQuery",
+                        "spec": {
+                          "datasource": {
+                            "kind": "PrometheusDatasource",
+                            "name": "PrometheusDemo"
+                          },
+                          "query": "up{job=\"grafana\",instance=\"demo.do.prometheus.io:3000\"}",
+                          "series_name_format": "formatted series example - {{job}} job - {{instance}}"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
         "CustomVisualOptions": {
           "kind": "Panel",
           "spec": {
@@ -2022,6 +2089,22 @@
                 "content": {
                   "$ref": "#/spec/panels/ConnectedNulls"
                 }
+              },
+              {
+                "x": 0,
+                "y": 7,
+                "width": 8,
+                "height": 7,
+                "content": {
+                  "$ref": "#/spec/panels/LegendBottom"
+                }
+              },
+              {
+                "x": 8,
+                "y": 7,
+                "width": 8,
+                "height": 10,
+                "content": { "$ref": "#/spec/panels/LegendTallFormatted" }
               }
             ]
           }

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -33,7 +33,13 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
     await happoPlaywright.finish();
   });
 
-  ['Single Line', 'Custom Visual Options', 'Connected Nulls'].forEach((panelName) => {
+  [
+    'Single Line',
+    'Custom Visual Options',
+    'Connected Nulls',
+    'Legend Position Bottom',
+    'Legend Tall Formatted',
+  ].forEach((panelName) => {
     test(`displays ${panelName} as expected`, async ({ page, dashboardPage, mockNow }) => {
       // Mock data response, so we can make assertions on consistent response data.
       await dashboardPage.mockQueryRangeRequests({

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -38,6 +38,7 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
     'Custom Visual Options',
     'Connected Nulls',
     'Legend Position Bottom',
+    'Legend Position Right',
     'Legend Tall Formatted',
   ].forEach((panelName) => {
     test(`displays ${panelName} as expected`, async ({ page, dashboardPage, mockNow }) => {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -234,8 +234,12 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   }
 
   const legendWidth = legend && legend.position === 'Right' ? 200 : adjustedContentDimensions.width;
-  let legendHeight = legend && legend.position === 'Right' ? adjustedContentDimensions.height : LEGEND_HEIGHT_SM;
-  if (adjustedContentDimensions.height > PANEL_HEIGHT_LG_BREAKPOINT) {
+
+  // TODO: account for number of time series returned when adjusting legend spacing
+  let legendHeight = LEGEND_HEIGHT_SM;
+  if (legend && legend.position === 'Right') {
+    legendHeight = adjustedContentDimensions.height;
+  } else if (adjustedContentDimensions.height > PANEL_HEIGHT_LG_BREAKPOINT) {
     legendHeight = LEGEND_HEIGHT_LG;
   }
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -28,7 +28,15 @@ import {
   useChartsTheme,
 } from '@perses-dev/components';
 import { useSuggestedStepMs } from '../../model/time';
-import { TimeSeriesChartOptions, DEFAULT_UNIT, DEFAULT_VISUAL, DEFAULT_Y_AXIS } from './time-series-chart-model';
+import {
+  TimeSeriesChartOptions,
+  DEFAULT_UNIT,
+  DEFAULT_VISUAL,
+  DEFAULT_Y_AXIS,
+  PANEL_HEIGHT_LG_BREAKPOINT,
+  LEGEND_HEIGHT_SM,
+  LEGEND_HEIGHT_LG,
+} from './time-series-chart-model';
 import {
   getLineSeries,
   getThresholdSeries,
@@ -226,7 +234,10 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   }
 
   const legendWidth = legend && legend.position === 'Right' ? 200 : adjustedContentDimensions.width;
-  const legendHeight = legend && legend.position === 'Right' ? adjustedContentDimensions.height : 40;
+  let legendHeight = legend && legend.position === 'Right' ? adjustedContentDimensions.height : LEGEND_HEIGHT_SM;
+  if (adjustedContentDimensions.height > PANEL_HEIGHT_LG_BREAKPOINT) {
+    legendHeight = LEGEND_HEIGHT_LG;
+  }
 
   // override default spacing, see: https://echarts.apache.org/en/option.html#grid
   const gridLeft = y_axis && y_axis.label ? 30 : 20;

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -109,6 +109,10 @@ export const Y_AXIS_CONFIG = {
   max: { label: 'Max' },
 };
 
+export const PANEL_HEIGHT_LG_BREAKPOINT = 300;
+export const LEGEND_HEIGHT_SM = 40;
+export const LEGEND_HEIGHT_LG = 100;
+
 /**
  * Creates an initial/empty options object for the TimeSeriesChartPanel.
  */


### PR DESCRIPTION
We got feedback that our legend is too scrunched up when using `position: 'Bottom'`. This PR increases our time series panel's legend size when panels reach a certain height (breakpoint currently set to 300 but this can be adjusted).

## Screenshot
<img width="569" alt="image" src="https://user-images.githubusercontent.com/9369625/222166960-06a1795e-d9f7-4694-9173-4f5549c34ed2.png">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
