### PR TITLE
[ENHANCEMENT] Virtualize legend to fix perf issues

### DIFF
--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -45,10 +45,13 @@
     "mathjs": "^10.6.4",
     "mdi-material-ui": "^7.4.0",
     "react-colorful": "^5.6.1",
-    "react-error-boundary": "^3.1.4"
+    "react-error-boundary": "^3.1.4",
+    "react-virtualized-auto-sizer": "^1.0.11",
+    "react-window": "^1.8.8"
   },
   "devDependencies": {
-    "@perses-dev/storybook": "0.26.1"
+    "@perses-dev/storybook": "0.26.1",
+    "@types/react-window": "^1.8.5"
   },
   "peerDependencies": {
     "@mui/material": "^5.10.0",

--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -46,7 +46,6 @@
     "mdi-material-ui": "^7.4.0",
     "react-colorful": "^5.6.1",
     "react-error-boundary": "^3.1.4",
-    "react-virtualized-auto-sizer": "^1.0.11",
     "react-window": "^1.8.8"
   },
   "devDependencies": {

--- a/ui/components/src/Legend/CompactLegend.tsx
+++ b/ui/components/src/Legend/CompactLegend.tsx
@@ -22,7 +22,9 @@ interface CompactLegendProps {
 
 /**
  * CompactLegend is default and used when legend items need to show side by side
- * which corresponds to when legend.position is `bottom`
+ * which corresponds to when legend.position is `bottom` with a relatively small
+ * number of items. The `ListLegend` is used for cases with large numbers of items
+ * because it is virtualized.
  */
 export function CompactLegend({ height, items }: CompactLegendProps) {
   return (

--- a/ui/components/src/Legend/Legend.stories.tsx
+++ b/ui/components/src/Legend/Legend.stories.tsx
@@ -49,6 +49,11 @@ const LegendWrapper = (props: LegendProps) => {
     options: { position },
   } = props;
 
+  // The legend does not look very interesting by itself in stories, especially
+  // when considering the positioning. This wrapper puts a box with a border
+  // and some additional height/width (depending on the positioning of the
+  // legend) to make it easier to see how the legend would look in context
+  // alongside other content.
   return (
     <Box
       sx={{

--- a/ui/components/src/Legend/Legend.stories.tsx
+++ b/ui/components/src/Legend/Legend.stories.tsx
@@ -53,17 +53,17 @@ const LegendWrapper = (props: LegendProps) => {
     <Box
       sx={{
         border: (theme) => `solid 1px ${theme.palette.divider}`,
+        position: 'relative',
+        width: position === 'Right' ? props.width + 100 : props.width,
+        height: position === 'Right' ? props.height : props.height + 100,
+
+        // This is a rare case where content-box is helpful because we want to
+        // have the border be additive, so we don't have to do any special
+        // math with the height/width or end up with an off-by-2px issue.
+        boxSizing: 'content-box',
       }}
     >
-      <Box
-        sx={{
-          position: 'relative',
-          width: position === 'Right' ? props.width + 100 : props.width,
-          height: position === 'Right' ? props.height : props.height + 100,
-        }}
-      >
-        <Legend {...props} />
-      </Box>
+      <Legend {...props} />
     </Box>
   );
 };

--- a/ui/components/src/Legend/Legend.stories.tsx
+++ b/ui/components/src/Legend/Legend.stories.tsx
@@ -52,13 +52,18 @@ const LegendWrapper = (props: LegendProps) => {
   return (
     <Box
       sx={{
-        position: 'relative',
-        width: position === 'Right' ? props.width + 100 : props.width,
-        height: position === 'Right' ? props.height : props.height + 100,
         border: (theme) => `solid 1px ${theme.palette.divider}`,
       }}
     >
-      <Legend {...props} />
+      <Box
+        sx={{
+          position: 'relative',
+          width: position === 'Right' ? props.width + 100 : props.width,
+          height: position === 'Right' ? props.height : props.height + 100,
+        }}
+      >
+        <Legend {...props} />
+      </Box>
     </Box>
   );
 };

--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -23,6 +23,13 @@ export interface LegendProps {
   options: LegendOptions;
 }
 
+// When the number of items to display is above this number, it is likely to
+// cause performance issues in the browser. The legend will be displayed in a
+// format (list) that allows for virtualization to minimize the performance impact.
+// Set this number based on testing, but it may need to be tuned a bit on the
+// future as people test this out on different machines.
+const NEED_VIRTUALIZATION_LIMIT = 500;
+
 export function Legend({ width, height, options, data }: LegendProps) {
   if (options.position === 'Right') {
     return (
@@ -33,8 +40,6 @@ export function Legend({ width, height, options, data }: LegendProps) {
           position: 'absolute',
           top: 0,
           right: 0,
-          overflowX: 'hidden',
-          overflowY: 'scroll',
         }}
       >
         <ListLegend items={data} />
@@ -42,6 +47,11 @@ export function Legend({ width, height, options, data }: LegendProps) {
     );
   }
 
+  // The bottom legend is displayed as a list when the number of items is too
+  // large and requires virtualization. Otherwise, it is rendered more compactly.
+  // We do not need this check for the right-side legend because it is always
+  // a virtualized list.
+  const needsVirtualization = data.length >= NEED_VIRTUALIZATION_LIMIT;
   return (
     <Box
       sx={{
@@ -51,7 +61,7 @@ export function Legend({ width, height, options, data }: LegendProps) {
         bottom: 0,
       }}
     >
-      <CompactLegend items={data} height={height} />
+      {needsVirtualization ? <ListLegend items={data} /> : <CompactLegend items={data} height={height} />}
     </Box>
   );
 }

--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -36,13 +36,13 @@ export function Legend({ width, height, options, data }: LegendProps) {
       <Box
         sx={{
           width: width,
-          height: '100%',
+          height: height,
           position: 'absolute',
           top: 0,
           right: 0,
         }}
       >
-        <ListLegend items={data} />
+        <ListLegend items={data} width={width} height={height} />
       </Box>
     );
   }
@@ -61,7 +61,11 @@ export function Legend({ width, height, options, data }: LegendProps) {
         bottom: 0,
       }}
     >
-      {needsVirtualization ? <ListLegend items={data} /> : <CompactLegend items={data} height={height} />}
+      {needsVirtualization ? (
+        <ListLegend items={data} width={width} height={height} />
+      ) : (
+        <CompactLegend items={data} height={height} />
+      )}
     </Box>
   );
 }

--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -29,7 +29,7 @@ export interface LegendProps {
    * - The legend has a large number of items to display and requires virtualization
    *   to render performantly.
    */
-  listLegendProps?: Pick<ListLegendProps, 'initialRowHeight'>;
+  listProps?: Pick<ListLegendProps, 'initialRowHeight'>;
 }
 
 // When the number of items to display is above this number, it is likely to
@@ -39,7 +39,7 @@ export interface LegendProps {
 // future as people test this out on different machines.
 const NEED_VIRTUALIZATION_LIMIT = 500;
 
-export function Legend({ width, height, options, data, listLegendProps }: LegendProps) {
+export function Legend({ width, height, options, data, listProps }: LegendProps) {
   if (options.position === 'Right') {
     return (
       <Box
@@ -51,7 +51,7 @@ export function Legend({ width, height, options, data, listLegendProps }: Legend
           right: 0,
         }}
       >
-        <ListLegend items={data} width={width} height={height} {...listLegendProps} />
+        <ListLegend items={data} width={width} height={height} {...listProps} />
       </Box>
     );
   }
@@ -71,7 +71,7 @@ export function Legend({ width, height, options, data, listLegendProps }: Legend
       }}
     >
       {needsVirtualization ? (
-        <ListLegend items={data} width={width} height={height} {...listLegendProps} />
+        <ListLegend items={data} width={width} height={height} {...listProps} />
       ) : (
         <CompactLegend items={data} height={height} />
       )}

--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -13,7 +13,7 @@
 
 import { Box } from '@mui/material';
 import { LegendOptions, LegendItem } from '../model';
-import { ListLegend } from './ListLegend';
+import { ListLegend, ListLegendProps } from './ListLegend';
 import { CompactLegend } from './CompactLegend';
 
 export interface LegendProps {
@@ -21,6 +21,15 @@ export interface LegendProps {
   height: number;
   data: LegendItem[];
   options: LegendOptions;
+
+  /**
+   * Additional props that will be passed to the list variation of the legend
+   * that is used when:
+   * - The legend is positioned on the right.
+   * - The legend has a large number of items to display and requires virtualization
+   *   to render performantly.
+   */
+  listLegendProps?: Pick<ListLegendProps, 'initialRowHeight'>;
 }
 
 // When the number of items to display is above this number, it is likely to
@@ -30,7 +39,7 @@ export interface LegendProps {
 // future as people test this out on different machines.
 const NEED_VIRTUALIZATION_LIMIT = 500;
 
-export function Legend({ width, height, options, data }: LegendProps) {
+export function Legend({ width, height, options, data, listLegendProps }: LegendProps) {
   if (options.position === 'Right') {
     return (
       <Box
@@ -42,7 +51,7 @@ export function Legend({ width, height, options, data }: LegendProps) {
           right: 0,
         }}
       >
-        <ListLegend items={data} width={width} height={height} />
+        <ListLegend items={data} width={width} height={height} {...listLegendProps} />
       </Box>
     );
   }
@@ -62,7 +71,7 @@ export function Legend({ width, height, options, data }: LegendProps) {
       }}
     >
       {needsVirtualization ? (
-        <ListLegend items={data} width={width} height={height} />
+        <ListLegend items={data} width={width} height={height} {...listLegendProps} />
       ) : (
         <CompactLegend items={data} height={height} />
       )}

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -80,13 +80,6 @@ export function ListLegend({ items, height, width, initialRowHeight = DEFAULT_IN
     // heights on hover.
     const rowRef = useRef<HTMLDivElement | null>(null);
 
-    // Adjust row heights when the row being rendered changes.
-    useEffect(() => {
-      if (rowRef.current) {
-        setRowHeight(index, rowRef.current.clientHeight);
-      }
-    }, [rowRef, index]);
-
     // useCallback is important here to avoid constantly running the useEffect
     // that calls this in `ListLegendItem`.
     const handleRowLayoutChange = useCallback(() => {
@@ -95,6 +88,11 @@ export function ListLegend({ items, height, width, initialRowHeight = DEFAULT_IN
         setRowHeight(index, rowRef.current.clientHeight);
       }
     }, [index]);
+
+    // Adjust row heights when the row being rendered changes.
+    useEffect(() => {
+      handleRowLayoutChange();
+    }, [handleRowLayoutChange]);
 
     const item = items[index];
 

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -11,7 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { List } from '@mui/material';
+import { useTheme } from '@mui/material';
+import { VariableSizeList, ListChildComponentProps } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { useRef, useEffect, forwardRef } from 'react';
 import { LegendItem } from '../model';
 import { ListLegendItem } from './ListLegendItem';
 
@@ -19,20 +22,99 @@ interface ListLegendProps {
   items: LegendItem[];
 }
 
+// Default height used to start while virtualizing the list before a true
+// height is determined.
+const DEFAULT_ROW_HEIGHT = 24;
+
 /**
- * ListLegend is used when legend.position is 'right' since legend items are stacked
+ * ListLegend is used when legend.position is 'right' since legend items are
+ * stacked. It is also used for `bottom` positioned legends when there are a
+ * large number of items because it is virtualized and easier to visually scan
+ * large numbers of items when there is a single item per row.
  */
 export function ListLegend({ items }: ListLegendProps) {
+  // Storing a ref to the react-window `VariableSizeList`, so we can call
+  // `resetAfterIndex` to resize the list after mouseover/out events to account
+  // for the change in list items on hover.
+  const listRef = useRef<VariableSizeList>(null);
+  // Storing row heights, so we can use dynamic heights, which enables the
+  // user the hover to show the full label, while still having a virtualized
+  // list.
+  const rowHeights = useRef<Record<number, number>>({});
+
+  const theme = useTheme();
+  // Padding value used throughout to adjust the react-window virtual layouts
+  // to simulate padding per the guidance from:
+  // https://github.com/bvaughn/react-window#can-i-add-padding-to-the-top-and-bottom-of-a-list
+  const LIST_PADDING = parseInt(theme.spacing(1), 10);
+
   // show full labels on hover when there are many total series
   const truncateLabels = items.length > 5;
-  return (
-    <List>
-      {items.map((item) => (
+
+  // Gets the row height for a given item to enable the virtualized list to
+  // render the row properly.
+  function getRowHeight(index: number) {
+    const currentHeight = rowHeights.current[index];
+    return currentHeight ?? DEFAULT_ROW_HEIGHT;
+  }
+
+  // Set the height for a given item to enable the virtualized list to
+  // adjust to size changes.
+  function setRowHeight(index: number, size: number) {
+    // Tell the virtualized list that items changed size and need to be
+    // re-evaluated.
+    listRef.current?.resetAfterIndex(0);
+    rowHeights.current = { ...rowHeights.current, [index]: size };
+  }
+
+  // Renderer for virtualized rows in `VariableSizeList`.
+  function ListLegendRow({ index, style }: ListChildComponentProps) {
+    // Storing a ref to the row's `ListLegendItem`, so we can get the "real"
+    // height and adjust the height of the row based on it, enabling the dynamic
+    // heights on hover.
+    const rowRef = useRef<HTMLDivElement | null>(null);
+
+    // Adjust row heights when the row being rendered changes.
+    useEffect(() => {
+      if (rowRef.current) {
+        setRowHeight(index, rowRef.current.clientHeight);
+      }
+    }, [rowRef, index]);
+
+    // Handle size changes from hover on mouseover/mouseout
+    function handleMouseOverOut() {
+      if (rowRef.current) {
+        setRowHeight(index, rowRef.current.clientHeight);
+      }
+    }
+
+    const item = items[index];
+
+    if (!item) {
+      // This shouldn't happen if configured correctly, but covering
+      // the case to appease the type checking and to cover any edge
+      // cases.
+      return null;
+    }
+
+    const originalTop = parseFloat(`${style.top}`);
+
+    return (
+      <div
+        style={{
+          ...style,
+          // Adjust the top position to simulate top padding on the list.
+          top: `${originalTop + LIST_PADDING}px`,
+          paddingRight: `${LIST_PADDING}px`,
+        }}
+      >
         <ListLegendItem
+          ref={rowRef}
           key={item.id}
           item={item}
+          onMouseOver={handleMouseOverOut}
+          onMouseOut={handleMouseOverOut}
           sx={{
-            width: 190,
             textOverflow: 'ellipsis',
             wordBreak: 'break-word',
             overflow: truncateLabels ? 'hidden' : 'visible',
@@ -44,7 +126,48 @@ export function ListLegend({ items }: ListLegendProps) {
             },
           }}
         />
-      ))}
-    </List>
+      </div>
+    );
+  }
+
+  // Renderer for the inner container element of the `VariableSizeList` used
+  // to adjust styles to simulate padding on the list per:
+  // https://github.com/bvaughn/react-window#can-i-add-padding-to-the-top-and-bottom-of-a-list
+  const InnerElementType = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(function InnerElementType(
+    { style, ...rest },
+    ref
+  ) {
+    const originalHeight = style?.height ? parseFloat(`${style?.height}`) : 0;
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          ...style,
+          // Adjust height to account for simulated padding.
+          height: `${originalHeight + LIST_PADDING * 2}px`,
+        }}
+        {...rest}
+      />
+    );
+  });
+
+  return (
+    <AutoSizer>
+      {({ height, width }) => {
+        return (
+          <VariableSizeList
+            height={height ?? 0}
+            width={width ?? 0}
+            itemCount={items.length}
+            itemSize={getRowHeight}
+            innerElementType={InnerElementType}
+            ref={listRef}
+          >
+            {ListLegendRow}
+          </VariableSizeList>
+        );
+      }}
+    </AutoSizer>
   );
 }

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -17,15 +17,20 @@ import { useRef, useEffect, forwardRef, useCallback } from 'react';
 import { LegendItem } from '../model';
 import { ListLegendItem } from './ListLegendItem';
 
-interface ListLegendProps {
+export interface ListLegendProps {
   items: LegendItem[];
   height: number;
   width: number;
+
+  /**
+   * The height used when initially laying out items in the list. Once items
+   * render, the height is determined based on the content. This is needed
+   * because the list is virtualized.
+   */
+  initialRowHeight?: number;
 }
 
-// Default height used to start while virtualizing the list before a true
-// height is determined.
-const DEFAULT_ROW_HEIGHT = 26;
+const DEFAULT_INITIAL_ROW_HEIGHT = 26;
 
 /**
  * ListLegend is used when legend.position is 'right' since legend items are
@@ -33,7 +38,7 @@ const DEFAULT_ROW_HEIGHT = 26;
  * large number of items because it is virtualized and easier to visually scan
  * large numbers of items when there is a single item per row.
  */
-export function ListLegend({ items, height, width }: ListLegendProps) {
+export function ListLegend({ items, height, width, initialRowHeight = DEFAULT_INITIAL_ROW_HEIGHT }: ListLegendProps) {
   // Storing a ref to the react-window `VariableSizeList`, so we can call
   // `resetAfterIndex` to resize the list after mouseover/out events to account
   // for the change in list items on hover.
@@ -56,7 +61,7 @@ export function ListLegend({ items, height, width }: ListLegendProps) {
   // render the row properly.
   function getRowHeight(index: number) {
     const currentHeight = rowHeights.current[index];
-    return currentHeight ?? DEFAULT_ROW_HEIGHT;
+    return currentHeight ?? initialRowHeight;
   }
 
   // Set the height for a given item to enable the virtualized list to

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -142,6 +142,7 @@ export function ListLegend({ items }: ListLegendProps) {
     return (
       <div
         ref={ref}
+        role="list"
         style={{
           ...style,
           // Adjust height to account for simulated padding.

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -25,7 +25,7 @@ interface ListLegendProps {
 
 // Default height used to start while virtualizing the list before a true
 // height is determined.
-const DEFAULT_ROW_HEIGHT = 24;
+const DEFAULT_ROW_HEIGHT = 26;
 
 /**
  * ListLegend is used when legend.position is 'right' since legend items are
@@ -121,6 +121,7 @@ export function ListLegend({ items, height, width }: ListLegendProps) {
             // work correctly. Subtract padding to simulate padding.
             width: width - LIST_PADDING,
             wordBreak: 'break-word',
+            overflow: 'hidden',
           }}
         />
       </div>

--- a/ui/components/src/Legend/ListLegendItem.tsx
+++ b/ui/components/src/Legend/ListLegendItem.tsx
@@ -29,6 +29,7 @@ const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(funct
     <ListItem
       {...others}
       component="div"
+      role="listitem"
       sx={combineSx(
         {
           padding: 0,

--- a/ui/components/src/Legend/ListLegendItem.tsx
+++ b/ui/components/src/Legend/ListLegendItem.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState, useEffect } from 'react';
 import { Box, ListItemText, ListItem, ListItemProps } from '@mui/material';
 import { LegendItem } from '../model';
 import { combineSx } from '../utils';
@@ -19,12 +19,46 @@ import { LegendColorBadge } from './LegendColorBadge';
 
 interface ListLegendItemProps extends ListItemProps<'div'> {
   item: LegendItem;
+
+  /**
+   * When `true`, will keep labels to a single line with overflow ellipsized. The
+   * full content will be shown on hover.
+   *
+   * When `false` or unset, will show the full label.
+   */
+  truncateLabel?: boolean;
+
+  /**
+   * Called when the layout of the legend item changes as a result of the hover
+   * behavior when `truncateLabel` is `true`.
+   */
+  onLayoutChange?: () => void;
 }
 
 const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(function ListLegendItem(
-  { item, sx, ...others },
+  { item, sx, truncateLabel, onLayoutChange, ...others },
   ref
 ) {
+  const [noWrap, setNoWrap] = useState(truncateLabel);
+
+  function handleMouseOver() {
+    if (truncateLabel) {
+      setNoWrap(false);
+    }
+  }
+
+  function handleMouseOut() {
+    if (truncateLabel) {
+      setNoWrap(true);
+    }
+  }
+
+  useEffect(() => {
+    // When `noWrap` changes, so does the layout of the component. Notifies the
+    // parent, so it can handle those changes.
+    onLayoutChange?.();
+  }, [noWrap, onLayoutChange]);
+
   return (
     <ListItem
       {...others}
@@ -46,7 +80,12 @@ const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(funct
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <LegendColorBadge color={item.color} />
       </Box>
-      <ListItemText primary={item.label}></ListItemText>
+      <ListItemText
+        primary={item.label}
+        primaryTypographyProps={{ noWrap: noWrap }}
+        onMouseOver={handleMouseOver}
+        onMouseOut={handleMouseOut}
+      ></ListItemText>
     </ListItem>
   );
 });

--- a/ui/components/src/Legend/ListLegendItem.tsx
+++ b/ui/components/src/Legend/ListLegendItem.tsx
@@ -11,20 +11,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { Box, ListItemText, ListItem, ListItemProps } from '@mui/material';
 import { LegendItem } from '../model';
 import { combineSx } from '../utils';
 import { LegendColorBadge } from './LegendColorBadge';
 
-interface ListLegendItemProps extends ListItemProps {
+interface ListLegendItemProps extends ListItemProps<'div'> {
   item: LegendItem;
 }
 
-export const ListLegendItem = React.memo(function ListLegendItem({ item, sx, ...others }: ListLegendItemProps) {
+const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(function ListLegendItem(
+  { item, sx, ...others },
+  ref
+) {
   return (
     <ListItem
       {...others}
+      component="div"
       sx={combineSx(
         {
           padding: 0,
@@ -36,6 +40,7 @@ export const ListLegendItem = React.memo(function ListLegendItem({ item, sx, ...
       key={item.id}
       onClick={item.onClick}
       selected={item.isSelected}
+      ref={ref}
     >
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <LegendColorBadge color={item.color} />
@@ -44,3 +49,5 @@ export const ListLegendItem = React.memo(function ListLegendItem({ item, sx, ...
     </ListItem>
   );
 });
+
+export const ListLegendItem = React.memo(ListLegendItemBase);

--- a/ui/components/src/model/legend.ts
+++ b/ui/components/src/model/legend.ts
@@ -26,7 +26,7 @@ export interface LegendItem {
   label: string;
   isSelected: boolean;
   color: string;
-  onClick: MouseEventHandler<HTMLLIElement>;
+  onClick: MouseEventHandler<HTMLElement>;
 }
 
 export type LegendPositionConfig = {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -129,7 +129,6 @@
         "mdi-material-ui": "^7.4.0",
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
-        "react-virtualized-auto-sizer": "^1.0.11",
         "react-window": "^1.8.8"
       },
       "devDependencies": {
@@ -20682,15 +20681,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
-      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
-      }
-    },
     "node_modules/react-window": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.8.tgz",
@@ -27044,7 +27034,6 @@
         "mdi-material-ui": "^7.4.0",
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
-        "react-virtualized-auto-sizer": "*",
         "react-window": "^1.8.8"
       }
     },
@@ -39377,12 +39366,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
-    },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
-      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
-      "requires": {}
     },
     "react-window": {
       "version": "1.8.8",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -128,10 +128,13 @@
         "mathjs": "^10.6.4",
         "mdi-material-ui": "^7.4.0",
         "react-colorful": "^5.6.1",
-        "react-error-boundary": "^3.1.4"
+        "react-error-boundary": "^3.1.4",
+        "react-virtualized-auto-sizer": "^1.0.11",
+        "react-window": "^1.8.8"
       },
       "devDependencies": {
-        "@perses-dev/storybook": "0.26.1"
+        "@perses-dev/storybook": "0.26.1",
+        "@types/react-window": "^1.8.5"
       },
       "peerDependencies": {
         "@mui/material": "^5.10.0",
@@ -9219,6 +9222,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -18269,6 +18281,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/memoizerific": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
@@ -20663,6 +20680,31 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
+      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-D4IiBeRtGXziZ1n0XklnFGu7h9gU684zepqyKzgPNzrsrk7xOCxni+TCckjg2Nr/DiaEEGVVmnhYSlT2rB47dQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -26992,6 +27034,7 @@
         "@mui/x-date-pickers": "^5.0.0-beta.1",
         "@perses-dev/core": "0.26.1",
         "@perses-dev/storybook": "0.26.1",
+        "@types/react-window": "^1.8.5",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.7",
@@ -27000,7 +27043,9 @@
         "mathjs": "^10.6.4",
         "mdi-material-ui": "^7.4.0",
         "react-colorful": "^5.6.1",
-        "react-error-boundary": "^3.1.4"
+        "react-error-boundary": "^3.1.4",
+        "react-virtualized-auto-sizer": "*",
+        "react-window": "^1.8.8"
       }
     },
     "@perses-dev/core": {
@@ -30794,6 +30839,15 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -37608,6 +37662,11 @@
         "fs-monkey": "^1.0.3"
       }
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "memoizerific": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
@@ -39317,6 +39376,21 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
+      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
+      "requires": {}
+    },
+    "react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-D4IiBeRtGXziZ1n0XklnFGu7h9gU684zepqyKzgPNzrsrk7xOCxni+TCckjg2Nr/DiaEEGVVmnhYSlT2rB47dQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -23,8 +23,18 @@ import {
   mockPluginRegistry,
   MockPlugin,
 } from '@perses-dev/plugin-system';
+import { Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { MOCK_TIME_SERIES_QUERY_RESULT, MOCK_TIME_SERIES_DATA } from '../../test';
 import { TimeSeriesChartPanel, TimeSeriesChartProps } from './TimeSeriesChartPanel';
+
+// Mock AutoSizer because it does not play well with jsdom.
+jest.mock('react-virtualized-auto-sizer', () => {
+  return {
+    ...jest.requireActual('react-virtualized-auto-sizer'),
+    __esModule: true,
+    default: ({ children }: AutoSizerProps) => children({ height: 1000, width: 1000 }),
+  };
+});
 
 jest.mock('@perses-dev/plugin-system', () => {
   return {
@@ -129,51 +139,52 @@ describe('TimeSeriesChartPanel', () => {
     renderPanel();
 
     const seriesArr = MOCK_TIME_SERIES_DATA.series;
-    const firstLegend = getLegendByName(seriesArr[0]?.name);
-    const secondLegend = getLegendByName(seriesArr[1]?.name);
+    const firstName = seriesArr[0]?.name;
+    const secondName = seriesArr[1]?.name;
 
-    userEvent.click(firstLegend);
-    expect(firstLegend).toHaveClass('Mui-selected');
-    expect(secondLegend).not.toHaveClass('Mui-selected');
+    userEvent.click(getLegendByName(firstName));
+    expect(getLegendByName(firstName)).toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).not.toHaveClass('Mui-selected');
 
-    userEvent.click(secondLegend);
-    expect(firstLegend).not.toHaveClass('Mui-selected');
-    expect(secondLegend).toHaveClass('Mui-selected');
+    userEvent.click(getLegendByName(secondName));
+    expect(getLegendByName(firstName)).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).toHaveClass('Mui-selected');
   });
 
   it('should modify selected state when a legend item is clicked with shift key', async () => {
     renderPanel();
     const seriesArr = MOCK_TIME_SERIES_DATA.series;
-    const firstLegend = getLegendByName(seriesArr[0]?.name);
-    const secondLegend = getLegendByName(seriesArr[1]?.name);
+
+    const firstName = seriesArr[0]?.name;
+    const secondName = seriesArr[1]?.name;
 
     // Add first legend item
-    userEvent.click(firstLegend, {
+    userEvent.click(getLegendByName(firstName), {
       shiftKey: true,
     });
-    expect(firstLegend).toHaveClass('Mui-selected');
-    expect(secondLegend).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(firstName)).toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).not.toHaveClass('Mui-selected');
 
     // Add second legend item
-    userEvent.click(secondLegend, {
+    userEvent.click(getLegendByName(secondName), {
       shiftKey: true,
     });
-    expect(firstLegend).toHaveClass('Mui-selected');
-    expect(secondLegend).toHaveClass('Mui-selected');
+    expect(getLegendByName(firstName)).toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).toHaveClass('Mui-selected');
 
     // Remove first legend item
-    userEvent.click(firstLegend, {
+    userEvent.click(getLegendByName(firstName), {
       shiftKey: true,
     });
-    expect(firstLegend).not.toHaveClass('Mui-selected');
-    expect(secondLegend).toHaveClass('Mui-selected');
+    expect(getLegendByName(firstName)).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).toHaveClass('Mui-selected');
 
     // Remove second legend item
-    userEvent.click(secondLegend, {
+    userEvent.click(getLegendByName(secondName), {
       shiftKey: true,
     });
-    expect(firstLegend).not.toHaveClass('Mui-selected');
-    expect(secondLegend).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(firstName)).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).not.toHaveClass('Mui-selected');
   });
 
   it('should modify selected state when a legend item is clicked with meta key', async () => {
@@ -184,35 +195,33 @@ describe('TimeSeriesChartPanel', () => {
     const firstName = seriesArr[0]?.name;
     const secondName = seriesArr[1]?.name;
 
-    const firstLegend = getLegendByName(firstName);
-    const secondLegend = getLegendByName(secondName);
-
     // Add first legend item
-    userEvent.click(firstLegend, {
+    userEvent.click(getLegendByName(firstName), {
       metaKey: true,
     });
-    expect(firstLegend).toHaveClass('Mui-selected');
-    expect(secondLegend).not.toHaveClass('Mui-selected');
+
+    expect(getLegendByName(firstName)).toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).not.toHaveClass('Mui-selected');
 
     // Add second legend item
-    userEvent.click(secondLegend, {
+    userEvent.click(getLegendByName(secondName), {
       metaKey: true,
     });
-    expect(firstLegend).toHaveClass('Mui-selected');
-    expect(secondLegend).toHaveClass('Mui-selected');
+    expect(getLegendByName(firstName)).toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).toHaveClass('Mui-selected');
 
     // Remove first legend item
-    userEvent.click(firstLegend, {
+    userEvent.click(getLegendByName(firstName), {
       metaKey: true,
     });
-    expect(firstLegend).not.toHaveClass('Mui-selected');
-    expect(secondLegend).toHaveClass('Mui-selected');
+    expect(getLegendByName(firstName)).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).toHaveClass('Mui-selected');
 
     // Remove second legend item
-    userEvent.click(secondLegend, {
+    userEvent.click(getLegendByName(secondName), {
       metaKey: true,
     });
-    expect(firstLegend).not.toHaveClass('Mui-selected');
-    expect(secondLegend).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(firstName)).not.toHaveClass('Mui-selected');
+    expect(getLegendByName(secondName)).not.toHaveClass('Mui-selected');
   });
 });

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -23,18 +23,8 @@ import {
   mockPluginRegistry,
   MockPlugin,
 } from '@perses-dev/plugin-system';
-import { Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { MOCK_TIME_SERIES_QUERY_RESULT, MOCK_TIME_SERIES_DATA } from '../../test';
 import { TimeSeriesChartPanel, TimeSeriesChartProps } from './TimeSeriesChartPanel';
-
-// Mock AutoSizer because it does not play well with jsdom.
-jest.mock('react-virtualized-auto-sizer', () => {
-  return {
-    ...jest.requireActual('react-virtualized-auto-sizer'),
-    __esModule: true,
-    default: ({ children }: AutoSizerProps) => children({ height: 1000, width: 1000 }),
-  };
-});
 
 jest.mock('@perses-dev/plugin-system', () => {
   return {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -260,7 +260,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   // TODO: account for number of time series returned when adjusting legend spacing
   let legendHeight = LEGEND_HEIGHT_SM;
   if (legend && legend.position === 'Right') {
-    legendHeight = adjustedContentDimensions.height;
+    legendHeight = contentDimensions?.height || adjustedContentDimensions.height;
   } else if (adjustedContentDimensions.height >= PANEL_HEIGHT_LG_BREAKPOINT) {
     legendHeight = LEGEND_HEIGHT_LG;
   }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -102,7 +102,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
   const { setTimeRange } = useTimeRange();
 
-  const onLegendItemClick = (e: React.MouseEvent<HTMLLIElement, MouseEvent>, seriesName: string) => {
+  const onLegendItemClick = (e: React.MouseEvent<HTMLElement, MouseEvent>, seriesName: string) => {
     const isModifiedClick = e.metaKey || e.shiftKey;
 
     setSelectedSeriesNames((current) => {


### PR DESCRIPTION
Prior to this fix, the entire legend would be rendered. This causes browser performance issues when there are a lot of items.

This fix modifies the legend to do the following:
- Virtualize the list variation of the legend.
- The `Right` positioned legend will always be virtualized because it always uses the list variation of the legend. The UX is consistent with prior behavior.
- The `Bottom` positioned legend will continue to use the compact, non-virtualized varation of the legend when it has a relative small (<500) items. When it has a larger (>= 500) items, it will instead be rendered with the list variation of the legend, so it can be virtualized. This is necessary because it would be very difficult to virtualize the compact view. The UX of skimming hundreds of items is much harder with the compact view, so this change also may assist with UX even if we are primarily doing it for performance reasons.
- Fixes broken ellipsizing of truncated labels.

# Notes for reviewers

- Please pull down the changes and test this out. The legend has a bunch of complex behavior, and I want to be extra-sure I didn't break any edge cases while trying to fix the performance.
- CCing @saminzadeh  on this because I _think_ some of his work was impacted by the perf issues, so he might be interested in the outcomes.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

# TODOs

- [X] Fix ellipsizing.
- [x] Some cross-browser testing. I'll make sure I do this before merging to be extra-sure all the behaviors work as expected.

# Screenshots 

*The loom video was made before I fixed the ellipsizing, but should still give you a sense of the major virtualization changes.*
[Loom video to describe the dynamic behavior](https://www.loom.com/share/7c25f2d3e5c64490991e612906083c7e)

*Screenshots are updated to the latest code with the ellipsizing fixes.*

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/396962/230231526-3175d851-8e6c-45fc-bd32-0c31f2e7225e.png">

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/396962/230231568-b1dcc35c-40bd-4269-9df2-0f746162a036.png">

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/396962/230232044-b4786e82-1e19-4ad1-8716-396675e7a64a.png">
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/396962/230232083-5459f6d7-2d46-46d8-9d5c-5e6e7b39882f.png">




## Ellipsizing fix
<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/396962/230231325-cbcea163-c506-450d-9881-d7bff1543cde.png">


</td>
		<td>
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/396962/230231345-2adce543-ba24-4343-bb8e-0a1ee30e6a5b.png">

</td>
	</tr>
</table>