### PR TITLE
[IGNORE] simplify the error management

### DIFF
--- a/internal/api/core/middleware/verification.go
+++ b/internal/api/core/middleware/verification.go
@@ -16,7 +16,6 @@ package middleware
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +24,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/perses/perses/internal/api/interface/v1/project"
 	"github.com/perses/perses/internal/api/shared"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 )
 
 type partialMetadata struct {
@@ -82,7 +82,7 @@ func CheckProject(svc project.Service) echo.MiddlewareFunc {
 			}
 			if len(projectName) > 0 {
 				if _, err := svc.Get(shared.Parameters{Name: projectName}); err != nil {
-					if errors.Is(err, shared.NotFoundError) {
+					if databaseModel.IsKeyNotFound(err) {
 						return fmt.Errorf("%w, metadata.project %q doesn't exist", shared.BadRequestError, projectName)
 					}
 					return err

--- a/internal/api/impl/v1/dashboard/service.go
+++ b/internal/api/impl/v1/dashboard/service.go
@@ -55,12 +55,7 @@ func (s *service) create(entity *v1.Dashboard) (*v1.Dashboard, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.dao.Create(entity); err != nil {
-		if databaseModel.IsKeyConflict(err) {
-			logrus.Debugf("unable to create the dashboard %q. It already exists", entity.Metadata.Name)
-			return nil, shared.ConflictError
-		}
-		logrus.WithError(err).Errorf("unable to perform the creation of the dashboard %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+		return nil, err
 	}
 	return entity, nil
 }
@@ -90,42 +85,24 @@ func (s *service) update(entity *v1.Dashboard, parameters shared.Parameters) (*v
 	}
 
 	// find the previous version of the dashboard
-	oldEntity, err := s.Get(parameters)
+	oldEntity, err := s.dao.Get(parameters.Project, parameters.Name)
 	if err != nil {
 		return nil, err
 	}
-	oldObject := oldEntity.(*v1.Dashboard)
-	entity.Metadata.Update(oldObject.Metadata)
-	if err := s.dao.Update(entity); err != nil {
-		logrus.WithError(err).Errorf("unable to perform the update of the dashboard %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+	entity.Metadata.Update(oldEntity.Metadata)
+	if updateErr := s.dao.Update(entity); updateErr != nil {
+		logrus.WithError(updateErr).Errorf("unable to perform the update of the dashboard %q, something wrong with the database", entity.Metadata.Name)
+		return nil, updateErr
 	}
 	return entity, nil
 }
 
 func (s *service) Delete(parameters shared.Parameters) error {
-	if err := s.dao.Delete(parameters.Project, parameters.Name); err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the dashboard %q", parameters.Name)
-			return shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to delete the dashboard %q, something wrong with the database", parameters.Name)
-		return shared.InternalError
-	}
-	return nil
+	return s.dao.Delete(parameters.Project, parameters.Name)
 }
 
 func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
-	entity, err := s.dao.Get(parameters.Project, parameters.Name)
-	if err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the dashboard %q", parameters.Name)
-			return nil, shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to find the previous version of the dashboard %q, something wrong with the database", parameters.Name)
-		return nil, shared.InternalError
-	}
-	return entity, nil
+	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
 func (s *service) List(q databaseModel.Query, _ shared.Parameters) (interface{}, error) {

--- a/internal/api/impl/v1/datasource/service.go
+++ b/internal/api/impl/v1/datasource/service.go
@@ -53,12 +53,7 @@ func (s *service) create(entity *v1.Datasource) (*v1.Datasource, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.dao.Create(entity); err != nil {
-		if databaseModel.IsKeyConflict(err) {
-			logrus.Debugf("unable to create the Datasource %q. It already exits", entity.Metadata.Name)
-			return nil, shared.ConflictError
-		}
-		logrus.WithError(err).Errorf("unable to perform the creation of the Datasource %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+		return nil, err
 	}
 	return entity, nil
 }
@@ -85,42 +80,24 @@ func (s *service) update(entity *v1.Datasource, parameters shared.Parameters) (*
 		return nil, fmt.Errorf("%w: metadata.project and the project name in the http path request don't match", shared.BadRequestError)
 	}
 	// find the previous version of the Datasource
-	oldEntity, err := s.Get(parameters)
+	oldEntity, err := s.dao.Get(parameters.Project, parameters.Name)
 	if err != nil {
 		return nil, err
 	}
-	oldObject := oldEntity.(*v1.Datasource)
-	entity.Metadata.Update(oldObject.Metadata)
-	if err := s.dao.Update(entity); err != nil {
-		logrus.WithError(err).Errorf("unable to perform the update of the Datasource %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+	entity.Metadata.Update(oldEntity.Metadata)
+	if updateErr := s.dao.Update(entity); updateErr != nil {
+		logrus.WithError(updateErr).Errorf("unable to perform the update of the Datasource %q, something wrong with the database", entity.Metadata.Name)
+		return nil, updateErr
 	}
 	return entity, nil
 }
 
 func (s *service) Delete(parameters shared.Parameters) error {
-	if err := s.dao.Delete(parameters.Project, parameters.Name); err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the Datasource %q", parameters.Name)
-			return shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to delete the Datasource %q, something wrong with the database", parameters.Name)
-		return shared.InternalError
-	}
-	return nil
+	return s.dao.Delete(parameters.Project, parameters.Name)
 }
 
 func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
-	entity, err := s.dao.Get(parameters.Project, parameters.Name)
-	if err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the Datasource %q", parameters.Name)
-			return nil, shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to find the previous version of the Datasource %q, something wrong with the database", parameters.Name)
-		return nil, shared.InternalError
-	}
-	return entity, nil
+	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
 func (s *service) List(q databaseModel.Query, _ shared.Parameters) (interface{}, error) {

--- a/internal/api/impl/v1/globaldatasource/service.go
+++ b/internal/api/impl/v1/globaldatasource/service.go
@@ -53,12 +53,7 @@ func (s *service) create(entity *v1.GlobalDatasource) (*v1.GlobalDatasource, err
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.dao.Create(entity); err != nil {
-		if databaseModel.IsKeyConflict(err) {
-			logrus.Debugf("unable to create the GlobalDatasource %q. It already exits", entity.Metadata.Name)
-			return nil, shared.ConflictError
-		}
-		logrus.WithError(err).Errorf("unable to perform the creation of the GlobalDatasource %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+		return nil, err
 	}
 	return entity, nil
 }
@@ -79,42 +74,24 @@ func (s *service) update(entity *v1.GlobalDatasource, parameters shared.Paramete
 		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request don't match", shared.BadRequestError)
 	}
 	// find the previous version of the Datasource
-	oldEntity, err := s.Get(parameters)
+	oldEntity, err := s.dao.Get(parameters.Name)
 	if err != nil {
 		return nil, err
 	}
-	oldObject := oldEntity.(*v1.GlobalDatasource)
-	entity.Metadata.Update(oldObject.Metadata)
-	if err := s.dao.Update(entity); err != nil {
-		logrus.WithError(err).Errorf("unable to perform the update of the GlobalDatasource %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+	entity.Metadata.Update(oldEntity.Metadata)
+	if updateErr := s.dao.Update(entity); updateErr != nil {
+		logrus.WithError(updateErr).Errorf("unable to perform the update of the GlobalDatasource %q, something wrong with the database", entity.Metadata.Name)
+		return nil, updateErr
 	}
 	return entity, nil
 }
 
 func (s *service) Delete(parameters shared.Parameters) error {
-	if err := s.dao.Delete(parameters.Name); err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the Datasource %q", parameters.Name)
-			return shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to delete the GlobalDatasource %q, something wrong with the database", parameters.Name)
-		return shared.InternalError
-	}
-	return nil
+	return s.dao.Delete(parameters.Name)
 }
 
 func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
-	entity, err := s.dao.Get(parameters.Name)
-	if err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the Datasource %q", parameters.Name)
-			return nil, shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to find the previous version of the GlobalDatasource %q, something wrong with the database", parameters.Name)
-		return nil, shared.InternalError
-	}
-	return entity, nil
+	return s.dao.Get(parameters.Name)
 }
 
 func (s *service) List(q databaseModel.Query, _ shared.Parameters) (interface{}, error) {

--- a/internal/api/impl/v1/project/service.go
+++ b/internal/api/impl/v1/project/service.go
@@ -55,12 +55,7 @@ func (s *service) create(entity *v1.Project) (*v1.Project, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.dao.Create(entity); err != nil {
-		if databaseModel.IsKeyConflict(err) {
-			logrus.Debugf("unable to create the project %q. It already exits", entity.Metadata.Name)
-			return nil, shared.ConflictError
-		}
-		logrus.WithError(err).Errorf("unable to perform the creation of the project %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+		return nil, err
 	}
 	return entity, nil
 }
@@ -78,15 +73,14 @@ func (s *service) update(entity *v1.Project, parameters shared.Parameters) (*v1.
 		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request don't match", shared.BadRequestError)
 	}
 	// find the previous version of the project
-	oldEntity, err := s.Get(parameters)
+	oldEntity, err := s.dao.Get(parameters.Name)
 	if err != nil {
 		return nil, err
 	}
-	oldObject := oldEntity.(*v1.Project)
-	entity.Metadata.Update(oldObject.Metadata)
-	if err := s.dao.Update(entity); err != nil {
-		logrus.WithError(err).Errorf("unable to perform the update of the project %q, something wrong with the database", entity.Metadata.Name)
-		return nil, shared.InternalError
+	entity.Metadata.Update(oldEntity.Metadata)
+	if updateErr := s.dao.Update(entity); updateErr != nil {
+		logrus.WithError(updateErr).Errorf("unable to perform the update of the project %q, something wrong with the database", entity.Metadata.Name)
+		return nil, updateErr
 	}
 	return entity, nil
 }
@@ -105,28 +99,11 @@ func (s *service) Delete(parameters shared.Parameters) error {
 		logrus.WithError(err).Error("unable to delete all datasources")
 		return err
 	}
-	if err := s.dao.Delete(parameters.Name); err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the project %q", parameters.Name)
-			return shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to delete the project %q, something wrong with the database", parameters.Name)
-		return shared.InternalError
-	}
-	return nil
+	return s.dao.Delete(parameters.Name)
 }
 
 func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
-	entity, err := s.dao.Get(parameters.Name)
-	if err != nil {
-		if databaseModel.IsKeyNotFound(err) {
-			logrus.Debugf("unable to find the project %q", parameters.Name)
-			return nil, shared.NotFoundError
-		}
-		logrus.WithError(err).Errorf("unable to find the previous version of the project %q, something wrong with the database", parameters.Name)
-		return nil, shared.InternalError
-	}
-	return entity, nil
+	return s.dao.Get(parameters.Name)
 }
 
 func (s *service) List(q databaseModel.Query, _ shared.Parameters) (interface{}, error) {

--- a/internal/api/shared/error.go
+++ b/internal/api/shared/error.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 	"github.com/sirupsen/logrus"
 )
 
@@ -45,10 +46,10 @@ func HandleError(err error) error {
 	if errors.Is(err, InternalError) {
 		return echo.NewHTTPError(http.StatusInternalServerError, InternalError.message)
 	}
-	if errors.Is(err, NotFoundError) {
+	if databaseModel.IsKeyNotFound(err) || errors.Is(err, NotFoundError) {
 		return echo.NewHTTPError(http.StatusNotFound, NotFoundError.message)
 	}
-	if errors.Is(err, ConflictError) {
+	if databaseModel.IsKeyConflict(err) || errors.Is(err, ConflictError) {
 		return echo.NewHTTPError(http.StatusConflict, ConflictError.message)
 	}
 	if errors.Is(err, BadRequestError) {


### PR DESCRIPTION
By adding the management of database error in the method `HandleError` called in a HTTP middleware, we can simplify a lot the error management in the different services