### PR TITLE
[BUGFIX] Fix favicon returning 500 inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine AS build-env
+RUN apk add --update --no-cache mailcap
 RUN mkdir /perses
 
 FROM gcr.io/distroless/static-debian11
@@ -14,6 +15,7 @@ COPY --chown=nobody:nobody schemas/                          /etc/perses/schemas
 COPY --chown=nobody:nobody cue.mod/                          /etc/perses/cue.mod/
 COPY --chown=nobody:nobody docs/examples/config.docker.yaml  /etc/perses/config.yaml
 COPY --from=build-env --chown=nobody:nobody                  /perses /perses
+COPY --from=build-env --chown=nobody:nobody                  /etc/mime.types /etc/mime.types
 
 WORKDIR /perses
 

--- a/distroless-debug.Dockerfile
+++ b/distroless-debug.Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine AS build-env
+RUN apk add --update --no-cache mailcap
 RUN mkdir /perses
 
 FROM gcr.io/distroless/static-debian11:debug
@@ -14,6 +15,7 @@ COPY --chown=nobody:nobody schemas/                          /etc/perses/schemas
 COPY --chown=nobody:nobody cue.mod/                          /etc/perses/cue.mod/
 COPY --chown=nobody:nobody docs/examples/config.docker.yaml  /etc/perses/config.yaml
 COPY --from=build-env --chown=nobody:nobody                  /perses /perses
+COPY --from=build-env --chown=nobody:nobody                  /etc/mime.types /etc/mime.types
 
 WORKDIR /perses
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Fixing favicon & font requests returning 500 (seeker can't seek) inside distroless container.

## Reason:
Found the issue and the fix thanks to: https://github.com/jaegertracing/jaeger/pull/3569
- net/http depends on mime-type to set the Content-Type for a http response (https://github.com/golang/go/blob/master/src/net/http/fs.go#L173-L176)
- mime-type is calculated using https://pkg.go.dev/mime#TypeByExtension (https://github.com/golang/go/blob/master/src/net/http/fs.go#L235)
- In distroless, there is no default installation of mime-type library hence net/http was setting application/text for favicon.ico which was leading to 500. Adding mailcap package will install /etc/mime.types (https://pkgs.alpinelinux.org/contents?branch=edge&name=mailcap&arch=x86_64&repo=main) and fix the issue by setting the right content-type.


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
