### PR TITLE
[ENHANCEMENT] Improve formatting for percent values 

### DIFF
--- a/ui/components/src/model/units/bytes.test.ts
+++ b/ui/components/src/model/units/bytes.test.ts
@@ -14,7 +14,7 @@
 import { formatValue } from './units';
 import { UnitTestCase } from './units.test';
 
-const bytesTests: UnitTestCase[] = [
+const BYTES_TESTS: UnitTestCase[] = [
   { value: 0, unit: { kind: 'Bytes' }, expected: '0 bytes' },
   { value: 1, unit: { kind: 'Bytes' }, expected: '1 byte' },
   {
@@ -245,7 +245,7 @@ const bytesTests: UnitTestCase[] = [
 ];
 
 describe('formatValue', () => {
-  it.each(bytesTests)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
+  it.each(BYTES_TESTS)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
     const { value, unit, expected } = args;
     expect(formatValue(value, unit)).toEqual(expected);
   });

--- a/ui/components/src/model/units/decimal.test.ts
+++ b/ui/components/src/model/units/decimal.test.ts
@@ -14,7 +14,7 @@
 import { formatValue } from './units';
 import { UnitTestCase } from './units.test';
 
-const decimalTests: UnitTestCase[] = [
+const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: -10,
     unit: { kind: 'Decimal' },
@@ -287,7 +287,7 @@ const decimalTests: UnitTestCase[] = [
 ];
 
 describe('formatValue', () => {
-  it.each(decimalTests)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
+  it.each(DECIMAL_TESTS)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
     const { value, unit, expected } = args;
     expect(formatValue(value, unit)).toEqual(expected);
   });

--- a/ui/components/src/model/units/percent.test.ts
+++ b/ui/components/src/model/units/percent.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { formatValue } from './units';
+import { UnitTestCase } from './units.test';
+
+const PERCENT_TESTS: UnitTestCase[] = [
+  // Percent
+  { value: 0, unit: { kind: 'Percent' }, expected: '0%' },
+  { value: 0, unit: { kind: 'Percent', decimal_places: 4 }, expected: '0%' },
+
+  { value: 0.001111, unit: { kind: 'Percent' }, expected: '0.00111%' },
+  { value: 0.001111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '0%' },
+  { value: 0.001111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '0.0011%' },
+
+  { value: 0.011111, unit: { kind: 'Percent' }, expected: '0.0111%' },
+  { value: 0.011111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '0%' },
+  { value: 0.011111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '0.0111%' },
+
+  { value: 0.111111, unit: { kind: 'Percent' }, expected: '0.111%' },
+  { value: 0.111111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '0%' },
+  { value: 0.111111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '0.1111%' },
+
+  { value: 1, unit: { kind: 'Percent' }, expected: '1%' },
+  { value: 1, unit: { kind: 'Percent', decimal_places: 4 }, expected: '1%' },
+
+  { value: 1.1111, unit: { kind: 'Percent' }, expected: '1.11%' },
+  { value: 1.1111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '1%' },
+  { value: 1.1111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '1.1111%' },
+
+  { value: 55, unit: { kind: 'Percent' }, expected: '55%' },
+  { value: 55, unit: { kind: 'Percent', decimal_places: 4 }, expected: '55%' },
+
+  { value: 55.555, unit: { kind: 'Percent' }, expected: '55.6%' },
+  { value: 55.555, unit: { kind: 'Percent', decimal_places: 0 }, expected: '56%' },
+  { value: 55.555, unit: { kind: 'Percent', decimal_places: 4 }, expected: '55.555%' },
+
+  { value: 111, unit: { kind: 'Percent' }, expected: '111%' },
+  { value: 111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '111%' },
+
+  { value: 111.111, unit: { kind: 'Percent' }, expected: '111%' },
+  { value: 111.111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '111%' },
+  { value: 111.111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '111.111%' },
+
+  { value: 100000, unit: { kind: 'Percent' }, expected: '100,000%' },
+
+  // PercentDecimal
+  { value: 0, unit: { kind: 'PercentDecimal' }, expected: '0%' },
+  { value: 0, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '0%' },
+
+  { value: 0.00001111, unit: { kind: 'PercentDecimal' }, expected: '0.00111%' },
+  { value: 0.00001111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '0%' },
+  { value: 0.00001111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '0.0011%' },
+
+  { value: 0.00011111, unit: { kind: 'PercentDecimal' }, expected: '0.0111%' },
+  { value: 0.00011111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '0%' },
+  { value: 0.00011111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '0.0111%' },
+
+  { value: 0.00111111, unit: { kind: 'PercentDecimal' }, expected: '0.111%' },
+  { value: 0.00111111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '0%' },
+  { value: 0.00111111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '0.1111%' },
+
+  { value: 0.01, unit: { kind: 'PercentDecimal' }, expected: '1%' },
+  { value: 0.01, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '1%' },
+  { value: 0.01, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '1%' },
+
+  { value: 0.01111, unit: { kind: 'PercentDecimal' }, expected: '1.11%' },
+  { value: 0.01111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '1%' },
+  { value: 0.01111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '1.111%' },
+
+  { value: 0.11, unit: { kind: 'PercentDecimal' }, expected: '11%' },
+  { value: 0.11, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '11%' },
+  { value: 0.11, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '11%' },
+
+  { value: 0.1111, unit: { kind: 'PercentDecimal' }, expected: '11.1%' },
+  { value: 0.1111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '11%' },
+  { value: 0.1111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '11.11%' },
+
+  { value: 1, unit: { kind: 'PercentDecimal' }, expected: '100%' },
+  { value: 1, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '100%' },
+  { value: 1, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '100%' },
+
+  { value: 10, unit: { kind: 'PercentDecimal' }, expected: '1,000%' },
+];
+
+describe('formatValue', () => {
+  it.each(PERCENT_TESTS)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
+    const { value, unit, expected } = args;
+    expect(formatValue(value, unit)).toEqual(expected);
+  });
+});

--- a/ui/components/src/model/units/percent.ts
+++ b/ui/components/src/model/units/percent.ts
@@ -43,6 +43,8 @@ export const PERCENT_UNIT_CONFIG: Readonly<Record<PercentUnitKind, UnitConfig>> 
   },
 };
 
