### PR TITLE
[ENHANCEMENT] TimeSeriesData now supports labels

### DIFF
--- a/ui/core/src/model/time-series-queries.ts
+++ b/ui/core/src/model/time-series-queries.ts
@@ -24,3 +24,5 @@ export interface TimeSeriesQuerySpec<PluginSpec> {
 }
 
 export type TimeSeriesValueTuple = [timestamp: UnixTimeMs, value: number | null];
+
+export type Labels = Record<string, string>;

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AbsoluteTimeRange, TimeSeriesValueTuple, UnknownSpec } from '@perses-dev/core';
+import { AbsoluteTimeRange, TimeSeriesValueTuple, UnknownSpec, Labels } from '@perses-dev/core';
 import { DatasourceStore, VariableStateMap } from '../runtime';
 import { Plugin } from './plugin-base';
 
@@ -55,4 +55,5 @@ export interface TimeSeries {
   name: string;
   values: TimeSeriesValueTuple[];
   formattedName?: string;
+  labels?: Labels;
 }

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -87,6 +87,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
         name,
         values: values.map(parseValueTuple),
         formattedName,
+        labels: metric,
       };
     }),
   };


### PR DESCRIPTION
`TimeSeriesData` now supports optional `Labels`. This is helpful when consumers of TimeSeriesData need to know which labels are associated to a time series.

Here is an example:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/6935733/224166330-fd7eb029-d85b-41be-9272-602b378e5a71.png">


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
