### PR TITLE
[ENHANCEMENT] Improve centering for stat chart

### DIFF
--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -119,7 +119,9 @@ export function StatChart(props: StatChartProps) {
         sx={(theme) => ({
           color: color ?? theme.palette.text.primary,
           fontSize: `clamp(${MIN_VALUE_SIZE}px, ${valueSize}px, ${MAX_VALUE_SIZE}px)`,
-          padding: `${containerPadding} ${containerPadding} 0 ${containerPadding}`,
+          padding: sparkline
+            ? `${containerPadding} ${containerPadding} 0 ${containerPadding}`
+            : ` 0 ${containerPadding}`,
         })}
       >
         {formattedValue}


### PR DESCRIPTION
While playing around with the Stat Chart, I noticed there was extra padding around the text when the chart doesn't have a sparkline. 

I figure this helps center the text a bit more. 

