### PR TITLE
[ENHANCEMENT] Update formatting to use exact decimal places

### DIFF
--- a/ui/components/src/UnitSelector/UnitSelector.test.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.test.tsx
@@ -137,7 +137,7 @@ describe('UnitSelector', () => {
     expect(onChange).toHaveBeenCalledWith({
       kind: 'Decimal',
       decimal_places: 0,
-      abbreviate: true,
+      abbreviate: false,
     });
   });
 

--- a/ui/components/src/UnitSelector/UnitSelector.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.tsx
@@ -12,6 +12,7 @@
 // limitations under the License.
 import { Box, Switch, TextField, Autocomplete, SwitchProps } from '@mui/material';
 import { UnitOptions, UNIT_CONFIG, UnitConfig, isUnitWithDecimalPlaces, isUnitWithAbbreviate } from '../model';
+import { shouldAbbreviate } from '../model/units/utils';
 import { OptionsEditorControl } from '../OptionsEditorLayout';
 
 export interface UnitSelectorProps {
@@ -79,7 +80,7 @@ export function UnitSelector({ value, onChange }: UnitSelectorProps) {
         label="Abbreviate"
         control={
           <Switch
-            checked={hasAbbreviate ? !!value.abbreviate : false}
+            checked={hasAbbreviate ? shouldAbbreviate(value.abbreviate) : false}
             onChange={handleAbbreviateChange}
             disabled={!hasAbbreviate}
           />

--- a/ui/components/src/model/units/bytes.test.ts
+++ b/ui/components/src/model/units/bytes.test.ts
@@ -28,7 +28,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: -1234,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '-1,234 bytes',
+    expected: '-1,234.0000 bytes',
   },
   {
     value: -1234,
@@ -38,7 +38,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: -1234,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '-1.234 KB',
+    expected: '-1.2340 KB',
   },
   { value: 0, unit: { kind: 'Bytes' }, expected: '0 bytes' },
   { value: 1, unit: { kind: 'Bytes' }, expected: '1 byte' },
@@ -55,7 +55,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 10,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '10 bytes',
+    expected: '10.0000 bytes',
   },
   {
     value: 10,
@@ -65,7 +65,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 10,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '10 bytes',
+    expected: '10.0000 bytes',
   },
   {
     value: 10.1234,
@@ -105,7 +105,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 1000,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '1,000 bytes',
+    expected: '1,000.0000 bytes',
   },
   {
     value: 1000,
@@ -115,7 +115,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 1000,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '1 KB',
+    expected: '1.0000 KB',
   },
   {
     value: 1234,
@@ -130,7 +130,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 1234,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '1,234 bytes',
+    expected: '1,234.0000 bytes',
   },
   {
     value: 1234,
@@ -140,7 +140,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 1234,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '1.234 KB',
+    expected: '1.2340 KB',
   },
   {
     value: 100000,
@@ -155,7 +155,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 100000,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '100,000 bytes',
+    expected: '100,000.0000 bytes',
   },
   {
     value: 100000,
@@ -165,7 +165,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 100000,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '100 KB',
+    expected: '100.0000 KB',
   },
   {
     value: 123456,
@@ -180,7 +180,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 123456,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '123,456 bytes',
+    expected: '123,456.0000 bytes',
   },
   {
     value: 123456,
@@ -190,7 +190,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 123456,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '123.456 KB',
+    expected: '123.4560 KB',
   },
   {
     value: 10000000,
@@ -205,7 +205,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 10000000,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '10,000,000 bytes',
+    expected: '10,000,000.0000 bytes',
   },
   {
     value: 10000000,
@@ -215,7 +215,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 10000000,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '10 MB',
+    expected: '10.0000 MB',
   },
   {
     value: 12345678,
@@ -230,7 +230,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 12345678,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '12,345,678 bytes',
+    expected: '12,345,678.0000 bytes',
   },
   {
     value: 12345678,
@@ -255,7 +255,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 1000000000,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '1,000,000,000 bytes',
+    expected: '1,000,000,000.0000 bytes',
   },
   {
     value: 1000000000,
@@ -265,7 +265,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 1000000000,
     unit: { kind: 'Bytes', abbreviate: true, decimal_places: 4 },
-    expected: '1 GB',
+    expected: '1.0000 GB',
   },
   {
     value: 1234567890,
@@ -280,7 +280,7 @@ const BYTES_TESTS: UnitTestCase[] = [
   {
     value: 1234567890,
     unit: { kind: 'Bytes', abbreviate: false, decimal_places: 4 },
-    expected: '1,234,567,890 bytes',
+    expected: '1,234,567,890.0000 bytes',
   },
   {
     value: 1234567890,

--- a/ui/components/src/model/units/bytes.ts
+++ b/ui/components/src/model/units/bytes.ts
@@ -70,7 +70,9 @@ export function formatBytes(bytes: number, options: BytesUnitOptions) {
     base: 'decimal',
     spaceSeparated: true,
     mantissa: hasDecimalPlaces(decimal_places) ? decimal_places : DEFAULT_NUMBRO_MANTISSA,
+    // trimMantissa trims trailing 0s
     trimMantissa: !hasDecimalPlaces(decimal_places),
+    // optionalMantissa excludes all the decimal places if they're all zeros
     optionalMantissa: !hasDecimalPlaces(decimal_places),
   });
 }

--- a/ui/components/src/model/units/bytes.ts
+++ b/ui/components/src/model/units/bytes.ts
@@ -32,7 +32,7 @@ export const BYTES_GROUP_CONFIG: UnitGroupConfig = {
   abbreviate: true,
 };
 export const BYTES_UNIT_CONFIG: Readonly<Record<BytesUnitKind, UnitConfig>> = {
-  // This uses units that are powers of 1000.
+  // These units are powers of 1000.
   // In other words, 1KB = 1000 bytes.
   Bytes: {
     group: 'Bytes',
@@ -52,6 +52,7 @@ export function formatBytes(bytes: number, options: BytesUnitOptions) {
     };
 
     if (hasDecimalPlaces(decimal_places)) {
+      formatterOptions.minimumFractionDigits = limitDecimalPlaces(decimal_places);
       formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimal_places);
     } else {
       // This can happen if bytes is between -1000 and 1000
@@ -60,8 +61,7 @@ export function formatBytes(bytes: number, options: BytesUnitOptions) {
       }
     }
 
-    const formatter = Intl.NumberFormat('en-US', formatterOptions);
-    return formatter.format(bytes);
+    return Intl.NumberFormat('en-US', formatterOptions).format(bytes);
   }
 
   // numbro is able to add units like KB, MB, GB, etc. correctly
@@ -69,8 +69,8 @@ export function formatBytes(bytes: number, options: BytesUnitOptions) {
     output: 'byte',
     base: 'decimal',
     spaceSeparated: true,
-    mantissa: decimal_places ?? DEFAULT_NUMBRO_MANTISSA,
-    trimMantissa: true,
-    optionalMantissa: true,
+    mantissa: hasDecimalPlaces(decimal_places) ? decimal_places : DEFAULT_NUMBRO_MANTISSA,
+    trimMantissa: !hasDecimalPlaces(decimal_places),
+    optionalMantissa: !hasDecimalPlaces(decimal_places),
   });
 }

