### PR TITLE
[BUGFIX] handle variable default with all in an array

### DIFF
--- a/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.stories.tsx
+++ b/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.stories.tsx
@@ -21,7 +21,7 @@ import {
   WithDashboard,
   WithPluginRegistry,
   WithQueryClient,
-  DEFAULT_DASHBOARD_INITIAL_STATE,
+  EMPTY_DASHBOARD_RESOURCE,
 } from '../../stories/decorators';
 
 const meta: Meta<typeof EmptyDashboard> = {
@@ -49,7 +49,7 @@ export const EditMode: Story = {
     withDashboard: {
       props: {
         initialState: {
-          ...DEFAULT_DASHBOARD_INITIAL_STATE,
+          dashboardResource: EMPTY_DASHBOARD_RESOURCE,
           isEditMode: true,
         },
       },

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { VariableDefinition } from '@perses-dev/core';
+import { DEFAULT_ALL_VALUE } from '@perses-dev/plugin-system';
+import { hydrateTemplateVariableStates } from './hydrationUtils';
+
+describe('hydrateTemplateVariableStates', () => {
+  test('normalizes single "all" value in an array', () => {
+    const definitions: VariableDefinition[] = [
+      {
+        kind: 'ListVariable',
+        spec: {
+          name: 'instance',
+          display: {
+            name: 'Instance',
+            hidden: false,
+          },
+          allow_all_value: true,
+          allow_multiple: true,
+          default_value: ['$__all'],
+          plugin: {
+            kind: 'PrometheusLabelValuesVariable',
+            spec: {
+              label_name: 'instance',
+            },
+          },
+        },
+      },
+    ];
+    const result = hydrateTemplateVariableStates(definitions, {});
+    expect(result?.instance?.value).toEqual(DEFAULT_ALL_VALUE);
+  });
+});

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
@@ -1,0 +1,65 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { VariableValue, VariableDefinition } from '@perses-dev/core';
+import { VariableStateMap, VariableState, DEFAULT_ALL_VALUE } from '@perses-dev/plugin-system';
+
+function hydrateTemplateVariableState(variable: VariableDefinition, initialValue?: VariableValue) {
+  const varState: VariableState = {
+    value: null,
+    loading: false,
+  };
+  switch (variable.kind) {
+    case 'TextVariable':
+      varState.value = initialValue ?? variable.spec.value;
+      break;
+    case 'ListVariable':
+      varState.options = [];
+      varState.value = initialValue ?? variable.spec.default_value ?? null;
+
+      if (varState.options.length > 0 && !varState.value) {
+        const firstOptionValue = varState.options[0]?.value ?? null;
+        if (firstOptionValue !== null) {
+          varState.value = variable.spec.allow_multiple ? [firstOptionValue] : firstOptionValue;
+        }
+      }
+
+      // "all" variable handling assumes the value is not in an array. This is
+      // handled properly during internal variable interactions, but it is possible
+      // to end up in a buggy state if the variables are initialized with an "all"
+      // value inside an array. When hydrating variables, normalize this to minimize
+      // bugs.
+      if (Array.isArray(varState.value) && varState.value.length === 1 && varState.value[0] === DEFAULT_ALL_VALUE) {
+        varState.value = DEFAULT_ALL_VALUE;
+      }
+      break;
+    default:
+      break;
+  }
+  return varState;
+}
+
+export function hydrateTemplateVariableStates(
+  definitions: VariableDefinition[],
+  initialValues: Record<string, VariableValue>
+): VariableStateMap {
+  const state: VariableStateMap = {};
+  definitions.forEach((v) => {
+    const name = v.spec.name;
+    const param = initialValues[name];
+    const initialValue = param ? param : null;
+    state[name] = hydrateTemplateVariableState(v, initialValue);
+  });
+
+  return state;
+}

--- a/ui/dashboards/src/stories/decorators/WithDashboard.tsx
+++ b/ui/dashboards/src/stories/decorators/WithDashboard.tsx
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import { StoryFn, StoryContext } from '@storybook/react';
-import { DashboardProvider, DashboardProviderProps, DashboardStoreProps } from '@perses-dev/dashboards';
+import { DashboardProvider, DashboardProviderProps } from '@perses-dev/dashboards';
+import { EMPTY_DASHBOARD_RESOURCE } from './constants';
 
 export type WithDashboardParameter = {
   props: Partial<DashboardProviderProps>;
@@ -23,32 +24,13 @@ function isWithDashboardParameter(parameter: unknown | WithDashboardParameter): 
   return !!parameter && typeof parameter === 'object' && 'props' in parameter;
 }
 
-export const DEFAULT_DASHBOARD_INITIAL_STATE: DashboardStoreProps = {
-  dashboardResource: {
-    kind: 'Dashboard',
-    metadata: {
-      name: 'My Dashboard',
-      project: 'Storybook',
-      created_at: '2021-11-09T00:00:00Z',
-      updated_at: '2021-11-09T00:00:00Z',
-      version: 0,
-    },
-    spec: {
-      duration: '1h',
-      variables: [],
-      layouts: [],
-      panels: {},
-    },
-  },
-};
-
 export const WithDashboard = (Story: StoryFn, context: StoryContext<unknown>) => {
   const initParameter = context.parameters.withDashboard;
   const parameter = isWithDashboardParameter(initParameter) ? initParameter : undefined;
   const props = parameter?.props;
 
   return (
-    <DashboardProvider initialState={DEFAULT_DASHBOARD_INITIAL_STATE} {...props}>
+    <DashboardProvider initialState={{ dashboardResource: EMPTY_DASHBOARD_RESOURCE }} {...props}>
       <Story />
     </DashboardProvider>
   );

--- a/ui/dashboards/src/stories/decorators/WithDatasourceStore.tsx
+++ b/ui/dashboards/src/stories/decorators/WithDatasourceStore.tsx
@@ -1,0 +1,83 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { StoryFn, StoryContext } from '@storybook/react';
+import { DatasourceStoreProvider, DatasourceStoreProviderProps } from '@perses-dev/dashboards';
+import { GlobalDatasource } from '@perses-dev/core';
+import { EMPTY_DASHBOARD_RESOURCE } from './constants';
+
+export type WithDatasourceStoreParameter = {
+  props: Partial<DatasourceStoreProviderProps>;
+};
+
+// Type guard because storybook types parameters as `any`
+function isWithDatasourceStoreParameter(
+  parameter: unknown | WithDatasourceStoreParameter
+): parameter is WithDatasourceStoreParameter {
+  return !!parameter && typeof parameter === 'object' && 'props' in parameter;
+}
+
+const prometheusDemoUrl = 'https://prometheus.demo.do.prometheus.io';
+const prometheusDemo: GlobalDatasource = {
+  kind: 'GlobalDatasource',
+  metadata: {
+    name: 'PrometheusDemo',
+    created_at: '0001-01-01T00:00:00Z',
+    updated_at: '0001-01-01T00:00:00Z',
+    version: 0,
+  },
+  spec: {
+    default: true,
+    plugin: {
+      kind: 'PrometheusDatasource',
+      spec: { direct_url: prometheusDemoUrl },
+    },
+  },
+} as const;
+
+export const WithDatasourceStore = (Story: StoryFn, context: StoryContext<unknown>) => {
+  const initParameter = context.parameters.withDatasourceStore;
+  const parameter = isWithDatasourceStoreParameter(initParameter) ? initParameter : undefined;
+  const props = parameter?.props;
+
+  // This default currently defines the bare minimum to get a story working in
+  // the `Dashboard` storybook with the Prometheus demo api. We'll likely want
+  // to expand it to do more in the future.
+  const defaultDatasourceProps: Pick<DatasourceStoreProviderProps, 'datasourceApi' | 'dashboardResource'> = {
+    dashboardResource: EMPTY_DASHBOARD_RESOURCE,
+    datasourceApi: {
+      getDatasource: () => {
+        return Promise.resolve(undefined);
+      },
+      getGlobalDatasource: (selector) => {
+        if (selector.kind === 'PrometheusDatasource') {
+          return Promise.resolve({ resource: prometheusDemo, proxyUrl: prometheusDemoUrl });
+        }
+
+        return Promise.resolve(undefined);
+      },
+      listDatasources: () => {
+        return Promise.resolve([]);
+      },
+      listGlobalDatasources: () => {
+        return Promise.resolve([]);
+      },
+    },
+  };
+
+  return (
+    <DatasourceStoreProvider {...defaultDatasourceProps} {...props}>
+      <Story />
+    </DatasourceStoreProvider>
+  );
+};

--- a/ui/dashboards/src/stories/decorators/WithTimeRange.tsx
+++ b/ui/dashboards/src/stories/decorators/WithTimeRange.tsx
@@ -12,27 +12,25 @@
 // limitations under the License.
 
 import { StoryFn, StoryContext } from '@storybook/react';
-import { TemplateVariableProvider, TemplateVariableProviderProps } from '@perses-dev/dashboards';
+import { TimeRangeProvider, TimeRangeProviderProps } from '@perses-dev/plugin-system';
 
-export type WithTemplateVariableParameter = {
-  props: Partial<TemplateVariableProviderProps>;
+export type WithTimeRangeParameter = {
+  props: Partial<TimeRangeProviderProps>;
 };
 
 // Type guard because storybook types parameters as `any`
-function isWithTemplateVariableParameter(
-  parameter: unknown | WithTemplateVariableParameter
-): parameter is WithTemplateVariableParameter {
+function isWithTimeRangeParameter(parameter: unknown | WithTimeRangeParameter): parameter is WithTimeRangeParameter {
   return !!parameter && typeof parameter === 'object' && 'props' in parameter;
 }
 
-export const WithTemplateVariables = (Story: StoryFn, context: StoryContext<unknown>) => {
-  const initParameter = context.parameters.withTemplateVariables;
-  const parameter = isWithTemplateVariableParameter(initParameter) ? initParameter : undefined;
+export const WithTimeRange = (Story: StoryFn, context: StoryContext<unknown>) => {
+  const initParameter = context.parameters.withTimeRange;
+  const parameter = isWithTimeRangeParameter(initParameter) ? initParameter : undefined;
   const props = parameter?.props;
 
   return (
-    <TemplateVariableProvider {...props}>
+    <TimeRangeProvider initialTimeRange={{ pastDuration: '1h' }} {...props}>
       <Story />
-    </TemplateVariableProvider>
+    </TimeRangeProvider>
   );
 };

--- a/ui/dashboards/src/stories/decorators/constants.ts
+++ b/ui/dashboards/src/stories/decorators/constants.ts
@@ -1,0 +1,18 @@
+import { DashboardResource } from '@perses-dev/core';
+
+export const EMPTY_DASHBOARD_RESOURCE: DashboardResource = {
+  kind: 'Dashboard',
+  metadata: {
+    name: 'My Dashboard',
+    project: 'Storybook',
+    created_at: '2021-11-09T00:00:00Z',
+    updated_at: '2021-11-09T00:00:00Z',
+    version: 0,
+  },
+  spec: {
+    duration: '1h',
+    variables: [],
+    layouts: [],
+    panels: {},
+  },
+};

--- a/ui/dashboards/src/stories/decorators/index.ts
+++ b/ui/dashboards/src/stories/decorators/index.ts
@@ -11,8 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export * from './constants';
 export * from './WithDashboard';
+export * from './WithDatasourceStore';
 export * from './WithPluginRegistry';
 export * from './WithQueryClient';
 export * from './WithQueryParams';
 export * from './WithTemplateVariables';
+export * from './WithTimeRange';


### PR DESCRIPTION
The variable handling assumes that `$__all` is alone as a value, which was managed in internal interactions, but not on intializing variables, which can lead to buggy behavior. This commit normalizes the all value when it is the single value in an array on intialization.

This comment also expands the stories for the relevant components to duplicate the issue and validate it is fixed.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
