### PR TITLE
[ENHANCEMENT] Add timerange and refresh buttons on the sticky toolbar

### DIFF
--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -1,0 +1,58 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react';
+import { AppBar, Box, IconButton, SxProps, Theme, useScrollTrigger } from '@mui/material';
+import PinOutline from 'mdi-material-ui/PinOutline';
+import PinOffOutline from 'mdi-material-ui/PinOffOutline';
+import { TemplateVariableList } from '../Variables';
+import { TimeRangeControls } from '../TimeRangeControls';
+
+interface DashboardStickyToolbarProps {
+  initialVariableIsSticky?: boolean;
+  sx?: SxProps<Theme>;
+}
+
+export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
+  const [isPin, setIsPin] = useState(props.initialVariableIsSticky);
+
+  const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
+  const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
+
+  return (
+    // marginBottom={-1} counteracts the marginBottom={1} on every variable input.
+    // The margin on the inputs is for spacing between inputs, but is not meant to add space to bottom of the container.
+    <Box marginBottom={-1} data-testid="variable-list">
+      <AppBar
+        color="inherit"
+        position={isSticky ? 'fixed' : 'static'}
+        elevation={isSticky ? 4 : 0}
+        sx={{ backgroundColor: 'inherit', ...props.sx }}
+      >
+        <Box display="flex" justifyContent="space-between">
+          <Box display="flex" flexWrap="wrap" alignItems="start" my={isSticky ? 2 : 0} ml={isSticky ? 2 : 0}>
+            <TemplateVariableList></TemplateVariableList>
+            {props.initialVariableIsSticky && (
+              <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
+            )}
+          </Box>
+          {isSticky && (
+            <Box my={2} mr={2}>
+              <TimeRangeControls></TimeRangeControls>
+            </Box>
+          )}
+        </Box>
+      </AppBar>
+    </Box>
+  );
+}

--- a/ui/dashboards/src/components/DashboardStickyToolbar/index.ts
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './DashboardStickyToolbar';

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -20,9 +20,10 @@ import { AddPanelButton } from '../AddPanelButton';
 import { AddGroupButton } from '../AddGroupButton';
 import { DownloadButton } from '../DownloadButton';
 import { TimeRangeControls } from '../TimeRangeControls';
-import { TemplateVariableList, EditVariablesButton } from '../Variables';
+import { EditVariablesButton } from '../Variables';
 import { EditButton } from '../EditButton';
 import { EditJsonButton } from '../EditJsonButton';
+import { DashboardStickyToolbar } from '../DashboardStickyToolbar';
 
 export interface DashboardToolbarProps {
   dashboardName: string;
@@ -106,7 +107,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             }}
           >
             <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <TemplateVariableList
+              <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}
                 sx={{
                   backgroundColor: ({ palette }) =>
@@ -153,7 +154,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
           </Box>
           <Box paddingY={2}>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <TemplateVariableList
+              <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}
                 sx={{
                   backgroundColor: ({ palette }) =>

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -11,10 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState } from 'react';
-import { AppBar, Box, IconButton, SxProps, Theme, useScrollTrigger } from '@mui/material';
-import PinOutline from 'mdi-material-ui/PinOutline';
-import PinOffOutline from 'mdi-material-ui/PinOffOutline';
+import { Box } from '@mui/material';
 import { VariableDefinition } from '@perses-dev/core';
 import { useTemplateVariableDefinitions } from '../../context';
 import { TemplateVariable } from './TemplateVariable';
@@ -22,47 +19,24 @@ import { TemplateVariable } from './TemplateVariable';
 const VARIABLE_INPUT_MIN_WIDTH = '120px';
 const VARIABLE_INPUT_MAX_WIDTH = '240px';
 
-interface TemplateVariableListProps {
-  initialVariableIsSticky?: boolean;
-  sx?: SxProps<Theme>;
-}
-
-export function TemplateVariableList(props: TemplateVariableListProps) {
-  const [isPin, setIsPin] = useState(props.initialVariableIsSticky);
+export function TemplateVariableList() {
   const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
 
-  const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
-  const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
-
   return (
-    // marginBottom={-1} counteracts the marginBottom={1} on every variable input.
-    // The margin on the inputs is for spacing between inputs, but is not meant to add space to bottom of the container.
-    <Box marginBottom={-1} data-testid="variable-list">
-      <AppBar
-        color="inherit"
-        position={isSticky ? 'fixed' : 'static'}
-        elevation={isSticky ? 4 : 0}
-        sx={{ backgroundColor: 'inherit', ...props.sx }}
-      >
-        <Box display="flex" flexWrap="wrap" alignItems="start" my={isSticky ? 2 : 0} ml={isSticky ? 2 : 0}>
-          {variableDefinitions.map((v) => (
-            <Box
-              key={v.spec.name}
-              display={v.spec.display?.hidden ? 'none' : undefined}
-              minWidth={VARIABLE_INPUT_MIN_WIDTH}
-              maxWidth={VARIABLE_INPUT_MAX_WIDTH}
-              marginBottom={1}
-              marginRight={1}
-              data-testid="template-variable"
-            >
-              <TemplateVariable key={v.spec.name} name={v.spec.name} />
-            </Box>
-          ))}
-          {props.initialVariableIsSticky && (
-            <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
-          )}
+    <>
+      {variableDefinitions.map((v) => (
+        <Box
+          key={v.spec.name}
+          display={v.spec.display?.hidden ? 'none' : undefined}
+          minWidth={VARIABLE_INPUT_MIN_WIDTH}
+          maxWidth={VARIABLE_INPUT_MAX_WIDTH}
+          marginBottom={1}
+          marginRight={1}
+          data-testid="template-variable"
+        >
+          <TemplateVariable key={v.spec.name} name={v.spec.name} />
         </Box>
-      </AppBar>
-    </Box>
+      ))}
+    </>
   );
 }

--- a/ui/dashboards/src/components/index.ts
+++ b/ui/dashboards/src/components/index.ts
@@ -15,6 +15,7 @@ export * from './AddGroupButton';
 export * from './AddPanelButton';
 export * from './Dashboard';
 export * from './DashboardToolbar';
+export * from './DashboardStickyToolbar';
 export * from './DeletePanelDialog';
 export * from './DeletePanelGroupDialog';
 export * from './DiscardChangesConfirmationDialog';


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Add time range and refresh buttons to the sticky toolbar (fix: #797).

# Screenshots
![image](https://user-images.githubusercontent.com/5657041/235936826-20b36ba1-eac9-456a-b1ce-e732776526e4.png)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
