### PR TITLE
[BUGFIX] Fix tooltip position on long dashboards

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -32,10 +32,6 @@ export const TOOLTIP_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
 
 export const defaultCursorData = {
   coords: {
-    viewport: {
-      x: 0,
-      y: 0,
-    },
     plotCanvas: {
       x: 0,
       y: 0,
@@ -55,10 +51,6 @@ export const emptyTooltipData = {
 };
 
 export interface CursorCoordinates {
-  viewport: {
-    x: number;
-    y: number;
-  };
   page: {
     x: number;
     y: number;
@@ -100,10 +92,6 @@ export const useMousePosition = (): CursorData['coords'] => {
   useEffect(() => {
     const setFromEvent = (e: ZRRawMouseEvent) => {
       return setCoords({
-        viewport: {
-          x: e.clientX,
-          y: e.clientY,
-        },
         page: {
           x: e.pageX,
           y: e.pageY,

--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -59,6 +59,10 @@ export interface CursorCoordinates {
     x: number;
     y: number;
   };
+  page: {
+    x: number;
+    y: number;
+  };
   plotCanvas: {
     x: number;
     y: number;
@@ -99,6 +103,10 @@ export const useMousePosition = (): CursorData['coords'] => {
         viewport: {
           x: e.clientX,
           y: e.clientY,
+        },
+        page: {
+          x: e.pageX,
+          y: e.pageY,
         },
         plotCanvas: {
           x: e.offsetX,

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -33,20 +33,20 @@ export function assembleTransform(
 
   const cursorPaddingX = 32;
   const cursorPaddingY = 16;
-  const x = mousePos.viewport.x;
-  let y = mousePos.viewport.y + cursorPaddingY;
+  const x = mousePos.page.x;
+  let y = mousePos.page.y + cursorPaddingY;
 
-  const isCloseToBottom = mousePos.viewport.y > window.innerHeight * 0.8;
+  const isCloseToBottom = mousePos.page.y > window.innerHeight * 0.8;
   const yPosAdjustThreshold = chartHeight * 0.75;
   // adjust so tooltip does not get cut off at bottom of chart, reduce multiplier to move up
   if (isCloseToBottom === true) {
     if (seriesNum > 6) {
-      y = mousePos.viewport.y * 0.65;
+      y = mousePos.page.y * 0.75;
     } else {
-      y = mousePos.viewport.y * 0.75;
+      y = mousePos.page.y * 0.85;
     }
   } else if (mousePos.plotCanvas.y > yPosAdjustThreshold) {
-    y = mousePos.viewport.y * 0.85;
+    y = mousePos.page.y * 0.95;
   }
 
   // use tooltip width to determine when to repos from right to left (width is narrower when only 1 focused series since labels wrap)

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -33,6 +33,10 @@ export function assembleTransform(
 
   const cursorPaddingX = 32;
   const cursorPaddingY = 16;
+
+  // Tooltip is located in a Portal attached to the body.
+  // Using page coordinates instead of viewport ensures the tooltip is
+  // absolutely positioned correctly as the user scrolls
   const x = mousePos.page.x;
   let y = mousePos.page.y + cursorPaddingY;
 
@@ -43,7 +47,7 @@ export function assembleTransform(
     if (seriesNum > 6) {
       y = mousePos.page.y * 0.75;
     } else {
-      y = mousePos.page.y * 0.85;
+      y = mousePos.page.y * 0.9;
     }
   } else if (mousePos.plotCanvas.y > yPosAdjustThreshold) {
     y = mousePos.page.y * 0.95;


### PR DESCRIPTION
Fixes the following tooltip positioning issue where on longer pages with lots of panels, there are certain cases where the tooltip shows way too high on the page, this PR adjust which x and y mouse coordinates are used to position the tooltip

## Before 

![tooltip_pos_issue](https://user-images.githubusercontent.com/9369625/229549478-9ed280a2-6c91-4f81-819f-c72c0bf2e565.png)

## After

<img width="1687" alt="image" src="https://user-images.githubusercontent.com/9369625/229552437-c952d114-d806-4ed1-ad3b-dc670d0600f6.png">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
