### PR TITLE
[BUGFIX] Fix dashboard creation dialog when there is one or less dashboards

### DIFF
--- a/ui/app/src/components/CreateDashboardDialog/CreateDashboardDialog.tsx
+++ b/ui/app/src/components/CreateDashboardDialog/CreateDashboardDialog.tsx
@@ -85,7 +85,7 @@ export const CreateDashboardDialog = (props: CreateDashboardProps) => {
       <Dialog.Header>Create Dashboard</Dialog.Header>
       <Dialog.Content>
         <Stack gap={1}>
-          {projectOptions && projectOptions.length > 1 && (
+          {projectOptions && projectOptions.length > 0 && (
             <FormControl size="small" fullWidth>
               <InputLabel id="project-name-id">Project name</InputLabel>
               <Select

--- a/ui/app/src/views/home/HomeView.tsx
+++ b/ui/app/src/views/home/HomeView.tsx
@@ -79,6 +79,7 @@ function HomeView() {
               size="small"
               sx={{ textTransform: 'uppercase' }}
               onClick={handleAddDashboardDialogOpen}
+              disabled={projectOptions.length === 0}
             >
               Add Dashboard
             </Button>


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
We shouldn't be able to create dashboard without creating a project before + fix a issue when there was only one dashboard 😅 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
