### PR TITLE
[BUGFIX] List variable input label should match fieldset

### DIFF
--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -104,7 +104,7 @@ function ListVariable({ name }: TemplateVariableProps) {
         <Select
           sx={{ minWidth: 100, maxWidth: 250 }}
           id={name}
-          label={name}
+          label={title}
           value={selectValue}
           onChange={(e) => {
             // Must be selected

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -17,7 +17,7 @@ import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
 import { VariableDefinition } from '@perses-dev/core';
 import { useTemplateVariableDefinitions } from '../../context';
-import { TemplateVariable } from './Variable';
+import { TemplateVariable } from './TemplateVariable';
 
 const VARIABLE_INPUT_MIN_WIDTH = '120px';
 const VARIABLE_INPUT_MAX_WIDTH = '240px';

--- a/ui/dashboards/src/components/Variables/index.tsx
+++ b/ui/dashboards/src/components/Variables/index.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 export * from './EditVariablesButton';
-export * from './Variable';
+export * from './TemplateVariable';
 export * from './VariableEditor';
 export * from './VariableEditorForm';
 export * from './VariableList';


### PR DESCRIPTION
Prior to this fix, the list variable used the variable's display name for the accessible input label and the variable's name for the `label` field on the select, which is turned into a `fieldset` that is used to leave space for the label in MUI. When these values have mismatched sizes, this can lead to unexpected rendering of the label.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).

# Screenshots

You can reproduce this bug by giving a list-based template variable a short name and a long display name. This bug does not happen in text-based template variables.

## Before the fix

<img width="236" alt="image" src="https://user-images.githubusercontent.com/396962/230686918-92f0bfd0-3146-405b-8faa-2f62c9b19238.png">


## After the fix

<img width="236" alt="image" src="https://user-images.githubusercontent.com/396962/230686900-fba59d77-ac92-49f5-9912-5792a6bca945.png">
