### PR TITLE
[FEATURE] Allow TLS configuration for mysql database

### DIFF
--- a/internal/api/config/database.go
+++ b/internal/api/config/database.go
@@ -43,6 +43,8 @@ func (f *File) Verify() error {
 }
 
 type SQL struct {
+	// TLS configuration
+	TLSConfig *config.TLSConfig `json:"tls_config,omitempty" yaml:"tls_config,omitempty"`
 	// Username
 	User config.Secret `json:"user,omitempty" yaml:"user,omitempty"`
 	// Password (requires User)


### PR DESCRIPTION
This PR add a ``sql.tls_config`` configuration that will allow TLS configuration foe database connections exactly with the same configuration as in prometheus.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

None
