### PR TITLE
[BUGFIX] Add undef check to fix add panel showContent error

### DIFF
--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -223,7 +223,7 @@ export function LineChart({
     >
       {/* Allows overrides prop to hide custom tooltip and use the ECharts option.tooltip instead */}
       {showTooltip === true &&
-        (option.tooltip as TooltipComponentOption).showContent === false &&
+        (option.tooltip as TooltipComponentOption)?.showContent === false &&
         tooltipConfig.hidden !== true && (
           <TimeSeriesTooltip
             chartRef={chartRef}


### PR DESCRIPTION
Follow up to PR #1023 to add an undefined check when using __experimentalEChartsOptionsOverride to hide the custom TimeSeriesTooltip

## Before

<img width="1711" alt="image" src="https://user-images.githubusercontent.com/9369625/229623074-96722c00-b69d-4ce4-95fc-45809817d85a.png">


## After

<img width="904" alt="image" src="https://user-images.githubusercontent.com/9369625/229622978-8d87e12a-d8e0-464c-957c-c676bb072af2.png">


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
