### PR TITLE
[IGNORE] Fix flaky visual test

### DIFF
--- a/ui/e2e/src/tests/persesApp.spec.ts
+++ b/ui/e2e/src/tests/persesApp.spec.ts
@@ -51,12 +51,12 @@ test.describe('App', () => {
     const projectPage = new AppProjectPage(page);
     await projectPage.createDashboard('my new dashboard');
 
-    // Should see empty state
-    await expect(page.getByRole('main')).toContainText("Let's get started");
-
     const dashboardPage = new DashboardPage(page);
 
     await dashboardPage.forEachTheme(async (themeName) => {
+      // Should see empty state
+      await expect(page.getByRole('main')).toContainText("Let's get started");
+
       await happoPlaywright.screenshot(page, dashboardPage.root, {
         component: 'Empty State',
         variant: themeName,


### PR DESCRIPTION
There is a small edge case where the page doesn't finish reloading the empty state when switching themes. Moving the check for the page content into the theme check loop should fix this.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
