### PR TITLE
[ENHANCEMENT] Move time series panel reset button

### DIFF
--- a/ui/components/src/YAxisLabel.tsx
+++ b/ui/components/src/YAxisLabel.tsx
@@ -34,6 +34,7 @@ export function YAxisLabel({ name, height }: YAxisLabelProps) {
     >
       <Typography
         variant="body1"
+        aria-label="y axis label"
         sx={{
           whiteSpace: 'nowrap',
           overflow: 'hidden',

--- a/ui/e2e/src/tests/panelEditor.spec.ts
+++ b/ui/e2e/src/tests/panelEditor.spec.ts
@@ -51,4 +51,24 @@ test.describe('Dashboard: Panel Editor', () => {
     await expect(discardChangesConfirmationDialog).toBeHidden();
     await panelEditor.isClosed();
   });
+
+  test('should reset y axis panel option to default', async ({ dashboardPage }) => {
+    await dashboardPage.startEditing();
+    await dashboardPage.addPanel();
+    const panelEditor = dashboardPage.getPanelEditor();
+    await panelEditor.isVisible();
+    const settingsTab = dashboardPage.page.getByRole('tab', { name: 'Settings', exact: true });
+    await settingsTab.click();
+    const resetButton = dashboardPage.page.getByRole('button', { name: 'Reset To Defaults', exact: true });
+    await expect(resetButton).toBeVisible();
+    await resetButton.click();
+    const EXAMPLE_AXIS_LABEL = 'Memory';
+    const yAxisLabelInput = dashboardPage.page.getByRole('textbox', { name: 'enter y axis label' });
+    await yAxisLabelInput.clear();
+    await yAxisLabelInput.type(EXAMPLE_AXIS_LABEL, { delay: 100 });
+    const yAxisLabelText = dashboardPage.page.getByText(EXAMPLE_AXIS_LABEL);
+    await expect(yAxisLabelText).toBeVisible();
+    await resetButton.click();
+    expect(await yAxisLabelText.count()).toEqual(0);
+  });
 });

--- a/ui/e2e/src/tests/panelEditor.spec.ts
+++ b/ui/e2e/src/tests/panelEditor.spec.ts
@@ -60,7 +60,6 @@ test.describe('Dashboard: Panel Editor', () => {
     const settingsTab = dashboardPage.page.getByRole('tab', { name: 'Settings', exact: true });
     await settingsTab.click();
     const resetButton = dashboardPage.page.getByRole('button', { name: 'Reset To Defaults', exact: true });
-    await expect(resetButton).toBeVisible();
     await resetButton.click();
     const EXAMPLE_AXIS_LABEL = 'Memory';
     const yAxisLabelInput = dashboardPage.page.getByRole('textbox', { name: 'enter y axis label' });

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
@@ -16,7 +16,6 @@ import { produce } from 'immer';
 import {
   LegendOptionsEditor,
   LegendOptionsEditorProps,
-  OptionsEditorControl,
   OptionsEditorGroup,
   OptionsEditorGrid,
   OptionsEditorColumn,

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartOptionsEditorSettings.tsx
@@ -16,6 +16,7 @@ import { produce } from 'immer';
 import {
   LegendOptionsEditor,
   LegendOptionsEditorProps,
+  OptionsEditorControl,
   OptionsEditorGroup,
   OptionsEditorGrid,
   OptionsEditorColumn,
@@ -80,23 +81,25 @@ export function TimeSeriesChartOptionsEditorSettings(props: TimeSeriesChartOptio
       </OptionsEditorColumn>
       <OptionsEditorColumn>
         <ThresholdsEditor hideDefault thresholds={value.thresholds} onChange={handleThresholdsChange} />
-        <Button
-          variant="outlined"
-          color="secondary"
-          onClick={() => {
-            onChange(
-              produce(value, (draft: TimeSeriesChartOptions) => {
-                // reset button removes all optional panel options
-                draft.y_axis = undefined;
-                draft.legend = undefined;
-                draft.visual = undefined;
-                draft.thresholds = undefined;
-              })
-            );
-          }}
-        >
-          Reset All Settings
-        </Button>
+        <OptionsEditorGroup title="Reset Settings">
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => {
+              onChange(
+                produce(value, (draft: TimeSeriesChartOptions) => {
+                  // reset button removes all optional panel options
+                  draft.y_axis = undefined;
+                  draft.legend = undefined;
+                  draft.visual = undefined;
+                  draft.thresholds = undefined;
+                })
+              );
+            }}
+          >
+            Reset To Defaults
+          </Button>
+        </OptionsEditorGroup>
       </OptionsEditorColumn>
     </OptionsEditorGrid>
   );

--- a/ui/panels-plugin/src/plugins/time-series-chart/YAxisOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/YAxisOptionsEditor.tsx
@@ -51,6 +51,7 @@ export function YAxisOptionsEditor({ value, onChange }: YAxisOptionsEditorProps)
         control={
           <TextField
             value={value.label ?? ''}
+            inputProps={{ 'aria-label': 'enter y axis label' }}
             onChange={(e) =>
               onChange({
                 ...value,


### PR DESCRIPTION
Feedback from Mohit so that it's more clear that the Reset button is for all panel options and not just related to the thresholds controls above it.

Added an e2e test that open add panel drawer, clicks settings tab, types a y_axis.label of "Memory" and then clicks the Reset button to check whether the axis label in the chart preview is hidden.

## Before

<img width="721" alt="image" src="https://user-images.githubusercontent.com/9369625/231634091-8e7d378f-09d2-4d51-a708-5388ff25947a.png">

## After

![image](https://user-images.githubusercontent.com/9369625/231633808-42e44236-feb2-4810-bff2-d71ed12abcde.png)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
