### PR TITLE
[ENHANCEMENT] Option to configure `show_query` in time series tooltip

### DIFF
--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -21,6 +21,10 @@ import (
 	position: "Bottom" | "Right"
 }
 
+#tooltip: {
+	show_query?: bool
+}
+
 #visual: {
 	line_width?:    number & >=0.25 & <=3
 	area_opacity?:  number & >=0 & <=1
@@ -45,6 +49,7 @@ spec: close({
 	y_axis?:     #y_axis
 	thresholds?: common.#thresholds
 	visual?:     #visual
+	tooltip?:    #tooltip
 })
 
 #ts_query: _

--- a/ui/components/src/TimeSeriesTooltip/SeriesInfo.tsx
+++ b/ui/components/src/TimeSeriesTooltip/SeriesInfo.tsx
@@ -41,7 +41,7 @@ export function SeriesInfo(props: SeriesInfoProps) {
   // determine whether to show labels on separate lines
   const splitLabels = formattedSeriesLabels.split(',');
   if (totalSeries === 1 && splitLabels.length > 1) {
-    const metricName = splitName[0] ? `${splitName[0]}:` : 'value:';
+    const metricName = splitName[0] && showQuery ? `${splitName[0]}:` : 'value:';
     return (
       <SeriesLabelsStack
         formattedY={formattedY}

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
@@ -43,7 +43,46 @@ describe('TooltipContent', () => {
     expect(screen.getByText('0.1')).toBeInTheDocument();
   });
 
-  it('should display multiple series data', () => {
+  it('should default to showing query', () => {
+    const tooltipContent: TooltipContentProps = {
+      focusedSeries: [
+        {
+          seriesIdx: 1,
+          datumIdx: 48,
+          seriesName: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+          date: 'Dec 23, 2022, 1:44:00 PM',
+          x: 1671821040000,
+          y: 33771520,
+          formattedY: '33.77M',
+          markerColor: 'hsla(158479636,50%,50%,0.8)',
+        },
+      ],
+    };
+    renderComponent(tooltipContent);
+    expect(screen.getByText('node_memory_Buffers_bytes:')).toBeInTheDocument();
+  });
+
+  it('should show value label instead of query', () => {
+    const tooltipContent: TooltipContentProps = {
+      focusedSeries: [
+        {
+          seriesIdx: 1,
+          datumIdx: 48,
+          seriesName: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+          date: 'Dec 23, 2022, 1:44:00 PM',
+          x: 1671821040000,
+          y: 33771520,
+          formattedY: '33.77M',
+          markerColor: 'hsla(158479636,50%,50%,0.8)',
+        },
+      ],
+      showQuery: false,
+    };
+    renderComponent(tooltipContent);
+    expect(screen.getByText('value:')).toBeInTheDocument();
+  });
+
+  it('should display wrapped series data with queries hidden', () => {
     const tooltipContent: TooltipContentProps = {
       focusedSeries: [
         {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -81,7 +81,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
   // control whether query is visible in TimeSeriesTooltip SeriesInfo component
   const tooltipConfig: TooltipConfig = {
-    showQuery: props.spec.tooltip?.show_query ?? true,
+    showQuery: props.spec.tooltip?.show_query ?? false,
     wrapLabels: true,
   };
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -26,6 +26,7 @@ import {
   YAxisLabel,
   ZoomEventData,
   useChartsTheme,
+  TooltipConfig,
 } from '@perses-dev/components';
 import { useSuggestedStepMs } from '../../model/time';
 import {
@@ -75,6 +76,12 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     props.spec.legend && validateLegendSpec(props.spec.legend)
       ? merge({}, DEFAULT_LEGEND, props.spec.legend)
       : undefined;
+
+  // control whether query is visible in TimeSeriesTooltip SeriesInfo component
+  const tooltipConfig: TooltipConfig = {
+    showQuery: props.spec.tooltip?.show_query ?? true,
+    wrapLabels: true,
+  };
 
   // TODO: add support for y_axis_alt.unit
   const unit = props.spec.y_axis?.unit ?? DEFAULT_UNIT;
@@ -269,7 +276,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         yAxis={yAxis}
         unit={unit}
         grid={gridOverrides}
-        tooltipConfig={{ showQuery: true, wrapLabels: true }}
+        tooltipConfig={tooltipConfig}
         onDataZoom={handleDataZoom}
       />
       {legend && graphData.legendItems && (

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -25,6 +25,7 @@ export interface TimeSeriesChartOptions {
   unit?: UnitOptions;
   thresholds?: ThresholdOptions;
   visual?: VisualOptions;
+  tooltip?: TooltipOptions;
 }
 
 export type TimeSeriesChartOptionsEditorProps = OptionsEditorProps<TimeSeriesChartOptions>;
@@ -45,6 +46,10 @@ export type VisualOptions = {
   stack?: StackOptions;
   connect_nulls?: boolean;
 };
+
+export interface TooltipOptions {
+  show_query?: boolean;
+}
 
 export const DEFAULT_UNIT: UnitOptions = {
   kind: 'Decimal',


### PR DESCRIPTION
Follow up to #1045, now that LineChart's tooltipConfig is available, it makes sense to have certain properties like `tooltip.show_query` to be configurable from the TimeSeriesChart panel spec. This PR just adds support in the JSON.

See CUE schema [here](https://github.com/perses/perses/blob/033d8049bdad21bb5f7901dabbf4cbf7ac737115/schemas/panels/time-series/time-series.cue#L24-L26) 
<!--
### Example when tooltip `show_query: false`:
![show_query_false](https://user-images.githubusercontent.com/9369625/229821440-59e4de9f-faf1-4e59-9f0f-fd7c63bc7c42.png)

### Example when tooltip `show_query: true`:
![show_query_true](https://user-images.githubusercontent.com/9369625/229821443-bdfb9588-501c-463b-8af6-af3946cc1f72.png)

### Default behavior when tooltip and `show_query` are undefined
![show_query_default_when_undef](https://user-images.githubusercontent.com/9369625/229821444-704b2dea-5db0-45b5-a91c-fa1750e7df02.png)

### Single focused series with `show_query: false`
<img width="900" alt="image" src="https://user-images.githubusercontent.com/9369625/229831500-69ba45c1-fea5-4d78-94e9-53bed5b43bb4.png">
-->
# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
