### PR TITLE
[WIP] Date format adjustment to round to nearest five minutes 

### DIFF
--- a/ui/components/src/LineChart/utils.test.ts
+++ b/ui/components/src/LineChart/utils.test.ts
@@ -1,0 +1,31 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getFormattedDate } from './utils';
+
+describe('getFormattedDate', () => {
+  it('should round value to nearest five minutes when pastDuration 1h', () => {
+    const xAxisLabel = getFormattedDate('1680533160000', 3600000);
+    expect(xAxisLabel).toEqual('14:45');
+  });
+
+  it('should round value to nearest five minutes when pastDuration 1d', () => {
+    const xAxisLabel = getFormattedDate('1680527760000', 86400000);
+    expect(xAxisLabel).toEqual('4/3 13:15');
+  });
+
+  it('should not round value to nearest five minutes when pastDuration 5m', () => {
+    const xAxisLabel = getFormattedDate('1680533385000', 300000);
+    expect(xAxisLabel).toEqual('14:49:45');
+  });
+});

--- a/ui/components/src/LineChart/utils.ts
+++ b/ui/components/src/LineChart/utils.ts
@@ -67,7 +67,7 @@ export function getDateRange(data: number[]) {
 /*
  * Determines time granularity for axis labels, defaults to hh:mm
  */
-export function getFormattedDate(value: number, rangeMs: number, timeZone?: string) {
+export function getFormattedDate(value: string, rangeMs: number, timeZone?: string) {
   const dateFormatOptions: Intl.DateTimeFormatOptions = dateFormatOptionsWithTimeZone(
     {
       hour: 'numeric',
@@ -95,7 +95,7 @@ export function getFormattedDate(value: number, rangeMs: number, timeZone?: stri
   }
 
   // remove comma when month / day present
-  return DATE_FORMAT.format(value).replace(/, /g, ' ');
+  return DATE_FORMAT.format(Number(value)).replace(/, /g, ' ');
 }
 
 /*

--- a/ui/components/src/LineChart/utils.ts
+++ b/ui/components/src/LineChart/utils.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { getUnixTime, roundToNearestMinutes } from 'date-fns';
 import { merge } from 'lodash-es';
 import type { YAXisComponentOption } from 'echarts';
 import { ECharts as EChartsInstance } from 'echarts/core';
@@ -75,15 +76,24 @@ export function getFormattedDate(value: number, rangeMs: number, timeZone?: stri
     },
     timeZone
   );
+  let roundToNearestFiveMinutes = true;
   const thirtyMinMs = 1800000;
   const dayMs = 86400000;
   if (rangeMs <= thirtyMinMs) {
     dateFormatOptions.second = 'numeric';
+    roundToNearestFiveMinutes = false;
   } else if (rangeMs >= dayMs) {
     dateFormatOptions.month = 'numeric';
     dateFormatOptions.day = 'numeric';
   }
   const DATE_FORMAT = new Intl.DateTimeFormat(undefined, dateFormatOptions);
+
+  if (roundToNearestFiveMinutes === true) {
+    // https://date-fns.org/v2.29.3/docs/roundToNearestMinutes
+    const roundedValue = roundToNearestMinutes(Number(value), { nearestTo: 5, roundingMethod: 'round' });
+    return DATE_FORMAT.format(roundedValue).replace(/, /g, ' ');
+  }
+
   // remove comma when month / day present
   return DATE_FORMAT.format(value).replace(/, /g, ' ');
 }


### PR DESCRIPTION
**DONOTMERGE** 
_(TBD on approach, what's described below needs to change)_

Adjust xAxis date formatter to show whole values, rounded to nearest five minutes

## Before 
<img width="839" alt="image" src="https://user-images.githubusercontent.com/9369625/229548697-45972ae1-7bbb-4f1e-bbe4-bacde1edc34b.png">

<img width="1691" alt="image" src="https://user-images.githubusercontent.com/9369625/229548055-af8fa074-a96a-4ce9-b208-0332d4f34b02.png">

## After

<img width="841" alt="image" src="https://user-images.githubusercontent.com/9369625/229548611-1840104a-a936-421a-b4de-315b301d92f9.png">

<img width="1689" alt="image" src="https://user-images.githubusercontent.com/9369625/229547832-ec4b137f-dfc2-4724-92d8-905f7849d8ed.png">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
