### PR TITLE
[BREAKINGCHANGE] Add interfaces for each panel's definition

### DIFF
--- a/ui/panels-plugin/src/index.ts
+++ b/ui/panels-plugin/src/index.ts
@@ -11,10 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GaugeChart } from './plugins/gauge-chart';
-import { TimeSeriesChart } from './plugins/time-series-chart';
-import { Markdown } from './plugins/markdown';
-import { StatChart } from './plugins/stat-chart';
+import { GaugeChart, GaugeChartDefinition } from './plugins/gauge-chart';
+import { TimeSeriesChart, TimeSeriesChartDefinition } from './plugins/time-series-chart';
+import { Markdown, MarkdownPanelDefinition } from './plugins/markdown';
+import { StatChart, StatChartDefinition } from './plugins/stat-chart';
 
 // Just export the plugins under the same name as the kinds they handle from the plugin.json
 export { TimeSeriesChart, GaugeChart, StatChart, Markdown };
+export type { TimeSeriesChartDefinition, GaugeChartDefinition, StatChartDefinition, MarkdownPanelDefinition };

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -19,6 +19,9 @@ export const DEFAULT_UNIT: UnitOptions = { kind: 'PercentDecimal' };
 export const DEFAULT_MAX_PERCENT = 100;
 export const DEFAULT_MAX_PERCENT_DECIMAL = 1;
 
+/**
+ * The schema for a GaugeChart panel.
+ */
 export interface GaugeChartDefinition extends Definition<GaugeChartOptions> {
   kind: 'GaugeChart';
 }

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -16,12 +16,13 @@ import { UnitOptions } from '@perses-dev/components';
 import { CalculationType, OptionsEditorProps } from '@perses-dev/plugin-system';
 
 export const DEFAULT_UNIT: UnitOptions = { kind: 'PercentDecimal' };
-
 export const DEFAULT_MAX_PERCENT = 100;
-
 export const DEFAULT_MAX_PERCENT_DECIMAL = 1;
 
