### PR TITLE
[BREAKINGCHANGE] Allow saving `duration` from JSON editor, useDefaultTimeRange renamed to useDashboardDuration

### DIFF
--- a/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
+++ b/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
@@ -14,6 +14,7 @@
 import { FormEvent, useState } from 'react';
 import { Alert, FormControl } from '@mui/material';
 import { Dialog, JSONEditor } from '@perses-dev/components';
+import { useTimeRange } from '@perses-dev/plugin-system';
 import { useEditJsonDialog } from '../../context/DashboardProvider';
 import { useDashboard } from '../../context/useDashboard';
 
@@ -30,12 +31,14 @@ export const EditJsonDialog = () => {
 
 const EditJsonDialogForm = () => {
   const { closeEditJsonDialog } = useEditJsonDialog();
+  const { setTimeRange } = useTimeRange();
   const { dashboard, setDashboard } = useDashboard();
   const [draftDashboard, setDraftDashboard] = useState(dashboard);
 
   const handleApply = (e: FormEvent) => {
     e.preventDefault();
     setDashboard(draftDashboard);
+    setTimeRange({ pastDuration: draftDashboard.spec.duration });
     closeEditJsonDialog();
   };
 

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -17,7 +17,7 @@ import { DateTimeRangePicker, InfoTooltip, TimeOption } from '@perses-dev/compon
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { isDurationString } from '@perses-dev/core';
 import { TOOLTIP_TEXT } from '../../constants';
-import { useDefaultTimeRange } from '../../context';
+import { useDashboardDuration } from '../../context';
 import { ToolbarIconButton } from '../ToolbarIconButton';
 
 export const TIME_OPTIONS: TimeOption[] = [
@@ -45,17 +45,17 @@ interface TimeRangeControlsProps {
 export function TimeRangeControls({ heightPx, showRefresh = true }: TimeRangeControlsProps) {
   const { timeRange, setTimeRange, refresh } = useTimeRange();
   // TODO: Remove this since it couples to the dashboard context
-  const defaultTimeRange = useDefaultTimeRange();
+  const dashboardDuration = useDashboardDuration();
 
   // Convert height to a string, then use the string for styling
   const height = heightPx === undefined ? DEFAULT_HEIGHT : `${heightPx}px`;
 
   // add time shortcut if one does not match duration from dashboard JSON
-  if (!TIME_OPTIONS.some((option) => option.value.pastDuration === defaultTimeRange.pastDuration)) {
-    if (isDurationString(defaultTimeRange.pastDuration)) {
+  if (!TIME_OPTIONS.some((option) => option.value.pastDuration === dashboardDuration)) {
+    if (isDurationString(dashboardDuration)) {
       TIME_OPTIONS.push({
-        value: { pastDuration: defaultTimeRange.pastDuration },
-        display: `Last ${defaultTimeRange.pastDuration}`,
+        value: { pastDuration: dashboardDuration },
+        display: `Last ${dashboardDuration}`,
       });
     }
   }

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -17,7 +17,7 @@ import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { shallow } from 'zustand/shallow';
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
-import { DashboardResource, Display, ProjectMetadata, RelativeTimeRange, DurationString } from '@perses-dev/core';
+import { DashboardResource, Display, ProjectMetadata, RelativeTimeRange } from '@perses-dev/core';
 import { usePlugin, usePluginRegistry } from '@perses-dev/plugin-system';
 import { createPanelGroupEditorSlice, PanelGroupEditorSlice } from './panel-group-editor-slice';
 import { convertLayoutsToPanelGroups, createPanelGroupSlice, PanelGroupSlice } from './panel-group-slice';
@@ -42,11 +42,10 @@ export interface DashboardStoreState
     EditJsonDialogSlice {
   isEditMode: boolean;
   setEditMode: (isEditMode: boolean) => void;
-  defaultTimeRange: RelativeTimeRange;
   setDashboard: (dashboard: DashboardResource) => void;
   metadata: ProjectMetadata;
   display?: Display;
-  duration: DurationString;
+  timeRange: RelativeTimeRange;
 }
 
 export interface DashboardStoreProps {
@@ -134,20 +133,18 @@ function initStore(props: DashboardProviderProps) {
           ...createEditJsonDialogSlice(...args),
           metadata,
           display,
-          duration,
-          defaultTimeRange: { pastDuration: duration },
+          timeRange: { pastDuration: duration },
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
           setDashboard: ({ metadata, spec: { display, panels = {}, layouts = [], duration } }) => {
             set((state) => {
-              console.log('setDashboard -> duration: ', duration);
               state.metadata = metadata;
               state.display = display;
               state.panels = panels;
               const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
               state.panelGroups = panelGroups;
               state.panelGroupOrder = panelGroupOrder;
-              state.duration = duration;
+              state.timeRange = { pastDuration: duration };
             });
           },
         };

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -17,7 +17,7 @@ import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { shallow } from 'zustand/shallow';
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
-import { DashboardResource, Display, ProjectMetadata, RelativeTimeRange } from '@perses-dev/core';
+import { DashboardResource, Display, ProjectMetadata, RelativeTimeRange, DurationString } from '@perses-dev/core';
 import { usePlugin, usePluginRegistry } from '@perses-dev/plugin-system';
 import { createPanelGroupEditorSlice, PanelGroupEditorSlice } from './panel-group-editor-slice';
 import { convertLayoutsToPanelGroups, createPanelGroupSlice, PanelGroupSlice } from './panel-group-slice';
@@ -46,6 +46,7 @@ export interface DashboardStoreState
   setDashboard: (dashboard: DashboardResource) => void;
   metadata: ProjectMetadata;
   display?: Display;
+  duration: DurationString;
 }
 
 export interface DashboardStoreProps {
@@ -133,17 +134,20 @@ function initStore(props: DashboardProviderProps) {
           ...createEditJsonDialogSlice(...args),
           metadata,
           display,
+          duration,
           defaultTimeRange: { pastDuration: duration },
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
-          setDashboard: ({ metadata, spec: { display, panels = {}, layouts = [] } }) => {
+          setDashboard: ({ metadata, spec: { display, panels = {}, layouts = [], duration } }) => {
             set((state) => {
+              console.log('setDashboard -> duration: ', duration);
               state.metadata = metadata;
               state.display = display;
               state.panels = panels;
               const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
               state.panelGroups = panelGroups;
               state.panelGroupOrder = panelGroupOrder;
+              state.duration = duration;
             });
           },
         };

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -17,7 +17,7 @@ import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { shallow } from 'zustand/shallow';
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
-import { DashboardResource, Display, ProjectMetadata, RelativeTimeRange } from '@perses-dev/core';
+import { DashboardResource, Display, ProjectMetadata, DurationString } from '@perses-dev/core';
 import { usePlugin, usePluginRegistry } from '@perses-dev/plugin-system';
 import { createPanelGroupEditorSlice, PanelGroupEditorSlice } from './panel-group-editor-slice';
 import { convertLayoutsToPanelGroups, createPanelGroupSlice, PanelGroupSlice } from './panel-group-slice';
@@ -44,8 +44,8 @@ export interface DashboardStoreState
   setEditMode: (isEditMode: boolean) => void;
   setDashboard: (dashboard: DashboardResource) => void;
   metadata: ProjectMetadata;
+  duration: DurationString;
   display?: Display;
-  timeRange: RelativeTimeRange;
 }
 
 export interface DashboardStoreProps {
@@ -133,7 +133,7 @@ function initStore(props: DashboardProviderProps) {
           ...createEditJsonDialogSlice(...args),
           metadata,
           display,
-          timeRange: { pastDuration: duration },
+          duration,
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
           setDashboard: ({ metadata, spec: { display, panels = {}, layouts = [], duration } }) => {
@@ -144,7 +144,7 @@ function initStore(props: DashboardProviderProps) {
               const { panelGroups, panelGroupOrder } = convertLayoutsToPanelGroups(layouts);
               state.panelGroups = panelGroups;
               state.panelGroupOrder = panelGroupOrder;
-              state.timeRange = { pastDuration: duration };
+              state.duration = duration;
             });
           },
         };

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -224,9 +224,9 @@ export function useDeletePanelDialog() {
   return useDashboardStore(selectDeletePanelDialog);
 }
 
-const selectDefaultTimeRange = (state: DashboardStoreState) => state.timeRange;
-export function useDefaultTimeRange() {
-  return useDashboardStore(selectDefaultTimeRange);
+const selectDashboardDuration = (state: DashboardStoreState) => state.duration;
+export function useDashboardDuration() {
+  return useDashboardStore(selectDashboardDuration);
 }
 
 const selectDiscardChangesConfirmationDialog = ({

--- a/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
+++ b/ui/dashboards/src/context/DashboardProvider/dashboard-provider-api.ts
@@ -224,7 +224,7 @@ export function useDeletePanelDialog() {
   return useDashboardStore(selectDeletePanelDialog);
 }
 
-const selectDefaultTimeRange = (state: DashboardStoreState) => state.defaultTimeRange;
+const selectDefaultTimeRange = (state: DashboardStoreState) => state.timeRange;
 export function useDefaultTimeRange() {
   return useDashboardStore(selectDefaultTimeRange);
 }

--- a/ui/dashboards/src/context/useDashboard.tsx
+++ b/ui/dashboards/src/context/useDashboard.tsx
@@ -20,12 +20,12 @@ export function useDashboard() {
     panels,
     panelGroups,
     panelGroupOrder,
-    defaultTimeRange,
+    duration,
     setDashboard: setDashboardResource,
     metadata,
     display,
   } = useDashboardStore(
-    ({ panels, panelGroups, panelGroupOrder, defaultTimeRange, setDashboard, metadata, display }) => ({
+    ({ panels, panelGroups, panelGroupOrder, defaultTimeRange, setDashboard, metadata, display, duration }) => ({
       panels,
       panelGroups,
       panelGroupOrder,
@@ -33,6 +33,7 @@ export function useDashboard() {
       setDashboard,
       metadata,
       display,
+      duration,
     })
   );
   const { setVariableDefinitions } = useTemplateVariableActions();
@@ -47,11 +48,12 @@ export function useDashboard() {
       panels,
       layouts,
       variables,
-      duration: defaultTimeRange.pastDuration,
+      duration: duration,
     },
   };
 
   const setDashboard = (dashboardResource: DashboardResource) => {
+    console.log('setDashboard -> dashboardResource: ', dashboardResource);
     setVariableDefinitions(dashboardResource.spec.variables);
     setDashboardResource(dashboardResource);
   };

--- a/ui/dashboards/src/context/useDashboard.tsx
+++ b/ui/dashboards/src/context/useDashboard.tsx
@@ -20,22 +20,19 @@ export function useDashboard() {
     panels,
     panelGroups,
     panelGroupOrder,
-    duration,
     setDashboard: setDashboardResource,
     metadata,
     display,
-  } = useDashboardStore(
-    ({ panels, panelGroups, panelGroupOrder, defaultTimeRange, setDashboard, metadata, display, duration }) => ({
-      panels,
-      panelGroups,
-      panelGroupOrder,
-      defaultTimeRange,
-      setDashboard,
-      metadata,
-      display,
-      duration,
-    })
-  );
+    timeRange,
+  } = useDashboardStore(({ panels, panelGroups, panelGroupOrder, setDashboard, metadata, display, timeRange }) => ({
+    panels,
+    panelGroups,
+    panelGroupOrder,
+    setDashboard,
+    metadata,
+    display,
+    timeRange,
+  }));
   const { setVariableDefinitions } = useTemplateVariableActions();
   const variables = useTemplateVariableDefinitions();
   const layouts = convertPanelGroupsToLayouts(panelGroups, panelGroupOrder);
@@ -48,12 +45,11 @@ export function useDashboard() {
       panels,
       layouts,
       variables,
-      duration: duration,
+      duration: timeRange.pastDuration,
     },
   };
 
   const setDashboard = (dashboardResource: DashboardResource) => {
-    console.log('setDashboard -> dashboardResource: ', dashboardResource);
     setVariableDefinitions(dashboardResource.spec.variables);
     setDashboardResource(dashboardResource);
   };

--- a/ui/dashboards/src/context/useDashboard.tsx
+++ b/ui/dashboards/src/context/useDashboard.tsx
@@ -23,15 +23,15 @@ export function useDashboard() {
     setDashboard: setDashboardResource,
     metadata,
     display,
-    timeRange,
-  } = useDashboardStore(({ panels, panelGroups, panelGroupOrder, setDashboard, metadata, display, timeRange }) => ({
+    duration,
+  } = useDashboardStore(({ panels, panelGroups, panelGroupOrder, setDashboard, metadata, display, duration }) => ({
     panels,
     panelGroups,
     panelGroupOrder,
     setDashboard,
     metadata,
     display,
-    timeRange,
+    duration,
   }));
   const { setVariableDefinitions } = useTemplateVariableActions();
   const variables = useTemplateVariableDefinitions();
@@ -45,7 +45,7 @@ export function useDashboard() {
       panels,
       layouts,
       variables,
-      duration: timeRange.pastDuration,
+      duration,
     },
   };
 


### PR DESCRIPTION
Now that a JSON editor was added in #1012, this PR allows saving a new `duration` from the editor. 

This is just the first PR of multiple that will allow users to pick if they want to save the selected time range as default and/or the selected variables as default.

## Screen recording

https://user-images.githubusercontent.com/9369625/236255218-cfdd270f-4a0a-4ff2-beac-55b055abd169.mp4

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
