### PR TITLE
[IGNORE] don't generate source map when building the ui

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "turbo run build",
+    "build": "GENERATE_SOURCEMAP=false turbo run build",
     "test": "turbo run test",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint -- --fix",


### PR DESCRIPTION
When we are building the UI for the production, we don't need anymore to generate the source map.
The build is also faster when it is disabled.