### PR TITLE
[ENHANCEMENT] Increase tooltip max height to fit more series w/o scrolling

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react';
 import { FocusedSeriesArray } from './focused-series';
 
 export const TOOLTIP_MAX_WIDTH = 650;
-export const TOOLTIP_MAX_HEIGHT = 230;
+export const TOOLTIP_MAX_HEIGHT = 400;
 export const TOOLTIP_LABELS_MAX_WIDTH = TOOLTIP_MAX_WIDTH - 150;
 
 export const TOOLTIP_MAX_ITEMS = 50;


### PR DESCRIPTION
Show more focused series in our TimeSeriesTooltip by default. 

Pin tooltip feature is not very discoverable and users think there isn't a way to get inside our tooltip and scroll. Until we address this, increasing the height is best workaround.

## Screenshot
![tooltip_new_height](https://user-images.githubusercontent.com/9369625/232136386-2c3e628e-f934-4047-832b-030d3d17d7a2.png)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
