### PR TITLE
[ENHANCEMENT] Add help text and placeholder for series_name_format control

### DIFF
--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -57,9 +57,9 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
       />
       <TextField
         fullWidth
-        label="Series Name Format"
-        placeholder="Templating ex: {{instance}} will be replaced with label value for instance"
-        helperText="Controls legend and tooltip formatting"
+        label="Name"
+        placeholder="Tip: Use {{variable_name}}. Example: {{instance}} will be replaced with values such as 'webserver-123' and 'webserver-456'."
+        helperText="Set the name for each series in the legend and the tooltip."
         value={format ?? ''}
         onChange={(e) => handleFormatChange(e.target.value)}
         onBlur={handleFormatBlur}

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -57,8 +57,8 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
       />
       <TextField
         fullWidth
-        label="Name"
-        placeholder="Tip: Use {{variable_name}}. Example: {{instance}} will be replaced with values such as 'webserver-123' and 'webserver-456'."
+        label="Legend Name"
+        placeholder="Tip: Use {{label_name}}. Example: {{instance}} will be replaced with values such as 'webserver-123' and 'webserver-456'."
         helperText="Set the name for each series in the legend and the tooltip."
         value={format ?? ''}
         onChange={(e) => handleFormatChange(e.target.value)}

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -58,10 +58,11 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
       <TextField
         fullWidth
         label="Series Name Format"
+        placeholder="Templating ex: {{instance}} will be replaced with label value for instance"
+        helperText="Controls legend and tooltip formatting"
         value={format ?? ''}
         onChange={(e) => handleFormatChange(e.target.value)}
         onBlur={handleFormatBlur}
-        margin="dense"
       />
       <FormControl margin="dense" fullWidth={false}>
         {/* TODO: How do we ensure unique ID values if there are multiple of these? Can we use React 18 useId and


### PR DESCRIPTION
Add context when using our Prom query editor so that users know how to use the `series_name_format` input, open to feedback on the wording!

## Screenshot
![image](https://user-images.githubusercontent.com/9369625/232093083-c68997be-a5de-45db-aa30-cdd08b28002c.png)

## Recording

https://user-images.githubusercontent.com/9369625/231636902-d2e2a5d4-abd7-4de7-a76d-9784d392347a.mp4

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
