### PR TITLE
[ENHANCEMENT] Make it possible to set decimal_places as undefined in UI

### DIFF
--- a/ui/components/src/UnitSelector/UnitSelector.test.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.test.tsx
@@ -26,11 +26,11 @@ describe('UnitSelector', () => {
   };
 
   const getUnitSelector = () => {
-    return screen.getByRole('combobox', { name: 'Units' });
+    return screen.getByRole('combobox', { name: 'Unit' });
   };
 
-  const getDecimalSelector = () => {
-    return screen.getByRole('combobox', { name: 'Decimal' });
+  const getDecimalPlacesSelector = () => {
+    return screen.getByRole('spinbutton', { name: 'Decimals' });
   };
 
   const getAbbreviateSwitch = () => {
@@ -79,15 +79,13 @@ describe('UnitSelector', () => {
     const onChange = jest.fn();
     renderUnitSelector({ kind: 'Decimal', decimal_places: 0, abbreviate: true }, onChange);
 
-    userEvent.click(getDecimalSelector());
-    const decimalOption = screen.getByRole('option', {
-      name: '1',
-    });
-    userEvent.click(decimalOption);
+    const decimalPlacesSelector = getDecimalPlacesSelector();
+    userEvent.click(decimalPlacesSelector);
+    userEvent.clear(decimalPlacesSelector);
 
     expect(onChange).toHaveBeenCalledWith({
       kind: 'Decimal',
-      decimal_places: 1,
+      decimal_places: undefined,
       abbreviate: true,
     });
   });
@@ -96,18 +94,11 @@ describe('UnitSelector', () => {
     const onChange = jest.fn();
     renderUnitSelector({ kind: 'Percent' }, onChange);
 
-    const decimalSelector = getDecimalSelector();
+    const decimalPlacesSelector = getDecimalPlacesSelector();
     userEvent.tab();
     userEvent.tab();
-    expect(decimalSelector).toHaveFocus();
-
-    userEvent.clear(decimalSelector);
+    expect(decimalPlacesSelector).toHaveFocus();
     userEvent.keyboard('3');
-    screen.getByRole('option', {
-      name: '3',
-    });
-
-    userEvent.keyboard('{arrowup}{enter}');
 
     expect(onChange).toHaveBeenCalledWith({
       kind: 'Percent',
@@ -152,7 +143,7 @@ describe('UnitSelector', () => {
   describe('with a percent unit selected', () => {
     it('allows the user to modify the decimal places', () => {
       renderUnitSelector({ kind: 'Percent' });
-      expect(getDecimalSelector()).toBeEnabled();
+      expect(getDecimalPlacesSelector()).toBeEnabled();
     });
 
     it('does not allow the user to set abbreviate', () => {
@@ -164,7 +155,7 @@ describe('UnitSelector', () => {
   describe('with a decimal unit selected', () => {
     it('allows the user to modify the decimal places', () => {
       renderUnitSelector({ kind: 'Decimal' });
-      expect(getDecimalSelector()).toBeEnabled();
+      expect(getDecimalPlacesSelector()).toBeEnabled();
     });
 
     it('allows the user to set abbreviate', () => {
@@ -176,7 +167,7 @@ describe('UnitSelector', () => {
   describe('with a bytes unit selected', () => {
     it('allows the user to modify the decimal places', () => {
       renderUnitSelector({ kind: 'Bytes' });
-      expect(getDecimalSelector()).toBeEnabled();
+      expect(getDecimalPlacesSelector()).toBeEnabled();
     });
 
     it('allows the user to set abbreviate', () => {

--- a/ui/components/src/UnitSelector/UnitSelector.test.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.test.tsx
@@ -30,7 +30,7 @@ describe('UnitSelector', () => {
   };
 
   const getDecimalPlacesSelector = () => {
-    return screen.getByRole('spinbutton', { name: 'Decimals' });
+    return screen.getByRole('combobox', { name: 'Decimals' });
   };
 
   const getAbbreviateSwitch = () => {
@@ -79,9 +79,11 @@ describe('UnitSelector', () => {
     const onChange = jest.fn();
     renderUnitSelector({ kind: 'Decimal', decimal_places: 0, abbreviate: true }, onChange);
 
-    const decimalPlacesSelector = getDecimalPlacesSelector();
-    userEvent.click(decimalPlacesSelector);
-    userEvent.clear(decimalPlacesSelector);
+    userEvent.click(getDecimalPlacesSelector());
+    const decimalPlacesOption = screen.getByRole('option', {
+      name: 'Default',
+    });
+    userEvent.click(decimalPlacesOption);
 
     expect(onChange).toHaveBeenCalledWith({
       kind: 'Decimal',
@@ -98,7 +100,13 @@ describe('UnitSelector', () => {
     userEvent.tab();
     userEvent.tab();
     expect(decimalPlacesSelector).toHaveFocus();
+
+    userEvent.clear(decimalPlacesSelector);
     userEvent.keyboard('3');
+    screen.getByRole('option', {
+      name: '3',
+    });
+    userEvent.keyboard('{arrowup}{enter}');
 
     expect(onChange).toHaveBeenCalledWith({
       kind: 'Percent',

--- a/ui/components/src/UnitSelector/UnitSelector.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.tsx
@@ -11,15 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Box, Switch, TextField, Autocomplete, SwitchProps } from '@mui/material';
-import {
-  UnitOptions,
-  UNIT_CONFIG,
-  UnitConfig,
-  isUnitWithDecimalPlaces,
-  isUnitWithAbbreviate,
-  DECIMAL_PLACES_MIN,
-  DECIMAL_PLACES_MAX,
-} from '../model';
+import { UnitOptions, UNIT_CONFIG, UnitConfig, isUnitWithDecimalPlaces, isUnitWithAbbreviate } from '../model';
 import { OptionsEditorControl } from '../OptionsEditorLayout';
 
 export interface UnitSelectorProps {
@@ -38,6 +30,19 @@ const KIND_OPTIONS: AutocompleteKindOption[] = Object.entries(UNIT_CONFIG)
   })
   .filter((config) => !config.disableSelectorOption);
 
+const DECIMAL_PLACES_OPTIONS = [
+  { label: 'Default', decimal_places: undefined },
+  { label: '0', decimal_places: 0 },
+  { label: '1', decimal_places: 1 },
+  { label: '2', decimal_places: 2 },
+  { label: '3', decimal_places: 3 },
+  { label: '4', decimal_places: 4 },
+];
+
+function getOptionByDecimalPlaces(decimal_places?: number) {
+  return DECIMAL_PLACES_OPTIONS.find((o) => o.decimal_places === decimal_places);
+}
+
 export function UnitSelector({ value, onChange }: UnitSelectorProps) {
   const hasDecimalPlaces = isUnitWithDecimalPlaces(value);
   const hasAbbreviate = isUnitWithAbbreviate(value);
@@ -48,11 +53,11 @@ export function UnitSelector({ value, onChange }: UnitSelectorProps) {
     });
   };
 
-  const handleDecimalChange = (newValue?: number) => {
+  const handleDecimalPlacesChange = (_: unknown, { decimal_places }: { decimal_places: number | undefined }) => {
     if (hasDecimalPlaces) {
       onChange({
         ...value,
-        decimal_places: newValue,
+        decimal_places: decimal_places,
       });
     }
   };
@@ -106,14 +111,15 @@ export function UnitSelector({ value, onChange }: UnitSelectorProps) {
       <OptionsEditorControl
         label="Decimals"
         control={
-          <TextField
-            type="number"
-            value={value.decimal_places ?? ''}
-            onChange={(e) => {
-              handleDecimalChange(e.target.value ? Number(e.target.value) : undefined);
-            }}
-            placeholder="Default"
-            inputProps={{ min: DECIMAL_PLACES_MIN, max: DECIMAL_PLACES_MAX }}
+          <Autocomplete
+            value={getOptionByDecimalPlaces(value.decimal_places)}
+            options={DECIMAL_PLACES_OPTIONS}
+            getOptionLabel={(o) => o.label}
+            isOptionEqualToValue={(option, value) => option.label === value.label}
+            renderInput={(params) => <TextField {...params} />}
+            onChange={handleDecimalPlacesChange}
+            disabled={!hasDecimalPlaces}
+            disableClearable
           />
         }
       />

--- a/ui/components/src/UnitSelector/UnitSelector.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.tsx
@@ -14,10 +14,11 @@ import { Box, Switch, TextField, Autocomplete, SwitchProps } from '@mui/material
 import {
   UnitOptions,
   UNIT_CONFIG,
-  DEFAULT_DECIMAL_PLACES,
   UnitConfig,
   isUnitWithDecimalPlaces,
   isUnitWithAbbreviate,
+  DECIMAL_PLACES_MIN,
+  DECIMAL_PLACES_MAX,
 } from '../model';
 import { OptionsEditorControl } from '../OptionsEditorLayout';
 
@@ -37,8 +38,6 @@ const KIND_OPTIONS: AutocompleteKindOption[] = Object.entries(UNIT_CONFIG)
   })
   .filter((config) => !config.disableSelectorOption);
 
-const DECIMAL_OPTIONS = [0, 1, 2, 3, 4];
-
 export function UnitSelector({ value, onChange }: UnitSelectorProps) {
   const hasDecimalPlaces = isUnitWithDecimalPlaces(value);
   const hasAbbreviate = isUnitWithAbbreviate(value);
@@ -49,7 +48,7 @@ export function UnitSelector({ value, onChange }: UnitSelectorProps) {
     });
   };
 
-  const handleDecimalChange = (_: unknown, newValue: number) => {
+  const handleDecimalChange = (newValue?: number) => {
     if (hasDecimalPlaces) {
       onChange({
         ...value,
@@ -82,7 +81,7 @@ export function UnitSelector({ value, onChange }: UnitSelectorProps) {
         }
       />
       <OptionsEditorControl
-        label="Units"
+        label="Unit"
         control={
           <Autocomplete
             value={{ id: value.kind, ...kindConfig }}
@@ -105,17 +104,17 @@ export function UnitSelector({ value, onChange }: UnitSelectorProps) {
         }
       />
       <OptionsEditorControl
-        label="Decimal"
+        label="Decimals"
         control={
-          <Autocomplete
-            value={hasDecimalPlaces ? value.decimal_places ?? DEFAULT_DECIMAL_PLACES : 0}
-            options={DECIMAL_OPTIONS}
-            getOptionLabel={(option) => `${option}`}
-            renderInput={(params) => <TextField {...params} />}
-            onChange={handleDecimalChange}
-            disabled={!hasDecimalPlaces}
-            disableClearable
-          ></Autocomplete>
+          <TextField
+            type="number"
+            value={value.decimal_places ?? ''}
+            onChange={(e) => {
+              handleDecimalChange(e.target.value ? Number(e.target.value) : undefined);
+            }}
+            placeholder="Default"
+            inputProps={{ min: DECIMAL_PLACES_MIN, max: DECIMAL_PLACES_MAX }}
+          />
         }
       />
     </>

--- a/ui/components/src/model/units/bytes.test.ts
+++ b/ui/components/src/model/units/bytes.test.ts
@@ -43,6 +43,31 @@ const BYTES_TESTS: UnitTestCase[] = [
     expected: '10 bytes',
   },
   {
+    value: 10.1234,
+    unit: { kind: 'Bytes' },
+    expected: '10.1 bytes',
+  },
+  {
+    value: 10.1234,
+    unit: { kind: 'Bytes', abbreviate: false },
+    expected: '10.123 bytes',
+  },
+  {
+    value: 10.1234,
+    unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
+    expected: '10.1234 bytes',
+  },
+  {
+    value: 10.1234,
+    unit: { kind: 'Bytes', abbreviate: true },
+    expected: '10.1 bytes',
+  },
+  {
+    value: 10.1234,
+    unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
+    expected: '10.1234 bytes',
+  },
+  {
     value: 1000,
     unit: { kind: 'Bytes' },
     expected: '1 KB',
@@ -241,6 +266,21 @@ const BYTES_TESTS: UnitTestCase[] = [
     value: 1234567890,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
     expected: '1.2346 GB',
+  },
+  {
+    value: 1000000000000,
+    unit: { kind: 'Bytes' },
+    expected: '1 TB',
+  },
+  {
+    value: 1000000000000000,
+    unit: { kind: 'Bytes' },
+    expected: '1 PB',
+  },
+  {
+    value: 1000000000000000000,
+    unit: { kind: 'Bytes' },
+    expected: '1 EB',
   },
 ];
 

--- a/ui/components/src/model/units/bytes.ts
+++ b/ui/components/src/model/units/bytes.ts
@@ -13,9 +13,9 @@
 
 import numbro from 'numbro';
 
+import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces, shouldAbbreviate } from './utils';
-import { MAX_SIGNIFICANT_DIGITS } from './constants';
 
 const DEFAULT_NUMBRO_MANTISSA = 2;
 

--- a/ui/components/src/model/units/constants.ts
+++ b/ui/components/src/model/units/constants.ts
@@ -14,6 +14,3 @@
 // Common constants needed across individual unit groups and the overall
 // combined units.
 export const MAX_SIGNIFICANT_DIGITS = 3;
-
-export const DECIMAL_PLACES_MIN = 0;
-export const DECIMAL_PLACES_MAX = 20;

--- a/ui/components/src/model/units/decimal.test.ts
+++ b/ui/components/src/model/units/decimal.test.ts
@@ -20,11 +20,10 @@ const DECIMAL_TESTS: UnitTestCase[] = [
     unit: { kind: 'Decimal' },
     expected: '-10',
   },
-  // Note: The default for decimal_places is 2. This can be changed if we want.
   {
     value: -0.123456789,
     unit: { kind: 'Decimal' },
-    expected: '-0.12',
+    expected: '-0.123',
   },
   { value: 0, unit: { kind: 'Decimal' }, expected: '0' },
   { value: 1, unit: { kind: 'Decimal' }, expected: '1' },
@@ -57,7 +56,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 10.123456,
     unit: { kind: 'Decimal' },
-    expected: '10.12',
+    expected: '10.1',
   },
   {
     value: 10.123456,
@@ -162,7 +161,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 666666,
     unit: { kind: 'Decimal' },
-    expected: '666.67K',
+    expected: '667K',
   },
   {
     value: 666666,
@@ -177,7 +176,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 666666,
     unit: { kind: 'Decimal', abbreviate: true },
-    expected: '666.67K',
+    expected: '667K',
   },
   {
     value: 666666,
@@ -212,7 +211,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 88888888,
     unit: { kind: 'Decimal' },
-    expected: '88.89M',
+    expected: '88.9M',
   },
   {
     value: 88888888,
@@ -227,7 +226,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 88888888,
     unit: { kind: 'Decimal', abbreviate: true },
-    expected: '88.89M',
+    expected: '88.9M',
   },
   {
     value: 88888888,

--- a/ui/components/src/model/units/percent.ts
+++ b/ui/components/src/model/units/percent.ts
@@ -13,7 +13,7 @@
 
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
-import { limitDecimalPlaces } from './utils';
+import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
 
 const percentUnitKinds = ['Percent', 'PercentDecimal', '%'] as const;
 type PercentUnitKind = (typeof percentUnitKinds)[number];
@@ -55,8 +55,7 @@ export function formatPercent(value: number, { kind, decimal_places }: PercentUn
     useGrouping: true,
   };
 
-  const hasDecimalPlaces = decimal_places !== undefined && decimal_places !== null;
-  if (hasDecimalPlaces) {
+  if (hasDecimalPlaces(decimal_places)) {
     formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimal_places);
   } else {
     formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;

--- a/ui/components/src/model/units/time.ts
+++ b/ui/components/src/model/units/time.ts
@@ -13,7 +13,7 @@
 
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
-import { limitDecimalPlaces } from './utils';
+import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
 
 const timeUnitKinds = ['Milliseconds', 'Seconds', 'Minutes', 'Hours', 'Days', 'Weeks', 'Months', 'Years'] as const;
 type TimeUnitKind = (typeof timeUnitKinds)[number];
@@ -83,8 +83,7 @@ export function formatTime(value: number, { kind, decimal_places }: TimeUnitOpti
     unitDisplay: isMonthOrYear ? 'long' : 'narrow',
   };
 
-  const hasDecimalPlaces = decimal_places !== undefined && decimal_places !== null;
-  if (hasDecimalPlaces) {
+  if (hasDecimalPlaces(decimal_places)) {
     formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimal_places);
   } else {
     formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;

--- a/ui/components/src/model/units/units.ts
+++ b/ui/components/src/model/units/units.ts
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import { BytesUnitOptions, BYTES_GROUP_CONFIG, BYTES_UNIT_CONFIG, formatBytes } from './bytes';
-import { DecimalUnitOptions, DECIMAL_UNIT_CONFIG, formatDecimal, PERCENT_GROUP_CONFIG } from './decimal';
-import { DECIMAL_GROUP_CONFIG, formatPercent, PercentUnitOptions, PERCENT_UNIT_CONFIG } from './percent';
+import { DecimalUnitOptions, DECIMAL_UNIT_CONFIG, formatDecimal, DECIMAL_GROUP_CONFIG } from './decimal';
+import { PERCENT_GROUP_CONFIG, formatPercent, PercentUnitOptions, PERCENT_UNIT_CONFIG } from './percent';
 import { formatTime, TimeUnitOptions, TIME_GROUP_CONFIG, TIME_UNIT_CONFIG } from './time';
 import { UnitGroup, UnitGroupConfig, UnitConfig } from './types';
 

--- a/ui/components/src/model/units/utils.ts
+++ b/ui/components/src/model/units/utils.ts
@@ -11,9 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Common constants needed across individual unit groups and the overall
-// combined units.
-export const MAX_SIGNIFICANT_DIGITS = 3;
+// Avoids maximumFractionDigits out-of-range error. Allowed values are 0 to 20.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
+export function limitDecimalPlaces(num?: number) {
+  if (!num) return num;
 
-export const DECIMAL_PLACES_MIN = 0;
-export const DECIMAL_PLACES_MAX = 20;
+  if (num < 0) {
+    num = 0;
+  } else if (num > 20) {
+    num = 20;
+  }
+
+  return num;
+}

--- a/ui/components/src/model/units/utils.ts
+++ b/ui/components/src/model/units/utils.ts
@@ -11,7 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Avoids maximumFractionDigits out-of-range error. Allowed values are 0 to 20.
+export function shouldAbbreviate(abbreviate?: boolean) {
+  return abbreviate !== false;
+}
+
+export function hasDecimalPlaces(decimal_places?: number) {
+  return typeof decimal_places === 'number';
+}
+
+// Avoids maximumFractionDigits out-of-range error.
+// Allowed values are 0 to 20.
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
 export function limitDecimalPlaces(num?: number) {
   if (!num) return num;

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.test.tsx
@@ -37,7 +37,7 @@ describe('GaugeChartOptionsEditorSettings', () => {
       },
       onChange
     );
-    const unitSelector = screen.getByRole('combobox', { name: 'Units' });
+    const unitSelector = screen.getByRole('combobox', { name: 'Unit' });
     userEvent.click(unitSelector);
     const yearOption = screen.getByRole('option', {
       name: 'Years',

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -15,7 +15,7 @@ import { ThresholdOptions } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
 import { CalculationType, OptionsEditorProps } from '@perses-dev/plugin-system';
 
-export const DEFAULT_UNIT: UnitOptions = { kind: 'PercentDecimal', decimal_places: 1 };
+export const DEFAULT_UNIT: UnitOptions = { kind: 'PercentDecimal' };
 
 export const DEFAULT_MAX_PERCENT = 100;
 

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.test.tsx
@@ -37,7 +37,7 @@ describe('StatChartOptionsEditorSettings', () => {
       },
       onChange
     );
-    const unitSelector = screen.getByRole('combobox', { name: 'Units' });
+    const unitSelector = screen.getByRole('combobox', { name: 'Unit' });
     userEvent.click(unitSelector);
     const percentOption = screen.getByRole('option', {
       name: 'Percent (0-100)',

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -53,7 +53,6 @@ export type VisualOptions = {
 
 export const DEFAULT_UNIT: UnitOptions = {
   kind: 'Decimal',
-  decimal_places: 2,
   abbreviate: true,
 };
 


### PR DESCRIPTION
This PR makes it possible to set `decimal_places` as `undefined` in the UI.

~To do this, I had to change the "Decimals" input from a dropdown to an input with `type="number"`.~

This allows the default behavior to kick in: When `decimal_places` is undefined, we can fall back to using significant figures to format numbers. 

## Before 
<img width="281" alt="Screenshot 2023-04-28 at 9 21 27 AM" src="https://user-images.githubusercontent.com/2584129/235201445-a6d0864a-79c0-4377-bb61-17846069b2dd.png">

## After 
<img width="331" alt="Screenshot 2023-05-02 at 12 09 30 PM" src="https://user-images.githubusercontent.com/2584129/235762494-bf1306f6-d120-4ae0-8064-fa4e58164f36.png">
