### PR TITLE
[BUGFIX] Prevent calendar icon from flipping over

### DIFF
--- a/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
+++ b/ui/components/src/DateTimeRangePicker/TimeRangeSelector.tsx
@@ -42,7 +42,10 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
     <Select
       value={formattedValue}
       onChange={onSelectChange}
-      IconComponent={Calendar}
+      IconComponent={(props) => {
+        // "transform: none" prevents calendar icon from flipping over when menu is open
+        return <Calendar {...props} sx={{ transform: 'none !important' }} />;
+      }}
       inputProps={{
         'aria-label': `Select time range. Currently set to ${formattedValue}`,
       }}
@@ -50,7 +53,10 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
         '.MuiSelect-icon': {
           marginTop: '1px',
         },
-        '.MuiSelect-select': height ? { lineHeight: height, paddingY: 0 } : {},
+        // "paddingRight" creates more space for the calendar icon (it's a bigger icon)
+        '.MuiSelect-select': height
+          ? { lineHeight: height, paddingY: 0, paddingRight: '36px !important' }
+          : { paddingRight: '36px !important' },
       }}
     >
       {timeOptions.map((item, idx) => (


### PR DESCRIPTION
We noticed that the `Calendar` icon will flip over when the time range menu is opened. This happens because the icon is typically an arrow/caret that is supposed to flip over. This PR prevents that behavior. 
