### PR TITLE
[BREAKINGCHANGE] Make "TimeSeriesQuery" required in DefaultPluginKinds

### DIFF
--- a/ui/dashboards/src/stories/decorators/WithPluginRegistry.tsx
+++ b/ui/dashboards/src/stories/decorators/WithPluginRegistry.tsx
@@ -47,7 +47,10 @@ const bundledPluginLoader: PluginLoader = dynamicImportPluginLoader([
 
 export const WithPluginRegistry = (Story: StoryFn) => {
   return (
-    <PluginRegistry pluginLoader={bundledPluginLoader}>
+    <PluginRegistry
+      pluginLoader={bundledPluginLoader}
+      defaultPluginKinds={{ TimeSeriesQuery: 'PrometheusTimeSeriesQuery' }}
+    >
       <Story />
     </PluginRegistry>
   );

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.test.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.test.tsx
@@ -110,6 +110,7 @@ describe('PluginEditor', () => {
       renderComponent({
         pluginType: 'Variable',
         defaultPluginKinds: {
+          TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
           Variable: 'ErnieVariable1',
         },
         value: { kind: '', spec: {} },
@@ -123,7 +124,7 @@ describe('PluginEditor', () => {
     it('does not use default when kind is provided', async () => {
       renderComponent({
         pluginType: 'Variable',
-        defaultPluginKinds: { Variable: 'ErnieVariable1' },
+        defaultPluginKinds: { Variable: 'ErnieVariable1', TimeSeriesQuery: 'PrometheusTimeSeriesQuery' },
         value: { kind: 'ErnieVariable2', spec: {} },
       });
 

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -25,9 +25,9 @@ import { PluginRegistryContext } from '../../runtime';
 import { usePluginIndexes, getTypeAndKindKey } from './plugin-indexes';
 
 export interface PluginRegistryProps {
-  children?: React.ReactNode;
   pluginLoader: PluginLoader;
-  defaultPluginKinds?: DefaultPluginKinds;
+  defaultPluginKinds: DefaultPluginKinds;
+  children?: React.ReactNode;
 }
 
 /**

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -71,4 +71,5 @@ export type PluginImplementation<Type extends PluginType> = SupportedPlugins[Typ
 /**
  * Default plugin kinds by plugin type.
  */
-export type DefaultPluginKinds = Partial<Record<PluginType, string>>;
+type PluginKinds = Partial<Record<PluginType, string>>;
+export type DefaultPluginKinds = Required<Pick<PluginKinds, 'TimeSeriesQuery'>> & Omit<PluginKinds, 'TimeSeriesQuery'>;

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -18,7 +18,7 @@ import { DefaultPluginKinds, PluginImplementation, PluginMetadata, PluginType } 
 export interface PluginRegistryContextType {
   getPlugin<T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>>;
   listPluginMetadata(pluginType: PluginType): Promise<PluginMetadata[]>;
-  defaultPluginKinds?: DefaultPluginKinds;
+  defaultPluginKinds: DefaultPluginKinds;
 }
 
 export const PluginRegistryContext = createContext<PluginRegistryContextType | undefined>(undefined);

--- a/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
+++ b/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
@@ -65,6 +65,9 @@ export function mockPluginRegistry(...mockPlugins: MockPlugin[]): Omit<PluginReg
 
   return {
     pluginLoader,
+    defaultPluginKinds: {
+      TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+    },
   };
 }
 

--- a/ui/plugin-system/src/test/render.tsx
+++ b/ui/plugin-system/src/test/render.tsx
@@ -45,7 +45,14 @@ export function renderWithContext(
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <PluginRegistry pluginLoader={testPluginLoader} defaultPluginKinds={contextOptions?.defaultPluginKinds}>
+      <PluginRegistry
+        pluginLoader={testPluginLoader}
+        defaultPluginKinds={
+          contextOptions?.defaultPluginKinds ?? {
+            TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+          }
+        }
+      >
         {ui}
       </PluginRegistry>
     </QueryClientProvider>,


### PR DESCRIPTION
Because of the changes in #1032, if `TimeSeriesQuery` isn't defined in DefaultPluginKinds, it will have weird/unexpected behaviors in the query editor. 

**BEFORE** 
```
export interface PluginRegistryProps {
  children?: React.ReactNode;
  pluginLoader: PluginLoader;
  defaultPluginKinds?: DefaultPluginKinds; // optional before
}
```

```
export type DefaultPluginKinds = Partial<Record<PluginType, string>>; // all plugin types were optional
```

**AFTER**
```
export interface PluginRegistryProps {
  children?: React.ReactNode;
  pluginLoader: PluginLoader;
  defaultPluginKinds: DefaultPluginKinds; // this is now required
}
```

```
type PluginKinds = Partial<Record<PluginType, string>>;
export type DefaultPluginKinds = 
    Required<Pick<PluginKinds, 'TimeSeriesQuery'>> // "TimeSeriesQuery" is now required
    & Omit<PluginKinds, 'TimeSeriesQuery'>; 
```