### PR TITLE
[BUGFIX] Fix datasource spamming by using a cache

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^4.7.1",
     "immer": "^9.0.15",
     "lodash-es": "^4.17.21",
+    "lru-cache": "^8.0.4",
     "mdi-material-ui": "^7.4.0",
     "notistack": "^2.0.5",
     "react": "^18.0.0",

--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -11,45 +11,203 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource, GlobalDatasource } from '@perses-dev/core';
+import { Datasource, DatasourceSelector, GlobalDatasource } from '@perses-dev/core';
 import { DatasourceApi } from '@perses-dev/dashboards';
+import LRUCache from 'lru-cache';
 import { fetchDatasourceList, fetchGlobalDatasourceList } from './datasource-client';
 
-export function useDatasourceApi(): DatasourceApi {
-  return {
-    getDatasource: async (project, selector) => {
-      return fetchDatasourceList(project, selector.kind, selector.name ? undefined : true, selector.name).then(
-        (list) => {
-          // hopefully it should return at most one element
-          if (list[0] !== undefined) {
-            return {
-              resource: list[0],
-              proxyUrl: getProxyUrl(list[0]),
-            };
-          }
-        }
-      );
-    },
-    getGlobalDatasource: async (selector) => {
-      return fetchGlobalDatasourceList(selector.kind, selector.name ? undefined : true, selector.name).then((list) => {
-        // hopefully it should return at most one element
-        if (list[0] !== undefined) {
-          return {
-            resource: list[0],
-            proxyUrl: getProxyUrl(list[0]),
-          };
-        }
-      });
-    },
+export class HTTPDatasourceAPI implements DatasourceApi {
+  getDatasource(
+    project: string,
+    selector: DatasourceSelector
+  ): Promise<{ resource: Datasource; proxyUrl: string } | undefined> {
+    return fetchDatasourceList(project, selector.kind, selector.name ? undefined : true, selector.name).then((list) => {
+      // hopefully it should return at most one element
+      if (list[0] !== undefined) {
+        return {
+          resource: list[0],
+          proxyUrl: getProxyUrl(list[0]),
+        };
+      }
+    });
+  }
 
-    listDatasources: async (project, pluginKind) => {
-      return fetchDatasourceList(project, pluginKind);
-    },
+  getGlobalDatasource(
+    selector: DatasourceSelector
+  ): Promise<{ resource: GlobalDatasource; proxyUrl: string } | undefined> {
+    return fetchGlobalDatasourceList(selector.kind, selector.name ? undefined : true, selector.name).then((list) => {
+      // hopefully it should return at most one element
+      if (list[0] !== undefined) {
+        return {
+          resource: list[0],
+          proxyUrl: getProxyUrl(list[0]),
+        };
+      }
+    });
+  }
 
-    listGlobalDatasources: async (pluginKind) => {
-      return fetchGlobalDatasourceList(pluginKind);
-    },
-  };
+  listDatasources(project: string, pluginKind: string | undefined): Promise<Datasource[]> {
+    return fetchDatasourceList(project, pluginKind);
+  }
+
+  listGlobalDatasources(pluginKind: string | undefined): Promise<GlobalDatasource[]> {
+    return fetchGlobalDatasourceList(pluginKind);
+  }
+}
+
+class Cache {
+  private datasources: LRUCache<string, Datasource>;
+  private emptyDatasources: LRUCache<string, boolean>;
+  private globalDatasources: LRUCache<string, GlobalDatasource>;
+
+  constructor() {
+    const option = { ttl: 5 * 60 * 1000, ttlAutopurge: true };
+    this.globalDatasources = new LRUCache<string, GlobalDatasource>(option);
+    this.datasources = new LRUCache<string, Datasource>(option);
+    this.emptyDatasources = new LRUCache<string, boolean>(option);
+  }
+
+  setDatasources(list: Datasource[]) {
+    for (const dts of list) {
+      this.setDatasource(dts);
+    }
+  }
+
+  setDatasource(dts: Datasource) {
+    const kind = dts.spec.plugin.kind;
+    const project = dts.metadata.project;
+    if (dts.spec.default) {
+      // in case it's the default datasource for the given kind, we store it twice
+      // because we might get the datasource with the name or because we want the default one.
+      this.datasources.set(this.generateKey({ kind: kind }, project), dts);
+    }
+    this.datasources.set(this.generateKey({ kind: kind, name: dts.metadata.name }, project), dts);
+  }
+
+  setUndefinedDatasource(project: string, selector: DatasourceSelector) {
+    this.emptyDatasources.set(this.generateKey(selector, project), true);
+  }
+
+  getDatasource(project: string, selector: DatasourceSelector) {
+    const key = this.generateKey(selector, project);
+    const resource = this.datasources.get(this.generateKey(selector, project));
+    let keyExist = true;
+    if (resource === undefined) {
+      keyExist = this.emptyDatasources.has(key);
+    }
+    return { resource: resource, keyExist: keyExist };
+  }
+
+  setGlobalDatasources(list: GlobalDatasource[]) {
+    for (const dts of list) {
+      this.setGlobalDatasource(dts);
+    }
+  }
+
+  setGlobalDatasource(dts: GlobalDatasource) {
+    const kind = dts.spec.plugin.kind;
+    if (dts.spec.default) {
+      // in case it's the default datasource for the given kind, we store it twice
+      // because we might get the datasource with the name or because we want the default one.
+      this.globalDatasources.set(this.generateKey({ kind: kind }), dts);
+    }
+    this.globalDatasources.set(this.generateKey({ kind: kind, name: dts.metadata.name }), dts);
+  }
+
+  setUndefinedGlobalDatasource(selector: DatasourceSelector) {
+    this.emptyDatasources.set(this.generateKey(selector), true);
+  }
+
+  getGlobalDatasource(selector: DatasourceSelector) {
+    const key = this.generateKey(selector);
+    const resource = this.globalDatasources.get(this.generateKey(selector));
+    let keyExist = true;
+    if (resource === undefined) {
+      keyExist = this.emptyDatasources.has(key);
+    }
+    return { resource: resource, keyExist: keyExist };
+  }
+
+  private generateKey(selector: DatasourceSelector, project?: string): string {
+    let key = selector.kind;
+    if (selector.name !== undefined) {
+      key += `-${selector.name}`;
+    }
+    if (project !== undefined) {
+      key += `-${project}`;
+    }
+    return key;
+  }
+}
+
+export class CachedDatasourceAPI implements DatasourceApi {
+  private readonly client: DatasourceApi;
+  private readonly cache: Cache;
+
+  constructor(client: DatasourceApi) {
+    this.client = client;
+    this.cache = new Cache();
+  }
+
+  getDatasource(
+    project: string,
+    selector: DatasourceSelector
+  ): Promise<{ resource: Datasource; proxyUrl: string } | undefined> {
+    const { resource, keyExist } = this.cache.getDatasource(project, selector);
+    if (resource) {
+      return Promise.resolve({ resource: resource, proxyUrl: getProxyUrl(resource) });
+    }
+    if (keyExist) {
+      // in case the keyExist, than mean we already did the query, but the datasource doesn't exist. So we can safely return an undefined Promise.
+      return Promise.resolve(undefined);
+    }
+    return this.client.getDatasource(project, selector).then((result) => {
+      if (result === undefined) {
+        // in case the result is undefined, we should then notify that the datasource doesn't exist for the given selector.
+        // Like that, next time another panel ask for the exact same datasource (with the same selector), then we won't query the server to try it again.
+        // It's ok to do it as the cache has an expiration of 5min.
+        // We have the same logic for the globalDatasources.
+        this.cache.setUndefinedDatasource(project, selector);
+      } else {
+        this.cache.setDatasource(result.resource);
+      }
+      return result;
+    });
+  }
+
+  getGlobalDatasource(
+    selector: DatasourceSelector
+  ): Promise<{ resource: GlobalDatasource; proxyUrl: string } | undefined> {
+    const { resource, keyExist } = this.cache.getGlobalDatasource(selector);
+    if (resource) {
+      return Promise.resolve({ resource: resource, proxyUrl: getProxyUrl(resource) });
+    }
+    if (keyExist) {
+      return Promise.resolve(undefined);
+    }
+    return this.client.getGlobalDatasource(selector).then((result) => {
+      if (result === undefined) {
+        this.cache.setUndefinedGlobalDatasource(selector);
+      } else {
+        this.cache.setGlobalDatasource(result.resource);
+      }
+      return result;
+    });
+  }
+
+  listDatasources(project: string, pluginKind: string | undefined): Promise<Datasource[]> {
+    return this.client.listDatasources(project, pluginKind).then((list) => {
+      this.cache.setDatasources(list);
+      return list;
+    });
+  }
+
+  listGlobalDatasources(pluginKind: string | undefined): Promise<GlobalDatasource[]> {
+    return this.client.listGlobalDatasources(pluginKind).then((list) => {
+      this.cache.setGlobalDatasources(list);
+      return list;
+    });
+  }
 }
 
 // Helper function for getting a proxy URL from a datasource or global datasource

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -18,14 +18,14 @@ import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { DashboardResource } from '@perses-dev/core';
 import { dashboardDisplayName, dashboardExtendedDisplayName } from '@perses-dev/core/dist/utils/text';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { bundledPluginLoader } from '../model/bundled-plugins';
 import { useCreateDashboardMutation, useDashboard, useUpdateDashboardMutation } from '../model/dashboard-client';
-import { useDatasourceApi } from '../model/datasource-api';
 import DashboardBreadcrumbs from '../components/DashboardBreadcrumbs';
 import { useIsReadonly } from '../model/config-client';
 import { useSnackbar } from '../context/SnackbarProvider';
 import { CreateAction } from '../model/action';
+import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../model/datasource-api';
 
 /**
  * Generated a resource name valid for the API.
@@ -52,7 +52,12 @@ function ViewDashboard() {
 
   const navigate = useNavigate();
   const { successSnackbar, exceptionSnackbar, warningSnackbar } = useSnackbar();
-  const datasourceApi = useDatasourceApi();
+  const [datasourceApi] = useState(new CachedDatasourceAPI(new HTTPDatasourceAPI()));
+  useEffect(() => {
+    // warm up the caching of the datasources
+    datasourceApi.listDatasources(projectName, undefined);
+    datasourceApi.listGlobalDatasources(undefined);
+  }, [datasourceApi, projectName]);
   const { isLoading } = useDashboard(projectName, dashboardName);
   let { data } = useDashboard(projectName, dashboardName);
   const isReadonly = useIsReadonly();

--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -52,11 +52,11 @@ function ViewDashboard() {
 
   const navigate = useNavigate();
   const { successSnackbar, exceptionSnackbar, warningSnackbar } = useSnackbar();
-  const [datasourceApi] = useState(new CachedDatasourceAPI(new HTTPDatasourceAPI()));
+  const [datasourceApi] = useState(() => new CachedDatasourceAPI(new HTTPDatasourceAPI()));
   useEffect(() => {
     // warm up the caching of the datasources
-    datasourceApi.listDatasources(projectName, undefined);
-    datasourceApi.listGlobalDatasources(undefined);
+    datasourceApi.listDatasources(projectName);
+    datasourceApi.listGlobalDatasources();
   }, [datasourceApi, projectName]);
   const { isLoading } = useDashboard(projectName, dashboardName);
   let { data } = useDashboard(projectName, dashboardName);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -71,6 +71,7 @@
         "@tanstack/react-query": "^4.7.1",
         "immer": "^9.0.15",
         "lodash-es": "^4.17.21",
+        "lru-cache": "^8.0.4",
         "mdi-material-ui": "^7.4.0",
         "notistack": "^2.0.5",
         "react": "^18.0.0",
@@ -100,6 +101,14 @@
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1",
         "webpack-merge": "^5.8.0"
+      }
+    },
+    "app/node_modules/lru-cache": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.4.tgz",
+      "integrity": "sha512-E9FF6+Oc/uFLqZCuZwRKUzgFt5Raih6LfxknOSAVTjNkrCZkBf7DQCwJxZQgd9l4eHjIJDGR+E+1QKD1RhThPw==",
+      "engines": {
+        "node": ">=16.14"
       }
     },
     "components": {
@@ -26957,6 +26966,7 @@
         "html-webpack-plugin": "^5.5.0",
         "immer": "^9.0.15",
         "lodash-es": "^4.17.21",
+        "lru-cache": "^8.0.4",
         "mdi-material-ui": "^7.4.0",
         "notistack": "^2.0.5",
         "react": "^18.0.0",
@@ -26974,6 +26984,13 @@
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1",
         "webpack-merge": "^5.8.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.4.tgz",
+          "integrity": "sha512-E9FF6+Oc/uFLqZCuZwRKUzgFt5Raih6LfxknOSAVTjNkrCZkBf7DQCwJxZQgd9l4eHjIJDGR+E+1QKD1RhThPw=="
+        }
       }
     },
     "@perses-dev/components": {


### PR DESCRIPTION
This PR is another proposition to fix #806.

The idea here is to proposed two implementations of the interface `DatasourceAPI`. 

* The first one `HTTPDatasourceAPI` is the regular implementation that is simply contacting the backend like it is done currently on the `main` branch.

* The second one is using a LRU cache in order to save temporary the list of the datasources used by the dashboard.

Finally, the cache is warming up before the dashboard is loaded, so each panel is actually using the cache to get their datasource and doesn't contact the backend anymore.

With this PR for the dashboard `Benchmark`, it contacts the backend 6 times instead of 20.
