### PR TITLE
[BUGFIX] Remove palette edit buttons after merge issue

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Autocomplete, Slider, Switch, TextField, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { Autocomplete, Slider, Switch, TextField } from '@mui/material';
 import { OptionsEditorControl, OptionsEditorGroup } from '@perses-dev/components';
 import {
   DEFAULT_AREA_OPACITY,
@@ -103,27 +103,6 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             max={VISUAL_CONFIG.area_opacity.max}
             onChange={handleAreaOpacityChange}
           />
-        }
-      />
-      <OptionsEditorControl
-        label={'Palette'}
-        control={
-          <ToggleButtonGroup
-            color="primary"
-            exclusive
-            value={value.palette?.kind ?? 'Auto'}
-            onChange={(__, newValue) => {
-              const palette: VisualOptions['palette'] =
-                newValue === 'Categorical' ? { kind: 'Categorical' } : undefined;
-              onChange({
-                ...value,
-                palette,
-              });
-            }}
-          >
-            <ToggleButton value="Auto">Auto</ToggleButton>
-            <ToggleButton value="Categorical">Categorical</ToggleButton>
-          </ToggleButtonGroup>
         }
       />
       <OptionsEditorControl


### PR DESCRIPTION
This was meant to be removed in #1124 (I messed up a rebase at some point 😞 since it was deleted at one point)

Mohit had asked for visual editing of palette to be removed, it also doesn't 100% work now that we automatically change the palette based on total series.