### PR TITLE
[BUGFIX] Migrate feature: fix issue with children panels wrongly positionned

### DIFF
--- a/internal/api/shared/migrate/migrate_test.go
+++ b/internal/api/shared/migrate/migrate_test.go
@@ -71,3 +71,13 @@ func TestMigrate(t *testing.T) {
 		})
 	}
 }
+
+func TestRearrangeGrafanaPanelsWithinExpandedRows(t *testing.T) {
+	input, _ := os.ReadFile("testdata/expanded_rows_before.json")
+	expectedAfter, _ := os.ReadFile("testdata/expanded_rows_after.json")
+
+	t.Run("It should move any wrongly-orphaned panels into the right expanded row", func(t *testing.T) {
+		actualAfter := rearrangeGrafanaPanelsWithinExpandedRows(input)
+		require.JSONEq(t, string(expectedAfter), string(actualAfter))
+	})
+}

--- a/internal/api/shared/migrate/testdata/expanded_rows_after.json
+++ b/internal/api/shared/migrate/testdata/expanded_rows_after.json
@@ -1,0 +1,81 @@
+{
+  "title": "Oversimplified grafana dashboard",
+  "description": "This file is like an oversimplified grafana dashboard, where we care only about the dashboard attributes used in rearrangePanelsWithinExpandedRows (also put some random fields to ensure we are not loosing content in the process)",
+  "panels": [
+    {
+      "title": "My 1rst panel is an orphan",
+      "type": "stat"
+    },
+    {
+      "title": "My 2nd panel is an orphan",
+      "type": "timeseries"
+    },
+    {
+      "title": "My 3rd panel is a collapsed row",
+      "type": "row",
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "My 4th panel has a parent",
+          "type": "gauge"
+        },
+        {
+          "title": "My 5th panel has a parent",
+          "type": "bargauge"
+        }
+      ]
+    },
+    {
+      "title": "My 6th panel is an expanded row",
+      "type": "row",
+      "collapsed": false,
+      "panels": [
+        {
+          "title": "My 7th panel has a parent",
+          "type": "graph"
+        },
+        {
+          "title": "My 8th panel has a parent",
+          "type": "heatmap"
+        }
+      ]
+    },
+    {
+      "title": "My 9th panel is an expanded row",
+      "type": "row",
+      "collapsed": false,
+      "panels": [
+        {
+          "title": "My 10th panel has a parent",
+          "type": "piechart"
+        },
+        {
+          "title": "My 11th panel has a parent",
+          "type": "statetimeline"
+        }
+      ]
+    },
+    {
+      "title": "My 12th panel is a collapsed row",
+      "type": "row",
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "My 13th panel has a parent",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "title": "My 14th panel is an expanded row",
+      "type": "row",
+      "collapsed": false,
+      "panels": [
+        {
+          "title": "My 15th panel has a parent",
+          "type": "stat"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/api/shared/migrate/testdata/expanded_rows_before.json
+++ b/internal/api/shared/migrate/testdata/expanded_rows_before.json
@@ -1,0 +1,78 @@
+{
+  "title": "Oversimplified grafana dashboard",
+  "description": "This file is like an oversimplified grafana dashboard, where we care only about the dashboard attributes used in rearrangePanelsWithinExpandedRows (also put some random fields to ensure we are not loosing content in the process)",
+  "panels": [
+    {
+      "title": "My 1rst panel is an orphan",
+      "type": "stat"
+    },
+    {
+      "title": "My 2nd panel is an orphan",
+      "type": "timeseries"
+    },
+    {
+      "title": "My 3rd panel is a collapsed row",
+      "type": "row",
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "My 4th panel has a parent",
+          "type": "gauge"
+        },
+        {
+          "title": "My 5th panel has a parent",
+          "type": "bargauge"
+        }
+      ]
+    },
+    {
+      "title": "My 6th panel is an expanded row",
+      "type": "row",
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "My 7th panel has a parent",
+      "type": "graph"
+    },
+    {
+      "title": "My 8th panel has a parent",
+      "type": "heatmap"
+    },
+    {
+      "title": "My 9th panel is an expanded row",
+      "type": "row",
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "My 10th panel has a parent",
+      "type": "piechart"
+    },
+    {
+      "title": "My 11th panel has a parent",
+      "type": "statetimeline"
+    },
+    {
+      "title": "My 12th panel is a collapsed row",
+      "type": "row",
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "My 13th panel has a parent",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "title": "My 14th panel is an expanded row",
+      "type": "row",
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "My 15th panel has a parent",
+      "type": "stat"
+    }
+  ]
+}

--- a/ui/app/src/views/ViewMigrate.tsx
+++ b/ui/app/src/views/ViewMigrate.tsx
@@ -93,9 +93,8 @@ function ViewMigrate() {
         </Alert>
         <Alert variant={'outlined'} severity={'warning'}>
           <Typography>
-            It is recommended to <u>collapse all the rows</u> of your Grafana dashboard before attempting to migrate it.
-            This ensures that your dashboard structure wont be alterated & that Library panels will get migrated nicely
-            (deep copied).
+            If your dashboard contains Library panels, in order to migrate these nicely you should collapse their
+            respective parent row (if applicable) before pasting the JSON here.
           </Typography>
         </Alert>
         <Button


### PR DESCRIPTION
This PR fixes an issue with children panels that were getting wrongly positioned in the translated Perses dashboard, in case their parent row was expanded. This issue came from a (weird) behavior of Grafana that I explained in previous PR #1044 (also detailed in code comments).

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
