### PR TITLE
[ENHANCEMENT] Format bytes with units that are powers of 1000

### DIFF
--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -44,6 +44,7 @@
     "lodash-es": "^4.17.21",
     "mathjs": "^10.6.4",
     "mdi-material-ui": "^7.4.0",
+    "numbro": "^2.3.6",
     "react-colorful": "^5.6.1",
     "react-error-boundary": "^3.1.4",
     "react-window": "^1.8.8"

--- a/ui/components/src/model/units/bytes.test.ts
+++ b/ui/components/src/model/units/bytes.test.ts
@@ -1,0 +1,231 @@
+import { UnitTestCase } from './units.test';
+
+export const bytesTests: UnitTestCase[] = [
+  { value: 0, unit: { kind: 'Bytes' }, expected: '0 bytes' },
+  { value: 1, unit: { kind: 'Bytes' }, expected: '1 byte' },
+  {
+    value: 10,
+    unit: { kind: 'Bytes' },
+    expected: '10 bytes',
+  },
+  {
+    value: 10,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '10 bytes',
+  },
+  {
+    value: 10,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '10 bytes',
+  },
+  {
+    value: 10,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '10 bytes',
+  },
+  {
+    value: 10,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '10 bytes',
+  },
+  {
+    value: 1000,
+    unit: { kind: 'Bytes' },
+    expected: '1 KB',
+  },
+  {
+    value: 1000,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '1,000 bytes',
+  },
+  {
+    value: 1000,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '1,000 bytes',
+  },
+  {
+    value: 1000,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '1 KB',
+  },
+  {
+    value: 1000,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '1 KB',
+  },
+  {
+    value: 1234,
+    unit: { kind: 'Bytes' },
+    expected: '1.23 KB',
+  },
+  {
+    value: 1234,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '1,234 bytes',
+  },
+  {
+    value: 1234,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '1,234 bytes',
+  },
+  {
+    value: 1234,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '1.23 KB',
+  },
+  {
+    value: 1234,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '1.234 KB',
+  },
+  {
+    value: 100000,
+    unit: { kind: 'Bytes' },
+    expected: '100 KB',
+  },
+  {
+    value: 100000,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '100,000 bytes',
+  },
+  {
+    value: 100000,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '100,000 bytes',
+  },
+  {
+    value: 100000,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '100 KB',
+  },
+  {
+    value: 100000,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '100 KB',
+  },
+  {
+    value: 123456,
+    unit: { kind: 'Bytes' },
+    expected: '123.46 KB',
+  },
+  {
+    value: 123456,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '123,456 bytes',
+  },
+  {
+    value: 123456,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '123,456 bytes',
+  },
+  {
+    value: 123456,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '123.46 KB',
+  },
+  {
+    value: 123456,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '123.456 KB',
+  },
+  {
+    value: 10000000,
+    unit: { kind: 'Bytes' },
+    expected: '10 MB',
+  },
+  {
+    value: 10000000,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '10,000,000 bytes',
+  },
+  {
+    value: 10000000,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '10,000,000 bytes',
+  },
+  {
+    value: 10000000,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '10 MB',
+  },
+  {
+    value: 10000000,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '10 MB',
+  },
+  {
+    value: 12345678,
+    unit: { kind: 'Bytes' },
+    expected: '12.35 MB',
+  },
+  {
+    value: 12345678,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '12,345,678 bytes',
+  },
+  {
+    value: 12345678,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '12,345,678 bytes',
+  },
+  {
+    value: 12345678,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '12.35 MB',
+  },
+  {
+    value: 12345678,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '12.3457 MB',
+  },
+  {
+    value: 1000000000,
+    unit: { kind: 'Bytes' },
+    expected: '1 GB',
+  },
+  {
+    value: 1000000000,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '1,000,000,000 bytes',
+  },
+  {
+    value: 1000000000,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '1,000,000,000 bytes',
+  },
+  {
+    value: 1000000000,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '1 GB',
+  },
+  {
+    value: 1000000000,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '1 GB',
+  },
+  {
+    value: 1234567890,
+    unit: { kind: 'Bytes' },
+    expected: '1.23 GB',
+  },
+  {
+    value: 1234567890,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '1,234,567,890 bytes',
+  },
+  {
+    value: 1234567890,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '1,234,567,890 bytes',
+  },
+  {
+    value: 1234567890,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '1.23 GB',
+  },
+  {
+    value: 1234567890,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '1.2346 GB',
+  },
+];

