### PR TITLE
[IGNORE] Migrate screen: add recommendation about keeping rows collapsed

### DIFF
--- a/internal/api/shared/migrate/migrate.go
+++ b/internal/api/shared/migrate/migrate.go
@@ -162,7 +162,7 @@ func (m *mig) Migrate(grafanaDashboard []byte) (*v1.Dashboard, error) {
 	err := mappingVal.Err()
 	if err != nil {
 		logrus.WithError(err).Trace("Unable to compile the migration schema using the received dashboard to resolve the paths")
-		return nil, shared.HandleBadRequestError(err.Error())
+		return nil, shared.HandleBadRequestError(fmt.Sprintf("unable to convert to Perses dashboard: %s", err))
 	}
 	logrus.Tracef("final value: %#v", mappingVal)
 
@@ -175,7 +175,7 @@ func (m *mig) Migrate(grafanaDashboard []byte) (*v1.Dashboard, error) {
 	err = json.Unmarshal(persesDashboardJSON, &persesDashboard)
 	if err != nil {
 		logrus.WithError(err).Trace("Unable to unmarshall JSON bytes to Dashboard struct")
-		return nil, shared.HandleBadRequestError(err.Error())
+		return nil, shared.HandleBadRequestError(fmt.Sprintf("the Perses dashboard constraints are not met: %s", err))
 	}
 
 	return &persesDashboard, nil

--- a/ui/app/src/views/ViewMigrate.tsx
+++ b/ui/app/src/views/ViewMigrate.tsx
@@ -91,6 +91,13 @@ function ViewMigrate() {
             dashboard structure.
           </Typography>
         </Alert>
+        <Alert variant={'outlined'} severity={'warning'}>
+          <Typography>
+            It is recommended to <u>collapse all the rows</u> of your Grafana dashboard before attempting to migrate it.
+            This ensures that your dashboard structure wont be alterated & that Library panels will get migrated nicely
+            (deep copied).
+          </Typography>
+        </Alert>
         <Button
           startIcon={<Upload />}
           variant="contained"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7058693/228001300-0c5f9977-b9b3-44c2-a63d-4351de8dc5bf.png)

We have currently 2 issues with expanded rows when attempting dashboard migration: 
1. When a row is expanded in Grafana, its children panels are no longer considered its children but instead put as siblings into the same list. For instance, if you have this dashboard with collapsed rows:
```
{ 
  ...
  panels: [
    {
      type: "row"
      panels: [
        A,
        B,
        C,
      ]
    },
    {
      type: "row"
      panels: [
        D,
        E,
        F,
      ]
    },
  ]
}
```

If the first row is expanded, this is how the datamodel would look like:
```
{ 
  ...
  panels: [
    {
      type: "row"
      panels: []
    },
    A,
    B,
    C,
    {
      type: "row"
      panels: [
        D,
        E,
        F,
      ]
    },
  ]
}
```
Due to our current (too simplistic) way of processing the panels, any panel contained in an expanded row will get put at the top of the Perses dashboard without any parent row.

2. [Library panels](https://grafana.com/docs/grafana/v8.4/panels/library-panels/) make the migration fail, because for some reason when you have a Library panel within an expanded row, it doesnt have all the attributes - even the panel type is missing! This is how it looks like (example with a Text panel):
```
{
	"gridPos": {
		"h": 5,
		"w": 12,
		"x": 0,
		"y": 1
	},
	"id": 170,
	"libraryPanel": {
		"name": "Argos POC",
		"uid": "eih898oVk"
	},
	"title": "Point of Contact"
}
```
While within a collapsed row, it does embed the full detail we need to achieve a proper conversion:
```
{
	"datasource": {
		"type": "prometheus",
		"uid": "argos-world"
	},
	"description": "",
	"gridPos": {
		"h": 5,
		"w": 12,
		"x": 0,
		"y": 1
	},
	"id": 170,
	"libraryPanel": {
		"description": "",
		"folderId": 6540,
		"folderUid": "-em418nMl",
		"id": 20,
		"kind": 1,
		"meta": {
			"connectedDashboards": 18,
			"created": "2023-01-25T22:10:34Z",
			"createdBy": {
				"avatarUrl": "/avatar/123456789",
				"id": 5455,
				"name": "antoine.thebaud@amadeus.com"
			},
			"folderName": "[SDC] ARGOS",
			"folderUid": "-em418nMl",
			"updated": "2023-01-25T22:10:34Z",
			"updatedBy": {
				"avatarUrl": "/avatar/123456789",
				"id": 5455,
				"name": "antoine.thebaud@amadeus.com"
			}
		},
		"model": {
			"datasource": {
				"type": "prometheus",
				"uid": "argos-world"
			},
			"description": "",
			"gridPos": {
				"h": 5,
				"w": 12,
				"x": 12,
				"y": 1
			},
			"id": 393,
			"libraryPanel": {
				"name": "Argos POC"
			},
			"links": [],
			"options": {
				"content": "In case of issue with this dashboard, please contact the ARGOS team",
				"mode": "html"
			},
			"pluginVersion": "9.1.2",
			"targets": [{
				"datasource": {
					"type": "prometheus",
					"uid": "argos-world"
				},
				"refId": "A"
			}],
			"title": "Point of Contact",
			"type": "text"
		},
		"name": "Argos POC",
		"orgId": 1,
		"type": "text",
		"uid": "eih898oVk",
		"version": 1
	},
	"links": [],
	"options": {
		"code": {
			"language": "plaintext",
			"showLineNumbers": false,
			"showMiniMap": false
		},
		"content": "In case of issue with this dashboard, please contact the ARGOS team",
		"mode": "html"
	},
	"pluginVersion": "9.4.3",
	"targets": [{
		"datasource": {
			"type": "prometheus",
			"uid": "argos-world"
		},
		"refId": "A"
	}],
	"title": "Point of Contact",
	"type": "text"
}
```

-> We could improve the migration algorithm to tackle the point 1) (I'm actually planning to in a near future), but regarding point 2) about Library panels I don't see any other solution right now* than telling the users to collapse the rows containing such panels before pasting the JSON to Perses, hence the proposal to add this warning message.

**I see a long term solution here the day Perses would support an equivalent of the Grafana Library panels: we could propose a mass migration feature (as already suggested by @sjcobb) with which we would process first all the available Library panels, to be able later on to resolve the references to these. This way the current issue would no longer be & as a cool side effect, we would be able to preserve the reference/include thingy instead of deep copying the panel content into each dashboard (= the only way we propose for now).*

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
