### PR TITLE
[BUGFIX] Fix the deletion of a project that didn't remove the related dashboards

### DIFF
--- a/internal/api/e2e/project_test.go
+++ b/internal/api/e2e/project_test.go
@@ -16,15 +16,40 @@
 package e2e
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/gavv/httpexpect/v2"
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	"github.com/perses/perses/internal/api/shared/dependency"
 	"github.com/perses/perses/pkg/model/api"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMainScenarioProject(t *testing.T) {
 	e2eframework.MainTestScenario(t, shared.PathProject, func(name string) api.Entity {
 		return e2eframework.NewProject(name)
+	})
+}
+
+func TestDeleteProjectWithSubResources(t *testing.T) {
+	e2eframework.WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+		projectName := "perses"
+		dash := e2eframework.NewDashboard(t, "perses", "Demo")
+		project := e2eframework.NewProject(projectName)
+		datasource := e2eframework.NewDatasource(t, "perses", "Demo")
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, project, dash, datasource)
+		expect.DELETE(fmt.Sprintf("%s/%s/%s", shared.APIV1Prefix, shared.PathProject, projectName)).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := manager.GetDashboard().Get(projectName, dash.Metadata.Name)
+		assert.True(t, databaseModel.IsKeyNotFound(err))
+		_, err = manager.GetDatasource().Get(projectName, datasource.Metadata.Name)
+		assert.True(t, databaseModel.IsKeyNotFound(err))
+		return []api.Entity{}
 	})
 }

--- a/internal/api/impl/v1/dashboard/persistence.go
+++ b/internal/api/impl/v1/dashboard/persistence.go
@@ -44,6 +44,10 @@ func (d *dao) Delete(project string, name string) error {
 	return d.client.Delete(d.kind, v1.NewProjectMetadata(project, name))
 }
 
+func (d *dao) DeleteAll(project string) error {
+	return d.client.DeleteByQuery(&dashboard.Query{Project: project})
+}
+
 func (d *dao) Get(project string, name string) (*v1.Dashboard, error) {
 	entity := &v1.Dashboard{}
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)

--- a/internal/api/impl/v1/datasource/persistence.go
+++ b/internal/api/impl/v1/datasource/persistence.go
@@ -44,6 +44,10 @@ func (d *dao) Delete(project string, name string) error {
 	return d.client.Delete(d.kind, v1.NewProjectMetadata(project, name))
 }
 
+func (d *dao) DeleteAll(project string) error {
+	return d.client.DeleteByQuery(&datasource.Query{Project: project})
+}
+
 func (d *dao) Get(project string, name string) (*v1.Datasource, error) {
 	entity := &v1.Datasource{}
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)

--- a/internal/api/impl/v1/folder/persistence.go
+++ b/internal/api/impl/v1/folder/persistence.go
@@ -44,6 +44,10 @@ func (d *dao) Delete(project string, name string) error {
 	return d.client.Delete(d.kind, v1.NewProjectMetadata(project, name))
 }
 
+func (d *dao) DeleteAll(project string) error {
+	return d.client.DeleteByQuery(&folder.Query{Project: project})
+}
+
 func (d *dao) Get(project string, name string) (*v1.Folder, error) {
 	entity := &v1.Folder{}
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)

--- a/internal/api/interface/v1/dashboard/interface.go
+++ b/internal/api/interface/v1/dashboard/interface.go
@@ -33,6 +33,7 @@ type DAO interface {
 	Create(entity *v1.Dashboard) error
 	Update(entity *v1.Dashboard) error
 	Delete(project string, name string) error
+	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Dashboard, error)
 	List(q databaseModel.Query) ([]*v1.Dashboard, error)
 }

--- a/internal/api/interface/v1/datasource/interface.go
+++ b/internal/api/interface/v1/datasource/interface.go
@@ -37,6 +37,7 @@ type DAO interface {
 	Create(entity *v1.Datasource) error
 	Update(entity *v1.Datasource) error
 	Delete(project string, name string) error
+	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Datasource, error)
 	List(q databaseModel.Query) ([]*v1.Datasource, error)
 }

--- a/internal/api/interface/v1/folder/interface.go
+++ b/internal/api/interface/v1/folder/interface.go
@@ -33,6 +33,7 @@ type DAO interface {
 	Create(entity *v1.Folder) error
 	Update(entity *v1.Folder) error
 	Delete(project string, name string) error
+	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Folder, error)
 	List(q databaseModel.Query) ([]*v1.Folder, error)
 }

--- a/internal/api/shared/database/file/file.go
+++ b/internal/api/shared/database/file/file.go
@@ -175,6 +175,33 @@ func (d *DAO) Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error {
 	return nil
 }
 
