### PR TITLE
[UX Feedback] Categorical palette as default, switch to generative based on total series

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Autocomplete, Slider, Switch, TextField, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { Autocomplete, Slider, Switch, TextField } from '@mui/material';
 import { OptionsEditorControl, OptionsEditorGroup } from '@perses-dev/components';
 import {
   DEFAULT_AREA_OPACITY,
@@ -103,27 +103,6 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             max={VISUAL_CONFIG.area_opacity.max}
             onChange={handleAreaOpacityChange}
           />
-        }
-      />
-      <OptionsEditorControl
-        label={'Palette'}
-        control={
-          <ToggleButtonGroup
-            color="primary"
-            exclusive
-            value={value.palette?.kind ?? 'Auto'}
-            onChange={(__, newValue) => {
-              const palette: VisualOptions['palette'] =
-                newValue === 'Categorical' ? { kind: 'Categorical' } : undefined;
-              onChange({
-                ...value,
-                palette,
-              });
-            }}
-          >
-            <ToggleButton value="Auto">Auto</ToggleButton>
-            <ToggleButton value="Categorical">Categorical</ToggleButton>
-          </ToggleButtonGroup>
         }
       />
       <OptionsEditorControl


### PR DESCRIPTION
Mohit feedback:
> “Auto” palette is our end goal so users don’t have to meddle with color settings period.
> 1. For now, we can default to this for the color palette (https://colorbrewer2.org/#type=qualitative&scheme=Set3&n=12) with 12 colors for categorical. 
> 2. If we have more than 12 series we switch the palette to generative colors automatically, users should never have to deal with repetition of colors and don’t know what to do. This is my reasoning for leaving the colors to default to auto (ideally), one less thing to deal with. The option of categorical should no longer be available
> 3. Regarding tweaking the color palette for use cases like error - I think we can have multiple such generative palettes based on different use cases: Auto - General, Auto - Error, Auto - Warning, Custom Palette (user enters hex code?), etc.

