### PR TITLE
[ENHANCEMENT] Highlight behavior slight improvement using opacity blur

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -73,9 +73,16 @@ export function getLineSeries(
       opacity: visual.area_opacity ?? DEFAULT_AREA_OPACITY,
     },
     emphasis: {
+      focus: 'series',
+      blurScope: 'coordinateSystem',
       disabled: visual.area_opacity !== undefined && visual.area_opacity > 0, // prevents flicker when moving cursor between shaded regions
       lineStyle: {
-        width: lineWidth + 1,
+        width: lineWidth,
+      },
+    },
+    blur: {
+      lineStyle: {
+        opacity: 0.6,
       },
     },
   };


### PR DESCRIPTION
Very slight improvement to TimeSeriesChart hover / focused series emphasis behavior. Tried adjusting non-focused series line opacity on blur. Removed the line width increase on emphasis and added: 
- https://echarts.apache.org/en/option.html#series-line.emphasis.focus
- https://echarts.apache.org/en/option.html#series-line.emphasis.blurScope

## Screen Recording

## Before

https://user-images.githubusercontent.com/9369625/232081609-d278b38e-8137-49d1-9ed0-62b32498507a.mp4

## After
### Default
https://user-images.githubusercontent.com/9369625/232081659-e19e83aa-eab4-4c99-b80c-1102e959ece5.mp4

### `visual.show_points: 'Always'`

https://user-images.githubusercontent.com/9369625/232084265-ab546f15-82a0-4561-bc8e-948f513cde11.mp4


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
