### PR TITLE
[BUGFIX] Stat chart value to use threshold color

### DIFF
--- a/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
+++ b/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
@@ -34,8 +34,8 @@ export const OptionsEditorControl = ({ label, control, description }: OptionsEdi
   return (
     <FormControl>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
-        <FormLabel htmlFor={controlId}>
-          {label}
+        <Stack direction="row" alignItems="center" justifyContent="center">
+          <FormLabel htmlFor={controlId}>{label}</FormLabel>
           {description && (
             <InfoTooltip description={description} enterDelay={100}>
               <IconButton
@@ -51,7 +51,7 @@ export const OptionsEditorControl = ({ label, control, description }: OptionsEdi
               </IconButton>
             </InfoTooltip>
           )}
-        </FormLabel>
+        </Stack>
         <Box sx={{ width: '150px', textAlign: 'right' }}> {React.cloneElement(control, controlProps)}</Box>
       </Stack>
     </FormControl>

--- a/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
+++ b/ui/components/src/OptionsEditorLayout/OptionsEditorControl.tsx
@@ -11,13 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FormControl, FormLabel, FormControlLabelProps, Stack, Box } from '@mui/material';
+import { FormControl, FormLabel, FormControlLabelProps, Stack, Box, IconButton } from '@mui/material';
 import React from 'react';
+import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import { useId } from '../utils';
+import { InfoTooltip } from '../InfoTooltip';
 
-export type OptionsEditorControlProps = Pick<FormControlLabelProps, 'label' | 'control'>;
+export type OptionsEditorControlProps = Pick<FormControlLabelProps, 'label' | 'control'> & {
+  description?: string;
+};
 
-export const OptionsEditorControl = ({ label, control }: OptionsEditorControlProps) => {
+export const OptionsEditorControl = ({ label, control, description }: OptionsEditorControlProps) => {
   // Make sure we have a unique ID we can use for associating labels and
   // controls for a11y.
   const generatedControlId = useId('EditorSectionControl');
@@ -30,7 +34,24 @@ export const OptionsEditorControl = ({ label, control }: OptionsEditorControlPro
   return (
     <FormControl>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
-        <FormLabel htmlFor={controlId}>{label}</FormLabel>
+        <FormLabel htmlFor={controlId}>
+          {label}
+          {description && (
+            <InfoTooltip description={description} enterDelay={100}>
+              <IconButton
+                size="small"
+                sx={(theme) => ({ borderRadius: theme.shape.borderRadius, padding: '4x', margin: '0 2px' })}
+              >
+                <InformationOutlineIcon
+                  aria-describedby="info-tooltip"
+                  aria-hidden={false}
+                  fontSize="inherit"
+                  sx={{ color: (theme) => theme.palette.grey[700] }}
+                />
+              </IconButton>
+            </InfoTooltip>
+          )}
+        </FormLabel>
         <Box sx={{ width: '150px', textAlign: 'right' }}> {React.cloneElement(control, controlProps)}</Box>
       </Stack>
     </FormControl>

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -38,11 +38,12 @@ export interface StatChartProps {
   height: number;
   data: StatChartData;
   unit: UnitOptions;
+  color?: string;
   sparkline?: LineSeriesOption;
 }
 
 export function StatChart(props: StatChartProps) {
-  const { width, height, data, unit, sparkline } = props;
+  const { width, height, data, unit, color, sparkline } = props;
   const chartsTheme = useChartsTheme();
 
   const formattedValue = data.calculatedValue === undefined ? '' : formatValue(data.calculatedValue, unit);
@@ -108,7 +109,7 @@ export function StatChart(props: StatChartProps) {
       <Typography
         variant="h3"
         sx={(theme) => ({
-          color: theme.palette.text.primary,
+          color: color ?? theme.palette.text.primary,
           fontSize: `clamp(${MIN_VALUE_SIZE}px, ${valueSize}px, ${MAX_VALUE_SIZE}px)`,
           padding: `${containerPadding} ${containerPadding} 0 ${containerPadding}`,
         })}

--- a/ui/components/src/ThresholdsEditor/ThresholdInput.tsx
+++ b/ui/components/src/ThresholdsEditor/ThresholdInput.tsx
@@ -12,8 +12,9 @@
 // limitations under the License.
 
 import { RefObject, useState } from 'react';
-import { Stack, FormLabel, TextField, IconButton } from '@mui/material';
+import { Stack, FormLabel, TextField, IconButton, Box } from '@mui/material';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import { ThresholdOptions } from '@perses-dev/core';
 import { ThresholdColorPicker } from './ThresholdColorPicker';
 
 export interface ThresholdInputProps {
@@ -25,6 +26,7 @@ export interface ThresholdInputProps {
   onBlur: () => void;
   onDelete: () => void;
   inputRef?: RefObject<HTMLInputElement | null>;
+  mode?: ThresholdOptions['mode'];
 }
 
 export function ThresholdInput({
@@ -32,6 +34,7 @@ export function ThresholdInput({
   label,
   color,
   value,
+  mode,
   onChange,
   onColorChange,
   onBlur,
@@ -56,6 +59,9 @@ export function ThresholdInput({
             onBlur();
             setKey(key + 1);
           }
+        }}
+        InputProps={{
+          endAdornment: mode === 'Percent' ? <Box paddingX={1}>%</Box> : undefined,
         }}
       />
       <IconButton aria-label={`delete threshold ${label}`} size="small" onClick={onDelete}>

--- a/ui/components/src/ThresholdsEditor/ThresholdsEditor.tsx
+++ b/ui/components/src/ThresholdsEditor/ThresholdsEditor.tsx
@@ -17,9 +17,8 @@ import { IconButton, ToggleButton, ToggleButtonGroup, Typography } from '@mui/ma
 import PlusIcon from 'mdi-material-ui/Plus';
 import { Stack } from '@mui/system';
 import { ThresholdOptions } from '@perses-dev/core';
-import { InfoTooltip } from '../InfoTooltip';
 import { useChartsTheme } from '../context/ChartsThemeProvider';
-import { OptionsEditorGroup } from '../OptionsEditorLayout';
+import { OptionsEditorControl, OptionsEditorGroup } from '../OptionsEditorLayout';
 import { ThresholdColorPicker } from './ThresholdColorPicker';
 import { ThresholdInput } from './ThresholdInput';
 
@@ -85,6 +84,10 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
           draft.default_color = color;
         })
       );
+    } else {
+      onChange({
+        default_color: color,
+      });
     }
   };
 
@@ -116,7 +119,7 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
 
   const addThresholdInput = (): void => {
     focusRef.current = true;
-    if (thresholds === undefined) {
+    if (thresholds?.steps === undefined) {
       onChange({
         steps: [{ value: DEFAULT_STEP }],
       });
@@ -158,20 +161,26 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
         </IconButton>
       }
     >
-      <ToggleButtonGroup
-        exclusive
-        disabled={disablePercentMode}
-        value={thresholds?.mode ?? 'Absolute'}
-        onChange={handleModeChange}
-        sx={{ height: '36px', marginLeft: 'auto' }}
-      >
-        <ToggleButton aria-label="absolute" value="Absolute">
-          <InfoTooltip description="Absolute">#</InfoTooltip>
-        </ToggleButton>
-        <ToggleButton aria-label="percent" value="Percent">
-          <InfoTooltip description="Percentage means thresholds relative to min & max">%</InfoTooltip>
-        </ToggleButton>
-      </ToggleButtonGroup>
+      <OptionsEditorControl
+        label="Mode"
+        description="Percentage means thresholds relative to min & max"
+        control={
+          <ToggleButtonGroup
+            exclusive
+            disabled={disablePercentMode}
+            value={thresholds?.mode ?? 'Absolute'}
+            onChange={handleModeChange}
+            sx={{ height: '36px', marginLeft: 'auto' }}
+          >
+            <ToggleButton aria-label="absolute" value="Absolute" sx={{ fontWeight: 500 }}>
+              Absolute
+            </ToggleButton>
+            <ToggleButton aria-label="percent" value="Percent" sx={{ fontWeight: 500 }}>
+              Percent
+            </ToggleButton>
+          </ToggleButtonGroup>
+        }
+      />
       {steps &&
         steps
           .map((step, i) => (
@@ -181,6 +190,7 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
               label={`T${i + 1}`}
               color={step.color ?? palette[i] ?? defaultThresholdColor}
               value={step.value}
+              mode={thresholds?.mode}
               onColorChange={(color) => handleThresholdColorChange(color, i)}
               onChange={(e) => {
                 handleThresholdValueChange(e, i);

--- a/ui/components/src/ThresholdsEditor/ThresholdsEditor.tsx
+++ b/ui/components/src/ThresholdsEditor/ThresholdsEditor.tsx
@@ -19,6 +19,7 @@ import { Stack } from '@mui/system';
 import { ThresholdOptions } from '@perses-dev/core';
 import { useChartsTheme } from '../context/ChartsThemeProvider';
 import { OptionsEditorControl, OptionsEditorGroup } from '../OptionsEditorLayout';
+import { InfoTooltip } from '../InfoTooltip';
 import { ThresholdColorPicker } from './ThresholdColorPicker';
 import { ThresholdInput } from './ThresholdInput';
 
@@ -119,10 +120,16 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
 
   const addThresholdInput = (): void => {
     focusRef.current = true;
-    if (thresholds?.steps === undefined) {
+    if (thresholds === undefined) {
       onChange({
         steps: [{ value: DEFAULT_STEP }],
       });
+    } else if (thresholds && thresholds.steps === undefined) {
+      onChange(
+        produce(thresholds, (draft) => {
+          draft.steps = [{ value: DEFAULT_STEP }];
+        })
+      );
     } else {
       onChange(
         produce(thresholds, (draft) => {
@@ -156,9 +163,11 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
     <OptionsEditorGroup
       title="Thresholds"
       icon={
-        <IconButton size="small" aria-label="add threshold" onClick={addThresholdInput}>
-          <PlusIcon />
-        </IconButton>
+        <InfoTooltip description={'Add threshold'}>
+          <IconButton size="small" aria-label="add threshold" onClick={addThresholdInput}>
+            <PlusIcon />
+          </IconButton>
+        </InfoTooltip>
       }
     >
       <OptionsEditorControl

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -18,7 +18,7 @@ import { TimeSeriesData } from '@perses-dev/core';
 import { useTimeSeriesQuery, PanelProps, CalculationsMap, CalculationType } from '@perses-dev/plugin-system';
 import { useSuggestedStepMs } from '../../model/time';
 import { StatChartOptions } from './stat-chart-model';
-import { convertSparkline } from './utils/data-transform';
+import { convertSparkline, getColorFromThresholds } from './utils/data-transform';
 
 export type StatChartPanelProps = PanelProps<StatChartOptions>;
 
@@ -54,6 +54,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
       height={contentDimensions.height}
       data={chartData}
       unit={unit}
+      color={getColorFromThresholds(chartsTheme, thresholds, chartData.calculatedValue)}
       sparkline={convertSparkline(chartsTheme, sparkline, thresholds, chartData.calculatedValue)}
     />
   );

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
@@ -35,15 +35,17 @@ const thresholds: ThresholdOptions = {
 };
 
 describe('getColorFromThresholds', () => {
-  it('should return default color if defined', () => {
-    const defaultColor = 'pink';
-    const value = getColorFromThresholds(testChartsTheme, thresholds, 5, defaultColor);
-    expect(value).toEqual(defaultColor);
-  });
+  describe('if threshold is not met', () => {
+    it('should return thresholds.default_color if defined', () => {
+      const default_color = 'purple';
+      const value = getColorFromThresholds(testChartsTheme, { ...thresholds, default_color }, 5);
+      expect(value).toEqual(default_color);
+    });
 
-  it('should return charts theme default threshold color if default color is undefined', () => {
-    const value = getColorFromThresholds(testChartsTheme, thresholds, 5);
-    expect(value).toEqual(testChartsTheme.thresholds.defaultColor);
+    it('should return charts theme default threshold color if thresholds.default_color is undefined', () => {
+      const value = getColorFromThresholds(testChartsTheme, thresholds, 5);
+      expect(value).toEqual(testChartsTheme.thresholds.defaultColor);
+    });
   });
 
   it('should return orange if value meets the threshold', () => {
@@ -57,17 +59,23 @@ describe('convertSparkline', () => {
     color: 'purple',
   };
 
-  it('should render charts theme default threshold color if sparkline.color is undefined', () => {
+  it('should render charts theme default threshold color', () => {
     testChartsTheme.thresholds.defaultColor = 'green';
     const options = convertSparkline(testChartsTheme, {}, thresholds, 5) as LineSeriesOption;
     expect(options.lineStyle?.color).toEqual('green');
     expect(options.areaStyle?.color).toEqual('green');
   });
 
-  it('should render sparkline.color if threshold is not met ', () => {
-    const options = convertSparkline(testChartsTheme, sparkline, thresholds, 5) as LineSeriesOption;
-    expect(options.lineStyle?.color).toEqual(sparkline.color);
-    expect(options.areaStyle?.color).toEqual(sparkline.color);
+  it('should render threshold default color if threshold is not met ', () => {
+    const default_color = 'purple';
+    const options = convertSparkline(
+      testChartsTheme,
+      sparkline,
+      { ...thresholds, default_color },
+      5
+    ) as LineSeriesOption;
+    expect(options.lineStyle?.color).toEqual(default_color);
+    expect(options.areaStyle?.color).toEqual(default_color);
   });
 
   it('should render orange if value meets the threshold', () => {

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
@@ -15,28 +15,46 @@ import { testChartsTheme } from '@perses-dev/components';
 import { ThresholdOptions } from '@perses-dev/core';
 import { LineSeriesOption } from 'echarts';
 import { SparklineOptions } from '../stat-chart-model';
-import { convertSparkline } from './data-transform';
+import { convertSparkline, getColorFromThresholds } from './data-transform';
+
+const thresholds: ThresholdOptions = {
+  steps: [
+    {
+      color: 'yellow',
+      value: 10,
+    },
+    {
+      color: 'orange',
+      value: 20,
+    },
+    {
+      color: 'red',
+      value: 30,
+    },
+  ],
+};
+
+describe('getColorFromThresholds', () => {
+  it('should return default color if defined', () => {
+    const defaultColor = 'pink';
+    const value = getColorFromThresholds(testChartsTheme, thresholds, 5, defaultColor);
+    expect(value).toEqual(defaultColor);
+  });
+
+  it('should return charts theme default threshold color if default color is undefined', () => {
+    const value = getColorFromThresholds(testChartsTheme, thresholds, 5);
+    expect(value).toEqual(testChartsTheme.thresholds.defaultColor);
+  });
+
+  it('should return orange if value meets the threshold', () => {
+    const value = getColorFromThresholds(testChartsTheme, thresholds, 25);
+    expect(value).toEqual('orange');
+  });
+});
 
 describe('convertSparkline', () => {
   const sparkline: SparklineOptions = {
     color: 'purple',
-  };
-
-  const thresholds: ThresholdOptions = {
-    steps: [
-      {
-        color: 'yellow',
-        value: 10,
-      },
-      {
-        color: 'orange',
-        value: 20,
-      },
-      {
-        color: 'red',
-        value: 30,
-      },
-    ],
   };
 
   it('should render charts theme default threshold color if sparkline.color is undefined', () => {

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
@@ -16,18 +16,15 @@ import { ThresholdOptions } from '@perses-dev/core';
 import { LineSeriesOption } from 'echarts/charts';
 import { SparklineOptions } from '../stat-chart-model';
 
-export function getColorFromThresholds(
-  chartsTheme: PersesChartsTheme,
-  thresholds?: ThresholdOptions,
-  value?: number,
-  defaultColor?: string
-) {
-  let color: string | undefined = defaultColor ?? chartsTheme.thresholds.defaultColor;
+export function getColorFromThresholds(chartsTheme: PersesChartsTheme, thresholds?: ThresholdOptions, value?: number) {
+  // thresholds color takes priority over other colors
+  const defaultColor = thresholds?.default_color ?? chartsTheme.thresholds.defaultColor;
 
   if (thresholds === undefined) {
-    return color;
+    return defaultColor;
   }
 
+  let color = defaultColor;
   if (thresholds.steps && value) {
     thresholds.steps.forEach((step, index) => {
       if (value > step.value) {
@@ -49,9 +46,9 @@ export function convertSparkline(
 ): LineSeriesOption | undefined {
   if (sparkline === undefined) return;
 
-  // TO DO: add option for color scheme? Should default color derive from threshold.defaultColor or sparkline.color?
-  const defaultColor = chartsTheme.thresholds.defaultColor ?? chartsTheme.sparkline.color;
-  const color = getColorFromThresholds(chartsTheme, thresholds, value, sparkline.color ?? defaultColor);
+  // sparkline color should always derive from thresholds
+  // ignore sparkline.color since you can always change the thresholds default color
+  const color = getColorFromThresholds(chartsTheme, thresholds, value);
 
   return {
     lineStyle: {

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
@@ -16,6 +16,31 @@ import { ThresholdOptions } from '@perses-dev/core';
 import { LineSeriesOption } from 'echarts/charts';
 import { SparklineOptions } from '../stat-chart-model';
 
+export function getColorFromThresholds(
+  chartsTheme: PersesChartsTheme,
+  thresholds?: ThresholdOptions,
+  value?: number,
+  defaultColor?: string
+) {
+  let color: string | undefined = defaultColor ?? chartsTheme.thresholds.defaultColor;
+
+  if (thresholds === undefined) {
+    return color;
+  }
+
+  if (thresholds.steps && value) {
+    thresholds.steps.forEach((step, index) => {
+      if (value > step.value) {
+        color = step.color ?? chartsTheme.thresholds.palette[index] ?? defaultColor;
+      } else {
+        // thresholds.steps should be in ascending order, so return if value is less than step.value
+        return;
+      }
+    });
+  }
+  return color;
+}
+
 export function convertSparkline(
   chartsTheme: PersesChartsTheme,
   sparkline?: SparklineOptions,
@@ -26,18 +51,7 @@ export function convertSparkline(
 
   // TO DO: add option for color scheme? Should default color derive from threshold.defaultColor or sparkline.color?
   const defaultColor = chartsTheme.thresholds.defaultColor ?? chartsTheme.sparkline.color;
-  let color: string = sparkline.color ?? defaultColor;
-
-  if (thresholds?.steps && value) {
-    thresholds.steps.forEach((step, index) => {
-      if (value > step.value) {
-        color = step.color ?? chartsTheme.thresholds.palette[index] ?? defaultColor;
-      } else {
-        // thresholds.steps should be in ascending order, so return if value is less than step.value
-        return;
-      }
-    });
-  }
+  const color = getColorFromThresholds(chartsTheme, thresholds, value, sparkline.color ?? defaultColor);
 
   return {
     lineStyle: {


### PR DESCRIPTION
Stat chart value wasn't using threshold color, so if sparkline was disabled, you could not tell if the chart met the threshold or not.

**BEFORE**
![image](https://user-images.githubusercontent.com/9817826/230674347-8165bc07-b5e9-40f6-8ed7-988b244a69cd.png)

**AFTER**
![image](https://user-images.githubusercontent.com/9817826/230673947-ded062e5-b98f-4b1a-bd73-627772bce710.png)


Also updated the look of Thresholds Editor:

![image](https://user-images.githubusercontent.com/9817826/230941808-9901c735-a4b8-4958-a248-1faae1e8a06a.png)
