### PR TITLE
[ENHANCEMENT] improve search in the home page

### DIFF
--- a/ui/app/src/views/home/ProjectsAndDashboards.tsx
+++ b/ui/app/src/views/home/ProjectsAndDashboards.tsx
@@ -162,7 +162,7 @@ export function SearchableDashboards(props: SearchableDashboardsProps) {
     } else {
       return projectRows;
     }
-  }, [kvSearch, projectRows, search]);
+  }, [kvSearch, projectRows, search, data]);
 
   const handleSearch = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.value) {

--- a/ui/app/src/views/home/ProjectsAndDashboards.tsx
+++ b/ui/app/src/views/home/ProjectsAndDashboards.tsx
@@ -121,14 +121,28 @@ interface SearchableDashboardsProps {
   id?: string;
 }
 
+function buildProjectRow(list: DashboardResource[]) {
+  const result: ProjectRow[] = [];
+  for (const item of list) {
+    const project = item.metadata.project;
+    const row = result.find((row) => row.project === item.metadata.project);
+    if (row) {
+      row.dashboards.push(item);
+    } else {
+      result.push({ project: project, dashboards: [item] });
+    }
+  }
+  return result;
+}
+
 export function SearchableDashboards(props: SearchableDashboardsProps) {
   const kvSearch = useMemo(
     () =>
-      new KVSearch<ProjectRow>({
+      new KVSearch<DashboardResource>({
         indexedKeys: [
-          ['project'], // Matching on the project name
-          ['dashboards', 'metadata', 'name'], // Matching on the dashboard name
-          ['dashboards', 'spec', 'display', 'name'], // Matching on the dashboard display name
+          ['metadata', 'project'], // Matching on the project name
+          ['metadata', 'name'], // Matching on the dashboard name
+          ['spec', 'display', 'name'], // Matching on the dashboard display name
         ],
       }),
     []
@@ -136,25 +150,15 @@ export function SearchableDashboards(props: SearchableDashboardsProps) {
 
   const { data, isLoading } = useDashboardList();
   const projectRows: ProjectRow[] = useMemo(() => {
-    const result: ProjectRow[] = [];
-    (data || []).forEach((dashboard) => {
-      const project = dashboard.metadata.project;
-      const row = result.find((row) => row.project === dashboard.metadata.project);
-      if (row) {
-        row.dashboards.push(dashboard);
-      } else {
-        result.push({ project: project, dashboards: [dashboard] });
-      }
-    });
-    return result;
+    return buildProjectRow(data || []);
   }, [data]);
 
   const [search, setSearch] = useState<string>('');
 
   const filteredProjectRows: ProjectRow[] = useMemo(() => {
     if (search) {
-      const result = kvSearch.filter(search, projectRows);
-      return result.map((res) => res.original);
+      const result = kvSearch.filter(search, data || []);
+      return buildProjectRow(result.map((res) => res.original));
     } else {
       return projectRows;
     }


### PR DESCRIPTION
This PR is improving the search in the home page.

Before when you were searching for a particular dashboard, it didn't returned the dashboard that matched the search. But it returned the project with every dashboards including the one that is matching.

Result with this PR: 

![image](https://user-images.githubusercontent.com/4548045/234862623-2962206e-112c-45fd-9d9e-e2e200361d02.png)

![MicrosoftTeams-image](https://user-images.githubusercontent.com/4548045/234862705-219b7156-dd98-4df9-82f0-1f619aafde2c.png)
