### PR TITLE
[ENHANCEMENT] Allow echarts wrapper to default to fluid width and height 

### DIFF
--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -188,6 +188,8 @@ export const EChart = React.memo(function EChart<T>({
       ref={containerRef}
       sx={combineSx(
         {
+          // Ensures chart fills container and updates size correctly when resizing,
+          // combineSx allows this default behavior to be overriden from parent component
           width: '100%',
           height: '100%',
         },

--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -16,6 +16,7 @@ import { ECharts, EChartsCoreOption, init } from 'echarts/core';
 import { Box, SxProps, Theme } from '@mui/material';
 import { isEqual, debounce } from 'lodash-es';
 import { EChartsTheme } from '../model';
+import { combineSx } from '../utils';
 
 // see docs for info about each property: https://echarts.apache.org/en/api.html#events
 export interface MouseEventsParameters<T> {
@@ -182,7 +183,18 @@ export const EChart = React.memo(function EChart<T>({
     updateSize();
   }, [sx]);
 
-  return <Box ref={containerRef} sx={sx}></Box>;
+  return (
+    <Box
+      ref={containerRef}
+      sx={combineSx(
+        {
+          width: '100%',
+          height: '100%',
+        },
+        sx
+      )}
+    ></Box>
+  );
 });
 
 // Validate event config and bind custom events

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -232,16 +232,7 @@ export function LineChart({
             unit={unit}
           />
         )}
-      <EChart
-        sx={{
-          width: '100%',
-          height: '100%',
-        }}
-        option={option}
-        theme={chartsTheme.echartsTheme}
-        onEvents={handleEvents}
-        _instance={chartRef}
-      />
+      <EChart option={option} theme={chartsTheme.echartsTheme} onEvents={handleEvents} _instance={chartRef} />
     </Box>
   );
 }

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -124,17 +124,7 @@ export function StatChart(props: StatChartProps) {
       >
         {formattedValue}
       </Typography>
-      {sparkline !== undefined && (
-        <EChart
-          sx={{
-            width: '100%',
-            height: '100%',
-          }}
-          option={option}
-          theme={chartsTheme.echartsTheme}
-          renderer="svg"
-        />
-      )}
+      {sparkline !== undefined && <EChart option={option} theme={chartsTheme.echartsTheme} renderer="svg" />}
     </Box>
   );
 }


### PR DESCRIPTION
Every usage of our echarts wrapper component `EChart.tsx` ends up setting an sx prop to control width and height resize behavior. This PR allows `width: '100%', height: '100%'` to be set by default. It is not a breaking change since combineSx is added and explicitly defining will not break anything, but those lines can be removed now if a user prefers to rely on defaults.

Building on PR #1112 to avoid merge conflicts and that PR will be merged first (legend highlight PR will be next in this PR stack).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
