### PR TITLE
[IGNORE] Ensure unique ids are used in legend

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -150,8 +150,8 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     };
     const xAxisData = [...getXValues(timeScale)];
 
-    // ensures color does not reset for every query
-    let seriesCount = 0;
+    // Index is counted across multiple queries which ensures the categorical color palette does not reset for every query
+    let seriesIndex = 0;
 
     for (const result of queryResults) {
       // Skip queries that are still loading or don't have data
@@ -168,11 +168,11 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
         const seriesColor = getSeriesColor(
           formattedSeriesName,
-          seriesCount,
+          seriesIndex,
           echartsPalette as string[],
           visual.palette?.kind
         );
-        seriesCount++; // used for repeating colors in Categorical palette
+        seriesIndex++; // Used for repeating colors in Categorical palette
 
         const yValues = getYValues(timeSeries, timeScale);
         const lineSeries = getLineSeries(formattedSeriesName, yValues, visual, seriesColor);
@@ -183,7 +183,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         }
         if (legend && graphData.legendItems) {
           graphData.legendItems.push({
-            id: timeSeries.name + seriesCount,
+            id: timeSeries.name + seriesIndex, // Avoids duplicate key console errors when there are duplicate series names
             label: formattedSeriesName,
             isSelected,
             color: seriesColor,

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -183,7 +183,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         }
         if (legend && graphData.legendItems) {
           graphData.legendItems.push({
-            id: timeSeries.name,
+            id: timeSeries.name + seriesCount,
             label: formattedSeriesName,
             isSelected,
             color: seriesColor,

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -31,12 +31,12 @@ export function getRandomColor(identifier: string): string {
  */
 export function getSeriesColor(
   name: string,
-  seriesCount: number,
+  seriesIndex: number,
   palette: string[],
   paletteKind: PaletteOptions['kind'] = 'Auto'
 ): string {
   if (paletteKind === 'Categorical' && Array.isArray(palette)) {
-    const colorIndex = seriesCount % palette.length;
+    const colorIndex = seriesIndex % palette.length;
     // TODO: take fallback color from theme
     const seriesColor = palette[colorIndex];
     if (seriesColor !== undefined) {


### PR DESCRIPTION
When testing with a migrated Node Exporter dashboard locally ([JSON here](https://grafana.com/grafana/dashboards/1860-node-exporter-full/)), I saw this warning in the console related to our legend:
![image](https://user-images.githubusercontent.com/9369625/231253431-f7a7037c-07b8-427f-a5a1-0f51d4c1f0a9.png)

This PR ensures that the keys will always been unique.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
