### PR TITLE
[BUGFIX] Add null checks for layouts and panels in DashboardProvider

### DIFF
--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -103,7 +103,7 @@ function initStore(props: DashboardProviderProps) {
     spec: { layouts, panels },
   } = dashboardResource;
 
-  // Set fallbacks
+  // Set fallbacks in case the frontend is used with a non-Perses backend
   layouts = layouts ?? [];
   panels = panels ?? {};
 

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -128,12 +128,12 @@ function initStore(props: DashboardProviderProps) {
           defaultTimeRange: { pastDuration: duration },
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
-          setDashboard: ({ metadata, spec: { display, panels, layouts } }) => {
+          setDashboard: ({ metadata, spec: { display, panels = {}, layouts = [] } }) => {
             set((state) => {
               state.metadata = metadata;
               state.display = display;
-              const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
               state.panels = panels;
+              const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
               state.panelGroups = panelGroups;
               state.panelGroupOrder = panelGroupOrder;
             });

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -95,22 +95,34 @@ function initStore(props: DashboardProviderProps) {
   } = props;
 
   const {
-    spec: { display, layouts, panels, duration },
+    spec: { display, duration },
     metadata,
   } = dashboardResource;
+
+  let {
+    spec: { layouts, panels },
+  } = dashboardResource;
+
+  // Set fallbacks
+  layouts = layouts ?? [];
+  panels = panels ?? {};
+
   const store = createStore<DashboardStoreState>()(
     immer(
       devtools((...args) => {
         const [set] = args;
         return {
+          /* Groups */
           ...createPanelGroupSlice(layouts)(...args),
-          ...createPanelSlice(panels)(...args),
           ...createPanelGroupEditorSlice(...args),
           ...createDeletePanelGroupSlice(...args),
+          /* Panels */
+          ...createPanelSlice(panels)(...args),
           ...createPanelEditorSlice()(...args),
           ...createDeletePanelSlice()(...args),
-          ...createDiscardChangesDialogSlice(...args),
           ...createDuplicatePanelSlice()(...args),
+          /* General */
+          ...createDiscardChangesDialogSlice(...args),
           metadata,
           display,
           defaultTimeRange: { pastDuration: duration },


### PR DESCRIPTION
If a dashboard passed into the DashboardProvider has `layouts` or `panels` that are `undefined`/`null` for some reason, this guarantees that they are initialized to `[]` or `{}`.


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
