### PR TITLE
[IGNORE] Wait for canvases in storybook visual test

### DIFF
--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -429,7 +429,9 @@ export const ExampleWithTimeSeriesPanels: Story = {
     },
     happo: {
       beforeScreenshot: async () => {
-        await waitForStableCanvas('canvas');
+        await waitForStableCanvas('canvas', {
+          expectedCount: 6,
+        });
       },
     },
     msw: {

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -20,7 +20,7 @@ import {
   mockTimeSeriesResponseWithNullValues,
   mockTimeSeriesResponseWithStableValue,
 } from '@perses-dev/internal-utils';
-import { mockQueryRangeRequests } from '@perses-dev/storybook';
+import { mockQueryRangeRequests, waitForStableCanvas } from '@perses-dev/storybook';
 import {
   WithDashboard,
   WithDatasourceStore,
@@ -425,6 +425,11 @@ export const ExampleWithTimeSeriesPanels: Story = {
           start: TIMESERIES_EXAMPLE_MOCK_START,
           end: TIMESERIES_EXAMPLE_MOCK_NOW,
         },
+      },
+    },
+    happo: {
+      beforeScreenshot: async () => {
+        await waitForStableCanvas('canvas');
       },
     },
     msw: {

--- a/ui/storybook/src/utils/happo/canvasUtils.ts
+++ b/ui/storybook/src/utils/happo/canvasUtils.ts
@@ -26,6 +26,12 @@ type WaitForStableCanvasOptions = {
    * @default 5000
    */
   timeout?: number;
+
+  /**
+   * Number of canvas elements you expect to see. This can be helpful for
+   * validating complex cases with lots of canvas elements.
+   */
+  expectedCount?: number;
 };
 
 /**
@@ -36,7 +42,7 @@ type WaitForStableCanvasOptions = {
  */
 export async function waitForStableCanvas(
   canvasSelector: string,
-  { interval = 250, timeout = 5000 }: WaitForStableCanvasOptions = {}
+  { interval = 250, timeout = 5000, expectedCount }: WaitForStableCanvasOptions = {}
 ) {
   const maxChecks = Math.floor(timeout / interval);
 
@@ -54,7 +60,13 @@ export async function waitForStableCanvas(
 
   async function checkCanvas() {
     const canvasData = getCanvasData();
-    if (prevCanvasData.length === canvasData.length && JSON.stringify(prevCanvasData) === JSON.stringify(canvasData)) {
+    const hasExpectedCount = expectedCount === undefined || expectedCount === canvasData.length;
+
+    if (
+      hasExpectedCount &&
+      prevCanvasData.length === canvasData.length &&
+      JSON.stringify(prevCanvasData) === JSON.stringify(canvasData)
+    ) {
       // Helpful for debugging
       console.log(`Canvas stable after ${totalChecks + 1} check(s).`);
 

--- a/ui/storybook/src/utils/happo/canvasUtils.ts
+++ b/ui/storybook/src/utils/happo/canvasUtils.ts
@@ -29,10 +29,10 @@ type WaitForStableCanvasOptions = {
 };
 
 /**
- * Wait for a canvas element to become stable (i.e. stop changing its contents).
- * Validates stability by comparing that the result of `toDataURL` is consistent
- * after a specified `interval`. Will throw an error if stability is not found
- * after the specified `timeout`.
+ * Wait for canvas element(s) to become stable (i.e. stop changing their contents).
+ * Validates stability by waiting for a consistent number of canvases with
+ * consistent  `toDataURL` values after a specified `interval`. Will throw an
+ * error if stability is not found after the specified `timeout`.
  */
 export async function waitForStableCanvas(
   canvasSelector: string,
@@ -44,18 +44,17 @@ export async function waitForStableCanvas(
     throw new Error('The canvas cannot be checked for stability with the current `interval` and `timeout` options.');
   }
 
-  function getCanvasDataURL() {
-    const canvas = document.querySelector(canvasSelector) as HTMLCanvasElement | null;
-    const dataUrl = canvas?.toDataURL();
-    return dataUrl;
+  function getCanvasData() {
+    const canvases = document.querySelectorAll<HTMLCanvasElement>(canvasSelector);
+    return [...canvases].map((canvas) => canvas?.toDataURL());
   }
 
-  let prevCanvasData = getCanvasDataURL();
+  let prevCanvasData = getCanvasData();
   let totalChecks = 0;
 
   async function checkCanvas() {
-    const canvasData = getCanvasDataURL();
-    if (canvasData && canvasData === prevCanvasData) {
+    const canvasData = getCanvasData();
+    if (prevCanvasData.length === canvasData.length && JSON.stringify(prevCanvasData) === JSON.stringify(canvasData)) {
       // Helpful for debugging
       console.log(`Canvas stable after ${totalChecks + 1} check(s).`);
 


### PR DESCRIPTION
If we do not wait, you can end up with flaky diffs where a loading state is still shown.

This commit also modifies the `waitForStableCanvas` utility to support multiple canvases, which is common when testing a dashboard with multiple panels.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