+func (d *DAO) DeleteByQuery(query databaseModel.Query) error {
+	folder, prefix, isExist, err := d.buildQuery(query)
+	if err != nil {
+		return fmt.Errorf("unable to build the query: %s", err)
+	}
+	if !isExist {
+		return nil
+	}
+	if len(prefix) == 0 {
+		return os.RemoveAll(folder)
+	}
+	// in case there is a prefix file name we need to delete only the files that is matching the prefix and not the folder entirely
+	var files []string
+	if files, err = d.visit(folder, prefix); err != nil {
+		return err
+	}
+	if len(files) <= 0 {
+		return nil
+	}
+	for _, file := range files {
+		if removeErr := os.Remove(file); removeErr != nil {
+			return removeErr
+		}
+	}
+	return nil
+}
+
 func (d *DAO) HealthCheck() bool {
 	return true
 }

--- a/internal/api/shared/database/model/dao.go
+++ b/internal/api/shared/database/model/dao.go
@@ -35,5 +35,6 @@ type DAO interface {
 	// slice is an interface for casting simplification. But slice must be a pointer to a slice of modelAPI.Metadata
 	Query(query Query, slice interface{}) error
 	Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error
+	DeleteByQuery(query Query) error
 	HealthCheck() bool
 }

--- a/internal/api/shared/database/sql/query.go
+++ b/internal/api/shared/database/sql/query.go
@@ -80,7 +80,7 @@ func (d *DAO) generateUpdateQuery(entity modelAPI.Entity) (string, []interface{}
 	return sql, args, nil
 }
 
-func generateProjectResourceSelectQuery(tableName string, project string, name string) (string, []interface{}) {
+func generatSelectQuery(tableName string, project string, name string) (string, []interface{}) {
 	queryBuilder := sqlbuilder.NewSelectBuilder().
 		Select(colDoc).
 		From(tableName)
@@ -89,16 +89,6 @@ func generateProjectResourceSelectQuery(tableName string, project string, name s
 	}
 	if len(project) > 0 {
 		queryBuilder.Where(queryBuilder.Equal(colProject, project))
-	}
-	return queryBuilder.Build()
-}
-
-func generateResourceSelectQuery(tableName string, name string) (string, []interface{}) {
-	queryBuilder := sqlbuilder.NewSelectBuilder().
-		Select(colDoc).
-		From(tableName)
-	if len(name) > 0 {
-		queryBuilder.Where(queryBuilder.Like(colName, fmt.Sprintf("%s%%", name)))
 	}
 	return queryBuilder.Build()
 }
@@ -108,22 +98,22 @@ func (d *DAO) buildQuery(query databaseModel.Query) (string, []interface{}, erro
 	var args []interface{}
 	switch qt := query.(type) {
 	case *dashboard.Query:
-		sqlQuery, args = generateProjectResourceSelectQuery(d.generateCompleteTableName(tableDashboard), qt.Project, qt.NamePrefix)
+		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableDashboard), qt.Project, qt.NamePrefix)
 	case *datasource.Query:
-		sqlQuery, args = generateProjectResourceSelectQuery(d.generateCompleteTableName(tableDatasource), qt.Project, qt.NamePrefix)
+		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableDatasource), qt.Project, qt.NamePrefix)
 	case *folder.Query:
-		sqlQuery, args = generateProjectResourceSelectQuery(d.generateCompleteTableName(tableFolder), qt.Project, qt.NamePrefix)
+		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableFolder), qt.Project, qt.NamePrefix)
 	case *globaldatasource.Query:
-		sqlQuery, args = generateResourceSelectQuery(d.generateCompleteTableName(tableGlobalDatasource), qt.NamePrefix)
+		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableGlobalDatasource), "", qt.NamePrefix)
 	case *project.Query:
-		sqlQuery, args = generateResourceSelectQuery(d.generateCompleteTableName(tableProject), qt.NamePrefix)
+		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableProject), "", qt.NamePrefix)
 	default:
 		return "", nil, fmt.Errorf("this type of query '%T' is not managed", qt)
 	}
 	return sqlQuery, args, nil
 }
 
-func generateProjectResourceDeleteQuery(tableName string, project string, name string) (string, []interface{}) {
+func generateDeleteQuery(tableName string, project string, name string) (string, []interface{}) {
 	queryBuilder := sqlbuilder.NewDeleteBuilder().
 		DeleteFrom(tableName)
 	if len(name) > 0 {
@@ -135,29 +125,20 @@ func generateProjectResourceDeleteQuery(tableName string, project string, name s
 	return queryBuilder.Build()
 }
 
-func generateResourceDeleteQuery(tableName string, name string) (string, []interface{}) {
-	queryBuilder := sqlbuilder.NewDeleteBuilder().
-		DeleteFrom(tableName)
-	if len(name) > 0 {
-		queryBuilder.Where(queryBuilder.Like(colName, fmt.Sprintf("%s%%", name)))
-	}
-	return queryBuilder.Build()
-}
-
 func (d *DAO) buildDeleteQuery(query databaseModel.Query) (string, []interface{}, error) {
 	var sqlQuery string
 	var args []interface{}
 	switch qt := query.(type) {
 	case *dashboard.Query:
-		sqlQuery, args = generateProjectResourceDeleteQuery(d.generateCompleteTableName(tableDashboard), qt.Project, qt.NamePrefix)
+		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableDashboard), qt.Project, qt.NamePrefix)
 	case *datasource.Query:
-		sqlQuery, args = generateProjectResourceDeleteQuery(d.generateCompleteTableName(tableDatasource), qt.Project, qt.NamePrefix)
+		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableDatasource), qt.Project, qt.NamePrefix)
 	case *folder.Query:
-		sqlQuery, args = generateProjectResourceDeleteQuery(d.generateCompleteTableName(tableFolder), qt.Project, qt.NamePrefix)
+		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableFolder), qt.Project, qt.NamePrefix)
 	case *globaldatasource.Query:
