### PR TITLE
[IGNORE] reduce visual test flakiness

### DIFF
--- a/ui/e2e/src/pages/Panel.ts
+++ b/ui/e2e/src/pages/Panel.ts
@@ -73,12 +73,11 @@ export class Panel {
       await expect(this.loader).toHaveCount(0);
     }).toPass();
 
-    // Trial a click to wait for the figure to be stable. Replace this with a
-    // baked in "stable" check when one is available.
+    // Scroll into view to make sure the panel is visible and to get a free
+    // "stable" check. Consider replacing this with a baked in "stable" check
+    // when one is available.
     // https://github.com/microsoft/playwright/issues/15195#issuecomment-1176370571
-    await this.figure.click({
-      trial: true,
-    });
+    await this.figure.scrollIntoViewIfNeeded();
   }
 
   async startEditing() {


### PR DESCRIPTION
Some of the flakiness was likely related to the panel being moused over as a result of the "trial click" workaround to wait for a stable panel. Trying out replacing that with a `scrollIntoViewIfNeeded`, which also checks for a stable element, but does not mouseover, and as an added benefit, it will make sure the panel is scrolled into view.

https://playwright.dev/docs/actionability

# Notes for reviewers

This led to a bunch of changes in the visual diffs for panels because the mouse is no longer sitting over the panel. I think this should lead to less flakiness going forward. If we have cases where we want to test the mouseover, we should do that explicitly with an explicit location, so there is not flakiness.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