+const MAX_SIGNIFICANT_DIGITS = 3;
+
 export function formatPercent(value: number, { kind, decimal_places }: PercentUnitOptions): string {
   // Intl.NumberFormat translates 0 -> 0%, 0.5 -> 50%, 1 -> 100%
   if (kind === 'Percent') {
@@ -53,15 +55,17 @@ export function formatPercent(value: number, { kind, decimal_places }: PercentUn
 
   let formatter;
   if (hasDecimalPlaces) {
+    // If there is a specified # of decimal places, use maximumFractionDigits
     formatter = new Intl.NumberFormat('en-US', {
       style: 'percent',
       maximumFractionDigits: decimal_places,
       useGrouping: true,
     });
   } else {
+    // By default, use maximumSignificantDigits
     formatter = new Intl.NumberFormat('en-US', {
       style: 'percent',
-      maximumSignificantDigits: 3,
+      maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS,
       useGrouping: true,
     });
   }

--- a/ui/components/src/model/units/percent.ts
+++ b/ui/components/src/model/units/percent.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { UnitGroupConfig, UnitConfig } from './types';
-import { DEFAULT_DECIMAL_PLACES } from './constants';
 
 const percentUnitKinds = ['Percent', 'PercentDecimal', '%'] as const;
 type PercentUnitKind = (typeof percentUnitKinds)[number];
@@ -44,12 +43,28 @@ export const PERCENT_UNIT_CONFIG: Readonly<Record<PercentUnitKind, UnitConfig>> 
   },
 };
 
-export function formatPercent(value: number, unitOptions: PercentUnitOptions): string {
-  const decimals = unitOptions.decimal_places ?? DEFAULT_DECIMAL_PLACES;
-
-  if (unitOptions.kind === 'PercentDecimal') {
-    value = value * 100;
+export function formatPercent(value: number, { kind, decimal_places }: PercentUnitOptions): string {
+  // Intl.NumberFormat translates 0 -> 0%, 0.5 -> 50%, 1 -> 100%
+  if (kind === 'Percent') {
+    value = value / 100;
   }
 
-  return value.toFixed(decimals) + '%';
+  const hasDecimalPlaces = decimal_places !== undefined;
+
+  let formatter;
+  if (hasDecimalPlaces) {
+    formatter = new Intl.NumberFormat('en-US', {
+      style: 'percent',
+      maximumFractionDigits: decimal_places,
+      useGrouping: true,
+    });
+  } else {
+    formatter = new Intl.NumberFormat('en-US', {
+      style: 'percent',
+      maximumSignificantDigits: 3,
+      useGrouping: true,
+    });
+  }
+
+  return formatter.format(value);
 }

--- a/ui/components/src/model/units/units.test.ts
+++ b/ui/components/src/model/units/units.test.ts
@@ -19,25 +19,9 @@ export interface UnitTestCase {
   expected: string;
 }
 
-// TODO: Create test files for percent and time. Write more tests for percent and time.
+// TODO: Create test files for time units. Write more tests for time units.
 describe('formatValue', () => {
   const tests: UnitTestCase[] = [
-    // Percent
-    {
-      value: 10,
-      unit: { kind: 'Percent' },
-      expected: '10.00%',
-    },
-    {
-      value: 50,
-      unit: { kind: 'Percent', decimal_places: 0 },
-      expected: '50%',
-    },
-    {
-      value: 0.1,
-      unit: { kind: 'PercentDecimal' },
-      expected: '10.00%',
-    },
     // Time
     {
       value: 8000,


### PR DESCRIPTION
This PR updates the formatting for the percent values. 

Right now, if the user picks `Percent` as the unit but the `decimal_places` option is undefined, and the value is`100`, then it would be automatically formatted as `100.00%`. We don't want those extra decimal places. 

This PR updates the logic so that if `decimal_places` is undefined, then we format based on significant digits instead of decimal places. 

See tests for how different values will be handled! 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
