### PR TITLE
[IGNORE] Add simple typedoc setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,25 @@ jobs:
           name: storybook
           path: ui/storybook/storybook-static
   
+  build-typedoc:
+    name: "build-typedoc"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_environment
+        with:
+          enable_npm: true
+      - name: Install UI deps
+        run: cd ./ui && npm install
+      - name: Build the typedoc docs
+        run: cd ./ui && npm run typedoc
+      - name: store typedoc build
+        uses: actions/upload-artifact@v3
+        with:
+          name: typedoc
+          path: ui/typedoc
+  
   libs-release:
     name: "libs-release"
     needs: "build-frontend"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Install UI deps
         run: cd ./ui && npm install
       - name: Build the typedoc docs
-        run: cd ./ui && npm run typedoc
+        run: cd ./ui && npm run build && npm run typedoc
       - name: store typedoc build
         uses: actions/upload-artifact@v3
         with:

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -23,6 +23,7 @@ yarn-error.log*
 
 # Build output
 dist
+typedoc
 
 # Ignore turborepo cache
 .turbo

--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -57,5 +57,8 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
+  }
 }

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -40,5 +40,8 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
+  }
 }

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -54,5 +54,8 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
+  }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -51,6 +51,7 @@
         "rimraf": "^3.0.2",
         "swc-loader": "^0.2.3",
         "turbo": "^1.7.0",
+        "typedoc": "^0.23.28",
         "typescript": "^4.7.4"
       }
     },
@@ -10013,6 +10014,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -17533,6 +17540,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -17892,6 +17905,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
     },
     "node_modules/lz-string": {
       "version": "1.4.4",
@@ -21695,6 +21714,18 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -23019,6 +23050,51 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
+      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -23510,6 +23586,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -31394,6 +31482,12 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -37007,6 +37101,12 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -37318,6 +37418,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
     },
     "lz-string": {
       "version": "1.4.4",
@@ -40135,6 +40241,18 @@
         }
       }
     },
+    "shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dev": true,
+      "requires": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -41136,6 +41254,38 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.23.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
+          "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -41497,6 +41647,18 @@
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,8 @@
     "clear-turbo-cache": "rimraf node_modules/.cache/turbo",
     "e2e": "turbo run e2e:local",
     "e2e:debug": "turbo run e2e -- --debug",
-    "e2e:ci": "turbo run e2e:ci"
+    "e2e:ci": "turbo run e2e:ci",
+    "typedoc": "typedoc"
   },
   "workspaces": [
     "app",
@@ -66,6 +67,7 @@
     "rimraf": "^3.0.2",
     "swc-loader": "^0.2.3",
     "turbo": "^1.7.0",
+    "typedoc": "^0.23.28",
     "typescript": "^4.7.4"
   }
 }

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -52,5 +52,8 @@
   "devDependencies": {
     "@types/dompurify": "^2.3.4",
     "@types/marked": "^4.0.7"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
   }
 }

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -42,5 +42,8 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
+  }
 }

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -45,5 +45,8 @@
   "files": [
     "dist",
     "plugin.json"
-  ]
+  ],
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
+  }
 }

--- a/ui/typedoc.json
+++ b/ui/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPointStrategy": "packages",
+  "entryPoints": [
+    "."
+  ],
+  "out": "typedoc"
+}


### PR DESCRIPTION
I have been struggling to keep track of what Perses exports from the various UI packages, which can make it tricky to figure out breaking changes when things are refactored. Typedoc does a nice job evaluating the entry point and creating documentation, so that seemed like a low effort way to get this information.

In the short term, storing these as artifacts in github actions runs. Longer-term, we could potentially publish these in github pages alongside storybook (which is only good at documenting React components) to provide documentation for the non-component utilities, types, etc. that Perses provides.

It is notable that typedoc isn't great at handling cross-package dependencies at this time, so there are some limitations to what we're getting. We can watch this issue to see when this is improved. https://github.com/TypeStrong/typedoc/issues/1835

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# Screenshots

<img width="525" alt="image" src="https://user-images.githubusercontent.com/396962/229179083-a5c2b8e1-8141-4d11-92cd-66423d1b982a.png">
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/396962/229179328-47a5e532-af0a-4d7f-82d8-102121d116b8.png">
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/396962/229179376-39a1c04f-b58f-4a2c-9df9-fc77ce6c79f1.png">

