### PR TITLE
[IGNORE] don't generate source map when building the ui

### DIFF
--- a/ui/app/webpack.prod.ts
+++ b/ui/app/webpack.prod.ts
@@ -19,7 +19,7 @@ import { commonConfig } from './webpack.common';
 const prodConfig: Configuration = {
   mode: 'production',
   bail: true,
-  devtool: 'source-map',
+  devtool: false,
   optimization: {
     // TODO: Could this also be replaced with swc minifier?
     minimizer: [new ESBuildMinifyPlugin({ target: 'es2018' })],


### PR DESCRIPTION
When we are building the UI for the production, we don't need anymore to generate the source map.

It also reduced the binary from 22 MB to 19 MB.