### PR TITLE
[ENHANCEMENT] Empty state can include image

### DIFF
--- a/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.stories.tsx
+++ b/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.stories.tsx
@@ -15,6 +15,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { EmptyDashboard } from '@perses-dev/dashboards';
 import { Button } from '@mui/material';
 import { action } from '@storybook/addon-actions';
+import ViewDashboardVariantOutline from 'mdi-material-ui/ViewDashboardVariantOutline';
 import {
   WithTemplateVariables,
   WithQueryParams,
@@ -63,6 +64,7 @@ export const EditMode: Story = {
 export const Custom: Story = {
   args: {
     title: 'Oh no!',
+    image: <ViewDashboardVariantOutline sx={{ fontSize: '100px', opacity: 0.5 }} color="secondary" />,
     description: 'This dashboard is empty.',
     additionalText: 'Tip: Add a panel group and a panel to get started.',
     actions: (

--- a/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.tsx
+++ b/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.tsx
@@ -24,6 +24,11 @@ export interface EmptyDashboardProps {
   title?: string;
 
   /**
+   * Imagery to display above the title.
+   */
+  image?: React.ReactNode;
+
+  /**
    * Descriptive text, which can be a bit longer.
    */
   description?: string;
@@ -103,6 +108,7 @@ const EmptyDashboardActions = ({ actions, isEditMode, onEditButtonClick }: Empty
  */
 export const EmptyDashboard = ({
   title = DEFAULT_TITLE,
+  image,
   description,
   additionalText,
   actions,
@@ -118,6 +124,7 @@ export const EmptyDashboard = ({
   return (
     <Box sx={{ width: CONTAINER_WIDTH, textAlign: 'center', margin: '0 auto' }}>
       <Box sx={{ width: PRIMARY_CONTENT_WIDTH, margin: '0 auto' }}>
+        {!!image && image}
         <Typography variant="h2" gutterBottom>
           {title}
         </Typography>

--- a/ui/turbo.json
+++ b/ui/turbo.json
@@ -23,7 +23,8 @@
     // than our packages and this makes it easier to separate.
     "storybook:start": {
       "dependsOn": [],
-      "outputs": []
+      "outputs": [],
+      "cache": false
     },
     "storybook:build": {
       "dependsOn": [],


### PR DESCRIPTION
Commit also includes a tweak to the turbo.json for storybook that I noticed was needed while working on this change.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# Screenshots

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/396962/226740375-bc1a0ccc-2b03-41b9-9e12-cf2f25e0a532.png">
