### PR TITLE
[BUGFIX] miscellaneous fixes to address console errors

### DIFF
--- a/ui/app/src/components/DashboardList.tsx
+++ b/ui/app/src/components/DashboardList.tsx
@@ -16,7 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import { Box, Divider, IconButton, List, ListItem, ListItemButton, ListItemText } from '@mui/material';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import PencilIcon from 'mdi-material-ui/Pencil';
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import { dashboardDisplayName } from '@perses-dev/core/dist/utils/text';
 import { DeleteDashboardDialog } from './DeleteDashboardDialog/DeleteDashboardDialog';
 import { RenameDashboardDialog } from './RenameDashboardDialog/RenameDashboardDialog';
@@ -49,31 +49,33 @@ function DashboardList(props: DashboardListProperties) {
       <List>
         {dashboardList.map((dashboard, i) => {
           return (
-            <>
+            <Fragment key={dashboard.metadata.name}>
               {i !== 0 && <Divider key={`divider-${i}`} />}
               <ListItem
                 disablePadding
                 sx={{ backgroundColor: (theme) => theme.palette.primary.main + '10' }}
                 key={`list-item-${i}`}
                 secondaryAction={
-                  <ListItem>
-                    <IconButton
-                      edge="start"
-                      aria-label="rename"
-                      onClick={() => onRenameButtonClick(dashboard)}
-                      disabled={isRenameDashboardDialogStateOpened || isDeleteDashboardDialogStateOpened}
-                    >
-                      <PencilIcon />
-                    </IconButton>
-                    <IconButton
-                      edge="end"
-                      aria-label="delete"
-                      onClick={() => onDeleteButtonClick(dashboard)}
-                      disabled={isRenameDashboardDialogStateOpened || isDeleteDashboardDialogStateOpened}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </ListItem>
+                  <List>
+                    <ListItem>
+                      <IconButton
+                        edge="start"
+                        aria-label="rename"
+                        onClick={() => onRenameButtonClick(dashboard)}
+                        disabled={isRenameDashboardDialogStateOpened || isDeleteDashboardDialogStateOpened}
+                      >
+                        <PencilIcon />
+                      </IconButton>
+                      <IconButton
+                        edge="end"
+                        aria-label="delete"
+                        onClick={() => onDeleteButtonClick(dashboard)}
+                        disabled={isRenameDashboardDialogStateOpened || isDeleteDashboardDialogStateOpened}
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </ListItem>
+                  </List>
                 }
               >
                 <ListItemButton
@@ -84,7 +86,7 @@ function DashboardList(props: DashboardListProperties) {
                   <ListItemText primary={dashboardDisplayName(dashboard)} />
                 </ListItemButton>
               </ListItem>
-            </>
+            </Fragment>
           );
         })}
       </List>

--- a/ui/components/src/InfoTooltip/InfoTooltip.tsx
+++ b/ui/components/src/InfoTooltip/InfoTooltip.tsx
@@ -41,10 +41,13 @@ export const InfoTooltip = ({
   enterDelay,
   enterNextDelay,
 }: InfoTooltipProps) => {
-  // Only wrap in a div if passed a non-element. This enables the tooltip to
-  // support text with a wrapper div while avoiding breaking css on element
-  // children by unnecessarily wrapping them.
-  const formattedChildren = React.isValidElement(children) ? children : <div>{children}</div>;
+  // Wrap children in a span to cover the following use cases:
+  //  - Disabled buttons. MUI console.errors on putting these inside a tooltip.
+  //  - Non-element tooltip children (e.g. text). The tooltip needs something that
+  //   can have a ref as a child.
+  // We wrap in a `span` and not a `div` to minimize the impact on page layout
+  // and styles.
+  const wrappedChildren = <span>{children}</span>;
 
   return (
     <StyledTooltip
@@ -55,7 +58,7 @@ export const InfoTooltip = ({
       enterDelay={enterDelay ?? 500}
       enterNextDelay={enterNextDelay ?? 500}
     >
-      {formattedChildren}
+      {wrappedChildren}
     </StyledTooltip>
   );
 };

--- a/ui/components/src/ThresholdsEditor/ThresholdInput.tsx
+++ b/ui/components/src/ThresholdsEditor/ThresholdInput.tsx
@@ -47,7 +47,7 @@ export function ThresholdInput({
         key={key}
         inputRef={inputRef}
         type="number"
-        value={value === 0 ? undefined : value}
+        value={value === 0 ? '' : value}
         placeholder="0"
         onChange={onChange}
         onBlur={onBlur}

--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -220,7 +220,7 @@ export function VariableEditForm({
             <TextField
               fullWidth
               label="Display Label"
-              value={state.title}
+              value={state.title || ''}
               onChange={(v) => {
                 setState((draft) => {
                   draft.title = v.target.value;
@@ -289,7 +289,7 @@ export function VariableEditForm({
                   <TextField
                     sx={{ mb: 1 }}
                     label="Capturing Regexp Filter"
-                    value={state.listVariableFields.capturing_regexp}
+                    value={state.listVariableFields.capturing_regexp || ''}
                     onChange={(e) => {
                       setState((draft) => {
                         draft.listVariableFields.capturing_regexp = e.target.value;

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -29,7 +29,7 @@ Tests are run during local development using the configuration in `local.playwri
 
 ### Locally with screenshots (maintainers only)
 
-*This option is limited to maintainers because it requires access to secrets in the Happo account.*
+_This option is limited to maintainers because it requires access to secrets in the Happo account._
 
 Occasionally, you may want to generate screenshots locally to debug an issue with visual tests.
 
@@ -86,3 +86,7 @@ This project uses a free open source account from [Happo](https://happo.io/) for
 
 - Go to the failing action in GitHub.
 - Follow the Playwright instructions for [viewing test logs](https://playwright.dev/docs/ci-intro#viewing-test-logs) and [viewing the html report](https://playwright.dev/docs/ci-intro#html-report).
+
+### Tests complaining about console errors
+
+Tests that use the `dashboardTest` fixture check for console errors and fail tests when they are found because they are often a sign of a subtle bug we have not accounted for. When debugging these issues, it can be helpful to run the e2e tests with a headed browser (using [headed mode](https://playwright.dev/docs/debug#headed-mode) or using the vcode extension with "show browser" checked) with the debugger console open. This will often provide you with a more detailed error message and a stack trace.

--- a/ui/e2e/src/fixtures/dashboardTest.ts
+++ b/ui/e2e/src/fixtures/dashboardTest.ts
@@ -86,6 +86,20 @@ async function deleteDashboard(projectName: string, dashboardName: string) {
   return result;
 }
 
+// We want to throw on console errors that may mean the app is broken.
+// Some of the libraries we use (e.g. emotion) throw console errors we do not
+// care about at this time. We track those here, so they can be ignored.
+const IGNORE_CONSOLE_ERRORS = [
+  // See https://github.com/emotion-js/emotion/issues/1105
+  'potentially unsafe when doing server-side rendering',
+];
+function shouldIgnoreConsoleError(message: ConsoleMessage) {
+  console.log('should ignore');
+  const msgText = message.text();
+  console.log(msgText);
+  return IGNORE_CONSOLE_ERRORS.some((ignoreErr) => msgText.includes(ignoreErr));
+}
+
 /**
  * Generates a dashboard name to use when duplicating a dashboard for a given
  * test.
@@ -143,7 +157,7 @@ export const test = testBase.extend<DashboardTestOptions & DashboardTestFixtures
 
     const consoleErrors: ConsoleMessage[] = [];
     page.on('console', (msg) => {
-      if (msg.type() === 'error') {
+      if (msg.type() === 'error' && !shouldIgnoreConsoleError(msg)) {
         // Watch for console errors because they are often a sign that something
         // is wrong.
         consoleErrors.push(msg);

--- a/ui/e2e/src/fixtures/dashboardTest.ts
+++ b/ui/e2e/src/fixtures/dashboardTest.ts
@@ -94,9 +94,7 @@ const IGNORE_CONSOLE_ERRORS = [
   'potentially unsafe when doing server-side rendering',
 ];
 function shouldIgnoreConsoleError(message: ConsoleMessage) {
-  console.log('should ignore');
   const msgText = message.text();
-  console.log(msgText);
   return IGNORE_CONSOLE_ERRORS.some((ignoreErr) => msgText.includes(ignoreErr));
 }
 

--- a/ui/e2e/src/fixtures/dashboardTest.ts
+++ b/ui/e2e/src/fixtures/dashboardTest.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ConsoleMessage, test as testBase } from '@playwright/test';
+import { ConsoleMessage, test as testBase, expect } from '@playwright/test';
 import fetch from 'node-fetch';
 import { AppHomePage, DashboardPage } from '../pages';
 
@@ -153,12 +153,12 @@ export const test = testBase.extend<DashboardTestOptions & DashboardTestFixtures
 
     const persesApp = new AppHomePage(page);
 
-    const consoleErrors: ConsoleMessage[] = [];
+    const consoleErrors: string[] = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error' && !shouldIgnoreConsoleError(msg)) {
         // Watch for console errors because they are often a sign that something
         // is wrong.
-        consoleErrors.push(msg);
+        consoleErrors.push(msg.text());
       }
     });
 
@@ -181,12 +181,7 @@ export const test = testBase.extend<DashboardTestOptions & DashboardTestFixtures
 
     // If console errors are found, log the errors to help with debugging and
     // fail the test.
-    if (consoleErrors.length) {
-      consoleErrors.forEach((pageError) => {
-        console.error(pageError);
-      });
-      throw new Error(`${consoleErrors.length} console errors seen while running test.`);
-    }
+    expect(consoleErrors, `${consoleErrors.length} console errors seen while running test.`).toHaveLength(0);
   },
 });
 


### PR DESCRIPTION
Adding e2e test failures on console errors because it would have caught the bug found in https://github.com/perses/perses/pull/1067.

# Description for squash 

*Saving this for future me when I squash this PR*

This commit introduces functionality that fails Playwright-based e2e tests if console errors
are seen during the test because this is often a sign of a subtle bug we would not catch
otherwise. 

As part of introducing this, we need to fix some of the underlying console errors from 
libraries we use (e.g. MUI, React). In one case, we ignore an emotion error because it is
tricky to fix and focused on a use case we are not currently focused on (SSR). Fixes include:

- Fixing React errors related to a text input changing from uncontrolled to controlled because a
  text input could sometimes be `undefined`. These now fall back to `''` instead.
- Fixing a use case where `li` elements were not properly parented to an `ul` or `ol`.
- Fixing a React `key` error by setting `key` value on children in a list.
- Wrapping tooltip children in a `span` to avoid MUI errors when the child is a disabled button.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# Screenshots 

Example of what the error output looks like -- I temporarily turned back on erroring on that emotion error to produce this.
<img width="983" alt="image" src="https://user-images.githubusercontent.com/396962/229656421-f8424450-15d4-4cf8-ae65-a3233cd3a7d7.png">
