### PR TITLE
[BUGFIX] Series name formatter return empty string when no resolved label value

### DIFF
--- a/ui/prometheus-plugin/src/utils/utils.test.ts
+++ b/ui/prometheus-plugin/src/utils/utils.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Metric } from '../model/api-types';
 import {
   parseTemplateVariables,
   replaceTemplateVariable,
@@ -189,7 +190,7 @@ describe('getFormattedPrometheusSeriesName', () => {
   });
 
   it('should show an empty string when no corresponding label values returned', () => {
-    const query = 'node_load15{instance=~"(demo.do.prometheus.io:9100)"';
+    const query = 'test_query';
     const metric = {
       job: 'node',
     };
@@ -199,6 +200,19 @@ describe('getFormattedPrometheusSeriesName', () => {
       name: '{job="node"}',
     };
     expect(getFormattedPrometheusSeriesName(query, metric, series_name_format)).toEqual(output);
+  });
+
+  it('should correctly handle invalid label value case', () => {
+    const query = 'test_query';
+    const metric = {
+      job: 99,
+    };
+    const series_name_format = 'job - {{job}}';
+    const output = {
+      formattedName: 'job - 99',
+      name: '{job="99"}',
+    };
+    expect(getFormattedPrometheusSeriesName(query, metric as unknown as Metric, series_name_format)).toEqual(output);
   });
 
   it('should show correct raw series name', () => {

--- a/ui/prometheus-plugin/src/utils/utils.test.ts
+++ b/ui/prometheus-plugin/src/utils/utils.test.ts
@@ -180,10 +180,23 @@ describe('getFormattedPrometheusSeriesName', () => {
       instance: 'demo.do.prometheus.io:9100',
       job: 'node',
     };
-    const series_name_format = 'custom example {{env}} {{instance}} {{node}}';
+    const series_name_format = 'custom example {{env}} {{instance}} {{job}}';
     const output = {
       formattedName: 'custom example demo demo.do.prometheus.io:9100 node',
       name: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+    };
+    expect(getFormattedPrometheusSeriesName(query, metric, series_name_format)).toEqual(output);
+  });
+
+  it('should show an empty string when no corresponding label values returned', () => {
+    const query = 'node_load15{instance=~"(demo.do.prometheus.io:9100)"';
+    const metric = {
+      job: 'node',
+    };
+    const series_name_format = 'test{{fake}}';
+    const output = {
+      formattedName: 'test',
+      name: '{job="node"}',
     };
     expect(getFormattedPrometheusSeriesName(query, metric, series_name_format)).toEqual(output);
   });

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -68,12 +68,18 @@ export const parseTemplateVariables = (text: string) => {
 export type SeriesLabels = Record<string, string>;
 
 /*
- * Formatter used for series name display in legends and tooltips
- * Regex replaces label {{ name }} with resolved label value
+ * Formatter used for series name display in legends and tooltips.
+ * Regex replaces label {{ name }} with resolved label value.
+ * If no resolved value, return empty string instead of the token inside double curly braces.
  */
 export function formatSeriesName(inputFormat: string, seriesLabels: SeriesLabels): string {
   const resolveLabelsRegex = /\{\{\s*(.+?)\s*\}\}/g;
-  return inputFormat.replace(resolveLabelsRegex, (_, g) => (seriesLabels[g] ? seriesLabels[g] : g));
+  return inputFormat.replace(resolveLabelsRegex, (_match, g1) => {
+    if (seriesLabels[g1]) {
+      return seriesLabels[g1] ?? '';
+    }
+    return '';
+  });
 }
 
 /*

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -76,7 +76,7 @@ export function formatSeriesName(inputFormat: string, seriesLabels: SeriesLabels
   const resolveLabelsRegex = /\{\{\s*(.+?)\s*\}\}/g;
   return inputFormat.replace(resolveLabelsRegex, (_match, token) => {
     const resolvedValue = seriesLabels[token] ?? '';
-    return resolvedValue.toString();
+    return resolvedValue;
   });
 }
 

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -74,11 +74,9 @@ export type SeriesLabels = Record<string, string>;
  */
 export function formatSeriesName(inputFormat: string, seriesLabels: SeriesLabels): string {
   const resolveLabelsRegex = /\{\{\s*(.+?)\s*\}\}/g;
-  return inputFormat.replace(resolveLabelsRegex, (_match, g1) => {
-    if (seriesLabels[g1]) {
-      return seriesLabels[g1] ?? '';
-    }
-    return '';
+  return inputFormat.replace(resolveLabelsRegex, (_match, token) => {
+    const resolvedValue = seriesLabels[token] ?? '';
+    return resolvedValue.toString();
   });
 }
 


### PR DESCRIPTION
## Overview

When a label_name token inside the double curly braces (aka handlebars syntax) for our `series_name_format` field in the query editor tab has no corresponding label values or is unintentionally set to value that isn't reflected in the query results, our formatter function used to show the token itself. Now instead, an empty string is returned, which makes more sense and is a better fallback for new users who might not 100% understand how this somewhat confusing field actually works under the hood (hopefully in the future, this will only be exposed to power users and we come up with a higher level, more intuitive way to format series names automatically and tie it to the legend more visibly).

## Before
<img width="725" alt="image" src="https://user-images.githubusercontent.com/9369625/235209295-0f14a295-95ec-4ce9-ac1f-020d857adeab.png">


## After

<img width="726" alt="image" src="https://user-images.githubusercontent.com/9369625/235209443-0720e815-0476-41cb-84ec-f461c293f72c.png">

<img width="838" alt="image" src="https://user-images.githubusercontent.com/9369625/235208705-6687d183-5336-4b20-a84d-3134b30f464b.png">


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
