### PR TITLE
[BUGFIX] fix time series vertical positioning

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -46,8 +46,7 @@ export const TimeSeriesTooltip = React.memo(function TimeSeriesTooltip({
   const chart = chartRef.current;
   const focusedSeries = getFocusedSeriesData(mousePos, chartData, pinnedPos, chart, unit);
   const chartWidth = chart?.getWidth() ?? 750;
-  const chartHeight = chart?.getHeight() ?? 230;
-  const cursorTransform = assembleTransform(mousePos, focusedSeries.length, chartWidth, chartHeight, pinnedPos);
+  const cursorTransform = assembleTransform(mousePos, focusedSeries.length, chartWidth, pinnedPos);
 
   if (focusedSeries.length === 0) {
     return null;

--- a/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -11,13 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useState } from 'react';
 import { Box, Portal } from '@mui/material';
 import { ECharts as EChartsInstance } from 'echarts/core';
+import React, { useState } from 'react';
+import useResizeObserver from 'use-resize-observer';
 import { EChartsDataFormat, UnitOptions } from '../model';
+import { TooltipContent } from './TooltipContent';
 import { getFocusedSeriesData } from './focused-series';
 import { CursorCoordinates, TOOLTIP_MAX_HEIGHT, TOOLTIP_MAX_WIDTH, useMousePosition } from './tooltip-model';
-import { TooltipContent } from './TooltipContent';
 import { assembleTransform } from './utils';
 
 interface TimeSeriesTooltipProps {
@@ -37,6 +38,7 @@ export const TimeSeriesTooltip = React.memo(function TimeSeriesTooltip({
 }: TimeSeriesTooltipProps) {
   const [pinnedPos, setPinnedPos] = useState<CursorCoordinates | null>(null);
   const mousePos = useMousePosition();
+  const { height, width, ref: tooltipRef } = useResizeObserver();
 
   if (mousePos === null || mousePos.target === null) return null;
 
@@ -46,7 +48,14 @@ export const TimeSeriesTooltip = React.memo(function TimeSeriesTooltip({
   const chart = chartRef.current;
   const focusedSeries = getFocusedSeriesData(mousePos, chartData, pinnedPos, chart, unit);
   const chartWidth = chart?.getWidth() ?? 750;
-  const cursorTransform = assembleTransform(mousePos, focusedSeries.length, chartWidth, pinnedPos);
+  const cursorTransform = assembleTransform(
+    mousePos,
+    focusedSeries.length,
+    chartWidth,
+    pinnedPos,
+    height ?? 0,
+    width ?? 0
+  );
 
   if (focusedSeries.length === 0) {
     return null;
@@ -59,6 +68,7 @@ export const TimeSeriesTooltip = React.memo(function TimeSeriesTooltip({
   return (
     <Portal>
       <Box
+        ref={tooltipRef}
         sx={(theme) => ({
           maxWidth: TOOLTIP_MAX_WIDTH,
           maxHeight: TOOLTIP_MAX_HEIGHT,

--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -55,6 +55,10 @@ export interface CursorCoordinates {
     x: number;
     y: number;
   };
+  client: {
+    x: number;
+    y: number;
+  };
   plotCanvas: {
     x: number;
     y: number;
@@ -95,6 +99,10 @@ export const useMousePosition = (): CursorData['coords'] => {
         page: {
           x: e.pageX,
           y: e.pageY,
+        },
+        client: {
+          x: e.clientX,
+          y: e.clientY,
         },
         plotCanvas: {
           x: e.offsetX,

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -11,13 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  CursorCoordinates,
-  CursorData,
-  TOOLTIP_MAX_HEIGHT,
-  TOOLTIP_MAX_ITEMS,
-  TOOLTIP_MAX_WIDTH,
-} from './tooltip-model';
+import { CursorCoordinates, CursorData, TOOLTIP_MAX_WIDTH } from './tooltip-model';
 
 /**
  * Determine position of tooltip depending on chart dimensions and the number of focused series
@@ -26,7 +20,9 @@ export function assembleTransform(
   mousePos: CursorData['coords'],
   seriesNum: number,
   chartWidth: number,
-  pinnedPos: CursorCoordinates | null
+  pinnedPos: CursorCoordinates | null,
+  tooltipHeight: number,
+  tooltipWidth: number
 ) {
   if (mousePos === null) {
     return 'translate3d(0, 0)';
@@ -45,16 +41,12 @@ export function assembleTransform(
   const x = mousePos.page.x;
   let y = mousePos.page.y + cursorPaddingY;
 
-  // approximate tootlip height based on number of series
-  const tooltipHeight = Math.min(Math.min(seriesNum, TOOLTIP_MAX_ITEMS) * 24, TOOLTIP_MAX_HEIGHT);
-
   // adjust so tooltip does not get cut off at bottom of chart
   if (mousePos.client.y + tooltipHeight + cursorPaddingY > window.innerHeight) {
     y = mousePos.page.y - tooltipHeight;
   }
 
-  // use tooltip width to determine when to repos from right to left (width is narrower when only 1 focused series since labels wrap)
-  const tooltipWidth = seriesNum > 1 ? TOOLTIP_MAX_WIDTH : TOOLTIP_MAX_WIDTH / 2;
+  // use tooltip width to determine when to repos from right to left
   const xPosAdjustThreshold = chartWidth - tooltipWidth * 0.9;
 
   // reposition so tooltip is never too close to right side of chart or left side of browser window

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -11,7 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CursorCoordinates, CursorData, TOOLTIP_MAX_WIDTH } from './tooltip-model';
+import {
+  CursorCoordinates,
+  CursorData,
+  TOOLTIP_MAX_HEIGHT,
+  TOOLTIP_MAX_ITEMS,
+  TOOLTIP_MAX_WIDTH,
+} from './tooltip-model';
 
 /**
  * Determine position of tooltip depending on chart dimensions and the number of focused series
@@ -20,7 +26,6 @@ export function assembleTransform(
   mousePos: CursorData['coords'],
   seriesNum: number,
   chartWidth: number,
-  chartHeight: number,
   pinnedPos: CursorCoordinates | null
 ) {
   if (mousePos === null) {
@@ -40,17 +45,12 @@ export function assembleTransform(
   const x = mousePos.page.x;
   let y = mousePos.page.y + cursorPaddingY;
 
-  const isCloseToBottom = mousePos.page.y > window.innerHeight * 0.8;
-  const yPosAdjustThreshold = chartHeight * 0.75;
-  // adjust so tooltip does not get cut off at bottom of chart, reduce multiplier to move up
-  if (isCloseToBottom === true) {
-    if (seriesNum > 6) {
-      y = mousePos.page.y * 0.75;
-    } else {
-      y = mousePos.page.y * 0.9;
-    }
-  } else if (mousePos.plotCanvas.y > yPosAdjustThreshold) {
-    y = mousePos.page.y * 0.95;
+  // approximate tootlip height based on number of series
+  const tooltipHeight = Math.min(Math.min(seriesNum, TOOLTIP_MAX_ITEMS) * 24, TOOLTIP_MAX_HEIGHT);
+
+  // adjust so tooltip does not get cut off at bottom of chart
+  if (mousePos.client.y + tooltipHeight + cursorPaddingY > window.innerHeight) {
+    y = mousePos.page.y - tooltipHeight;
   }
 
   // use tooltip width to determine when to repos from right to left (width is narrower when only 1 focused series since labels wrap)


### PR DESCRIPTION
This PR fixes the vertical positioning of the time series tooltip on a dashboard with several panels.

Issue:

https://github.com/perses/perses/assets/5461414/ef274d99-6696-4331-8ba1-9ef082a5b025

Fix:

https://github.com/perses/perses/assets/5461414/ad9da70f-0641-487a-86b6-e79f6d8f185a



