### PR TITLE
[BUGFIX] Fix getting dashboard from an empty project

### DIFF
--- a/internal/api/e2e/dashboard_test.go
+++ b/internal/api/e2e/dashboard_test.go
@@ -83,6 +83,25 @@ func TestUpdateDashboardIncreaseVersion(t *testing.T) {
 	})
 }
 
+func TestListDashboardInEmptyProject(t *testing.T) {
+	e2eframework.WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+		demoDashboard := e2eframework.NewDashboard(t, "perses", "Demo")
+		persesProject := e2eframework.NewProject("perses")
+		demoProject := e2eframework.NewProject("Demo")
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, persesProject, demoProject, demoDashboard)
+
+		expect.GET(fmt.Sprintf("%s/%s/%s/%s", shared.APIV1Prefix, shared.PathProject, demoProject.GetMetadata().GetName(), shared.PathDashboard)).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array().
+			Length().
+			IsEqual(0)
+
+		return []api.Entity{persesProject, demoProject, demoDashboard}
+	})
+}
+
 func extractDashboardFromHTTPBody(body interface{}, t *testing.T) *modelV1.Dashboard {
 	b, err := json.Marshal(body)
 	if err != nil {

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -73,6 +73,11 @@ func CreateGetFunc(t *testing.T, persistenceManager dependency.PersistenceManage
 	return getFunc, upsertFunc
 }
 
+func CreateAndWaitUntilEntitiesExist(t *testing.T, persistenceManager dependency.PersistenceManager, objects ...interface{}) {
+	for _, object := range objects {
+		CreateAndWaitUntilEntityExists(t, persistenceManager, object)
+	}
+}
 func CreateAndWaitUntilEntityExists(t *testing.T, persistenceManager dependency.PersistenceManager, object interface{}) {
 	getFunc, upsertFunc := CreateGetFunc(t, persistenceManager, object)
 

--- a/internal/api/e2e/framework/scenario.go
+++ b/internal/api/e2e/framework/scenario.go
@@ -199,8 +199,7 @@ func MainTestScenarioWithProject(t *testing.T, path string, creator func(project
 	t.Run(fmt.Sprintf("Conflict test (%s)", path), func(t *testing.T) {
 		WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 			parent, entity := creator("myProject", "myResource")
-			CreateAndWaitUntilEntityExists(t, manager, parent)
-			CreateAndWaitUntilEntityExists(t, manager, entity)
+			CreateAndWaitUntilEntitiesExist(t, manager, parent, entity)
 
 			expect.POST(fmt.Sprintf("%s/%s/%s/%s", shared.APIV1Prefix, shared.PathProject, parent.GetMetadata().GetName(), path)).
 				WithJSON(entity).
@@ -215,8 +214,7 @@ func MainTestScenarioWithProject(t *testing.T, path string, creator func(project
 	t.Run(fmt.Sprintf("Retrieval tests (%s)", path), func(t *testing.T) {
 		WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 			parent, entity := creator("myProject", "myResource")
-			CreateAndWaitUntilEntityExists(t, manager, parent)
-			CreateAndWaitUntilEntityExists(t, manager, entity)
+			CreateAndWaitUntilEntitiesExist(t, manager, parent, entity)
 
 			// For the "get all" requests, we have no choice to wait a bit of time between the creation and the "get all"
 			time.Sleep(3 * time.Second)
@@ -248,10 +246,7 @@ func MainTestScenarioWithProject(t *testing.T, path string, creator func(project
 		WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 			parent1, entity1 := creator("myProject1", "myResource1")
 			parent2, entity2 := creator("myProject2", "myResource2")
-			CreateAndWaitUntilEntityExists(t, manager, parent1)
-			CreateAndWaitUntilEntityExists(t, manager, parent2)
-			CreateAndWaitUntilEntityExists(t, manager, entity1)
-			CreateAndWaitUntilEntityExists(t, manager, entity2)
+			CreateAndWaitUntilEntitiesExist(t, manager, parent1, parent2, entity1, entity2)
 
 			// For the "get all" requests, we have no choice to wait a bit of time between the creation and the "get all"
 			time.Sleep(3 * time.Second)
@@ -291,8 +286,7 @@ func MainTestScenarioWithProject(t *testing.T, path string, creator func(project
 	t.Run(fmt.Sprintf("Update test (%s)", path), func(t *testing.T) {
 		WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 			parent, entity := creator("myProject", "myResource")
-			CreateAndWaitUntilEntityExists(t, manager, parent)
-			CreateAndWaitUntilEntityExists(t, manager, entity)
+			CreateAndWaitUntilEntitiesExist(t, manager, parent, entity)
 
 			// call now the update endpoint, shouldn't return an error
 			o := expect.PUT(fmt.Sprintf("%s/%s/%s/%s/%s", shared.APIV1Prefix, shared.PathProject, parent.GetMetadata().GetName(), path, entity.GetMetadata().GetName())).
@@ -329,8 +323,7 @@ func MainTestScenarioWithProject(t *testing.T, path string, creator func(project
 	t.Run(fmt.Sprintf("Deletion test (%s)", path), func(t *testing.T) {
 		WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 			parent, entity := creator("myParentResource", "myResource")
-			CreateAndWaitUntilEntityExists(t, manager, parent)
-			CreateAndWaitUntilEntityExists(t, manager, entity)
+			CreateAndWaitUntilEntitiesExist(t, manager, parent, entity)
 
 			expect.DELETE(fmt.Sprintf("%s/%s/%s/%s/%s", shared.APIV1Prefix, shared.PathProject, parent.GetMetadata().GetName(), path, entity.GetMetadata().GetName())).
 				Expect().

--- a/internal/api/shared/database/file/file.go
+++ b/internal/api/shared/database/file/file.go
@@ -108,31 +108,16 @@ func (d *DAO) Query(query databaseModel.Query, slice interface{}) error {
 	if typeParameter.Kind() != reflect.Slice {
 		return fmt.Errorf("slice in parameter is not actually a slice but a %q", typeParameter.Kind())
 	}
-	q, err := buildQuery(query)
+	folder, prefix, isExist, err := d.buildQuery(query)
 	if err != nil {
 		return fmt.Errorf("unable to build the query: %s", err)
 	}
-	// the query returned looks like a path and can finish with a partial name.
-	// So we have to figure if the last path is the actual directory to looking for.
-	// Or it's the partial name, and it should only be used to filter the list of the document.
-	// For example: `/projects/per`.
-	// `/projects` is the folder we are looking for, `per` is the partial name.
-	folder := path.Join(d.Folder, q)
-	prefix := ""
-	// An easy way to achieve is to:
-	// 1. try if the path exist with the given query.
-	if _, err = os.Stat(folder); os.IsNotExist(err) {
-		// The path doesn't exist. So we certainly have to move to the parent path.
-		prefix = filepath.Base(folder)
-		folder = filepath.Dir(folder)
-		// Let's try again if the path exists this time.
-		if _, err = os.Stat(folder); os.IsNotExist(err) {
-			// worst case, there is nothing to return. So let's initialize the slice just to avoid returning a nil slice
-			sliceElem = reflect.MakeSlice(typeParameter, 0, 0)
-			//and finally reset the element of the slice to ensure we didn't disconnect the link between the pointer to the slice and the actual slice
-			result.Elem().Set(sliceElem)
-			return nil
-		}
+	if !isExist {
+		// there is nothing to return. So let's initialize the slice just to avoid returning a nil slice
+		sliceElem = reflect.MakeSlice(typeParameter, 0, 0)
+		//and finally reset the element of the slice to ensure we didn't disconnect the link between the pointer to the slice and the actual slice
+		result.Elem().Set(sliceElem)
+		return nil
 	}
 	// so now we have the proper folder to looking for and potentially a filter to use
 	var files []string
@@ -169,7 +154,6 @@ func (d *DAO) Query(query databaseModel.Query, slice interface{}) error {
 		} else {
 			sliceElem.Set(reflect.Append(sliceElem, value))
 		}
-
 	}
 	// at the end reset the element of the slice to ensure we didn't disconnect the link between the pointer to the slice and the actual slice
 	result.Elem().Set(sliceElem)

--- a/internal/api/shared/database/file/query_test.go
+++ b/internal/api/shared/database/file/query_test.go
@@ -27,9 +27,10 @@ import (
 
 func TestBuildQuery(t *testing.T) {
 	testSuite := []struct {
-		title  string
-		query  databaseModel.Query
-		expect string
+		title              string
+		query              databaseModel.Query
+		expectedPath       string
+		expectedNamePrefix string
 	}{
 		{
 			title: "dashboardQuery",
@@ -37,14 +38,16 @@ func TestBuildQuery(t *testing.T) {
 				NamePrefix: "meta",
 				Project:    "perses",
 			},
-			expect: "/dashboards/perses/meta",
+			expectedPath:       "dashboards/perses",
+			expectedNamePrefix: "meta",
 		},
 		{
 			title: "dashboardQuery with empty project",
 			query: &dashboard.Query{
 				NamePrefix: "meta",
 			},
-			expect: "/dashboards",
+			expectedPath:       "dashboards",
+			expectedNamePrefix: "meta",
 		},
 		{
 			title: "datasourceQuery",
@@ -52,7 +55,8 @@ func TestBuildQuery(t *testing.T) {
 				NamePrefix: "meta",
 				Project:    "perses",
 			},
-			expect: "/datasources/perses/meta",
+			expectedPath:       "datasources/perses",
+			expectedNamePrefix: "meta",
 		},
 		{
 			title: "folderQuery",
@@ -60,29 +64,34 @@ func TestBuildQuery(t *testing.T) {
 				NamePrefix: "meta",
 				Project:    "perses",
 			},
-			expect: "/folders/perses/meta",
+			expectedPath:       "folders/perses",
+			expectedNamePrefix: "meta",
 		},
 		{
 			title: "globalDatasourceQuery",
 			query: &globaldatasource.Query{
 				NamePrefix: "meta",
 			},
-			expect: "/globaldatasources/meta",
+			expectedPath:       "globaldatasources",
+			expectedNamePrefix: "meta",
 		},
 		{
 			title: "projectQuery",
 			query: &project.Query{
 				NamePrefix: "meta",
 			},
-			expect: "/projects/meta",
+			expectedPath:       "projects",
+			expectedNamePrefix: "meta",
 		},
 	}
 
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
-			result, err := buildQuery(test.query)
+			d := &DAO{Folder: ""}
+			result, prefix, _, err := d.buildQuery(test.query)
 			assert.NoError(t, err)
-			assert.Equal(t, test.expect, result)
+			assert.Equal(t, test.expectedPath, result)
+			assert.Equal(t, test.expectedNamePrefix, prefix)
 		})
 	}
 }


### PR DESCRIPTION
this PR is here to fix #959

I'm adding a dedicated e2e tests to cover the use case described by the opened issue.
The issue was only when the FileDB were used. After a couple time to figure out what's happening, I entirely review the way we are building the query for the FileDB. It wasn't really coherent but no I think it's far better and also cover other use cases like doing this query : `curl -XGET http://perses.dev/api/v1/dashboards?name=perses`.

In the use case above I think the query parameter `name` was ignored.