### PR TITLE
[IGNORE] bumps @prometheus-io/codemirror-promql to v0.43.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2294,9 +2294,9 @@
       "dev": true
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.4.tgz",
-      "integrity": "sha512-irxKsTSjS0OkfMWWt9YxtNK97++/E+XIHfKnRpSVfZyHzda/amYF0BR+T8mMkrGQWidx2zApxHx08GT13egyQA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz",
+      "integrity": "sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -4163,31 +4163,31 @@
       }
     },
     "node_modules/@prometheus-io/codemirror-promql": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.40.5.tgz",
-      "integrity": "sha512-0yTlIyH+zx3TOH2hl4k6Y1wPmF0Q2Y2ZimmPPRl3g/7fCo8jgfk+qcpVxbLJtMtSd9tfekwuSCC4TblIMMqjeQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.43.0.tgz",
+      "integrity": "sha512-rNWsMn1Qw6QYNZCv1jMs9Ndx9N5/2if0+mynwzuBmnff44kekJXvDbI/wQHPhN+FG929prXKCDwS4KSSHVo8MQ==",
       "dependencies": {
-        "@prometheus-io/lezer-promql": "^0.40.5",
+        "@prometheus-io/lezer-promql": "0.43.0",
         "lru-cache": "^6.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "@codemirror/autocomplete": "^6.2.0",
-        "@codemirror/language": "^6.2.1",
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/language": "^6.3.0",
         "@codemirror/lint": "^6.0.0",
         "@codemirror/state": "^6.1.1",
-        "@codemirror/view": "^6.2.4",
+        "@codemirror/view": "^6.4.0",
         "@lezer/common": "^1.0.1"
       }
     },
     "node_modules/@prometheus-io/lezer-promql": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.40.5.tgz",
-      "integrity": "sha512-d0wdw2ktxD/WnUYOiwMmIGlGT45F/RbiWHX5WZGkGmiLPQHOOsnBNlqxCX9fHF3gfcyVgBu32fz286dgkEkihg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.43.0.tgz",
+      "integrity": "sha512-pETCiiJK24GotBytjNzE3tK+rGafl7F/Wxhd8l05T8a1hXR+kgelxyyfFCj/TxPqrQuzM24TW/mqFBKZZ0pSpQ==",
       "peerDependencies": {
-        "@lezer/highlight": "^1.1.0",
+        "@lezer/highlight": "^1.1.2",
         "@lezer/lr": "^1.2.3"
       }
     },
@@ -24305,22 +24305,13 @@
         "@perses-dev/components": "0.25.0",
         "@perses-dev/core": "0.25.0",
         "@perses-dev/plugin-system": "0.25.0",
-        "@prometheus-io/codemirror-promql": "^0.40.5",
-        "@prometheus-io/lezer-promql": "^0.37.0",
+        "@prometheus-io/codemirror-promql": "^0.43.0",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
         "immer": "^9.0.15"
       },
       "peerDependencies": {
         "react": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "prometheus-plugin/node_modules/@prometheus-io/lezer-promql": {
-      "version": "0.37.0",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
       }
     },
     "storybook": {
@@ -25829,9 +25820,9 @@
       "dev": true
     },
     "@codemirror/autocomplete": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.4.tgz",
-      "integrity": "sha512-irxKsTSjS0OkfMWWt9YxtNK97++/E+XIHfKnRpSVfZyHzda/amYF0BR+T8mMkrGQWidx2zApxHx08GT13egyQA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz",
+      "integrity": "sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -27070,17 +27061,10 @@
         "@perses-dev/components": "0.25.0",
         "@perses-dev/core": "0.25.0",
         "@perses-dev/plugin-system": "0.25.0",
-        "@prometheus-io/codemirror-promql": "^0.40.5",
-        "@prometheus-io/lezer-promql": "^0.37.0",
+        "@prometheus-io/codemirror-promql": "^0.43.0",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
         "immer": "^9.0.15"
-      },
-      "dependencies": {
-        "@prometheus-io/lezer-promql": {
-          "version": "0.37.0",
-          "requires": {}
-        }
       }
     },
     "@perses-dev/storybook": {
@@ -27213,18 +27197,18 @@
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@prometheus-io/codemirror-promql": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.40.5.tgz",
-      "integrity": "sha512-0yTlIyH+zx3TOH2hl4k6Y1wPmF0Q2Y2ZimmPPRl3g/7fCo8jgfk+qcpVxbLJtMtSd9tfekwuSCC4TblIMMqjeQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.43.0.tgz",
+      "integrity": "sha512-rNWsMn1Qw6QYNZCv1jMs9Ndx9N5/2if0+mynwzuBmnff44kekJXvDbI/wQHPhN+FG929prXKCDwS4KSSHVo8MQ==",
       "requires": {
-        "@prometheus-io/lezer-promql": "^0.40.5",
+        "@prometheus-io/lezer-promql": "0.43.0",
         "lru-cache": "^6.0.0"
       }
     },
     "@prometheus-io/lezer-promql": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.40.5.tgz",
-      "integrity": "sha512-d0wdw2ktxD/WnUYOiwMmIGlGT45F/RbiWHX5WZGkGmiLPQHOOsnBNlqxCX9fHF3gfcyVgBu32fz286dgkEkihg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.43.0.tgz",
+      "integrity": "sha512-pETCiiJK24GotBytjNzE3tK+rGafl7F/Wxhd8l05T8a1hXR+kgelxyyfFCj/TxPqrQuzM24TW/mqFBKZZ0pSpQ==",
       "requires": {}
     },
     "@sinclair/typebox": {

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -34,8 +34,7 @@
     "@perses-dev/components": "0.25.0",
     "@perses-dev/core": "0.25.0",
     "@perses-dev/plugin-system": "0.25.0",
-    "@prometheus-io/codemirror-promql": "^0.40.5",
-    "@prometheus-io/lezer-promql": "^0.37.0",
+    "@prometheus-io/codemirror-promql": "^0.43.0",
     "@uiw/react-codemirror": "^4.19.1",
     "date-fns": "^2.28.0",
     "immer": "^9.0.15"


### PR DESCRIPTION
This PR update the dependence `@prometheus-io/codemirror-promql` to the last version and remove the dependency to `@prometheus-dev/lezer-promql` which is already brought by `codemirror-promql`