### PR TITLE
[BUGFIX] Revert tooltip prop to show full query and always show resolved series name

### DIFF
--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -58,7 +58,6 @@ use([
 ]);
 
 export type TooltipConfig = {
-  showQuery: boolean;
   wrapLabels: boolean;
   hidden?: boolean;
 };
@@ -86,7 +85,7 @@ export function LineChart({
   unit,
   grid,
   legend,
-  tooltipConfig = { wrapLabels: true, showQuery: true },
+  tooltipConfig = { wrapLabels: true },
   onDataZoom,
   onDoubleClick,
   __experimentalEChartsOptionsOverride,
@@ -228,7 +227,6 @@ export function LineChart({
           <TimeSeriesTooltip
             chartRef={chartRef}
             chartData={data}
-            showQuery={tooltipConfig.showQuery}
             wrapLabels={tooltipConfig.wrapLabels}
             pinTooltip={pinTooltip}
             unit={unit}

--- a/ui/components/src/TimeSeriesTooltip/SeriesInfo.tsx
+++ b/ui/components/src/TimeSeriesTooltip/SeriesInfo.tsx
@@ -23,11 +23,10 @@ export interface SeriesInfoProps {
   markerColor: string;
   totalSeries: number;
   wrapLabels?: boolean;
-  showQuery?: boolean;
 }
 
 export function SeriesInfo(props: SeriesInfoProps) {
-  const { seriesName, formattedY, markerColor, totalSeries, wrapLabels = true, showQuery = true } = props;
+  const { seriesName, formattedY, markerColor, totalSeries, wrapLabels = true } = props;
 
   // metric __name__ comes before opening curly brace, ignore if not populated
   // ex with metric name: node_load15{env="demo",job="node"}
@@ -52,9 +51,8 @@ export function SeriesInfo(props: SeriesInfoProps) {
     );
   }
 
-  // when more than one series, either show full series name or formatted labels only
-  const seriesInfo = showQuery ? seriesName : formattedSeriesLabels;
-  const formattedSeriesInfo = seriesInfo.replace(/[,]/g, ', '); // add space after commas so wrapLabels works
+  // add space after commas so wrapLabels works
+  const formattedSeriesInfo = seriesName.replace(/[,]/g, ', ');
 
   return (
     <Box

--- a/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -24,7 +24,6 @@ interface TimeSeriesTooltipProps {
   chartRef: React.MutableRefObject<EChartsInstance | undefined>;
   chartData: EChartsDataFormat;
   pinTooltip: boolean;
-  showQuery?: boolean;
   wrapLabels?: boolean;
   unit?: UnitOptions;
 }
@@ -33,7 +32,6 @@ export const TimeSeriesTooltip = React.memo(function TimeSeriesTooltip({
   chartRef,
   chartData,
   wrapLabels,
-  showQuery,
   pinTooltip,
   unit,
 }: TimeSeriesTooltipProps) {
@@ -85,7 +83,7 @@ export const TimeSeriesTooltip = React.memo(function TimeSeriesTooltip({
           transform: cursorTransform,
         }}
       >
-        <TooltipContent focusedSeries={focusedSeries} wrapLabels={wrapLabels} showQuery={showQuery} />
+        <TooltipContent focusedSeries={focusedSeries} wrapLabels={wrapLabels} />
       </Box>
     </Portal>
   );

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
@@ -72,7 +72,12 @@ describe('TooltipContent', () => {
     renderComponent(tooltipContent);
     expect(screen.getByText('84.64M')).toBeInTheDocument();
     expect(screen.getByText('33.77M')).toBeInTheDocument();
-    expect(screen.getAllByText('env="demo", instance="demo.do.prometheus.io:9100", job="node"')).toHaveLength(2);
+    expect(
+      screen.getAllByText('node_memory_Buffers_bytes{env="demo", instance="demo.do.prometheus.io:9100", job="node"}')
+    ).toHaveLength(1);
+    expect(
+      screen.getAllByText('node_memory_MemFree_bytes{env="demo", instance="demo.do.prometheus.io:9100", job="node"}')
+    ).toHaveLength(1);
   });
 
   it('should display query before wrapped labels', () => {

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
@@ -68,7 +68,6 @@ describe('TooltipContent', () => {
         },
       ],
       wrapLabels: true,
-      showQuery: false,
     };
     renderComponent(tooltipContent);
     expect(screen.getByText('84.64M')).toBeInTheDocument();
@@ -101,7 +100,6 @@ describe('TooltipContent', () => {
         },
       ],
       wrapLabels: true,
-      showQuery: true,
     };
     renderComponent(tooltipContent);
     expect(

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
@@ -19,12 +19,11 @@ import { SeriesInfo } from './SeriesInfo';
 
 export interface TooltipContentProps {
   focusedSeries: FocusedSeriesArray | null;
-  showQuery?: boolean;
   wrapLabels?: boolean;
 }
 
 export function TooltipContent(props: TooltipContentProps) {
-  const { focusedSeries, showQuery, wrapLabels } = props;
+  const { focusedSeries, wrapLabels } = props;
   const { formatWithUserTimeZone } = useTimeZone();
 
   const seriesTime = focusedSeries && focusedSeries[0] && focusedSeries[0].date ? focusedSeries[0].date : null;
@@ -82,7 +81,6 @@ export function TooltipContent(props: TooltipContentProps) {
                 formattedY={formattedY}
                 markerColor={markerColor}
                 totalSeries={sortedFocusedSeries.length}
-                showQuery={showQuery}
                 wrapLabels={wrapLabels}
               />
             );

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -289,7 +289,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         yAxis={yAxis}
         unit={unit}
         grid={gridOverrides}
-        tooltipConfig={{ showQuery: true, wrapLabels: true }}
+        tooltipConfig={{ wrapLabels: true }}
         onDataZoom={handleDataZoom}
       />
       {legend && graphData.legendItems && (


### PR DESCRIPTION
Revert `showQuery` prop addition in LineChart's tooltipConfig, always use series name instead of trying to be smart about parsing out metric name in certain cases.

## Screenshot

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/9369625/230104189-87fb629d-8e4f-4fde-9095-0710974455b9.png">


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