-export type GaugeChartOptionsEditorProps = OptionsEditorProps<GaugeChartOptions>;
+export interface GaugeChart {
+  kind: 'GaugeChart';
+  spec: GaugeChartOptions;
+}
 
 /**
  * The Options object type supported by the GaugeChart panel plugin.
@@ -32,6 +33,8 @@ export interface GaugeChartOptions {
   thresholds?: ThresholdOptions;
   max?: number;
 }
+
+export type GaugeChartOptionsEditorProps = OptionsEditorProps<GaugeChartOptions>;
 
 /**
  * Creates the initial/empty options for a GaugeChart panel.

--- a/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/gauge-chart-model.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ThresholdOptions } from '@perses-dev/core';
+import { Definition, ThresholdOptions } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
 import { CalculationType, OptionsEditorProps } from '@perses-dev/plugin-system';
 
@@ -19,9 +19,8 @@ export const DEFAULT_UNIT: UnitOptions = { kind: 'PercentDecimal' };
 export const DEFAULT_MAX_PERCENT = 100;
 export const DEFAULT_MAX_PERCENT_DECIMAL = 1;
 
-export interface GaugeChart {
+export interface GaugeChartDefinition extends Definition<GaugeChartOptions> {
   kind: 'GaugeChart';
-  spec: GaugeChartOptions;
 }
 
 /**

--- a/ui/panels-plugin/src/plugins/gauge-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './GaugeChart';
+export type { GaugeChartDefinition } from './gauge-chart-model';

--- a/ui/panels-plugin/src/plugins/markdown/index.ts
+++ b/ui/panels-plugin/src/plugins/markdown/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './Markdown';
+export type { MarkdownPanelDefinition } from './markdown-panel-model';

--- a/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
+++ b/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export interface MarkdownPanel {
+import { Definition } from '@perses-dev/core';
+
+export interface MarkdownPanelDefinition extends Definition<MarkdownPanelOptions> {
   kind: 'MarkdownPanel';
-  spec: MarkdownPanelOptions;
 }
 
 export interface MarkdownPanelOptions {

--- a/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
+++ b/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
@@ -11,6 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export interface MarkdownPanel {
+  kind: 'MarkdownPanel';
+  spec: MarkdownPanelOptions;
+}
+
 export interface MarkdownPanelOptions {
   text: string;
 }

--- a/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
+++ b/ui/panels-plugin/src/plugins/markdown/markdown-panel-model.ts
@@ -13,8 +13,11 @@
 
 import { Definition } from '@perses-dev/core';
 
+/**
+ * The schema for a Markdown panel.
+ */
 export interface MarkdownPanelDefinition extends Definition<MarkdownPanelOptions> {
-  kind: 'MarkdownPanel';
+  kind: 'Markdown';
 }
 
 export interface MarkdownPanelOptions {

--- a/ui/panels-plugin/src/plugins/stat-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './StatChart';
+export type { StatChartDefinition } from './stat-chart-model';

--- a/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
@@ -15,6 +15,9 @@ import { Definition, ThresholdOptions } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
 import { CalculationType, OptionsEditorProps } from '@perses-dev/plugin-system';
 
+/**
+ * The schema for a StatChart panel.
+ */
 export interface StatChartDefinition extends Definition<StatChartOptions> {
   kind: 'StatChart';
 }

--- a/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
@@ -15,12 +15,10 @@ import { ThresholdOptions } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
 import { CalculationType, OptionsEditorProps } from '@perses-dev/plugin-system';
 
-export interface SparklineOptions {
-  color?: string;
-  width?: number;
-}
-
-export type StatChartOptionsEditorProps = OptionsEditorProps<StatChartOptions>;
+export type StatChart = {
+  kind: 'StatChart';
+  spec: StatChartOptions;
+};
 
 export interface StatChartOptions {
   calculation: CalculationType;
@@ -28,6 +26,13 @@ export interface StatChartOptions {
   thresholds?: ThresholdOptions;
   sparkline?: SparklineOptions;
 }
+
+export interface SparklineOptions {
+  color?: string;
+  width?: number;
+}
+
+export type StatChartOptionsEditorProps = OptionsEditorProps<StatChartOptions>;
 
 export function createInitialStatChartOptions(): StatChartOptions {
   return {

--- a/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
@@ -11,14 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ThresholdOptions } from '@perses-dev/core';
+import { Definition, ThresholdOptions } from '@perses-dev/core';
 import { UnitOptions } from '@perses-dev/components';
 import { CalculationType, OptionsEditorProps } from '@perses-dev/plugin-system';
 
-export type StatChart = {
+export interface StatChartDefinition extends Definition<StatChartOptions> {
   kind: 'StatChart';
-  spec: StatChartOptions;
-};
+}
 
 export interface StatChartOptions {
   calculation: CalculationType;

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -57,9 +57,11 @@ const TEST_TIME_SERIES_PANEL: TimeSeriesChartProps = {
     height: 500,
   },
   spec: {
-    unit: { kind: 'Decimal', decimal_places: 2 },
     legend: {
       position: 'Right',
+    },
+    y_axis: {
+      unit: { kind: 'Decimal', decimal_places: 2 },
     },
   },
 };

--- a/ui/panels-plugin/src/plugins/time-series-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './TimeSeriesChart';
+export type { TimeSeriesChartDefinition } from './time-series-chart-model';

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -15,6 +15,9 @@ import { Definition, ThresholdOptions } from '@perses-dev/core';
 import { UnitOptions, LegendOptions } from '@perses-dev/components';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 
+/**
+ * The schema for a TimeSeriesChart panel.
+ */
 export interface TimeSeriesChartDefinition extends Definition<TimeSeriesChartOptions> {
   kind: 'TimeSeriesChart';
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -15,13 +15,17 @@ import { UnitOptions, LegendOptions } from '@perses-dev/components';
 import { ThresholdOptions } from '@perses-dev/core';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 
+export interface TimeSeriesChart {
+  kind: 'TimeSeriesChart';
+  spec: TimeSeriesChartOptions;
+}
+
 /**
  * The Options object supported by the TimeSeriesChartPanel plugin.
  */
 export interface TimeSeriesChartOptions {
   legend?: LegendOptions;
   y_axis?: YAxisOptions;
-  unit?: UnitOptions;
   thresholds?: ThresholdOptions;
   visual?: VisualOptions;
 }
@@ -56,12 +60,25 @@ export const DEFAULT_UNIT: UnitOptions = {
   abbreviate: true,
 };
 
+export const DEFAULT_Y_AXIS: YAxisOptions = {
+  show: true,
+  label: '',
+  unit: DEFAULT_UNIT,
+  min: undefined,
+  max: undefined,
+};
+
+export const Y_AXIS_CONFIG = {
+  show: { label: 'Show' },
+  label: { label: 'Label' },
+  unit: { label: 'Unit' },
+  min: { label: 'Min' },
+  max: { label: 'Max' },
+};
+
 export const DEFAULT_LINE_WIDTH = 1.5;
-
 export const DEFAULT_AREA_OPACITY = 0;
-
 export const DEFAULT_POINT_RADIUS = 4;
-
 export const DEFAULT_CONNECT_NULLS = false;
 
 export const DEFAULT_VISUAL: VisualOptions = {
@@ -99,22 +116,6 @@ export const VISUAL_CONFIG = {
   connect_nulls: {
     label: 'Connect Nulls',
   },
-};
-
-export const DEFAULT_Y_AXIS: YAxisOptions = {
-  show: true,
-  label: '',
-  unit: DEFAULT_UNIT,
-  min: undefined,
-  max: undefined,
-};
-
-export const Y_AXIS_CONFIG = {
-  show: { label: 'Show' },
-  label: { label: 'Label' },
-  unit: { label: 'Unit' },
-  min: { label: 'Min' },
-  max: { label: 'Max' },
 };
 
 // None is equivalent to undefined since stack is optional

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -11,13 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Definition, ThresholdOptions } from '@perses-dev/core';
 import { UnitOptions, LegendOptions } from '@perses-dev/components';
-import { ThresholdOptions } from '@perses-dev/core';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 
-export interface TimeSeriesChart {
+export interface TimeSeriesChartDefinition extends Definition<TimeSeriesChartOptions> {
   kind: 'TimeSeriesChart';
-  spec: TimeSeriesChartOptions;
 }
 
 /**


### PR DESCRIPTION
This PR adds an `interface` that represents the schema for each type of panel (`TimeSeriesChart`, `GaugeChart`, `StatChart`, and `MarkdownPanel`).

The goal is to use these in the converter code.

## Breaking Changes
Removes `spec.unit` from the TimeSeriesDefinition, because we actually use `spec.y_axis.unit`.  

To fix a broken dashboard, either move the data in `spec.unit` to `spec.y_axis.unit` OR remove `spec.unit` if `spec.y_axis.unit` is already defined. 