--- a/ui/components/src/model/units/bytes.test.ts
+++ b/ui/components/src/model/units/bytes.test.ts
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { formatValue } from './units';
 import { UnitTestCase } from './units.test';
 
-export const bytesTests: UnitTestCase[] = [
+const bytesTests: UnitTestCase[] = [
   { value: 0, unit: { kind: 'Bytes' }, expected: '0 bytes' },
   { value: 1, unit: { kind: 'Bytes' }, expected: '1 byte' },
   {
@@ -242,3 +243,10 @@ export const bytesTests: UnitTestCase[] = [
     expected: '1.2346 GB',
   },
 ];
+
+describe('formatValue', () => {
+  it.each(bytesTests)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
+    const { value, unit, expected } = args;
+    expect(formatValue(value, unit)).toEqual(expected);
+  });
+});

--- a/ui/components/src/model/units/bytes.test.ts
+++ b/ui/components/src/model/units/bytes.test.ts
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { UnitTestCase } from './units.test';
 
 export const bytesTests: UnitTestCase[] = [

--- a/ui/components/src/model/units/bytes.ts
+++ b/ui/components/src/model/units/bytes.ts
@@ -29,21 +29,19 @@ export const BYTES_GROUP_CONFIG: UnitGroupConfig = {
   abbreviate: true,
 };
 export const BYTES_UNIT_CONFIG: Readonly<Record<BytesUnitKind, UnitConfig>> = {
-  // Using units that are powers of 1000. In other words, 1KB = 1000 bytes.
+  // This uses units that are powers of 1000.
+  // In other words, 1KB = 1000 bytes.
   Bytes: {
     group: 'Bytes',
     label: 'Bytes',
   },
 };
 
-/**
- * Format value as bytes. Use abbreviate option for more readable numbers (KB, MB, GB, etc.).
- */
 export function formatBytes(bytes: number, { abbreviate, decimal_places }: BytesUnitOptions) {
   if (bytes === 0) return '0 bytes';
 
   decimal_places = decimal_places ?? DEFAULT_DECIMAL_PLACES;
-  // avoids maximumFractionDigits value is out of range error, possible values are 0 to 20
+  // Avoids maximumFractionDigits value is out of range error. Possible values are 0 to 20.
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumfractiondigits
   if (decimal_places < 0) {
     decimal_places = 0;

--- a/ui/components/src/model/units/bytes.ts
+++ b/ui/components/src/model/units/bytes.ts
@@ -67,6 +67,7 @@ export function formatBytes(bytes: number, { abbreviate, decimal_places }: Bytes
   return numbro(bytes).format({
     output: 'byte',
     base: 'decimal',
+    spaceSeparated: true,
     mantissa: decimal_places,
     trimMantissa: true,
     optionalMantissa: true,

--- a/ui/components/src/model/units/units.test.ts
+++ b/ui/components/src/model/units/units.test.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { formatValue, UnitOptions } from './units';
-import { bytesTests } from './bytes.test';
 
 export interface UnitTestCase {
   value: number;
@@ -182,7 +181,7 @@ describe('formatValue', () => {
       expected: '300 years',
     },
   ];
-  it.each([...tests, ...bytesTests])('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
+  it.each(tests)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
     const { value, unit, expected } = args;
     expect(formatValue(value, unit)).toEqual(expected);
   });

--- a/ui/components/src/model/units/units.test.ts
+++ b/ui/components/src/model/units/units.test.ts
@@ -21,6 +21,7 @@ interface UnitTestCase {
 
 describe('formatValue', () => {
   const tests: UnitTestCase[] = [
+    // Decimal
     {
       value: 10,
       unit: { kind: 'Decimal' },
@@ -122,6 +123,7 @@ describe('formatValue', () => {
       unit: { kind: 'Decimal', decimal_places: 2, abbreviate: true },
       expected: '0',
     },
+    // Percent
     {
       value: 10,
       unit: { kind: 'Percent' },
@@ -137,26 +139,190 @@ describe('formatValue', () => {
       unit: { kind: 'PercentDecimal' },
       expected: '10.00%',
     },
+    // Bytes
+    { value: 0, unit: { kind: 'Bytes' }, expected: '0 bytes' },
+    { value: 1, unit: { kind: 'Bytes' }, expected: '1 byte' },
     {
-      value: 100,
-      unit: { kind: 'Bytes', decimal_places: 0, abbreviate: false },
-      expected: '100 bytes',
-    },
-    {
-      value: 100,
-      unit: { kind: 'Bytes', decimal_places: -1, abbreviate: false },
-      expected: '100 bytes',
-    },
-    {
-      value: 225000,
-      unit: { kind: 'Bytes', decimal_places: 0, abbreviate: true },
-      expected: '220 KB',
-    },
-    {
-      value: 505200,
+      value: 10,
       unit: { kind: 'Bytes' },
-      expected: '505,200 bytes',
+      expected: '10 bytes',
     },
+    {
+      value: 10,
+      unit: { kind: 'Bytes', abbreviate: false },
+      expected: '10 bytes',
+    },
+    {
+      value: 10,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
+      expected: '10 bytes',
+    },
+    {
+      value: 10,
+      unit: { kind: 'Bytes', abbreviate: true },
+      expected: '10 bytes',
+    },
+    {
+      value: 10,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
+      expected: '10 bytes',
+    },
+    {
+      value: 10.12345,
+      unit: { kind: 'Bytes' },
+      expected: '10.12 bytes',
+    },
+    {
+      value: 10.12345,
+      unit: { kind: 'Bytes', abbreviate: false },
+      expected: '10.12 bytes',
+    },
+    {
+      value: 10.12345,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
+      expected: '10.12 bytes',
+    },
+    {
+      value: 10.12345,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+      expected: '10.1235 bytes',
+    },
+    {
+      value: 10.12345,
+      unit: { kind: 'Bytes', abbreviate: true },
+      expected: '10.12 bytes',
+    },
+    {
+      value: 10.12345,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
+      expected: '10.12 bytes',
+    },
+    {
+      value: 10.12345,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+      expected: '10.1235 bytes',
+    },
+    {
+      value: 1000,
+      unit: { kind: 'Bytes' },
+      expected: '1KB',
+    },
+    {
+      value: 1000,
+      unit: { kind: 'Bytes', abbreviate: false },
+      expected: '1,000 bytes',
+    },
+    {
+      value: 1000,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
+      expected: '1,000 bytes',
+    },
+    {
+      value: 1000,
+      unit: { kind: 'Bytes', abbreviate: true },
+      expected: '1KB',
+    },
+    {
+      value: 1000,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
+      expected: '1KB',
+    },
+    {
+      value: 1000.12345,
+      unit: { kind: 'Bytes' },
+      expected: '1KB',
+    },
+    {
+      value: 1000.12345,
+      unit: { kind: 'Bytes', abbreviate: false },
+      expected: '1,000.12 bytes',
+    },
+    {
+      value: 1000.12345,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
+      expected: '1,000.12 bytes',
+    },
+    {
+      value: 1000.12345,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+      expected: '1,000.1235 bytes',
+    },
+    {
+      value: 1000.12345,
+      unit: { kind: 'Bytes', abbreviate: true },
+      expected: '1KB',
+    },
+    {
+      value: 1000.12345,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
+      expected: '1KB',
+    },
+    {
+      value: 1000.12345,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+      expected: '1.0001KB',
+    },
+    {
+      value: 100000,
+      unit: { kind: 'Bytes' },
+      expected: '100KB',
+    },
+    {
+      value: 100000,
+      unit: { kind: 'Bytes', abbreviate: false },
+      expected: '100,000 bytes',
+    },
+    {
+      value: 100000,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
+      expected: '100,000 bytes',
+    },
+    {
+      value: 100000,
+      unit: { kind: 'Bytes', abbreviate: true },
+      expected: '100KB',
+    },
+    {
+      value: 100000,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
+      expected: '100KB',
+    },
+    {
+      value: 100000.12345,
+      unit: { kind: 'Bytes' },
+      expected: '100KB',
+    },
+    {
+      value: 100000.12345,
+      unit: { kind: 'Bytes', abbreviate: false },
+      expected: '100,000.12 bytes',
+    },
+    {
+      value: 100000.12345,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
+      expected: '100,000.12 bytes',
+    },
+    {
+      value: 100000.12345,
+      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+      expected: '100,000.1235 bytes',
+    },
+    {
+      value: 100000.12345,
+      unit: { kind: 'Bytes', abbreviate: true },
+      expected: '100KB',
+    },
+    {
+      value: 100000.12345,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
+      expected: '100KB',
+    },
+    {
+      value: 100000.12345,
+      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+      expected: '100.0001KB',
+    },
+    // Time
     {
       value: 8000,
       unit: { kind: 'Milliseconds' },

--- a/ui/components/src/model/units/units.test.ts
+++ b/ui/components/src/model/units/units.test.ts
@@ -12,8 +12,9 @@
 // limitations under the License.
 
 import { formatValue, UnitOptions } from './units';
+import { bytesTests } from './bytes.test';
 
-interface UnitTestCase {
+export interface UnitTestCase {
   value: number;
   unit: UnitOptions;
   expected: string;
@@ -139,189 +140,6 @@ describe('formatValue', () => {
       unit: { kind: 'PercentDecimal' },
       expected: '10.00%',
     },
-    // Bytes
-    { value: 0, unit: { kind: 'Bytes' }, expected: '0 bytes' },
-    { value: 1, unit: { kind: 'Bytes' }, expected: '1 byte' },
-    {
-      value: 10,
-      unit: { kind: 'Bytes' },
-      expected: '10 bytes',
-    },
-    {
-      value: 10,
-      unit: { kind: 'Bytes', abbreviate: false },
-      expected: '10 bytes',
-    },
-    {
-      value: 10,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
-      expected: '10 bytes',
-    },
-    {
-      value: 10,
-      unit: { kind: 'Bytes', abbreviate: true },
-      expected: '10 bytes',
-    },
-    {
-      value: 10,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
-      expected: '10 bytes',
-    },
-    {
-      value: 10.12345,
-      unit: { kind: 'Bytes' },
-      expected: '10.12 bytes',
-    },
-    {
-      value: 10.12345,
-      unit: { kind: 'Bytes', abbreviate: false },
-      expected: '10.12 bytes',
-    },
-    {
-      value: 10.12345,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
-      expected: '10.12 bytes',
-    },
-    {
-      value: 10.12345,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-      expected: '10.1235 bytes',
-    },
-    {
-      value: 10.12345,
-      unit: { kind: 'Bytes', abbreviate: true },
-      expected: '10.12 bytes',
-    },
-    {
-      value: 10.12345,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
-      expected: '10.12 bytes',
-    },
-    {
-      value: 10.12345,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-      expected: '10.1235 bytes',
-    },
-    {
-      value: 1000,
-      unit: { kind: 'Bytes' },
-      expected: '1KB',
-    },
-    {
-      value: 1000,
-      unit: { kind: 'Bytes', abbreviate: false },
-      expected: '1,000 bytes',
-    },
-    {
-      value: 1000,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
-      expected: '1,000 bytes',
-    },
-    {
-      value: 1000,
-      unit: { kind: 'Bytes', abbreviate: true },
-      expected: '1KB',
-    },
-    {
-      value: 1000,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
-      expected: '1KB',
-    },
-    {
-      value: 1000.12345,
-      unit: { kind: 'Bytes' },
-      expected: '1KB',
-    },
-    {
-      value: 1000.12345,
-      unit: { kind: 'Bytes', abbreviate: false },
-      expected: '1,000.12 bytes',
-    },
-    {
-      value: 1000.12345,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
-      expected: '1,000.12 bytes',
-    },
-    {
-      value: 1000.12345,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-      expected: '1,000.1235 bytes',
-    },
-    {
-      value: 1000.12345,
-      unit: { kind: 'Bytes', abbreviate: true },
-      expected: '1KB',
-    },
-    {
-      value: 1000.12345,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
-      expected: '1KB',
-    },
-    {
-      value: 1000.12345,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-      expected: '1.0001KB',
-    },
-    {
-      value: 100000,
-      unit: { kind: 'Bytes' },
-      expected: '100KB',
-    },
-    {
-      value: 100000,
-      unit: { kind: 'Bytes', abbreviate: false },
-      expected: '100,000 bytes',
-    },
-    {
-      value: 100000,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
-      expected: '100,000 bytes',
-    },
-    {
-      value: 100000,
-      unit: { kind: 'Bytes', abbreviate: true },
-      expected: '100KB',
-    },
-    {
-      value: 100000,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
-      expected: '100KB',
-    },
-    {
-      value: 100000.12345,
-      unit: { kind: 'Bytes' },
-      expected: '100KB',
-    },
-    {
-      value: 100000.12345,
-      unit: { kind: 'Bytes', abbreviate: false },
-      expected: '100,000.12 bytes',
-    },
-    {
-      value: 100000.12345,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 2 },
-      expected: '100,000.12 bytes',
-    },
-    {
-      value: 100000.12345,
-      unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-      expected: '100,000.1235 bytes',
-    },
-    {
-      value: 100000.12345,
-      unit: { kind: 'Bytes', abbreviate: true },
-      expected: '100KB',
-    },
-    {
-      value: 100000.12345,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 2 },
-      expected: '100KB',
-    },
-    {
-      value: 100000.12345,
-      unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-      expected: '100.0001KB',
-    },
     // Time
     {
       value: 8000,
@@ -364,7 +182,7 @@ describe('formatValue', () => {
       expected: '300 years',
     },
   ];
-  it.each(tests)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
+  it.each([...tests, ...bytesTests])('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
     const { value, unit, expected } = args;
     expect(formatValue(value, unit)).toEqual(expected);
   });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -128,6 +128,7 @@
         "lodash-es": "^4.17.21",
         "mathjs": "^10.6.4",
         "mdi-material-ui": "^7.4.0",
+        "numbro": "^2.3.6",
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
         "react-window": "^1.8.8"
@@ -10693,6 +10694,14 @@
         "node": "*"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -19322,6 +19331,17 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/numbro": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.3.6.tgz",
+      "integrity": "sha512-pxpoTT3hVxQGaOA2RTzXR/muonQNd1K1HPJbWo7QOmxPwiPmoFCFfsG9XXgW3uqjyzezJ0P9IvCPDXUtJexjwg==",
+      "dependencies": {
+        "bignumber.js": "^8.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
@@ -27120,6 +27140,7 @@
         "lodash-es": "^4.17.21",
         "mathjs": "^10.6.4",
         "mdi-material-ui": "^7.4.0",
+        "numbro": "^2.3.6",
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
         "react-window": "^1.8.8"
@@ -32066,6 +32087,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -38437,6 +38463,14 @@
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
+      }
+    },
+    "numbro": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.3.6.tgz",
+      "integrity": "sha512-pxpoTT3hVxQGaOA2RTzXR/muonQNd1K1HPJbWo7QOmxPwiPmoFCFfsG9XXgW3uqjyzezJ0P9IvCPDXUtJexjwg==",
+      "requires": {
+        "bignumber.js": "^8.1.1"
       }
     },
     "nwsapi": {


### PR DESCRIPTION
## Changes
* Add `numbro` package
* Use `numbro` with `base: decimal` to get units that are powers of 1000
* Use `Intl.NumberFormat` with `{ style: 'unit', unit: 'byte' }` instead of `{ style: 'decimal' }`
* Add a bunch of unit tests