### PR TITLE
[IGNORE] add eslint rule to avoid duplicate imports

### DIFF
--- a/ui/.eslintrc.base.js
+++ b/ui/.eslintrc.base.js
@@ -71,6 +71,11 @@ module.exports = {
     // Not necessary in React 17
     'react/react-in-jsx-scope': 'off',
 
+    // We use this rule instead of the core eslint `no-duplicate-imports`
+    // because it avoids false errors on cases where we have a regular
+    // import and an `import type`.
+    'import/no-duplicates': 'error',
+
     'no-restricted-imports': [
       'error',
       {

--- a/ui/app/src/context/DarkMode.tsx
+++ b/ui/app/src/context/DarkMode.tsx
@@ -13,8 +13,7 @@
 
 import React, { createContext, useContext, useMemo } from 'react';
 import { CssBaseline, ThemeProvider, useMediaQuery } from '@mui/material';
-import { ChartsThemeProvider, generateChartsTheme, PersesChartsTheme } from '@perses-dev/components';
-import { getTheme } from '@perses-dev/components';
+import { ChartsThemeProvider, generateChartsTheme, PersesChartsTheme, getTheme } from '@perses-dev/components';
 import { useLocalStorage } from '../utils/browser-storage';
 
 // app specific echarts option overrides, empty since perses uses default

--- a/ui/e2e/src/config/base.playwright.config.ts
+++ b/ui/e2e/src/config/base.playwright.config.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { PlaywrightTestConfig, devices } from '@playwright/test';
+import { PlaywrightTestConfig, devices } from '@playwright/test';
 
 /**
  * This is the base playwright configuration that contains common settings.

--- a/ui/e2e/src/config/base.playwright.config.ts
+++ b/ui/e2e/src/config/base.playwright.config.ts
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { PlaywrightTestConfig } from '@playwright/test';
-import { devices } from '@playwright/test';
+import type { PlaywrightTestConfig, devices } from '@playwright/test';
 
 /**
  * This is the base playwright configuration that contains common settings.

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
@@ -13,9 +13,8 @@
 
 import { merge } from 'lodash-es';
 import { TextField } from '@mui/material';
-import { CalculationSelector, CalculationSelectorProps } from '@perses-dev/plugin-system';
+import { CalculationSelector, CalculationSelectorProps, DEFAULT_CALCULATION } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
-import { DEFAULT_CALCULATION } from '@perses-dev/plugin-system';
 import {
   UnitSelector,
   UnitSelectorProps,
@@ -23,8 +22,8 @@ import {
   OptionsEditorGrid,
   OptionsEditorColumn,
   OptionsEditorControl,
+  ThresholdsEditor,
 } from '@perses-dev/components';
-import { ThresholdsEditor } from '@perses-dev/components';
 import { ThresholdOptions } from '@perses-dev/core';
 import {
   GaugeChartOptions,

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -14,8 +14,13 @@
 import { StatChart, StatChartData, useChartsTheme } from '@perses-dev/components';
 import { Box, Skeleton } from '@mui/material';
 import { useMemo } from 'react';
-import { TimeSeriesData, useTimeSeriesQuery, PanelProps } from '@perses-dev/plugin-system';
-import { CalculationsMap, CalculationType } from '@perses-dev/plugin-system';
+import {
+  TimeSeriesData,
+  useTimeSeriesQuery,
+  PanelProps,
+  CalculationsMap,
+  CalculationType,
+} from '@perses-dev/plugin-system';
 import { useSuggestedStepMs } from '../../model/time';
 import { StatChartOptions } from './stat-chart-model';
 import { convertSparkline } from './utils/data-transform';

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -12,8 +12,7 @@
 // limitations under the License.
 
 import { AbsoluteTimeRange, StepOptions } from '@perses-dev/core';
-import { OPTIMIZED_MODE_SERIES_LIMIT } from '@perses-dev/components';
-import { EChartsTimeSeries, EChartsValues } from '@perses-dev/components';
+import { OPTIMIZED_MODE_SERIES_LIMIT, EChartsTimeSeries, EChartsValues } from '@perses-dev/components';
 import { TimeSeries, useTimeSeriesQueries } from '@perses-dev/plugin-system';
 import { gcd } from '../../../utils/mathjs';
 import {

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -14,8 +14,7 @@
 import { useQuery, useQueries, useQueryClient, Query, QueryCache, QueryKey } from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec } from '@perses-dev/core';
 import { TimeSeriesData, TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryPlugin } from '../model';
-import { VariableStateMap } from './template-variables';
-import { useTemplateVariableValues } from './template-variables';
+import { VariableStateMap, useTemplateVariableValues } from './template-variables';
 import { useTimeRange } from './TimeRangeProvider';
 import { useDatasourceStore } from './datasources';
 import { usePlugin, usePluginRegistry, usePlugins } from './plugin-registry';

--- a/ui/storybook/src/config/decorators/WithBackground.tsx
+++ b/ui/storybook/src/config/decorators/WithBackground.tsx
@@ -11,11 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
 import { useTheme } from '@mui/material';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { Decorator } from '@storybook/react';
-import { useEffect } from 'react';
 
 // Much of the code for this decorator is cribbed from the backgrounds addon. We cannot
 // use that addon directly because it requires hardcoding the colors instead

--- a/ui/storybook/src/config/decorators/WithThemes.tsx
+++ b/ui/storybook/src/config/decorators/WithThemes.tsx
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { useMemo } from 'react';
 import { Decorator } from '@storybook/react';


### PR DESCRIPTION
Commit also fixes any duplicate imports caught by the rule.

# Notes for reviewers

I ran into this while working on the refactor for https://github.com/perses/perses/pull/1053. Removing duplicate imports makes these sorts of refactors easier and makes the code a little cleaner. I'm hoping this is a non-controversial eslint rule, but please let me know if you disagree with adding it!

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
