### PR TITLE
[IGNORE] stories can directly import plugin.json files

### DIFF
--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginRegistry.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginRegistry.tsx
@@ -19,12 +19,8 @@ import {
   dynamicImportPluginLoader,
 } from '@perses-dev/plugin-system';
 
-// NOTE: the aliases we use for components break these top level imports, so we
-// import relatively.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const prometheusResource = require('../../../../../prometheus-plugin/plugin.json');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const panelsResource = require('../../../../../panels-plugin/plugin.json');
+import prometheusResource from '@perses-dev/prometheus-plugin/plugin.json';
+import panelsResource from '@perses-dev/panels-plugin/plugin.json';
 
 const bundledPluginLoader: PluginLoader = dynamicImportPluginLoader([
   {

--- a/ui/storybook/src/config/main.ts
+++ b/ui/storybook/src/config/main.ts
@@ -30,13 +30,7 @@ type PkgConfig = {
    * Absolute path to the source directory for the package. Used to look for
    * stories and to configure a webpack alias.
    */
-  srcDir: string;
-
-  /**
-   * Absolute path to the plugin.json for packages with plugins. Used to
-   * configure a webpack alias.
-   */
-  pluginPath: string;
+  directory: string;
 
   /**
    * Title for items from that package. Will be used as the name for the folder
@@ -48,41 +42,35 @@ type PkgConfig = {
 const pkgConfig: PkgConfig[] = [
   {
     pkg: '@perses-dev/components',
+    directory: path.resolve(uiRoot, 'components/src'),
     title: 'Components',
   },
   {
     pkg: '@perses-dev/core',
+    directory: path.resolve(uiRoot, 'core/src'),
     title: 'Core',
   },
   {
     pkg: '@perses-dev/dashboards',
+    directory: path.resolve(uiRoot, 'dashboards/src'),
     title: 'Dashboards',
   },
   {
     pkg: '@perses-dev/panels-plugin',
+    directory: path.resolve(uiRoot, 'panels-plugin/src'),
     title: 'Panels Plugin',
   },
   {
     pkg: '@perses-dev/plugin-system',
+    directory: path.resolve(uiRoot, 'plugin-system/src'),
     title: 'Plugin System',
   },
   {
     pkg: '@perses-dev/prometheus-plugin',
+    directory: path.resolve(uiRoot, 'prometheus-plugin/src'),
     title: 'Prometheus Plugin',
   },
-].map((pkgConfig) => {
-  const { pkg } = pkgConfig;
-
-  // Assumes all packages have names matching the non-namespaced part of the
-  // package name.
-  const pkgDir = path.resolve(uiRoot, pkg.replace('@perses-dev/', ''));
-
-  return {
-    ...pkgConfig,
-    srcDir: path.resolve(pkgDir, 'src'),
-    pluginPath: path.resolve(pkgDir, 'plugin.json'),
-  };
-});
+];
 
 // File selector for stories.
 const BASE_STORY_SELECTOR = '*.stories.@(ts|tsx|mdx)';
@@ -102,7 +90,7 @@ const config: StorybookConfig = {
   stories: [
     // Package-specific stories that live alongside their components or in
     // the `stories` directory.
-    ...pkgConfig.map(({ srcDir: directory, title }) => {
+    ...pkgConfig.map(({ directory, title }) => {
       return {
         directory,
         titlePrefix: title,
@@ -136,7 +124,7 @@ const config: StorybookConfig = {
       // providers/context, leading to them not working properly.
       // Note that this does not work correctly for top-level items not in `src`
       // (e.g. `plugin.json` files).
-      ...pkgConfig.reduce((result, { pkg, srcDir, pluginPath }) => {
+      ...pkgConfig.reduce((result, { pkg, directory }) => {
         return {
           ...result,
 
@@ -148,8 +136,7 @@ const config: StorybookConfig = {
           // This helps us define provider/context decorators once in the
           // packages that define the context, which makes it easier to share
           // utils without hitting circular dependencies with turbo.
-          [`${pkg}$`]: srcDir,
-          [`${pkg}/plugin.json$`]: pluginPath,
+          [`${pkg}$`]: directory,
         };
       }, {}),
     };


### PR DESCRIPTION
This PR helps address https://github.com/perses/perses/pull/1121#discussion_r1181679790. 

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
