### PR TITLE
[ENHANCEMENT] Ensure all bad request error has the same format

### DIFF
--- a/internal/api/core/middleware/verification.go
+++ b/internal/api/core/middleware/verification.go
@@ -63,17 +63,17 @@ func CheckProject(svc project.Service) echo.MiddlewareFunc {
 						// So we read the body, and then we re-inject it in the request.
 						bodyBytes, err := io.ReadAll(c.Request().Body)
 						if err != nil {
-							return fmt.Errorf("%w: %s", shared.BadRequestError, err)
+							return shared.HandleBadRequestError(err.Error())
 						}
 						// write back to request body
 						c.Request().Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 						// now we can safely partially decode the body
 						o := &partialObject{}
 						if unmarshalErr := json.Unmarshal(bodyBytes, o); unmarshalErr != nil {
-							return fmt.Errorf("%w: %s", shared.BadRequestError, unmarshalErr)
+							return shared.HandleBadRequestError(unmarshalErr.Error())
 						}
 						if len(o.Metadata.Project) == 0 {
-							return fmt.Errorf("%w: metadata.project cannot be empty", shared.BadRequestError)
+							return shared.HandleBadRequestError("metadata.project cannot be empty")
 						}
 						projectName = o.Metadata.Project
 						break
@@ -83,7 +83,7 @@ func CheckProject(svc project.Service) echo.MiddlewareFunc {
 			if len(projectName) > 0 {
 				if _, err := svc.Get(shared.Parameters{Name: projectName}); err != nil {
 					if databaseModel.IsKeyNotFound(err) {
-						return fmt.Errorf("%w, metadata.project %q doesn't exist", shared.BadRequestError, projectName)
+						return shared.HandleBadRequestError(fmt.Sprintf("metadata.project %q doesn't exist", projectName))
 					}
 					return err
 				}

--- a/internal/api/impl/migrate/migrate.go
+++ b/internal/api/impl/migrate/migrate.go
@@ -14,7 +14,6 @@
 package migrate
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -46,7 +45,7 @@ func (e *Endpoint) RegisterRoutes(g *echo.Group) {
 func (e *Endpoint) Migrate(ctx echo.Context) error {
 	body := &api.Migrate{}
 	if err := ctx.Bind(body); err != nil {
-		return fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return shared.HandleBadRequestError(err.Error())
 	}
 	grafanaDashboard := migrate.ReplaceInputValue(body.Input, string(body.GrafanaDashboard))
 	persesDashboard, err := e.migrationService.Migrate([]byte(grafanaDashboard))

--- a/internal/api/impl/v1/dashboard/service.go
+++ b/internal/api/impl/v1/dashboard/service.go
@@ -43,13 +43,13 @@ func (s *service) Create(entity api.Entity) (interface{}, error) {
 	if dashboardObject, ok := entity.(*v1.Dashboard); ok {
 		return s.create(dashboardObject)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting dashboard format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting dashboard format, received '%T'", entity))
 }
 
 func (s *service) create(entity *v1.Dashboard) (*v1.Dashboard, error) {
 	// verify this new dashboard passes the validation
 	if err := validate.Dashboard(entity, s.sch); err != nil {
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 
 	// Update the time contains in the entity
@@ -64,24 +64,24 @@ func (s *service) Update(entity api.Entity, parameters shared.Parameters) (inter
 	if dashboardObject, ok := entity.(*v1.Dashboard); ok {
 		return s.update(dashboardObject, parameters)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting dashboard format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting dashboard format, received '%T'", entity))
 }
 
 func (s *service) update(entity *v1.Dashboard, parameters shared.Parameters) (*v1.Dashboard, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in dashboard %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
-		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.name and the name in the http path request don't match")
 	}
 	if len(entity.Metadata.Project) == 0 {
 		entity.Metadata.Project = parameters.Project
 	} else if entity.Metadata.Project != parameters.Project {
 		logrus.Debugf("project in dashboard %q and project from the http request %q don't match", entity.Metadata.Project, parameters.Project)
-		return nil, fmt.Errorf("%w: metadata.project and the project name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.project and the project name in the http path request don't match")
 	}
 
 	// verify this new dashboard passes the validation
 	if err := validate.Dashboard(entity, s.sch); err != nil {
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 
 	// find the previous version of the dashboard

--- a/internal/api/impl/v1/datasource/service.go
+++ b/internal/api/impl/v1/datasource/service.go
@@ -43,12 +43,12 @@ func (s *service) Create(entity api.Entity) (interface{}, error) {
 	if datasourceObject, ok := entity.(*v1.Datasource); ok {
 		return s.create(datasourceObject)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting Datasource format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Datasource format, received '%T'", entity))
 }
 
 func (s *service) create(entity *v1.Datasource) (*v1.Datasource, error) {
 	if err := s.validate(entity); err != nil {
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
@@ -62,22 +62,22 @@ func (s *service) Update(entity api.Entity, parameters shared.Parameters) (inter
 	if DatasourceObject, ok := entity.(*v1.Datasource); ok {
 		return s.update(DatasourceObject, parameters)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting Datasource format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Datasource format, received '%T'", entity))
 }
 
 func (s *service) update(entity *v1.Datasource, parameters shared.Parameters) (*v1.Datasource, error) {
 	if err := s.validate(entity); err != nil {
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Datasource %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
-		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.name and the name in the http path request don't match")
 	}
 	if len(entity.Metadata.Project) == 0 {
 		entity.Metadata.Project = parameters.Project
 	} else if entity.Metadata.Project != parameters.Project {
 		logrus.Debugf("project in datasource %q and project from the http request %q don't match", entity.Metadata.Project, parameters.Project)
-		return nil, fmt.Errorf("%w: metadata.project and the project name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.project and the project name in the http path request don't match")
 	}
 	// find the previous version of the Datasource
 	oldEntity, err := s.dao.Get(parameters.Project, parameters.Name)

--- a/internal/api/impl/v1/folder/service.go
+++ b/internal/api/impl/v1/folder/service.go
@@ -39,7 +39,7 @@ func (s *service) Create(entity api.Entity) (interface{}, error) {
 	if datasourceObject, ok := entity.(*v1.Folder); ok {
 		return s.create(datasourceObject)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting Folder format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Folder format, received '%T'", entity))
 }
 
 func (s *service) create(entity *v1.Folder) (*v1.Folder, error) {
@@ -55,19 +55,19 @@ func (s *service) Update(entity api.Entity, parameters shared.Parameters) (inter
 	if FolderObject, ok := entity.(*v1.Folder); ok {
 		return s.update(FolderObject, parameters)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting Folder format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Folder format, received '%T'", entity))
 }
 
 func (s *service) update(entity *v1.Folder, parameters shared.Parameters) (*v1.Folder, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Folder %q and name from the http request: %q don't match", entity.Metadata.Name, parameters.Name)
-		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.name and the name in the http path request don't match")
 	}
 	if len(entity.Metadata.Project) == 0 {
 		entity.Metadata.Project = parameters.Project
 	} else if entity.Metadata.Project != parameters.Project {
 		logrus.Debugf("project in folder %q and project from the http request %q don't match", entity.Metadata.Project, parameters.Project)
-		return nil, fmt.Errorf("%w: metadata.project and the project name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.project and the project name in the http path request don't match")
 	}
 	// find the previous version of the Folder
 	oldEntity, err := s.dao.Get(parameters.Project, parameters.Name)

--- a/internal/api/impl/v1/globaldatasource/service.go
+++ b/internal/api/impl/v1/globaldatasource/service.go
@@ -43,12 +43,12 @@ func (s *service) Create(entity api.Entity) (interface{}, error) {
 	if datasourceObject, ok := entity.(*v1.GlobalDatasource); ok {
 		return s.create(datasourceObject)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting GlobalDatasource format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting GlobalDatasource format, received '%T'", entity))
 }
 
 func (s *service) create(entity *v1.GlobalDatasource) (*v1.GlobalDatasource, error) {
 	if err := s.validate(entity); err != nil {
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
@@ -62,16 +62,16 @@ func (s *service) Update(entity api.Entity, parameters shared.Parameters) (inter
 	if DatasourceObject, ok := entity.(*v1.GlobalDatasource); ok {
 		return s.update(DatasourceObject, parameters)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting GlobalDatasource format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting GlobalDatasource format, received '%T'", entity))
 }
 
 func (s *service) update(entity *v1.GlobalDatasource, parameters shared.Parameters) (*v1.GlobalDatasource, error) {
 	if err := s.validate(entity); err != nil {
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Datasource %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
-		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.name and the name in the http path request don't match")
 	}
 	// find the previous version of the Datasource
 	oldEntity, err := s.dao.Get(parameters.Name)

--- a/internal/api/impl/v1/project/service.go
+++ b/internal/api/impl/v1/project/service.go
@@ -48,7 +48,7 @@ func (s *service) Create(entity api.Entity) (interface{}, error) {
 	if projectObject, ok := entity.(*v1.Project); ok {
 		return s.create(projectObject)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting project format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting project format, received '%T'", entity))
 }
 
 func (s *service) create(entity *v1.Project) (*v1.Project, error) {
@@ -64,13 +64,13 @@ func (s *service) Update(entity api.Entity, parameters shared.Parameters) (inter
 	if projectObject, ok := entity.(*v1.Project); ok {
 		return s.update(projectObject, parameters)
 	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting project format, received '%T'", shared.BadRequestError, entity)
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting project format, received '%T'", entity))
 }
 
 func (s *service) update(entity *v1.Project, parameters shared.Parameters) (*v1.Project, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in project %q and name from the http request: %q don't match", entity.Metadata.Name, parameters.Name)
-		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request don't match", shared.BadRequestError)
+		return nil, shared.HandleBadRequestError("metadata.name and the name in the http path request don't match")
 	}
 	// find the previous version of the project
 	oldEntity, err := s.dao.Get(parameters.Name)

--- a/internal/api/impl/validate/validate.go
+++ b/internal/api/impl/validate/validate.go
@@ -42,10 +42,10 @@ func (e *Endpoint) RegisterRoutes(g *echo.Group) {
 func (e *Endpoint) ValidateDashboard(ctx echo.Context) error {
 	entity := &v1.Dashboard{}
 	if err := ctx.Bind(entity); err != nil {
-		return fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return shared.HandleBadRequestError(err.Error())
 	}
 	if err := validate.Dashboard(entity, e.sch); err != nil {
-		return fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return shared.HandleBadRequestError(err.Error())
 	}
 	return ctx.NoContent(http.StatusOK)
 }
@@ -60,10 +60,10 @@ func (e *Endpoint) ValidateGlobalDatasource(ctx echo.Context) error {
 
 func validateDatasource[T v1.DatasourceInterface](entity T, sch schemas.Schemas, ctx echo.Context) error {
 	if err := ctx.Bind(entity); err != nil {
-		return fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return shared.HandleBadRequestError(err.Error())
 	}
 	if err := validate.Datasource(entity, nil, sch); err != nil {
-		return fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return shared.HandleBadRequestError(err.Error())
 	}
 	return ctx.NoContent(http.StatusOK)
 }

--- a/internal/api/shared/error.go
+++ b/internal/api/shared/error.go
@@ -15,6 +15,7 @@ package shared
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -57,4 +58,8 @@ func HandleError(err error) error {
 	}
 	logrus.WithError(err).Error("unexpected error not handle")
 	return echo.NewHTTPError(http.StatusInternalServerError, InternalError.message)
+}
+
+func HandleBadRequestError(msg string) error {
+	return fmt.Errorf("%w: %s", BadRequestError, msg)
 }

--- a/internal/api/shared/migrate/migrate.go
+++ b/internal/api/shared/migrate/migrate.go
@@ -152,7 +152,7 @@ func (m *mig) Migrate(grafanaDashboard []byte) (*v1.Dashboard, error) {
 	)
 	if err := grafanaDashboardVal.Validate(cue.Final()); err != nil {
 		logrus.WithError(err).Trace("Unable to wrap the received json into a CUE definition")
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 
 	// Compile the migration schema using the grafana def to resolve the paths
@@ -162,7 +162,7 @@ func (m *mig) Migrate(grafanaDashboard []byte) (*v1.Dashboard, error) {
 	err := mappingVal.Err()
 	if err != nil {
 		logrus.WithError(err).Trace("Unable to compile the migration schema using the received dashboard to resolve the paths")
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 	logrus.Tracef("final value: %#v", mappingVal)
 
@@ -175,7 +175,7 @@ func (m *mig) Migrate(grafanaDashboard []byte) (*v1.Dashboard, error) {
 	err = json.Unmarshal(persesDashboardJSON, &persesDashboard)
 	if err != nil {
 		logrus.WithError(err).Trace("Unable to unmarshall JSON bytes to Dashboard struct")
-		return nil, fmt.Errorf("%w: %s", shared.BadRequestError, err)
+		return nil, shared.HandleBadRequestError(err.Error())
 	}
 
 	return &persesDashboard, nil

--- a/internal/api/shared/toolbox.go
+++ b/internal/api/shared/toolbox.go
@@ -14,7 +14,6 @@
 package shared
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -105,7 +104,7 @@ func (t *toolbox) Get(ctx echo.Context) error {
 
 func (t *toolbox) List(ctx echo.Context, q databaseModel.Query) error {
 	if err := ctx.Bind(q); err != nil {
-		return fmt.Errorf("%w: %s", BadRequestError, err)
+		return HandleBadRequestError(err.Error())
 	}
 	parameters := extractParameters(ctx)
 	result, err := t.service.List(q, parameters)
@@ -117,10 +116,10 @@ func (t *toolbox) List(ctx echo.Context, q databaseModel.Query) error {
 
 func (t *toolbox) bind(ctx echo.Context, entity api.Entity) error {
 	if err := ctx.Bind(entity); err != nil {
-		return fmt.Errorf("%w: %s", BadRequestError, err)
+		return HandleBadRequestError(err.Error())
 	}
 	if err := validateMetadata(ctx, entity.GetMetadata()); err != nil {
-		return fmt.Errorf("%w: %s", BadRequestError, err)
+		return HandleBadRequestError(err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
Just improving the error management in the backend by adding a utils function that will help to create a `BadRequest` error. Using this function ensure also to have the same format across all endpoint.