### PR TITLE
[BUGFIX] Dashboard validation: fix issue with variable parsing when the query embeds a regexp

### DIFF
--- a/internal/api/e2e/dashboard_test.go
+++ b/internal/api/e2e/dashboard_test.go
@@ -16,7 +16,6 @@
 package e2e
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,6 +24,7 @@ import (
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared"
 	"github.com/perses/perses/internal/api/shared/dependency"
+	testUtils "github.com/perses/perses/internal/test"
 	"github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/stretchr/testify/assert"
@@ -103,13 +103,8 @@ func TestListDashboardInEmptyProject(t *testing.T) {
 }
 
 func extractDashboardFromHTTPBody(body interface{}, t *testing.T) *modelV1.Dashboard {
-	b, err := json.Marshal(body)
-	if err != nil {
-		t.Fatal(err)
-	}
+	b := testUtils.JSONMarshalStrict(body)
 	dashboard := &modelV1.Dashboard{}
-	if unmarshalErr := json.Unmarshal(b, dashboard); unmarshalErr != nil {
-		t.Fatal(unmarshalErr)
-	}
+	testUtils.JSONUnmarshal(b, dashboard)
 	return dashboard
 }

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -18,13 +18,13 @@ package e2eframework
 import (
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/perses/perses/internal/api/shared/dependency"
+	test "github.com/perses/perses/internal/test"
 	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
@@ -117,7 +117,7 @@ func newDatasourceSpec(t *testing.T) v1.DatasourceSpec {
 	if err != nil {
 		t.Fatal(err)
 	}
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	pluginSpec := &datasource.Prometheus{
 		Proxy: datasourceHTTP.Proxy{
 			Kind: "HTTPProxy",
@@ -152,6 +152,8 @@ func newDatasourceSpec(t *testing.T) v1.DatasourceSpec {
 			},
 		},
 	}
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	data, err := json.Marshal(pluginSpec)
 	if err != nil {
 		t.Fatal(err)
@@ -160,6 +162,7 @@ func newDatasourceSpec(t *testing.T) v1.DatasourceSpec {
 	if err := json.Unmarshal(data, &pluginSpecAsMapInterface); err != nil {
 		t.Fatal(err)
 	}
+
 	return v1.DatasourceSpec{
 		Default: false,
 		Plugin: common.Plugin{
@@ -197,16 +200,13 @@ func NewGlobalDatasource(t *testing.T, name string) *v1.GlobalDatasource {
 }
 
 func NewDashboard(t *testing.T, projectName string, name string) *v1.Dashboard {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	// Creating a full dashboard is quite long and to ensure the changes are still matching the dev environment,
 	// it's better to use the dashboard written in the dev/data/dashboard.json
-	persesRepositoryPath := GetRepositoryPath(t)
+	persesRepositoryPath := test.GetRepositoryPath()
 	dashboardJSONFilePath := filepath.Join(persesRepositoryPath, "dev", "data", "dashboard.json")
 	var list []*v1.Dashboard
-	data, err := os.ReadFile(dashboardJSONFilePath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	data := test.ReadFile(dashboardJSONFilePath)
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if unmarshallErr := json.Unmarshal(data, &list); unmarshallErr != nil {
 		t.Fatal(unmarshallErr)
 	}

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -18,9 +18,7 @@ package e2eframework
 import (
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
@@ -28,20 +26,13 @@ import (
 	"github.com/perses/perses/internal/api/core"
 	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 	"github.com/perses/perses/internal/api/shared/dependency"
+	test "github.com/perses/perses/internal/test"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var useSQL = os.Getenv("PERSES_TEST_USE_SQL")
-
-func GetRepositoryPath(t *testing.T) string {
-	projectPathByte, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return strings.TrimSpace(string(projectPathByte))
-}
 
 func ClearAllKeys(t *testing.T, dao databaseModel.DAO, entities ...modelAPI.Entity) {
 	for _, entity := range entities {
@@ -60,7 +51,7 @@ func defaultFileConfig() *config.File {
 }
 
 func CreateServer(t *testing.T) (*httptest.Server, *httpexpect.Expect, dependency.PersistenceManager) {
-	projectPath := GetRepositoryPath(t)
+	projectPath := test.GetRepositoryPath()
 	conf := config.Config{
 		Schemas: config.Schemas{
 			PanelsPath:      filepath.Join(projectPath, config.DefaultPanelsPath),

--- a/internal/api/e2e/migrate_test.go
+++ b/internal/api/e2e/migrate_test.go
@@ -18,13 +18,13 @@ package e2e
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared/dependency"
+	testUtils "github.com/perses/perses/internal/test"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
@@ -48,22 +48,14 @@ func TestMigrateEndpoint(t *testing.T) {
 	}
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
-			rawGrafanaDashboard, err := os.ReadFile(filepath.Join(e2eframework.GetRepositoryPath(t), test.initialDashboardPath))
-			if err != nil {
-				t.Fatal(err)
-			}
-			rawPersesDashboard, err := os.ReadFile(filepath.Join(e2eframework.GetRepositoryPath(t), test.resultDashboardPath))
-			if err != nil {
-				t.Fatal(err)
-			}
+			rawGrafanaDashboard := testUtils.ReadFile(filepath.Join(testUtils.GetRepositoryPath(), test.initialDashboardPath))
+			rawPersesDashboard := testUtils.ReadFile(filepath.Join(testUtils.GetRepositoryPath(), test.resultDashboardPath))
+
 			var grafanaDashboard json.RawMessage
-			if unmarshalErr := json.Unmarshal(rawGrafanaDashboard, &grafanaDashboard); unmarshalErr != nil {
-				t.Fatal(unmarshalErr)
-			}
+			testUtils.JSONUnmarshal(rawGrafanaDashboard, &grafanaDashboard)
 			var persesDashboard modelV1.Dashboard
-			if unmarshallErr := json.Unmarshal(rawPersesDashboard, &persesDashboard); unmarshallErr != nil {
-				t.Fatal(unmarshallErr)
-			}
+			testUtils.JSONUnmarshal(rawPersesDashboard, &persesDashboard)
+
 			e2eframework.WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 				entity := modelAPI.Migrate{
 					GrafanaDashboard: grafanaDashboard,

--- a/internal/api/shared/migrate/migrate_test.go
+++ b/internal/api/shared/migrate/migrate_test.go
@@ -11,18 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package migrate
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/perses/perses/internal/api/config"
-	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
+	testUtils "github.com/perses/perses/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,16 +50,10 @@ func TestMigrate(t *testing.T) {
 
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
-			inputGrafanaDashboardRaw, readErr := os.ReadFile(filepath.Join(testDataFolder, test.inputGrafanaDashboardFile))
-			if readErr != nil {
-				t.Fatal(readErr)
-			}
-			expectedPersesDashboardRaw, readErr := os.ReadFile(filepath.Join(testDataFolder, test.expectedPersesDashboardFile))
-			if readErr != nil {
-				t.Fatal(readErr)
-			}
+			inputGrafanaDashboardRaw := testUtils.ReadFile(filepath.Join(testDataFolder, test.inputGrafanaDashboardFile))
+			expectedPersesDashboardRaw := testUtils.ReadFile(filepath.Join(testDataFolder, test.expectedPersesDashboardFile))
 
-			projectPath := e2eframework.GetRepositoryPath(t)
+			projectPath := testUtils.GetRepositoryPath()
 			svc, err := New(config.Schemas{
 				// use the real schemas for these tests
 				PanelsPath:    filepath.Join(projectPath, config.DefaultPanelsPath),
@@ -79,7 +70,7 @@ func TestMigrate(t *testing.T) {
 			}
 			assert.Equal(t, test.expectedErrorStr, actualErrorStr)
 
-			actualPersesDashboardRaw, _ := json.Marshal(actualPersesDashboard)
+			actualPersesDashboardRaw := testUtils.JSONMarshalStrict(actualPersesDashboard)
 			require.JSONEq(t, string(expectedPersesDashboardRaw), string(actualPersesDashboardRaw))
 		})
 	}

--- a/internal/api/shared/validate/testdata/variable_with_regex_dashboard.json
+++ b/internal/api/shared/validate/testdata/variable_with_regex_dashboard.json
@@ -1,0 +1,113 @@
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "dlDJrcf4z",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "Perses testing / .* in label matcher"
+    },
+    "duration": "1h",
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "iaas_loc",
+          "display": {
+            "name": "IaaS location",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "label_name": "stack",
+              "matchers": [
+                "thanos_build_info{stack=~\"\\\\w{4}\"}"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "stack",
+          "display": {
+            "name": "Stack (label_values)",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "label_name": "stack",
+              "matchers": [
+                "thanos_build_info{stack=~\"$iaas_loc.*\"}"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "stack_bis",
+          "display": {
+            "name": "Stack (query_result)",
+            "hidden": false
+          },
+          "allow_all_value": false,
+          "allow_multiple": false,
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "group by (stack) (thanos_build_info{stack=~\"$iaas_loc.*\"})",
+              "label_name": "stack"
+            }
+          }
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Just a text panel"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "# Title\n\nLorem ipsum"
+            }
+          }
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 10,
+              "y": 0,
+              "width": 4,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/internal/api/shared/validate/validate_test.go
+++ b/internal/api/shared/validate/validate_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package validate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/perses/perses/internal/api/config"
+	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
+	"github.com/perses/perses/internal/api/shared/schemas"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+const testDataFolder = "testdata"
+
+func TestDashboard(t *testing.T) {
+
+	testSuite := []struct {
+		title            string
+		dashboardFile    string
+		expectedErrorStr string
+	}{
+		{
+			title:            "dashboard with variables queries mixing parent variable & regex",
+			dashboardFile:    "variable_with_regex_dashboard.json",
+			expectedErrorStr: "",
+		},
+	}
+
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			persesDashboardRaw, readErr := os.ReadFile(filepath.Join(testDataFolder, test.dashboardFile))
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			projectPath := e2eframework.GetRepositoryPath(t)
+			schemasService, schErr := schemas.New(config.Schemas{
+				// use the real schemas for these tests
+				PanelsPath:    filepath.Join(projectPath, config.DefaultPanelsPath),
+				QueriesPath:   filepath.Join(projectPath, config.DefaultQueriesPath),
+				VariablesPath: filepath.Join(projectPath, config.DefaultVariablesPath),
+			})
+			if schErr != nil {
+				t.Fatal(schErr)
+			}
+
+			var persesDashboard modelV1.Dashboard
+			unmarshallErr := json.Unmarshal(persesDashboardRaw, &persesDashboard)
+			if unmarshallErr != nil {
+				t.Fatal(unmarshallErr)
+			}
+
+			err := Dashboard(&persesDashboard, schemasService)
+
+			actualErrorStr := ""
+			if err != nil {
+				actualErrorStr = err.Error()
+			}
+			assert.Equal(t, test.expectedErrorStr, actualErrorStr)
+		})
+	}
+}

--- a/internal/api/shared/validate/validate_test.go
+++ b/internal/api/shared/validate/validate_test.go
@@ -11,19 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package validate
 
 import (
-	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/perses/perses/internal/api/config"
-	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared/schemas"
+	testUtils "github.com/perses/perses/internal/test"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,11 +42,9 @@ func TestDashboard(t *testing.T) {
 
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
-			persesDashboardRaw, readErr := os.ReadFile(filepath.Join(testDataFolder, test.dashboardFile))
-			if readErr != nil {
-				t.Fatal(readErr)
-			}
-			projectPath := e2eframework.GetRepositoryPath(t)
+			persesDashboardRaw := testUtils.ReadFile(filepath.Join(testDataFolder, test.dashboardFile))
+
+			projectPath := testUtils.GetRepositoryPath()
 			schemasService, schErr := schemas.New(config.Schemas{
 				// use the real schemas for these tests
 				PanelsPath:    filepath.Join(projectPath, config.DefaultPanelsPath),
@@ -62,10 +56,7 @@ func TestDashboard(t *testing.T) {
 			}
 
 			var persesDashboard modelV1.Dashboard
-			unmarshallErr := json.Unmarshal(persesDashboardRaw, &persesDashboard)
-			if unmarshallErr != nil {
-				t.Fatal(unmarshallErr)
-			}
+			testUtils.JSONUnmarshal(persesDashboardRaw, &persesDashboard)
 
 			err := Dashboard(&persesDashboard, schemasService)
 

--- a/internal/cli/cmd/describe/describe_test.go
+++ b/internal/cli/cmd/describe/describe_test.go
@@ -18,7 +18,8 @@ import (
 
 	"github.com/perses/perses/internal/cli/resource"
 	cmdTest "github.com/perses/perses/internal/cli/test"
-	"github.com/perses/perses/pkg/client/fake/api"
+	test "github.com/perses/perses/internal/test"
+	fakeapi "github.com/perses/perses/pkg/client/fake/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -59,7 +60,7 @@ func TestDescribeCMD(t *testing.T) {
 			Args:            []string{"project", "perses", "-ojson"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(
+			ExpectedMessage: string(test.JSONMarshalStrict(
 				&modelV1.Project{
 					Kind: modelV1.KindProject,
 					Metadata: modelV1.Metadata{
@@ -72,7 +73,7 @@ func TestDescribeCMD(t *testing.T) {
 			Args:            []string{"project", "perses", "-oyaml"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.YAMLMarshalStrict(
+			ExpectedMessage: string(test.YAMLMarshalStrict(
 				&modelV1.Project{
 					Kind: modelV1.KindProject,
 					Metadata: modelV1.Metadata{
@@ -85,7 +86,7 @@ func TestDescribeCMD(t *testing.T) {
 			Args:            []string{"folder", "myFolder", "-ojson", "-p", "perses"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(&modelV1.Folder{
+			ExpectedMessage: string(test.JSONMarshalStrict(&modelV1.Folder{
 				Kind: modelV1.KindFolder,
 				Metadata: modelV1.ProjectMetadata{
 					Metadata: modelV1.Metadata{
@@ -101,7 +102,7 @@ func TestDescribeCMD(t *testing.T) {
 			Project:         "perses",
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(&modelV1.Folder{
+			ExpectedMessage: string(test.JSONMarshalStrict(&modelV1.Folder{
 				Kind: modelV1.KindFolder,
 				Metadata: modelV1.ProjectMetadata{
 					Metadata: modelV1.Metadata{

--- a/internal/cli/cmd/get/get_test.go
+++ b/internal/cli/cmd/get/get_test.go
@@ -18,8 +18,9 @@ import (
 
 	"github.com/perses/perses/internal/cli/resource"
 	cmdTest "github.com/perses/perses/internal/cli/test"
-	"github.com/perses/perses/pkg/client/fake/api"
-	"github.com/perses/perses/pkg/client/fake/api/v1"
+	test "github.com/perses/perses/internal/test"
+	fakeapi "github.com/perses/perses/pkg/client/fake/api"
+	fakev1 "github.com/perses/perses/pkg/client/fake/api/v1"
 )
 
 func TestGetCMD(t *testing.T) {
@@ -47,35 +48,35 @@ func TestGetCMD(t *testing.T) {
 			Args:            []string{"project", "-ojson"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(fakev1.ProjectList(""))) + "\n",
+			ExpectedMessage: string(test.JSONMarshalStrict(fakev1.ProjectList(""))) + "\n",
 		},
 		{
 			Title:           "get project with prefix in json format",
 			Args:            []string{"project", "per", "-ojson"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(fakev1.ProjectList("per"))) + "\n",
+			ExpectedMessage: string(test.JSONMarshalStrict(fakev1.ProjectList("per"))) + "\n",
 		},
 		{
 			Title:           "get globaldatasource in json format",
 			Args:            []string{"gdts", "-ojson"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(fakev1.GlobalDatasourceList(""))) + "\n",
+			ExpectedMessage: string(test.JSONMarshalStrict(fakev1.GlobalDatasourceList(""))) + "\n",
 		},
 		{
 			Title:           "get all folder in json format",
 			Args:            []string{"folder", "-ojson", "--all"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(fakev1.FolderList("", ""))) + "\n",
+			ExpectedMessage: string(test.JSONMarshalStrict(fakev1.FolderList("", ""))) + "\n",
 		},
 		{
 			Title:           "get folder in a specific project in json format",
 			Args:            []string{"folder", "-ojson", "-p", "perses"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(fakev1.FolderList("perses", ""))) + "\n",
+			ExpectedMessage: string(test.JSONMarshalStrict(fakev1.FolderList("perses", ""))) + "\n",
 		},
 		{
 			Title:           "get folder with default project in json format",
@@ -83,7 +84,7 @@ func TestGetCMD(t *testing.T) {
 			Project:         "perses",
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
-			ExpectedMessage: string(cmdTest.JSONMarshalStrict(fakev1.FolderList("perses", ""))) + "\n",
+			ExpectedMessage: string(test.JSONMarshalStrict(fakev1.FolderList("perses", ""))) + "\n",
 		},
 	}
 

--- a/internal/cli/test/test.go
+++ b/internal/cli/test/test.go
@@ -15,31 +15,13 @@ package test
 
 import (
 	"bytes"
-	"encoding/json"
 	"testing"
 
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/pkg/client/api"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 )
-
-func JSONMarshalStrict(obj interface{}) []byte {
-	data, err := json.Marshal(obj)
-	if err != nil {
-		panic(err)
-	}
-	return data
-}
-
-func YAMLMarshalStrict(obj interface{}) []byte {
-	data, err := yaml.Marshal(obj)
-	if err != nil {
-		panic(err)
-	}
-	return data
-}
 
 type Suite struct {
 	Title           string

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// this file gathers functions for common needs in tests
+
+package test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// simple wrapper to json.Marshal for testing, to ensure the test gets aborted in case of error
+func JSONMarshalStrict(obj interface{}) []byte {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+// simple wrapper to json.Unmarshal for testing, to ensure the test gets aborted in case of error
+func JSONUnmarshal(src []byte, dst interface{}) {
+	if err := json.Unmarshal(src, dst); err != nil {
+		panic(err)
+	}
+}
+
+// simple wrapper to yaml.Unmarshal for testing, to ensure the test gets aborted in case of error
+func YAMLMarshalStrict(obj interface{}) []byte {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func GetRepositoryPath() string {
+	projectPathByte, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(string(projectPathByte))
+}
+
+// simple wrapper to os.ReadFile for testing, to ensure the test gets aborted in case of error
+func ReadFile(filepath string) []byte {
+	fileContentBytes, err := os.ReadFile(filepath)
+	if err != nil {
+		panic(err)
+	}
+	return fileContentBytes
+}

--- a/pkg/model/api/v1/dashboard/variable_build_order.go
+++ b/pkg/model/api/v1/dashboard/variable_build_order.go
@@ -22,7 +22,7 @@ import (
 	"github.com/perses/perses/pkg/model/api/v1/common"
 )
 
-var variableTemplateSyntaxRegexp = regexp.MustCompile(`\$([a-zA-Z0-9_.:-]+)`)
+var variableTemplateSyntaxRegexp = regexp.MustCompile(`\$([a-zA-Z0-9_-]+)`)
 
 type VariableGroup struct {
 	Variables []string


### PR DESCRIPTION
When migrating/validating a dashboard with such variable query expr:
`thanos_build_info{stack=~"$iaas_loc.*"}`
we would encounter such validation issue (notice the trailing dot):
`bad request: variable "iaas_loc." is used in the variable "stack" but not defined`

So the easiest & pragmatic solution for now is simply to not authorize characters like `.` in variables name that could conflict with regexp syntax, which was basically the case before [last change](https://github.com/perses/perses/commit/ba17e4d2e073f766b41d7d9ae7819c36bf424d0f#diff-5fee94bdc9b5e8bf134768e6f062f3379a78da68cefa3f3ecf9690c72b3ed9efL24).

⚠️ Also there was a misalignment with the regexp used on the frontend side
https://github.com/perses/perses/blob/main/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx#L53, which is thus solved by this PR, but there are room for future improvements here: if ever we decide to (continue to) not have plugin-based variables syntax, it would be good to have a common source for this kind of regexp for both the frontend & backend, to avoid such misalignment to happen again.

EDIT: In the end this PR also embeds quite some refactor around unit tests for multiple cases. 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
