### PR TITLE
[IGNORE] Make webpack overlay opt in and use error for eslint rules

### DIFF
--- a/ui/.eslintrc.base.js
+++ b/ui/.eslintrc.base.js
@@ -56,18 +56,18 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/array-type': [
-      'warn',
+      'error',
       {
         default: 'array-simple',
       },
     ],
-    'import/order': 'warn',
+    'import/order': 'error',
     // you must disable the base rule as it can report incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ['error'],
 
     'react/prop-types': 'off',
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': 'error',
     // Not necessary in React 17
     'react/react-in-jsx-scope': 'off',
 

--- a/ui/app/src/views/home/ProjectsAndDashboards.tsx
+++ b/ui/app/src/views/home/ProjectsAndDashboards.tsx
@@ -158,7 +158,7 @@ export function SearchableDashboards(props: SearchableDashboardsProps) {
     } else {
       return projectRows;
     }
-  }, [kvSearch, projectRows]);
+  }, [kvSearch, projectRows, search]);
 
   const handleSearch = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.value) {

--- a/ui/app/src/views/home/ProjectsAndDashboards.tsx
+++ b/ui/app/src/views/home/ProjectsAndDashboards.tsx
@@ -158,7 +158,7 @@ export function SearchableDashboards(props: SearchableDashboardsProps) {
     } else {
       return projectRows;
     }
-  }, [kvSearch, projectRows, search]);
+  }, [kvSearch, projectRows]);
 
   const handleSearch = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.value) {

--- a/ui/app/webpack.dev.ts
+++ b/ui/app/webpack.dev.ts
@@ -71,6 +71,9 @@ const devConfig: Configuration = {
       '/api': 'http://localhost:8080',
       '/proxy': 'http://localhost:8080',
     },
+    client: {
+      overlay: false,
+    },
   },
   cache: true,
 };

--- a/ui/app/webpack.dev.ts
+++ b/ui/app/webpack.dev.ts
@@ -72,7 +72,11 @@ const devConfig: Configuration = {
       '/proxy': 'http://localhost:8080',
     },
     client: {
-      overlay: false,
+      // By default, the error overlay is not shown because it can get in the
+      // way of e2e tests and can be annoying for some developer workflows.
+      // If you like the overlay, you can enable it by setting the the specified
+      // env var.
+      overlay: process.env.ERROR_OVERLAY === 'true' ?? false,
     },
   },
   cache: true,

--- a/ui/ui-guidelines.md
+++ b/ui/ui-guidelines.md
@@ -105,8 +105,9 @@ are reflected in how the packages are organized. There is some variability from 
 
 ### All packages
 
-- Eslint enforces certain style and correctness rules, these can be ignored on a case
-  by case basis but usually are intended to help you avoid common JS pitfalls
+- Eslint enforces certain style and correctness rules to help avoid common coding pitfalls and maintain consistency.
+  - Exceptions can be made on a case-by-case basis using `eslint-disable-next-line` and a comment that communicates the reason for the exception.
+  - We prefer `error` (instead of `warn`) for eslint rules because it makes it easier to catch and enforce linting issues.
 - Typescript is used to provide a stronger guarantee of correctness across the
   application. Please avoid using escape hatches like `any`, prefer using `unknown`
   and type narrowing instead.


### PR DESCRIPTION
We previously [ran into some issues](https://github.com/perses/perses/pull/1127) where the webpack overlay caused
problems with e2e tests because there was an eslint warning that
triggered the webpack overlay. This commit will help minimize that
recurring in the future by doing the following:
- Change the webpack overlay to be off by default and opt-in using an
  env var.
- Change eslint rules to all be "error" (instead of "warn"). This makes
  it clearer to developers when they broke an eslint rule in the PR
  checks.

# Notes for reviewers

- We could consider looking into having the e2e tests run against prod webpack, but if we do that, I think we'd lose throwing errors on those dev mode console errors we get from react/mui/etc., which can help us catch subtle bugs. Let me know if you feel strongly about one vs. the other.
- I generally find "error" only to be a helpful approach to eslint. Otherwise you collect a big list of warnings that are meaningless. Let me know if you have strong feelings about keeping warn for some use cases.
- My impression is that few people actually like the webpack error overlay, so hopefully making it opt-in is not disruptive. Let me know if anyone feels strongly and would prefer it be switched to opt-out instead.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
