### PR TITLE
[WIP] Categorical contrast color palette that is consistent across panels

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -174,6 +174,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
           formattedSeriesName,
           seriesCount,
           echartsPalette as string[],
+          echartsPalette[0],
           visual.palette?.kind
         );
         seriesCount++; // used for repeating colors in Categorical palette

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.test.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.test.ts
@@ -14,23 +14,49 @@
 import { getSeriesColor } from './palette-gen';
 
 describe('getSeriesColor', () => {
+  const fallbackColor = '#ff0000';
+
   it('should return Auto generated color', () => {
-    const value = getSeriesColor('p90 test api subdomain', 2, ['#fff', '000', '#111', '#222', '#333'], 'Auto');
+    const value = getSeriesColor(
+      'p90 test api subdomain',
+      2,
+      ['#fff', '000', '#111', '#222', '#333'],
+      '#ff0000',
+      'Auto'
+    );
     expect(value).toEqual('hsla(1008901844,50%,50%,0.8)');
   });
 
   it('should return 1st color in Categorical palette', () => {
-    const value = getSeriesColor('p90 test api subdomain', 0, ['#fff', '000', '#111', '#222', '#333'], 'Categorical');
+    const value = getSeriesColor(
+      'p90 test api subdomain',
+      0,
+      ['#fff', '000', '#111', '#222', '#333'],
+      fallbackColor,
+      'Categorical'
+    );
     expect(value).toEqual('#fff');
   });
 
   it('should return 3rd color in Categorical palette', () => {
-    const value = getSeriesColor('p90 test api subdomain', 2, ['#fff', '000', '#111', '#222', '#333'], 'Categorical');
+    const value = getSeriesColor(
+      'p90 test api subdomain',
+      2,
+      ['#fff', '000', '#111', '#222', '#333'],
+      fallbackColor,
+      'Categorical'
+    );
     expect(value).toEqual('#111');
   });
 
   it('should return repeated 1st color in Categorical palette', () => {
-    const value = getSeriesColor('p90 test api subdomain', 5, ['#fff', '000', '#111', '#222', '#333'], 'Categorical');
+    const value = getSeriesColor(
+      'p90 test api subdomain',
+      5,
+      ['#fff', '000', '#111', '#222', '#333'],
+      fallbackColor,
+      'Categorical'
+    );
     expect(value).toEqual('#fff');
   });
 });

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.test.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.test.ts
@@ -16,7 +16,7 @@ import { getSeriesColor } from './palette-gen';
 describe('getSeriesColor', () => {
   const fallbackColor = '#ff0000';
 
-  it('should return Auto generated color', () => {
+  it('should return generated color from series name', () => {
     const value = getSeriesColor(
       'p90 test api subdomain',
       2,
@@ -24,7 +24,12 @@ describe('getSeriesColor', () => {
       '#ff0000',
       'Auto'
     );
-    expect(value).toEqual('hsla(1008901844,50%,50%,0.8)');
+    expect(value).toEqual('#8DD3C7');
+  });
+
+  it('should return alternate contrast palette color', () => {
+    const value = getSeriesColor('test series name', 3, ['#fff', '000', '#111', '#222', '#333'], '#ff0000', 'Auto');
+    expect(value).toEqual('#01FFFE');
   });
 
   it('should return 1st color in Categorical palette', () => {

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -52,19 +52,21 @@ export function getSeriesColor(
 
 interface StringToColorInstance {
   stringToColorHash: Record<string, string | undefined>;
-  nextVeryDifferentColorIdx: number;
-  veryDifferentColors: string[];
+  contrastPaletteColorIdx: number;
+  contrastPalette: string[];
 }
 
 /*
- * Color conversion from string using palette for contrast
- * https://stackoverflow.com/a/31037383/17575201
+ * Color conversion from string using predefined palette for contrast
+ * String to color approach from: https://stackoverflow.com/a/31037383/17575201
+ * Contrast colors started from: https://stackoverflow.com/a/12224359/17575201
  */
 export const stringToColor = (() => {
   const instance: StringToColorInstance = {
     stringToColorHash: {},
-    nextVeryDifferentColorIdx: 0,
-    veryDifferentColors: [
+    contrastPaletteColorIdx: 0,
+    contrastPalette: [
+      '#8DD3C7', // Turquoise
       '#01FFFE', // Cyan
       '#FFA6FE', // Pink
       '#006401', // Dark Green
@@ -72,13 +74,12 @@ export const stringToColor = (() => {
       '#95003A', // Dark Red
       '#007DB5', // Azure
       '#FF00F6', // Magenta
-      '#FFEEE8', // Very Light Pink
       '#774D00', // Dark Brown
       '#90FB92', // Light Green
       '#0076FF', // Azure Blue
       '#FF937E', // Light Salmon
       '#6A826C', // Khaki
-      '#FF029D', // Magenta (pink-purple)
+      '#FF029D', // Magenta
       '#FE8900', // Dark Orange
       '#7A4782', // Dark Purple
       '#7E2DD2', // Purple
@@ -103,29 +104,14 @@ export const stringToColor = (() => {
       '#BE9970', // Tan
       '#968AE8', // Light Lavender
       '#BB8800', // Goldenrod
-      '#43002C', // Dark Raspberry (Purplish Red)
+      '#43002C', // Dark Raspberry
     ],
-    // https://colorbrewer2.org/#type=qualitative&scheme=Paired&n=12
-    // veryDifferentColors: [
-    //   '#a6cee3',
-    //   '#1f78b4',
-    //   '#b2df8a',
-    //   '#33a02c',
-    //   '#fb9a99',
-    //   '#e31a1c',
-    //   '#fdbf6f',
-    //   '#ff7f00',
-    //   '#cab2d6',
-    //   '#6a3d9a',
-    //   '#ffff99',
-    //   '#b15928',
-    // ],
   };
 
   return {
     next: (str: string) => {
       if (!instance.stringToColorHash[str]) {
-        instance.stringToColorHash[str] = instance.veryDifferentColors[instance.nextVeryDifferentColorIdx++];
+        instance.stringToColorHash[str] = instance.contrastPalette[instance.contrastPaletteColorIdx++];
       }
       return instance.stringToColorHash[str];
     },

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -111,7 +111,9 @@ export const stringToColor = (() => {
   return {
     next: (str: string) => {
       if (!instance.stringToColorHash[str]) {
-        instance.stringToColorHash[str] = instance.contrastPalette[instance.contrastPaletteColorIdx++];
+        instance.contrastPaletteColorIdx++;
+        instance.contrastPaletteColorIdx %= instance.contrastPalette.length;
+        instance.stringToColorHash[str] = instance.contrastPalette[instance.contrastPaletteColorIdx];
       }
       return instance.stringToColorHash[str];
     },

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -45,5 +45,95 @@ export function getSeriesColor(
   }
 
   // corresponds to 'Auto' in palette.kind
-  return getRandomColor(name);
+  // return getRandomColor(name);
+  const generatedColor = stringToColor.next(name);
+  return generatedColor;
 }
+
+/*
+ * Color conversion from string using palette for contrast
+ * https://stackoverflow.com/a/31037383/17575201
+ */
+
+const stringToColor = (function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let instance: any = null;
+  return {
+    next: function stringToColor(str: string) {
+      if (instance === null) {
+        instance = {};
+        instance.stringToColorHash = {};
+        instance.nextVeryDifferntColorIdx = 0;
+        instance.veryDifferentColors = [
+          '#000000',
+          '#00FF00',
+          '#0000FF',
+          '#FF0000',
+          '#01FFFE',
+          '#FFA6FE',
+          '#FFDB66',
+          '#006401',
+          '#010067',
+          '#95003A',
+          '#007DB5',
+          '#FF00F6',
+          '#FFEEE8',
+          '#774D00',
+          '#90FB92',
+          '#0076FF',
+          '#D5FF00',
+          '#FF937E',
+          '#6A826C',
+          '#FF029D',
+          '#FE8900',
+          '#7A4782',
+          '#7E2DD2',
+          '#85A900',
+          '#FF0056',
+          '#A42400',
+          '#00AE7E',
+          '#683D3B',
+          '#BDC6FF',
+          '#263400',
+          '#BDD393',
+          '#00B917',
+          '#9E008E',
+          '#001544',
+          '#C28C9F',
+          '#FF74A3',
+          '#01D0FF',
+          '#004754',
+          '#E56FFE',
+          '#788231',
+          '#0E4CA1',
+          '#91D0CB',
+          '#BE9970',
+          '#968AE8',
+          '#BB8800',
+          '#43002C',
+          '#DEFF74',
+          '#00FFC6',
+          '#FFE502',
+          '#620E00',
+          '#008F9C',
+          '#98FF52',
+          '#7544B1',
+          '#B500FF',
+          '#00FF78',
+          '#FF6E41',
+          '#005F39',
+          '#6B6882',
+          '#5FAD4E',
+          '#A75740',
+          '#A5FFD2',
+          '#FFB167',
+          '#009BFF',
+          '#E85EBE',
+        ];
+      }
+      if (!instance.stringToColorHash[str])
+        instance.stringToColorHash[str] = instance.veryDifferentColors[instance.nextVeryDifferntColorIdx++];
+      return instance.stringToColorHash[str] as string;
+    },
+  };
+})();

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -65,71 +65,61 @@ export const stringToColor = (() => {
     stringToColorHash: {},
     nextVeryDifferentColorIdx: 0,
     veryDifferentColors: [
-      '#000000',
-      '#00FF00',
-      '#0000FF',
-      '#FF0000',
-      '#01FFFE',
-      '#FFA6FE',
-      '#FFDB66',
-      '#006401',
-      '#010067',
-      '#95003A',
-      '#007DB5',
-      '#FF00F6',
-      '#FFEEE8',
-      '#774D00',
-      '#90FB92',
-      '#0076FF',
-      '#D5FF00',
-      '#FF937E',
-      '#6A826C',
-      '#FF029D',
-      '#FE8900',
-      '#7A4782',
-      '#7E2DD2',
-      '#85A900',
-      '#FF0056',
-      '#A42400',
-      '#00AE7E',
-      '#683D3B',
-      '#BDC6FF',
-      '#263400',
-      '#BDD393',
-      '#00B917',
-      '#9E008E',
-      '#001544',
-      '#C28C9F',
-      '#FF74A3',
-      '#01D0FF',
-      '#004754',
-      '#E56FFE',
-      '#788231',
-      '#0E4CA1',
-      '#91D0CB',
-      '#BE9970',
-      '#968AE8',
-      '#BB8800',
-      '#43002C',
-      '#DEFF74',
-      '#00FFC6',
-      '#FFE502',
-      '#620E00',
-      '#008F9C',
-      '#98FF52',
-      '#7544B1',
-      '#B500FF',
-      '#00FF78',
-      '#FF6E41',
-      '#005F39',
-      '#6B6882',
-      '#5FAD4E',
-      '#A75740',
-      '#A5FFD2',
-      '#FFB167',
-      '#009BFF',
-      '#E85EBE',
+      '#01FFFE', // Cyan
+      '#FFA6FE', // Pink
+      '#006401', // Dark Green
+      '#010067', // Dark Blue
+      '#95003A', // Dark Red
+      '#007DB5', // Azure
+      '#FF00F6', // Magenta
+      '#FFEEE8', // Very Light Pink
+      '#774D00', // Dark Brown
+      '#90FB92', // Light Green
+      '#0076FF', // Azure Blue
+      '#FF937E', // Light Salmon
+      '#6A826C', // Khaki
+      '#FF029D', // Magenta (pink-purple)
+      '#FE8900', // Dark Orange
+      '#7A4782', // Dark Purple
+      '#7E2DD2', // Purple
+      '#85A900', // Olive
+      '#FF0056', // Red
+      '#A42400', // Burnt Umber
+      '#00AE7E', // Green
+      '#683D3B', // Reddish Brown
+      '#BDC6FF', // Light Blue
+      '#263400', // Dark Olive Green
+      '#BDD393', // Light Greenish Gray
+      '#9E008E', // Deep Magenta
+      '#001544', // Dark Blue (Navy)
+      '#C28C9F', // Pale Pinkish Grey
+      '#FF74A3', // Light Pink
+      '#01D0FF', // Bright Cyan
+      '#004754', // Very Dark Blue
+      '#E56FFE', // Pinkish Purple
+      '#788231', // Olive Drab
+      '#0E4CA1', // Indigo
+      '#91D0CB', // Light Bluish Green
+      '#BE9970', // Tan
+      '#968AE8', // Light Lavender
+      '#BB8800', // Goldenrod
+      '#43002C', // Dark Raspberry (Purplish Red)
     ],
+    // https://colorbrewer2.org/#type=qualitative&scheme=Paired&n=12
+    // veryDifferentColors: [
+    //   '#a6cee3',
+    //   '#1f78b4',
+    //   '#b2df8a',
+    //   '#33a02c',
+    //   '#fb9a99',
+    //   '#e31a1c',
+    //   '#fdbf6f',
+    //   '#ff7f00',
+    //   '#cab2d6',
+    //   '#6a3d9a',
+    //   '#ffff99',
+    //   '#b15928',
+    // ],
   };
 
   return {

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -55,85 +55,90 @@ export function getSeriesColor(
  * https://stackoverflow.com/a/31037383/17575201
  */
 
-const stringToColor = (function () {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let instance: any = null;
+interface StringToColorInstance {
+  stringToColorHash: Record<string, string>;
+  nextVeryDifferentColorIdx: number;
+  veryDifferentColors: string[];
+}
+
+export const stringToColor = (() => {
+  const instance: StringToColorInstance = {
+    stringToColorHash: {},
+    nextVeryDifferentColorIdx: 0,
+    veryDifferentColors: [
+      '#000000',
+      '#00FF00',
+      '#0000FF',
+      '#FF0000',
+      '#01FFFE',
+      '#FFA6FE',
+      '#FFDB66',
+      '#006401',
+      '#010067',
+      '#95003A',
+      '#007DB5',
+      '#FF00F6',
+      '#FFEEE8',
+      '#774D00',
+      '#90FB92',
+      '#0076FF',
+      '#D5FF00',
+      '#FF937E',
+      '#6A826C',
+      '#FF029D',
+      '#FE8900',
+      '#7A4782',
+      '#7E2DD2',
+      '#85A900',
+      '#FF0056',
+      '#A42400',
+      '#00AE7E',
+      '#683D3B',
+      '#BDC6FF',
+      '#263400',
+      '#BDD393',
+      '#00B917',
+      '#9E008E',
+      '#001544',
+      '#C28C9F',
+      '#FF74A3',
+      '#01D0FF',
+      '#004754',
+      '#E56FFE',
+      '#788231',
+      '#0E4CA1',
+      '#91D0CB',
+      '#BE9970',
+      '#968AE8',
+      '#BB8800',
+      '#43002C',
+      '#DEFF74',
+      '#00FFC6',
+      '#FFE502',
+      '#620E00',
+      '#008F9C',
+      '#98FF52',
+      '#7544B1',
+      '#B500FF',
+      '#00FF78',
+      '#FF6E41',
+      '#005F39',
+      '#6B6882',
+      '#5FAD4E',
+      '#A75740',
+      '#A5FFD2',
+      '#FFB167',
+      '#009BFF',
+      '#E85EBE',
+    ],
+  };
+
   return {
-    next: function stringToColor(str: string) {
-      if (instance === null) {
-        instance = {};
-        instance.stringToColorHash = {};
-        instance.nextVeryDifferntColorIdx = 0;
-        instance.veryDifferentColors = [
-          '#000000',
-          '#00FF00',
-          '#0000FF',
-          '#FF0000',
-          '#01FFFE',
-          '#FFA6FE',
-          '#FFDB66',
-          '#006401',
-          '#010067',
-          '#95003A',
-          '#007DB5',
-          '#FF00F6',
-          '#FFEEE8',
-          '#774D00',
-          '#90FB92',
-          '#0076FF',
-          '#D5FF00',
-          '#FF937E',
-          '#6A826C',
-          '#FF029D',
-          '#FE8900',
-          '#7A4782',
-          '#7E2DD2',
-          '#85A900',
-          '#FF0056',
-          '#A42400',
-          '#00AE7E',
-          '#683D3B',
-          '#BDC6FF',
-          '#263400',
-          '#BDD393',
-          '#00B917',
-          '#9E008E',
-          '#001544',
-          '#C28C9F',
-          '#FF74A3',
-          '#01D0FF',
-          '#004754',
-          '#E56FFE',
-          '#788231',
-          '#0E4CA1',
-          '#91D0CB',
-          '#BE9970',
-          '#968AE8',
-          '#BB8800',
-          '#43002C',
-          '#DEFF74',
-          '#00FFC6',
-          '#FFE502',
-          '#620E00',
-          '#008F9C',
-          '#98FF52',
-          '#7544B1',
-          '#B500FF',
-          '#00FF78',
-          '#FF6E41',
-          '#005F39',
-          '#6B6882',
-          '#5FAD4E',
-          '#A75740',
-          '#A5FFD2',
-          '#FFB167',
-          '#009BFF',
-          '#E85EBE',
-        ];
+    next: (str: string) => {
+      if (!instance.stringToColorHash[str]) {
+        instance.stringToColorHash[str] = instance.veryDifferentColors[instance.nextVeryDifferentColorIdx++] ?? '#000';
       }
-      if (!instance.stringToColorHash[str])
-        instance.stringToColorHash[str] = instance.veryDifferentColors[instance.nextVeryDifferntColorIdx++];
-      return instance.stringToColorHash[str] as string;
+      return instance.stringToColorHash[str];
     },
   };
 })();

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -33,6 +33,7 @@ export function getSeriesColor(
   name: string,
   seriesCount: number,
   palette: string[],
+  fallbackColor: string,
   paletteKind: PaletteOptions['kind'] = 'Auto'
 ): string {
   if (paletteKind === 'Categorical' && Array.isArray(palette)) {
@@ -45,22 +46,20 @@ export function getSeriesColor(
   }
 
   // corresponds to 'Auto' in palette.kind
-  // return getRandomColor(name);
   const generatedColor = stringToColor.next(name);
-  return generatedColor;
+  return generatedColor ?? fallbackColor;
+}
+
+interface StringToColorInstance {
+  stringToColorHash: Record<string, string | undefined>;
+  nextVeryDifferentColorIdx: number;
+  veryDifferentColors: string[];
 }
 
 /*
  * Color conversion from string using palette for contrast
  * https://stackoverflow.com/a/31037383/17575201
  */
-
-interface StringToColorInstance {
-  stringToColorHash: Record<string, string>;
-  nextVeryDifferentColorIdx: number;
-  veryDifferentColors: string[];
-}
-
 export const stringToColor = (() => {
   const instance: StringToColorInstance = {
     stringToColorHash: {},
@@ -136,7 +135,7 @@ export const stringToColor = (() => {
   return {
     next: (str: string) => {
       if (!instance.stringToColorHash[str]) {
-        instance.stringToColorHash[str] = instance.veryDifferentColors[instance.nextVeryDifferentColorIdx++] ?? '#000';
+        instance.stringToColorHash[str] = instance.veryDifferentColors[instance.nextVeryDifferentColorIdx++];
       }
       return instance.stringToColorHash[str];
     },


### PR DESCRIPTION
Follow up to #1079, this branch has a demo of another approach: 
 * Color conversion using predefined palette for contrast
 * Overall approach adapted from: https://stackoverflow.com/a/31037383/17575201
 * Contrast colors started from: https://stackoverflow.com/a/12224359/17575201

_Downside here is the colors have a lot of contrast, but they start to repeat after 38 timeseries_

https://user-images.githubusercontent.com/9369625/230654974-641f980e-7233-4e25-84c0-60bc6574d75b.mov

![image](https://user-images.githubusercontent.com/9369625/230655711-06ab930e-1c1f-4cbd-8fa5-1a455fa3106f.png)


