### PR TITLE
[IGNORE] add override flag that would reset the local DB

### DIFF
--- a/scripts/api_backend_dev.sh
+++ b/scripts/api_backend_dev.sh
@@ -4,16 +4,32 @@
 ## This script automates the steps for running the api backend server during
 ## development.
 
-# Populate database
-echo ">> populate the local database"
-cd dev 
-rm -rf local_db
-./populate.sh
+localDBFolder="dev/local_db"
 
-# Make api
-echo ">> build the api server"
-cd ..
-make build-api
+# Populate database
+function generateLocalDB() {
+  echo ">> populate the local database"
+  cd dev
+  rm -rf local_db
+  ./populate.sh
+  cd ../
+}
+
+function buildAPI() {
+    # Make api
+    echo ">> build the api server"
+    make build-api
+}
+
+if ! [[ -d "${localDBFolder}" ]]; then
+  generateLocalDB
+fi
+
+if [[ "$1" == "--override" ]]; then
+  generateLocalDB
+fi
+
+buildAPI
 
 # Run backend server
 echo ">> start the api server"


### PR DESCRIPTION
you can now use it like that:

```bash
./scripts/api_backend_dev.sh --override
```

In case the folder `loca_db` doesn't exist when running this script whatever the flag is used, it will generate the DB.
But in case it already exists, then you need to use the flag `--override` to re-generate it