### PR TITLE
[BUGFIX] Respect `series_name_format` in legend and tooltip when metric labels are empty

### DIFF
--- a/ui/prometheus-plugin/src/utils/utils.test.ts
+++ b/ui/prometheus-plugin/src/utils/utils.test.ts
@@ -160,8 +160,16 @@ describe('getFormattedPrometheusSeriesName', () => {
   it('should resolve empty metric to instead show query', () => {
     const query = 'node_load15{instance=~"(demo.do.prometheus.io:9100)"';
     const metric = {};
-    const output = { name: query, formattedName: 'node_load15{instance=~"(demo.do.prometheus.io:9100)"' };
+    const output = { name: query, formattedName: query };
     expect(getFormattedPrometheusSeriesName(query, metric)).toEqual(output);
+  });
+
+  it('should resolve empty metric with formatted series name', () => {
+    const query = 'up';
+    const metric = {};
+    const series_name_format = 'Custom series name';
+    const output = { name: query, formattedName: 'Custom series name' };
+    expect(getFormattedPrometheusSeriesName(query, metric, series_name_format)).toEqual(output);
   });
 
   it('should show correct formatted series name', () => {
@@ -178,5 +186,20 @@ describe('getFormattedPrometheusSeriesName', () => {
       name: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
     };
     expect(getFormattedPrometheusSeriesName(query, metric, series_name_format)).toEqual(output);
+  });
+
+  it('should show correct raw series name', () => {
+    const query = 'node_load15{instance=~"(demo.do.prometheus.io:9100)"';
+    const metric = {
+      __name__: 'node_memory_Buffers_bytes',
+      env: 'demo',
+      instance: 'demo.do.prometheus.io:9100',
+      job: 'node',
+    };
+    const output = {
+      name: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+      formattedName: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+    };
+    expect(getFormattedPrometheusSeriesName(query, metric)).toEqual(output);
   });
 });

--- a/ui/prometheus-plugin/src/utils/utils.test.ts
+++ b/ui/prometheus-plugin/src/utils/utils.test.ts
@@ -160,7 +160,7 @@ describe('getFormattedPrometheusSeriesName', () => {
   it('should resolve empty metric to instead show query', () => {
     const query = 'node_load15{instance=~"(demo.do.prometheus.io:9100)"';
     const metric = {};
-    const output = { name: query };
+    const output = { name: query, formattedName: 'node_load15{instance=~"(demo.do.prometheus.io:9100)"' };
     expect(getFormattedPrometheusSeriesName(query, metric)).toEqual(output);
   });
 

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -130,6 +130,11 @@ export function getUniqueKeyForPrometheusResult(
  * Determine human-readable series name to be used in legend and tooltip
  */
 export function getFormattedPrometheusSeriesName(query: string, metric: Metric, formatter?: string) {
+  // // TODO: debug
+  // if (isEmptyObject(metric) && formatter === undefined) {
+  //   return { name: query };
+  // }
+
   // Name the series after the metric labels or if no metric, use the query
   let name = getUniqueKeyForPrometheusResult(metric);
   if (name === '' || isEmptyObject(metric)) {

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -130,19 +130,15 @@ export function getUniqueKeyForPrometheusResult(
  * Determine human-readable series name to be used in legend and tooltip
  */
 export function getFormattedPrometheusSeriesName(query: string, metric: Metric, formatter?: string) {
-  // // TODO: debug
-  // if (isEmptyObject(metric) && formatter === undefined) {
-  //   return { name: query };
-  // }
-
-  // Name the series after the metric labels or if no metric, use the query
+  // Name the series after the metric labels by default.
+  // Use the query if no metric or metric labels are empty.
   let name = getUniqueKeyForPrometheusResult(metric);
   if (name === '' || isEmptyObject(metric)) {
     name = query;
   }
 
-  // Query editor allows you to define an optional series_name_format
-  // property to customize legend and tooltip display
+  // Query editor allows you to define an optional series_name_format property.
+  // This controls the regex used to customize legend and tooltip display.
   const formattedName = formatter ? formatSeriesName(formatter, metric) : name;
   return { name, formattedName };
 }

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -130,13 +130,9 @@ export function getUniqueKeyForPrometheusResult(
  * Determine human-readable series name to be used in legend and tooltip
  */
 export function getFormattedPrometheusSeriesName(query: string, metric: Metric, formatter?: string) {
-  if (isEmptyObject(metric)) {
-    return { name: query };
-  }
-
   // Name the series after the metric labels or if no metric, use the query
   let name = getUniqueKeyForPrometheusResult(metric);
-  if (name === '') {
+  if (name === '' || isEmptyObject(metric)) {
     name = query;
   }
 


### PR DESCRIPTION
Fixes a regression from my PR #1045, in that PR I fixed an issue with the series name showing as `{}` when a metric's labels were empty, but I caused an issue when `series_name_format` is set, where it was no longer respected when labels are empty (still worked normally in all other cases). I've added additional unit tests to catch this.

## Broken test case before bugfix:
![series_name_format_broken_test_case](https://user-images.githubusercontent.com/9369625/230907594-c359c190-3e08-456b-aee5-3e4d0cac7c1a.png)

## After Fix
<img width="724" alt="image" src="https://user-images.githubusercontent.com/9369625/230908161-3c7d27cd-9feb-488c-bab4-8f7029b52b75.png">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