-		sqlQuery, args = generateResourceDeleteQuery(d.generateCompleteTableName(tableGlobalDatasource), qt.NamePrefix)
+		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableGlobalDatasource), "", qt.NamePrefix)
 	case *project.Query:
-		sqlQuery, args = generateResourceDeleteQuery(d.generateCompleteTableName(tableProject), qt.NamePrefix)
+		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableProject), "", qt.NamePrefix)
 	default:
 		return "", nil, fmt.Errorf("this type of query '%T' is not managed", qt)
 	}

--- a/internal/api/shared/database/sql/query_test.go
+++ b/internal/api/shared/database/sql/query_test.go
@@ -19,35 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateResourceSelectQuery(t *testing.T) {
-	testSuite := []struct {
-		title    string
-		name     string
-		sqlQuery string
-		sqlArgs  []interface{}
-	}{
-		{
-			title:    "with a prefix name",
-			name:     "test",
-			sqlQuery: "SELECT doc FROM perses.project WHERE name LIKE ?",
-			sqlArgs:  []interface{}{"test%"},
-		},
-		{
-			title:    "empty query",
-			name:     "",
-			sqlQuery: "SELECT doc FROM perses.project",
-		},
-	}
-
-	for _, test := range testSuite {
-		t.Run(test.title, func(t *testing.T) {
-			sqlQuery, args := generateResourceSelectQuery("perses.project", test.name)
-			assert.Equal(t, test.sqlQuery, sqlQuery)
-			assert.Equal(t, test.sqlArgs, args)
-		})
-	}
-}
-
 func TestGenerateProjectResourceSelectQuery(t *testing.T) {
 	testSuite := []struct {
 		title    string
@@ -58,6 +29,13 @@ func TestGenerateProjectResourceSelectQuery(t *testing.T) {
 	}{
 		{
 			title:    "no project with a prefix name",
+			project:  "",
+			name:     "test",
+			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ?",
+			sqlArgs:  []interface{}{"test%"},
+		},
+		{
+			title:    "with a prefix name",
 			project:  "",
 			name:     "test",
 			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ?",
@@ -80,7 +58,7 @@ func TestGenerateProjectResourceSelectQuery(t *testing.T) {
 
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
-			sqlQuery, args := generateProjectResourceSelectQuery("perses.dashboard", test.project, test.name)
+			sqlQuery, args := generatSelectQuery("perses.dashboard", test.project, test.name)
 			assert.Equal(t, test.sqlQuery, sqlQuery)
 			assert.Equal(t, test.sqlArgs, args)
 		})

--- a/internal/api/shared/database/sql/sql.go
+++ b/internal/api/shared/database/sql/sql.go
@@ -273,6 +273,18 @@ func (d *DAO) Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error {
 	return deleteQuery.Close()
 }
 
+func (d *DAO) DeleteByQuery(query databaseModel.Query) error {
+	q, args, buildQueryErr := d.buildDeleteQuery(query)
+	if buildQueryErr != nil {
+		return fmt.Errorf("unable to build the query: %s", buildQueryErr)
+	}
+	rows, runQueryErr := d.DB.Query(q, args...)
+	if runQueryErr != nil {
+		return runQueryErr
+	}
+	return rows.Close()
+}
+
 func (d *DAO) HealthCheck() bool {
 	if err := d.DB.Ping(); err != nil {
 		logrus.WithError(err).Error("unable to ping the database")

--- a/internal/api/shared/dependency/service_manager.go
+++ b/internal/api/shared/dependency/service_manager.go
@@ -70,7 +70,7 @@ func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 	folderService := folderImpl.NewService(dao.GetFolder())
 	globalDatasourceService := globalDatasourceImpl.NewService(dao.GetGlobalDatasource(), schemasService)
 	healthService := healthImpl.NewService(dao.GetHealth())
-	projectService := projectImpl.NewService(dao.GetProject())
+	projectService := projectImpl.NewService(dao.GetProject(), dao.GetFolder(), dao.GetDatasource(), dao.GetDashboard())
 	return &service{
 		dashboard:        dashboardService,
 		datasource:       datasourceService,


### PR DESCRIPTION
Before this PR, when you remove a project, the related dashboards, folders and datasources were not removed as well. So when you re-created the project with the same name, you were seeing again the old dashboard / folders / datasources