### PR TITLE
[BUGFIX] Fix http method not allowed not handled

### DIFF
--- a/internal/api/shared/error.go
+++ b/internal/api/shared/error.go
@@ -56,6 +56,12 @@ func HandleError(err error) error {
 	if errors.Is(err, BadRequestError) {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
+
+	if _, ok := err.(*echo.HTTPError); ok {
+		// the error is coming from the echo framework likely because the route doesn't exist.
+		// In this particular case, we shouldn't touch to the error and let it like that
+		return err
+	}
 	logrus.WithError(err).Error("unexpected error not handle")
 	return echo.NewHTTPError(http.StatusInternalServerError, InternalError.message)
 }


### PR DESCRIPTION
When the API is in a readonly mode, if you try to delete an object it currently returns an HTTP error 500 "internal server error" instead of saying that the method or the route doesn't exist.

This PR is fixing that