--- a/ui/components/src/model/units/bytes.ts
+++ b/ui/components/src/model/units/bytes.ts
@@ -33,7 +33,7 @@ export const BYTES_GROUP_CONFIG: UnitGroupConfig = {
 };
 export const BYTES_UNIT_CONFIG: Readonly<Record<BytesUnitKind, UnitConfig>> = {
   // These units are powers of 1000.
-  // In other words, 1KB = 1000 bytes.
+  // In other words, 1 KB = 1000 bytes.
   Bytes: {
     group: 'Bytes',
     label: 'Bytes',

--- a/ui/components/src/model/units/decimal.test.ts
+++ b/ui/components/src/model/units/decimal.test.ts
@@ -16,18 +16,57 @@ import { UnitTestCase } from './types';
 
 const DECIMAL_TESTS: UnitTestCase[] = [
   {
-    value: -10,
+    value: -4444,
     unit: { kind: 'Decimal' },
-    expected: '-10',
+    expected: '-4.44K',
+  },
+  {
+    value: -4444,
+    unit: { kind: 'Decimal', abbreviate: false },
+    expected: '-4,444',
+  },
+  {
+    value: -4444,
+    unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
+    expected: '-4,444.0000',
+  },
+  {
+    value: -4444,
+    unit: { kind: 'Decimal', abbreviate: true },
+    expected: '-4.44K',
+  },
+  {
+    value: -4444,
+    unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
+    expected: '-4.4440K',
   },
   {
     value: -0.123456789,
     unit: { kind: 'Decimal' },
     expected: '-0.123',
   },
+  {
+    value: -0.123456789,
+    unit: { kind: 'Decimal', abbreviate: false },
+    expected: '-0.123',
+  },
+  {
+    value: -0.123456789,
+    unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
+    expected: '-0.1235',
+  },
+  {
+    value: -0.123456789,
+    unit: { kind: 'Decimal', abbreviate: true },
+    expected: '-0.123',
+  },
+  {
+    value: -0.123456789,
+    unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
+    expected: '-0.1235',
+  },
   { value: 0, unit: { kind: 'Decimal' }, expected: '0' },
   { value: 1, unit: { kind: 'Decimal' }, expected: '1' },
-
   {
     value: 10,
     unit: { kind: 'Decimal' },
@@ -41,7 +80,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 10,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '10',
+    expected: '10.0000',
   },
   {
     value: 10,
@@ -51,7 +90,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 10,
     unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
-    expected: '10',
+    expected: '10.0000',
   },
   {
     value: 10.123456,
@@ -60,27 +99,22 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   },
   {
     value: 10.123456,
-    unit: { kind: 'Decimal', decimal_places: 0 },
-    expected: '10',
-  },
-  {
-    value: 10.123456,
-    unit: { kind: 'Decimal', decimal_places: 1 },
-    expected: '10.1',
-  },
-  {
-    value: 10.123456,
-    unit: { kind: 'Decimal', decimal_places: 2 },
-    expected: '10.12',
-  },
-  {
-    value: 10.123456,
-    unit: { kind: 'Decimal', decimal_places: 3 },
+    unit: { kind: 'Decimal', abbreviate: false },
     expected: '10.123',
   },
   {
     value: 10.123456,
-    unit: { kind: 'Decimal', decimal_places: 4 },
+    unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
+    expected: '10.1235',
+  },
+  {
+    value: 10.123456,
+    unit: { kind: 'Decimal', abbreviate: true },
+    expected: '10.1',
+  },
+  {
+    value: 10.123456,
+    unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
     expected: '10.1235',
   },
   {
@@ -96,7 +130,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 1000,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '1,000',
+    expected: '1,000.0000',
   },
   {
     value: 1000,
@@ -106,7 +140,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 1000,
     unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
-    expected: '1K',
+    expected: '1.0000K',
   },
   {
     value: 4444,
@@ -121,7 +155,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 4444,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '4,444',
+    expected: '4,444.0000',
   },
   {
     value: 4444,
@@ -131,7 +165,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 4444,
     unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
-    expected: '4.444K',
+    expected: '4.4440K',
   },
   {
     value: 100000,
@@ -146,7 +180,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 100000,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '100,000',
+    expected: '100,000.0000',
   },
   {
     value: 100000,
@@ -156,7 +190,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 100000,
     unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
-    expected: '100K',
+    expected: '100.0000K',
   },
   {
     value: 666666,
@@ -171,7 +205,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 666666,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '666,666',
+    expected: '666,666.0000',
   },
   {
     value: 666666,
@@ -181,7 +215,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 666666,
     unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
-    expected: '666.666K',
+    expected: '666.6660K',
   },
   {
     value: 10000000,
@@ -196,7 +230,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 10000000,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '10,000,000',
+    expected: '10,000,000.0000',
   },
   {
     value: 10000000,
@@ -206,7 +240,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 10000000,
     unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
-    expected: '10M',
+    expected: '10.0000M',
   },
   {
     value: 88888888,
@@ -221,7 +255,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 88888888,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '88,888,888',
+    expected: '88,888,888.0000',
   },
   {
     value: 88888888,
@@ -246,7 +280,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 1000000000,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '1,000,000,000',
+    expected: '1,000,000,000.0000',
   },
   {
     value: 1000000000,
@@ -256,7 +290,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 1000000000,
     unit: { kind: 'Decimal', abbreviate: true, decimal_places: 4 },
-    expected: '1B',
+    expected: '1.0000B',
   },
   {
     value: 1010101010,
@@ -271,7 +305,7 @@ const DECIMAL_TESTS: UnitTestCase[] = [
   {
     value: 1010101010,
     unit: { kind: 'Decimal', abbreviate: false, decimal_places: 4 },
-    expected: '1,010,101,010',
+    expected: '1,010,101,010.0000',
   },
   {
     value: 1010101010,

--- a/ui/components/src/model/units/decimal.ts
+++ b/ui/components/src/model/units/decimal.ts
@@ -47,6 +47,7 @@ export function formatDecimal(value: number, options: DecimalUnitOptions): strin
   }
 
   if (hasDecimalPlaces(decimal_places)) {
+    formatterOptions.minimumFractionDigits = limitDecimalPlaces(decimal_places);
     formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimal_places);
   } else {
     if (shouldAbbreviate(abbreviate)) {
@@ -54,6 +55,5 @@ export function formatDecimal(value: number, options: DecimalUnitOptions): strin
     }
   }
 
-  const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(value);
+  return Intl.NumberFormat('en-US', formatterOptions).format(value);
 }

--- a/ui/components/src/model/units/percent.test.ts
+++ b/ui/components/src/model/units/percent.test.ts
@@ -17,7 +17,7 @@ import { UnitTestCase } from './types';
 const PERCENT_TESTS: UnitTestCase[] = [
   // Percent
   { value: 0, unit: { kind: 'Percent' }, expected: '0%' },
-  { value: 0, unit: { kind: 'Percent', decimal_places: 4 }, expected: '0%' },
+  { value: 0, unit: { kind: 'Percent', decimal_places: 4 }, expected: '0.0000%' },
 
   { value: 0.001111, unit: { kind: 'Percent' }, expected: '0.00111%' },
   { value: 0.001111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '0%' },
@@ -32,31 +32,31 @@ const PERCENT_TESTS: UnitTestCase[] = [
   { value: 0.111111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '0.1111%' },
 
   { value: 1, unit: { kind: 'Percent' }, expected: '1%' },
-  { value: 1, unit: { kind: 'Percent', decimal_places: 4 }, expected: '1%' },
+  { value: 1, unit: { kind: 'Percent', decimal_places: 4 }, expected: '1.0000%' },
 
   { value: 1.1111, unit: { kind: 'Percent' }, expected: '1.11%' },
   { value: 1.1111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '1%' },
   { value: 1.1111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '1.1111%' },
 
   { value: 55, unit: { kind: 'Percent' }, expected: '55%' },
-  { value: 55, unit: { kind: 'Percent', decimal_places: 4 }, expected: '55%' },
+  { value: 55, unit: { kind: 'Percent', decimal_places: 4 }, expected: '55.0000%' },
 
   { value: 55.555, unit: { kind: 'Percent' }, expected: '55.6%' },
   { value: 55.555, unit: { kind: 'Percent', decimal_places: 0 }, expected: '56%' },
-  { value: 55.555, unit: { kind: 'Percent', decimal_places: 4 }, expected: '55.555%' },
+  { value: 55.555, unit: { kind: 'Percent', decimal_places: 4 }, expected: '55.5550%' },
 
   { value: 111, unit: { kind: 'Percent' }, expected: '111%' },
-  { value: 111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '111%' },
+  { value: 111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '111.0000%' },
 
   { value: 111.111, unit: { kind: 'Percent' }, expected: '111%' },
   { value: 111.111, unit: { kind: 'Percent', decimal_places: 0 }, expected: '111%' },
-  { value: 111.111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '111.111%' },
+  { value: 111.111, unit: { kind: 'Percent', decimal_places: 4 }, expected: '111.1110%' },
 
   { value: 100000, unit: { kind: 'Percent' }, expected: '100,000%' },
 
   // PercentDecimal
   { value: 0, unit: { kind: 'PercentDecimal' }, expected: '0%' },
-  { value: 0, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '0%' },
+  { value: 0, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '0.0000%' },
 
   { value: 0.00001111, unit: { kind: 'PercentDecimal' }, expected: '0.00111%' },
   { value: 0.00001111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '0%' },
@@ -72,23 +72,23 @@ const PERCENT_TESTS: UnitTestCase[] = [
 
   { value: 0.01, unit: { kind: 'PercentDecimal' }, expected: '1%' },
   { value: 0.01, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '1%' },
-  { value: 0.01, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '1%' },
+  { value: 0.01, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '1.0000%' },
 
   { value: 0.01111, unit: { kind: 'PercentDecimal' }, expected: '1.11%' },
   { value: 0.01111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '1%' },
-  { value: 0.01111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '1.111%' },
+  { value: 0.01111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '1.1110%' },
 
   { value: 0.11, unit: { kind: 'PercentDecimal' }, expected: '11%' },
   { value: 0.11, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '11%' },
-  { value: 0.11, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '11%' },
+  { value: 0.11, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '11.0000%' },
 
   { value: 0.1111, unit: { kind: 'PercentDecimal' }, expected: '11.1%' },
   { value: 0.1111, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '11%' },
-  { value: 0.1111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '11.11%' },
+  { value: 0.1111, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '11.1100%' },
 
   { value: 1, unit: { kind: 'PercentDecimal' }, expected: '100%' },
   { value: 1, unit: { kind: 'PercentDecimal', decimal_places: 0 }, expected: '100%' },
-  { value: 1, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '100%' },
+  { value: 1, unit: { kind: 'PercentDecimal', decimal_places: 4 }, expected: '100.0000%' },
 
   { value: 10, unit: { kind: 'PercentDecimal' }, expected: '1,000%' },
 ];

--- a/ui/components/src/model/units/percent.ts
+++ b/ui/components/src/model/units/percent.ts
@@ -56,11 +56,11 @@ export function formatPercent(value: number, { kind, decimal_places }: PercentUn
   };
 
   if (hasDecimalPlaces(decimal_places)) {
+    formatterOptions.minimumFractionDigits = limitDecimalPlaces(decimal_places);
     formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimal_places);
   } else {
     formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
   }
 
-  const formatter = Intl.NumberFormat('en-us', formatterOptions);
-  return formatter.format(value);
+  return Intl.NumberFormat('en-US', formatterOptions).format(value);
 }

--- a/ui/components/src/model/units/time.ts
+++ b/ui/components/src/model/units/time.ts
@@ -84,11 +84,11 @@ export function formatTime(value: number, { kind, decimal_places }: TimeUnitOpti
   };
 
   if (hasDecimalPlaces(decimal_places)) {
+    formatterOptions.minimumFractionDigits = limitDecimalPlaces(decimal_places);
     formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimal_places);
   } else {
     formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
   }
 
-  const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(value);
+  return Intl.NumberFormat('en-US', formatterOptions).format(value);
 }


### PR DESCRIPTION
This is a follow-up to a bunch of number formatting work.

We noticed we had a lot of numbers with unnecessary decimal places like 100.00, 400.00, etc.

We changed "Decimals" and made it so that when "Decimals" is set to X, use _at maximum_ X decimal places. That solved the problem but wasn't quite complete.

Now, we've added the ability to set "Decimals" to undefined. Using this, we can avoid having numbers like 100.00. This means we can go back to being explicit: When "Decimals" is set to X, use exactly X decimal places.
