### PR TITLE
[IGNORE] stabilize time range in story

### DIFF
--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -168,7 +168,7 @@ function formatProviderParameters(dashboardState: DashboardResource) {
         initialVariableDefinitions: dashboardState.spec.variables,
       },
     },
-    WithTimeRange: {
+    withTimeRange: {
       props: {
         dashboardDuration: dashboardState.spec.duration,
       },
@@ -415,9 +415,18 @@ const TIMESERIES_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
 };
 
 const TIMESERIES_EXAMPLE_MOCK_NOW = 1673805600000;
+const TIMESERIES_EXAMPLE_MOCK_START = TIMESERIES_EXAMPLE_MOCK_NOW - 6 * 60 * 60 * 1000;
 export const ExampleWithTimeSeriesPanels: Story = {
   parameters: {
     ...formatProviderParameters(TIMESERIES_EXAMPLE_DASHBOARD_RESOURCE),
+    withTimeRange: {
+      props: {
+        initialTimeRange: {
+          start: TIMESERIES_EXAMPLE_MOCK_START,
+          end: TIMESERIES_EXAMPLE_MOCK_NOW,
+        },
+      },
+    },
     msw: {
       handlers: {
         queryRange: mockQueryRangeRequests({
@@ -436,7 +445,7 @@ export const ExampleWithTimeSeriesPanels: Story = {
                       value: '1',
                     },
                   ],
-                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_NOW - 6 * 60 * 60 * 1000,
+                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
                   endTimeMs: TIMESERIES_EXAMPLE_MOCK_NOW,
                 }),
               },
@@ -445,7 +454,7 @@ export const ExampleWithTimeSeriesPanels: Story = {
               query: 'fake_graphite_query_with_nulls',
               response: {
                 body: mockTimeSeriesResponseWithNullValues({
-                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_NOW - 6 * 60 * 60 * 1000,
+                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
                   endTimeMs: TIMESERIES_EXAMPLE_MOCK_NOW,
                 }),
               },

--- a/ui/storybook/src/utils/requests/queryRangeRequests.ts
+++ b/ui/storybook/src/utils/requests/queryRangeRequests.ts
@@ -42,9 +42,6 @@ export function mockQueryRangeRequests({ queries }: MockQueryRangeConfig): Reque
       const requestQuery = typeof requestPostData === 'object' ? requestPostData['query'] : undefined;
       const mockQuery = queries.find((mockQueryConfig) => mockQueryConfig.query === requestQuery);
 
-      console.log(requestQuery);
-      console.log(queries);
-
       if (mockQuery) {
         // Found a config for mocking this query. Return the mock response.
         return res(ctx.json(mockQuery.response.body));


### PR DESCRIPTION
I stabilized the data, but NOT the time range in my previous commit, leading to some flaky visual tests. This commit stabilized the time range.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
