### PR TITLE
[ENHANCEMENT] always show info icon when panel has a description

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -63,12 +63,6 @@ describe('Panel', () => {
   it('shows panel description', async () => {
     renderPanel();
 
-    const panel = getPanel();
-
-    // Description button should not be visible until hover on panel
-    const missingButton = screen.queryByRole('button', { name: /description/i });
-    expect(missingButton).not.toBeInTheDocument();
-    userEvent.hover(panel);
     const descriptionButton = screen.getByRole('button', { name: /description/i });
     expect(descriptionButton).toBeInTheDocument();
 

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -36,7 +36,6 @@ export function Panel(props: PanelProps) {
   const headerId = `${generatedPanelId}-header`;
 
   const [contentElement, setContentElement] = useState<HTMLElement | null>(null);
-  const [isHovered, setIsHovered] = useState(false);
 
   const { width, height } = useResizeObserver({ ref: contentElement });
 
@@ -54,12 +53,10 @@ export function Panel(props: PanelProps) {
   const chartsTheme = useChartsTheme();
 
   const handleMouseEnter: CardProps['onMouseEnter'] = (e) => {
-    setIsHovered(true);
     onMouseEnter?.(e);
   };
 
   const handleMouseLeave: CardProps['onMouseLeave'] = (e) => {
-    setIsHovered(false);
     onMouseLeave?.(e);
   };
 
@@ -89,7 +86,6 @@ export function Panel(props: PanelProps) {
         title={definition.spec.display.name}
         description={definition.spec.display.description}
         editHandlers={editHandlers}
-        isHovered={isHovered}
         sx={{ paddingX: `${chartsTheme.container.padding.default}px` }}
       />
       <CardContent

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -31,10 +31,9 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
     onDuplicatePanelClick: () => void;
     onDeletePanelClick: () => void;
   };
-  isHovered: boolean;
 }
 
-export function PanelHeader({ id, title, description, editHandlers, isHovered, sx, ...rest }: PanelHeaderProps) {
+export function PanelHeader({ id, title, description, editHandlers, sx, ...rest }: PanelHeaderProps) {
   const titleElementId = `${id}-title`;
   const descriptionTooltipId = `${id}-description`;
 
@@ -84,7 +83,7 @@ export function PanelHeader({ id, title, description, editHandlers, isHovered, s
         </InfoTooltip>
       </>
     );
-  } else if (description !== undefined && isHovered) {
+  } else if (description !== undefined) {
     // If there aren't edit handlers and we have a description, show a button with a tooltip for the panel description
     actions = (
       <InfoTooltip id={descriptionTooltipId} description={description} enterDelay={100}>


### PR DESCRIPTION
Prior to this change, the info icon was only shown when the user was hovering over the panel, which significantly reduces discoverability of the description information, especially on larger dashboards.

After this change, the info icon is always shown in "view" mode when a panel has a description. The hover over the icon to show the description in a tooltip continues to behave as before.

Making this change based on a request from @foxbat07  to improve usability.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# Screenshots

## Before 

<img width="1307" alt="image" src="https://user-images.githubusercontent.com/396962/229201092-ec647fd0-0427-47b1-8ea1-965cb128bd80.png">


## After

<img width="1307" alt="image" src="https://user-images.githubusercontent.com/396962/229200940-9a434f84-8fa5-494c-ae69-5174abded5e8.png">
