### PR TITLE
[FEATURE] Add HTTP endpoint to manage global variable

### DIFF
--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -23,8 +23,10 @@ import (
 	"github.com/perses/perses/internal/api/impl/v1/datasource"
 	"github.com/perses/perses/internal/api/impl/v1/folder"
 	"github.com/perses/perses/internal/api/impl/v1/globaldatasource"
+	"github.com/perses/perses/internal/api/impl/v1/globalvariable"
 	"github.com/perses/perses/internal/api/impl/v1/health"
 	"github.com/perses/perses/internal/api/impl/v1/project"
+	"github.com/perses/perses/internal/api/impl/v1/variable"
 	validateendpoint "github.com/perses/perses/internal/api/impl/validate"
 	"github.com/perses/perses/internal/api/shared"
 	"github.com/perses/perses/internal/api/shared/dependency"
@@ -47,8 +49,10 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, cfg config.Config) e
 		datasource.NewEndpoint(serviceManager.GetDatasource(), readonly),
 		folder.NewEndpoint(serviceManager.GetFolder(), readonly),
 		globaldatasource.NewEndpoint(serviceManager.GetGlobalDatasource(), readonly),
+		globalvariable.NewEndpoint(serviceManager.GetGlobalVariable(), readonly),
 		health.NewEndpoint(serviceManager.GetHealth()),
 		project.NewEndpoint(serviceManager.GetProject(), readonly),
+		variable.NewEndpoint(serviceManager.GetVariable(), readonly),
 	}
 	apiEndpoints := []endpoint{
 		configendpoint.New(cfg),

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -19,3 +19,5 @@ package api
 //go:generate go run generate.go -package=project -plural=projects -kind=Project
 //go:generate go run generate.go -package=dashboard -plural=dashboards -kind=Dashboard -isProjectResource=true
 //go:generate go run generate.go -package=folder -plural=folders -kind=Folder -isProjectResource=true
+//go:generate go run generate.go -package=globalvariable -plural=globalvariables -kind=GlobalVariable
+//go:generate go run generate.go -package=variable -plural=variables -kind=Variable -isProjectResource=true

--- a/internal/api/e2e/globalvariable_test.go
+++ b/internal/api/e2e/globalvariable_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package e2e
+
+import (
+	"testing"
+
+	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
+	"github.com/perses/perses/internal/api/shared"
+	"github.com/perses/perses/pkg/model/api"
+)
+
+func TestMainScenarioGlobalVariable(t *testing.T) {
+	e2eframework.MainTestScenario(t, shared.PathGlobalVariable, func(name string) api.Entity {
+		return e2eframework.NewGlobalVariable(name)
+	})
+}

--- a/internal/api/e2e/variable_test.go
+++ b/internal/api/e2e/variable_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package e2e
+
+import (
+	"testing"
+
+	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
+	"github.com/perses/perses/internal/api/shared"
+	"github.com/perses/perses/pkg/model/api"
+)
+
+func TestMainScenarioVariable(t *testing.T) {
+	e2eframework.MainTestScenarioWithProject(t, shared.PathVariable, func(projectName string, name string) (api.Entity, api.Entity) {
+		return e2eframework.NewProject(projectName), e2eframework.NewVariable(projectName, name)
+	})
+}

--- a/internal/api/impl/v1/globalvariable/persistence.go
+++ b/internal/api/impl/v1/globalvariable/persistence.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalvariable
+
+import (
+	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type dao struct {
+	globalvariable.DAO
+	client databaseModel.DAO
+	kind   v1.Kind
+}
+
+func NewDAO(persesDAO databaseModel.DAO) globalvariable.DAO {
+	return &dao{
+		client: persesDAO,
+		kind:   v1.KindGlobalVariable,
+	}
+}
+
+func (d *dao) Create(entity *v1.GlobalVariable) error {
+	return d.client.Create(entity)
+}
+
+func (d *dao) Update(entity *v1.GlobalVariable) error {
+	return d.client.Upsert(entity)
+}
+
+func (d *dao) Delete(name string) error {
+	return d.client.Delete(d.kind, v1.NewMetadata(name))
+}
+
+func (d *dao) Get(name string) (*v1.GlobalVariable, error) {
+	entity := &v1.GlobalVariable{}
+	return entity, d.client.Get(d.kind, v1.NewMetadata(name), entity)
+}
+
+func (d *dao) List(q databaseModel.Query) ([]*v1.GlobalVariable, error) {
+	var result []*v1.GlobalVariable
+	err := d.client.Query(q, &result)
+	return result, err
+}

--- a/internal/api/impl/v1/globalvariable/service.go
+++ b/internal/api/impl/v1/globalvariable/service.go
@@ -1,0 +1,91 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalvariable
+
+import (
+	"fmt"
+
+	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
+	"github.com/perses/perses/internal/api/shared"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	"github.com/perses/perses/pkg/model/api"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
+)
+
+type service struct {
+	globalvariable.Service
+	dao globalvariable.DAO
+}
+
+func NewService(dao globalvariable.DAO) globalvariable.Service {
+	return &service{
+		dao: dao,
+	}
+}
+
+func (s *service) Create(entity api.Entity) (interface{}, error) {
+	if datasourceObject, ok := entity.(*v1.GlobalVariable); ok {
+		return s.create(datasourceObject)
+	}
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Globalvariable format, received '%T'", entity))
+}
+
+func (s *service) create(entity *v1.GlobalVariable) (*v1.GlobalVariable, error) {
+	//TODO need to validate the plugin
+
+	// Update the time contains in the entity
+	entity.Metadata.CreateNow()
+	if err := s.dao.Create(entity); err != nil {
+		return nil, err
+	}
+	return entity, nil
+}
+
+func (s *service) Update(entity api.Entity, parameters shared.Parameters) (interface{}, error) {
+	if DatasourceObject, ok := entity.(*v1.GlobalVariable); ok {
+		return s.update(DatasourceObject, parameters)
+	}
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Globalvariable format, received '%T'", entity))
+}
+
+func (s *service) update(entity *v1.GlobalVariable, parameters shared.Parameters) (*v1.GlobalVariable, error) {
+	if entity.Metadata.Name != parameters.Name {
+		logrus.Debugf("name in Datasource %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
+		return nil, shared.HandleBadRequestError("metadata.name and the name in the http path request don't match")
+	}
+	// find the previous version of the Datasource
+	oldEntity, err := s.dao.Get(parameters.Name)
+	if err != nil {
+		return nil, err
+	}
+	entity.Metadata.Update(oldEntity.Metadata)
+	if updateErr := s.dao.Update(entity); updateErr != nil {
+		logrus.WithError(updateErr).Errorf("unable to perform the update of the Globalvariable %q, something wrong with the database", entity.Metadata.Name)
+		return nil, updateErr
+	}
+	return entity, nil
+}
+
+func (s *service) Delete(parameters shared.Parameters) error {
+	return s.dao.Delete(parameters.Name)
+}
+
+func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
+	return s.dao.Get(parameters.Name)
+}
+
+func (s *service) List(q databaseModel.Query, _ shared.Parameters) (interface{}, error) {
+	return s.dao.List(q)
+}

--- a/internal/api/impl/v1/project/service.go
+++ b/internal/api/impl/v1/project/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/internal/api/shared"
 	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 	"github.com/perses/perses/pkg/model/api"
@@ -33,14 +34,16 @@ type service struct {
 	folderDAO     folder.DAO
 	datasourceDAO datasource.DAO
 	dashboardDAO  dashboard.DAO
+	variableDAO   variable.DAO
 }
 
-func NewService(dao project.DAO, folderDAO folder.DAO, datasourceDAO datasource.DAO, dashboardDAO dashboard.DAO) project.Service {
+func NewService(dao project.DAO, folderDAO folder.DAO, datasourceDAO datasource.DAO, dashboardDAO dashboard.DAO, variableDAO variable.DAO) project.Service {
 	return &service{
 		dao:           dao,
 		folderDAO:     folderDAO,
 		datasourceDAO: datasourceDAO,
 		dashboardDAO:  dashboardDAO,
+		variableDAO:   variableDAO,
 	}
 }
 
@@ -97,6 +100,10 @@ func (s *service) Delete(parameters shared.Parameters) error {
 	}
 	if err := s.datasourceDAO.DeleteAll(projectName); err != nil {
 		logrus.WithError(err).Error("unable to delete all datasources")
+		return err
+	}
+	if err := s.variableDAO.DeleteAll(projectName); err != nil {
+		logrus.WithError(err).Error("unable to delete all variables")
 		return err
 	}
 	return s.dao.Delete(parameters.Name)

--- a/internal/api/impl/v1/variable/persistence.go
+++ b/internal/api/impl/v1/variable/persistence.go
@@ -1,0 +1,60 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package variable
+
+import (
+	"github.com/perses/perses/internal/api/interface/v1/variable"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type dao struct {
+	variable.DAO
+	client databaseModel.DAO
+	kind   v1.Kind
+}
+
+func NewDAO(persesDAO databaseModel.DAO) variable.DAO {
+	return &dao{
+		client: persesDAO,
+		kind:   v1.KindVariable,
+	}
+}
+
+func (d *dao) Create(entity *v1.Variable) error {
+	return d.client.Create(entity)
+}
+
+func (d *dao) Update(entity *v1.Variable) error {
+	return d.client.Upsert(entity)
+}
+
+func (d *dao) Delete(project string, name string) error {
+	return d.client.Delete(d.kind, v1.NewProjectMetadata(project, name))
+}
+
+func (d *dao) DeleteAll(project string) error {
+	return d.client.DeleteByQuery(&variable.Query{Project: project})
+}
+
+func (d *dao) Get(project string, name string) (*v1.Variable, error) {
+	entity := &v1.Variable{}
+	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
+}
+
+func (d *dao) List(q databaseModel.Query) ([]*v1.Variable, error) {
+	var result []*v1.Variable
+	err := d.client.Query(q, &result)
+	return result, err
+}

--- a/internal/api/impl/v1/variable/variable.go
+++ b/internal/api/impl/v1/variable/variable.go
@@ -1,0 +1,97 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package variable
+
+import (
+	"fmt"
+
+	"github.com/perses/perses/internal/api/interface/v1/variable"
+	"github.com/perses/perses/internal/api/shared"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	"github.com/perses/perses/pkg/model/api"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
+)
+
+type service struct {
+	variable.Service
+	dao variable.DAO
+}
+
+func NewService(dao variable.DAO) variable.Service {
+	return &service{
+		dao: dao,
+	}
+}
+
+func (s *service) Create(entity api.Entity) (interface{}, error) {
+	if variableObject, ok := entity.(*v1.Variable); ok {
+		return s.create(variableObject)
+	}
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Variable format, received '%T'", entity))
+}
+
+func (s *service) create(entity *v1.Variable) (*v1.Variable, error) {
+	//TODO need to validate the plugin
+
+	// Update the time contains in the entity
+	entity.Metadata.CreateNow()
+	if err := s.dao.Create(entity); err != nil {
+		return nil, err
+	}
+	return entity, nil
+}
+
+func (s *service) Update(entity api.Entity, parameters shared.Parameters) (interface{}, error) {
+	if VariableObject, ok := entity.(*v1.Variable); ok {
+		return s.update(VariableObject, parameters)
+	}
+	return nil, shared.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Variable format, received '%T'", entity))
+}
+
+func (s *service) update(entity *v1.Variable, parameters shared.Parameters) (*v1.Variable, error) {
+	if entity.Metadata.Name != parameters.Name {
+		logrus.Debugf("name in Variable %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
+		return nil, shared.HandleBadRequestError("metadata.name and the name in the http path request don't match")
+	}
+	if len(entity.Metadata.Project) == 0 {
+		entity.Metadata.Project = parameters.Project
+	} else if entity.Metadata.Project != parameters.Project {
+		logrus.Debugf("project in variable %q and project from the http request %q don't match", entity.Metadata.Project, parameters.Project)
+		return nil, shared.HandleBadRequestError("metadata.project and the project name in the http path request don't match")
+	}
+	// find the previous version of the Variable
+	oldEntity, err := s.dao.Get(parameters.Project, parameters.Name)
+	if err != nil {
+		return nil, err
+	}
+	entity.Metadata.Update(oldEntity.Metadata)
+	if updateErr := s.dao.Update(entity); updateErr != nil {
+		logrus.WithError(updateErr).Errorf("unable to perform the update of the Variable %q, something wrong with the database", entity.Metadata.Name)
+		return nil, updateErr
+	}
+	return entity, nil
+}
+
+func (s *service) Delete(parameters shared.Parameters) error {
+	return s.dao.Delete(parameters.Project, parameters.Name)
+}
+
+func (s *service) Get(parameters shared.Parameters) (interface{}, error) {
+	return s.dao.Get(parameters.Project, parameters.Name)
+}
+
+func (s *service) List(q databaseModel.Query, _ shared.Parameters) (interface{}, error) {
+	return s.dao.List(q)
+}

--- a/internal/api/interface/v1/globalvariable/interface.go
+++ b/internal/api/interface/v1/globalvariable/interface.go
@@ -1,0 +1,38 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalvariable
+
+import (
+	"github.com/perses/perses/internal/api/shared"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type Query struct {
+	databaseModel.Query
+	// NamePrefix is a prefix of the GlobalVariable.metadata.name that is used to filter the list of the GlobalVariable.
+	// NamePrefix can be empty in case you want to return the full list of GlobalVariable available.
+	NamePrefix string `query:"name"`
+}
+type DAO interface {
+	Create(entity *v1.GlobalVariable) error
+	Update(entity *v1.GlobalVariable) error
+	Delete(name string) error
+	Get(name string) (*v1.GlobalVariable, error)
+	List(q databaseModel.Query) ([]*v1.GlobalVariable, error)
+}
+
+type Service interface {
+	shared.ToolboxService
+}

--- a/internal/api/interface/v1/variable/interface.go
+++ b/internal/api/interface/v1/variable/interface.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package variable
+
+import (
+	"github.com/perses/perses/internal/api/shared"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type Query struct {
+	databaseModel.Query
+	// NamePrefix is a prefix of the Variable.metadata.name that is used to filter the list of the Variable.
+	// NamePrefix can be empty in case you want to return the full list of Variable available.
+	NamePrefix string `query:"name"`
+	// Project is the exact name of the project.
+	// The value can come from the path of the URL or from the query parameter
+	Project string `param:"project" query:"project"`
+}
+type DAO interface {
+	Create(entity *v1.Variable) error
+	Update(entity *v1.Variable) error
+	Delete(project string, name string) error
+	DeleteAll(project string) error
+	Get(project string, name string) (*v1.Variable, error)
+	List(q databaseModel.Query) ([]*v1.Variable, error)
+}
+
+type Service interface {
+	shared.ToolboxService
+}

--- a/internal/api/shared/database/file/query.go
+++ b/internal/api/shared/database/file/query.go
@@ -22,7 +22,9 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
+	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/internal/api/interface/v1/variable"
 	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
@@ -66,8 +68,14 @@ func (d *DAO) buildQuery(query databaseModel.Query) (pathFolder string, prefix s
 	case *globaldatasource.Query:
 		pathFolder = d.generateResourceQuery(v1.KindGlobalDatasource)
 		prefix = qt.NamePrefix
+	case *globalvariable.Query:
+		pathFolder = d.generateResourceQuery(v1.KindGlobalVariable)
+		prefix = qt.NamePrefix
 	case *project.Query:
 		pathFolder = d.generateResourceQuery(v1.KindProject)
+		prefix = qt.NamePrefix
+	case *variable.Query:
+		pathFolder = d.generateProjectResourceQuery(v1.KindVariable, qt.Project)
 		prefix = qt.NamePrefix
 	default:
 		return "", "", false, fmt.Errorf("this type of query '%T' is not managed", qt)

--- a/internal/api/shared/database/sql/query.go
+++ b/internal/api/shared/database/sql/query.go
@@ -22,7 +22,9 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
+	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/internal/api/interface/v1/variable"
 	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
@@ -105,8 +107,12 @@ func (d *DAO) buildQuery(query databaseModel.Query) (string, []interface{}, erro
 		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableFolder), qt.Project, qt.NamePrefix)
 	case *globaldatasource.Query:
 		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableGlobalDatasource), "", qt.NamePrefix)
+	case *globalvariable.Query:
+		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableGlobalVariable), "", qt.NamePrefix)
 	case *project.Query:
 		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableProject), "", qt.NamePrefix)
+	case *variable.Query:
+		sqlQuery, args = generatSelectQuery(d.generateCompleteTableName(tableVariable), qt.Project, qt.NamePrefix)
 	default:
 		return "", nil, fmt.Errorf("this type of query '%T' is not managed", qt)
 	}
@@ -137,8 +143,12 @@ func (d *DAO) buildDeleteQuery(query databaseModel.Query) (string, []interface{}
 		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableFolder), qt.Project, qt.NamePrefix)
 	case *globaldatasource.Query:
 		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableGlobalDatasource), "", qt.NamePrefix)
+	case *globalvariable.Query:
+		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableGlobalVariable), "", qt.NamePrefix)
 	case *project.Query:
 		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableProject), "", qt.NamePrefix)
+	case *variable.Query:
+		sqlQuery, args = generateDeleteQuery(d.generateCompleteTableName(tableVariable), qt.Project, qt.NamePrefix)
 	default:
 		return "", nil, fmt.Errorf("this type of query '%T' is not managed", qt)
 	}

--- a/internal/api/shared/database/sql/sql.go
+++ b/internal/api/shared/database/sql/sql.go
@@ -28,10 +28,12 @@ import (
 
 const (
 	tableGlobalDatasource = "globaldatasource"
+	tableGlobalVariable   = "globalvariable"
 	tableProject          = "project"
 	tableDashboard        = "dashboard"
 	tableFolder           = "folder"
 	tableDatasource       = "datasource"
+	tableVariable         = "variable"
 
 	colID      = "id"
 	colDoc     = "doc"
@@ -49,8 +51,12 @@ func getTableName(kind modelV1.Kind) (string, error) {
 		return tableFolder, nil
 	case modelV1.KindGlobalDatasource:
 		return tableGlobalDatasource, nil
+	case modelV1.KindGlobalVariable:
+		return tableGlobalVariable, nil
 	case modelV1.KindProject:
 		return tableProject, nil
+	case modelV1.KindVariable:
+		return tableVariable, nil
 	default:
 		return "", fmt.Errorf("%q has no associated table", kind)
 	}
@@ -73,26 +79,23 @@ type DAO struct {
 }
 
 func (d *DAO) Init() error {
-	globalDatasource := d.createResourceTable(tableGlobalDatasource)
-	project := d.createResourceTable(tableProject)
+	tables := []string{
+		d.createResourceTable(tableGlobalDatasource),
+		d.createResourceTable(tableGlobalVariable),
+		d.createResourceTable(tableProject),
 
-	dashboard := d.createProjectResourceTable(tableDashboard)
-	folder := d.createProjectResourceTable(tableFolder)
-	datasource := d.createProjectResourceTable(tableDatasource)
+		d.createProjectResourceTable(tableDashboard),
+		d.createProjectResourceTable(tableFolder),
+		d.createProjectResourceTable(tableDatasource),
+		d.createProjectResourceTable(tableVariable),
+	}
 
-	if err := d.createTable(globalDatasource); err != nil {
-		return err
+	for _, table := range tables {
+		if err := d.createTable(table); err != nil {
+			return err
+		}
 	}
-	if err := d.createTable(project); err != nil {
-		return err
-	}
-	if err := d.createTable(dashboard); err != nil {
-		return err
-	}
-	if err := d.createTable(folder); err != nil {
-		return err
-	}
-	return d.createTable(datasource)
+	return nil
 }
 
 func (d *DAO) createResourceTable(tableName string) string {

--- a/internal/api/shared/dependency/persistence_manager.go
+++ b/internal/api/shared/dependency/persistence_manager.go
@@ -19,14 +19,18 @@ import (
 	datasourceImpl "github.com/perses/perses/internal/api/impl/v1/datasource"
 	folderImpl "github.com/perses/perses/internal/api/impl/v1/folder"
 	globalDatasourceImpl "github.com/perses/perses/internal/api/impl/v1/globaldatasource"
+	globalVariableImpl "github.com/perses/perses/internal/api/impl/v1/globalvariable"
 	healthImpl "github.com/perses/perses/internal/api/impl/v1/health"
 	projectImpl "github.com/perses/perses/internal/api/impl/v1/project"
+	variableImpl "github.com/perses/perses/internal/api/impl/v1/variable"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
+	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/interface/v1/health"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/internal/api/shared/database"
 	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 )
@@ -36,9 +40,11 @@ type PersistenceManager interface {
 	GetDatasource() datasource.DAO
 	GetFolder() folder.DAO
 	GetGlobalDatasource() globaldatasource.DAO
+	GetGlobalVariable() globalvariable.DAO
 	GetHealth() health.DAO
 	GetPersesDAO() databaseModel.DAO
 	GetProject() project.DAO
+	GetVariable() variable.DAO
 }
 
 type persistence struct {
@@ -47,9 +53,11 @@ type persistence struct {
 	datasource       datasource.DAO
 	folder           folder.DAO
 	globalDatasource globaldatasource.DAO
+	globalVariable   globalvariable.DAO
 	health           health.DAO
 	perses           databaseModel.DAO
 	project          project.DAO
+	variable         variable.DAO
 }
 
 func NewPersistenceManager(conf config.Database) (PersistenceManager, error) {
@@ -61,16 +69,20 @@ func NewPersistenceManager(conf config.Database) (PersistenceManager, error) {
 	datasourceDAO := datasourceImpl.NewDAO(persesDAO)
 	folderDAO := folderImpl.NewDAO(persesDAO)
 	globalDatatasourceDAO := globalDatasourceImpl.NewDAO(persesDAO)
+	globalVariableDAO := globalVariableImpl.NewDAO(persesDAO)
 	healthDAO := healthImpl.NewDAO(persesDAO)
 	projectDAO := projectImpl.NewDAO(persesDAO)
+	variableDAO := variableImpl.NewDAO(persesDAO)
 	return &persistence{
 		dashboard:        dashboardDAO,
 		datasource:       datasourceDAO,
 		folder:           folderDAO,
 		globalDatasource: globalDatatasourceDAO,
+		globalVariable:   globalVariableDAO,
 		health:           healthDAO,
 		perses:           persesDAO,
 		project:          projectDAO,
+		variable:         variableDAO,
 	}, nil
 }
 
@@ -90,6 +102,10 @@ func (p *persistence) GetGlobalDatasource() globaldatasource.DAO {
 	return p.globalDatasource
 }
 
+func (p *persistence) GetGlobalVariable() globalvariable.DAO {
+	return p.globalVariable
+}
+
 func (p *persistence) GetHealth() health.DAO {
 	return p.health
 }
@@ -100,4 +116,8 @@ func (p *persistence) GetPersesDAO() databaseModel.DAO {
 
 func (p *persistence) GetProject() project.DAO {
 	return p.project
+}
+
+func (p *persistence) GetVariable() variable.DAO {
+	return p.variable
 }

--- a/internal/api/shared/dependency/service_manager.go
+++ b/internal/api/shared/dependency/service_manager.go
@@ -21,14 +21,18 @@ import (
 	datasourceImpl "github.com/perses/perses/internal/api/impl/v1/datasource"
 	folderImpl "github.com/perses/perses/internal/api/impl/v1/folder"
 	globalDatasourceImpl "github.com/perses/perses/internal/api/impl/v1/globaldatasource"
+	globalVariableImpl "github.com/perses/perses/internal/api/impl/v1/globalvariable"
 	healthImpl "github.com/perses/perses/internal/api/impl/v1/health"
 	projectImpl "github.com/perses/perses/internal/api/impl/v1/project"
+	variableImpl "github.com/perses/perses/internal/api/impl/v1/variable"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
+	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/interface/v1/health"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/internal/api/shared/migrate"
 	"github.com/perses/perses/internal/api/shared/schemas"
 )
@@ -38,10 +42,12 @@ type ServiceManager interface {
 	GetDatasource() datasource.Service
 	GetFolder() folder.Service
 	GetGlobalDatasource() globaldatasource.Service
+	GetGlobalVariable() globalvariable.Service
 	GetHealth() health.Service
 	GetMigration() migrate.Migration
 	GetProject() project.Service
 	GetSchemas() schemas.Schemas
+	GetVariable() variable.Service
 }
 
 type service struct {
@@ -50,10 +56,12 @@ type service struct {
 	datasource       datasource.Service
 	folder           folder.Service
 	globalDatasource globaldatasource.Service
+	globalVariable   globalvariable.Service
 	health           health.Service
 	migrate          migrate.Migration
 	project          project.Service
 	schemas          schemas.Schemas
+	variable         variable.Service
 }
 
 func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManager, error) {
@@ -68,18 +76,22 @@ func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 	dashboardService := dashboardImpl.NewService(dao.GetDashboard(), schemasService)
 	datasourceService := datasourceImpl.NewService(dao.GetDatasource(), schemasService)
 	folderService := folderImpl.NewService(dao.GetFolder())
+	variableService := variableImpl.NewService(dao.GetVariable())
 	globalDatasourceService := globalDatasourceImpl.NewService(dao.GetGlobalDatasource(), schemasService)
+	globalVariableService := globalVariableImpl.NewService(dao.GetGlobalVariable())
 	healthService := healthImpl.NewService(dao.GetHealth())
-	projectService := projectImpl.NewService(dao.GetProject(), dao.GetFolder(), dao.GetDatasource(), dao.GetDashboard())
+	projectService := projectImpl.NewService(dao.GetProject(), dao.GetFolder(), dao.GetDatasource(), dao.GetDashboard(), dao.GetVariable())
 	return &service{
 		dashboard:        dashboardService,
 		datasource:       datasourceService,
 		folder:           folderService,
 		globalDatasource: globalDatasourceService,
+		globalVariable:   globalVariableService,
 		health:           healthService,
 		migrate:          migrateService,
 		project:          projectService,
 		schemas:          schemasService,
+		variable:         variableService,
 	}, nil
 }
 
@@ -99,6 +111,10 @@ func (s *service) GetGlobalDatasource() globaldatasource.Service {
 	return s.globalDatasource
 }
 
+func (s *service) GetGlobalVariable() globalvariable.Service {
+	return s.globalVariable
+}
+
 func (s *service) GetHealth() health.Service {
 	return s.health
 }
@@ -113,4 +129,8 @@ func (s *service) GetProject() project.Service {
 
 func (s *service) GetSchemas() schemas.Schemas {
 	return s.schemas
+}
+
+func (s *service) GetVariable() variable.Service {
+	return s.variable
 }

--- a/internal/api/shared/schemas/schemas.go
+++ b/internal/api/shared/schemas/schemas.go
@@ -66,7 +66,7 @@ type Schemas interface {
 	ValidateDatasource(plugin common.Plugin) error
 	ValidatePanels(panels map[string]*modelV1.Panel) error
 	ValidatePanel(plugin common.Plugin, panelName string) error
-	ValidateVariables([]dashboard.Variable) error
+	ValidateDashboardVariables([]dashboard.Variable) error
 	ValidateVariable(plugin common.Plugin, varName string) error
 	GetLoaders() []Loader
 }
@@ -177,11 +177,11 @@ func (s *sch) ValidateQuery(plugin common.Plugin) error {
 	return s.validatePlugin(plugin, "query", "", s.queries)
 }
 
-// ValidateVariables verify a list of variables.
+// ValidateDashboardVariables verify a list of variables defines in a dashboard.
 // The variables are matched against the known list of CUE definitions (schemas)
 // This applies to the ListVariable type only (TextVariable is skipped)
 // If no schema matches for at least 1 variable, the validation fails.
-func (s *sch) ValidateVariables(variables []dashboard.Variable) error {
+func (s *sch) ValidateDashboardVariables(variables []dashboard.Variable) error {
 	if s.vars == nil {
 		logrus.Warning("variable schemas are not loaded")
 		return nil

--- a/internal/api/shared/schemas/schemas.go
+++ b/internal/api/shared/schemas/schemas.go
@@ -25,6 +25,7 @@ import (
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
 	"github.com/sirupsen/logrus"
 )
 
@@ -187,13 +188,13 @@ func (s *sch) ValidateVariables(variables []dashboard.Variable) error {
 	}
 	// go through the variables list
 	// the processing stops as soon as it detects an invalid variable  -> TODO: improve this to return a list of all the errors encountered ?
-	for _, variable := range variables {
+	for _, v := range variables {
 		// skip if this is not a ListVariable (no validation needed in this case)
-		if variable.Kind != dashboard.ListVariable {
+		if v.Kind != variable.KindList {
 			continue
 		}
 		// convert the variable's spec to ListVariableSpec
-		listVariableSpec, ok := variable.Spec.(*dashboard.ListVariableSpec)
+		listVariableSpec, ok := v.Spec.(*dashboard.ListVariableSpec)
 		if !ok {
 			return errors.New("Error converting Variable to ListVariable")
 		}

--- a/internal/api/shared/schemas/schemas_test.go
+++ b/internal/api/shared/schemas/schemas_test.go
@@ -221,7 +221,7 @@ func TestValidatePanels(t *testing.T) {
 	}
 }
 
-func TestValidateVariables(t *testing.T) {
+func TestValidateDashboardVariables(t *testing.T) {
 	validFirstVariable := loadPlugin("testdata/samples/variables/valid_first_variable.json", t)
 	validSecondVariable := loadPlugin("testdata/samples/variables/valid_second_variable.json", t)
 	invalidUnknownVariable := loadPlugin("testdata/samples/variables/invalid_unknown_variable.json", t)
@@ -325,7 +325,7 @@ func TestValidateVariables(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = schema.ValidateVariables(test.dashboard.Spec.Variables)
+			err = schema.ValidateDashboardVariables(test.dashboard.Spec.Variables)
 			errString := ""
 			if err != nil {
 				errString = err.Error()

--- a/internal/api/shared/schemas/schemas_test.go
+++ b/internal/api/shared/schemas/schemas_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -246,35 +247,35 @@ func TestValidateVariables(t *testing.T) {
 					Duration: model.Duration(6 * time.Hour),
 					Variables: []dashboard.Variable{
 						{
-							Kind: "ListVariable",
+							Kind: variable.KindList,
 							Spec: &dashboard.ListVariableSpec{
-								CommonVariableSpec: dashboard.CommonVariableSpec{
-									Name: "my1rstVar",
-									Display: &dashboard.VariableDisplay{
+								ListSpec: variable.ListSpec{
+									Display: &variable.Display{
 										Name:        "My First Variable",
 										Description: "A simple variable of type FirstVariable",
 										Hidden:      false,
 									},
+									AllowAllValue: true,
+									AllowMultiple: false,
+									Plugin:        validFirstVariable,
 								},
-								AllowAllValue: true,
-								AllowMultiple: false,
-								Plugin:        validFirstVariable,
+								Name: "my1rstVar",
 							},
 						},
 						{
-							Kind: "ListVariable",
+							Kind: variable.KindList,
 							Spec: &dashboard.ListVariableSpec{
-								CommonVariableSpec: dashboard.CommonVariableSpec{
-									Name: "my2ndVar",
-									Display: &dashboard.VariableDisplay{
+								ListSpec: variable.ListSpec{
+									Display: &variable.Display{
 										Name:        "My Second Variable",
 										Description: "A simple variable of type SecondVariable",
 										Hidden:      false,
 									},
+									AllowAllValue: true,
+									AllowMultiple: false,
+									Plugin:        validSecondVariable,
 								},
-								AllowAllValue: true,
-								AllowMultiple: false,
-								Plugin:        validSecondVariable,
+								Name: "my2ndVar",
 							},
 						},
 					},
@@ -295,17 +296,17 @@ func TestValidateVariables(t *testing.T) {
 						{
 							Kind: "ListVariable",
 							Spec: &dashboard.ListVariableSpec{
-								CommonVariableSpec: dashboard.CommonVariableSpec{
-									Name: "myUnknownVar",
-									Display: &dashboard.VariableDisplay{
+								ListSpec: variable.ListSpec{
+									Display: &variable.Display{
 										Name:        "My Unknown Variable",
 										Description: "A simple variable of type UnknownVariable",
 										Hidden:      false,
 									},
+									AllowAllValue: false,
+									AllowMultiple: true,
+									Plugin:        invalidUnknownVariable,
 								},
-								AllowAllValue: false,
-								AllowMultiple: true,
-								Plugin:        invalidUnknownVariable,
+								Name: "myUnknownVar",
 							},
 						},
 					},

--- a/internal/api/shared/utils.go
+++ b/internal/api/shared/utils.go
@@ -31,12 +31,14 @@ const (
 	PathDatasource       = "datasources"
 	PathFolder           = "folders"
 	PathGlobalDatasource = "globaldatasources"
+	PathGlobalVariable   = "globalvariables"
 	PathProject          = "projects"
+	PathVariable         = "variables"
 )
 
 // ProjectResourcePathList is containing the list of the resource path that are part of a project.
 var ProjectResourcePathList = []string{
-	PathDashboard, PathDatasource, PathFolder,
+	PathDashboard, PathDatasource, PathFolder, PathVariable,
 }
 
 func getNameParameter(ctx echo.Context) string {

--- a/internal/api/shared/validate/validate.go
+++ b/internal/api/shared/validate/validate.go
@@ -28,7 +28,7 @@ func Dashboard(entity *modelV1.Dashboard, sch schemas.Schemas) error {
 		return err
 	}
 	if sch != nil {
-		if err := sch.ValidateVariables(entity.Spec.Variables); err != nil {
+		if err := sch.ValidateDashboardVariables(entity.Spec.Variables); err != nil {
 			return err
 		}
 		if err := sch.ValidatePanels(entity.Spec.Panels); err != nil {

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -80,7 +80,7 @@ func FormatArrayMessage(message string, list []string) string {
 	return builder.String()
 }
 
-// FormatTime formats a time with human readable format
+// FormatTime formats a time with human-readable format
 func FormatTime(t time.Time) string {
 	var age string
 

--- a/internal/cli/resource/resource.go
+++ b/internal/cli/resource/resource.go
@@ -62,9 +62,27 @@ var resources = []resource{
 		},
 	},
 	{
+		kind:      modelV1.KindGlobalVariable,
+		shortTerm: "gv",
+		aliases: []string{
+			"globalVariables",
+			"gvar",
+			"gvars",
+			"gvs",
+		},
+	},
+	{
 		kind: modelV1.KindProject,
 		aliases: []string{
 			"projects",
+		},
+	},
+	{
+		kind:      modelV1.KindVariable,
+		shortTerm: "var",
+		aliases: []string{
+			"variables",
+			"vars",
 		},
 	},
 }
@@ -83,7 +101,7 @@ func HandleSuccessMessage(writer io.Writer, kind modelV1.Kind, project string, g
 // Returns false otherwise.
 func IsGlobal(kind modelV1.Kind) bool {
 	switch kind {
-	case modelV1.KindProject, modelV1.KindGlobalDatasource:
+	case modelV1.KindProject, modelV1.KindGlobalDatasource, modelV1.KindGlobalVariable:
 		return true
 	default:
 		return false

--- a/internal/cli/service/globalvariable.go
+++ b/internal/cli/service/globalvariable.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"github.com/perses/perses/internal/cli/output"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type globalVariable struct {
+	Service
+	apiClient v1.GlobalVariableInterface
+}
+
+func (d *globalVariable) CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Create(entity.(*modelV1.GlobalVariable))
+}
+
+func (d *globalVariable) UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Update(entity.(*modelV1.GlobalVariable))
+}
+
+func (d *globalVariable) ListResource(prefix string) ([]modelAPI.Entity, error) {
+	return convertToEntityIfNoError(d.apiClient.List(prefix))
+}
+
+func (d *globalVariable) GetResource(name string) (modelAPI.Entity, error) {
+	return d.apiClient.Get(name)
+}
+
+func (d *globalVariable) DeleteResource(name string) error {
+	return d.apiClient.Delete(name)
+}
+
+func (d *globalVariable) BuildMatrix(hits []modelAPI.Entity) [][]string {
+	var data [][]string
+	for _, hit := range hits {
+		entity := hit.(*modelV1.GlobalVariable)
+		line := []string{
+			entity.Metadata.Name,
+			string(entity.Spec.Kind),
+			output.FormatTime(entity.Metadata.UpdatedAt),
+		}
+		data = append(data, line)
+	}
+	return data
+}
+
+func (d *globalVariable) GetColumHeader() []string {
+	return []string{
+		"NAME",
+		"VARIABLE_TYPE",
+		"AGE",
+	}
+}

--- a/internal/cli/service/service.go
+++ b/internal/cli/service/service.go
@@ -60,9 +60,17 @@ func New(kind modelV1.Kind, projectName string, apiClient api.ClientInterface) (
 		return &globalDatasource{
 			apiClient: apiClient.V1().GlobalDatasource(),
 		}, nil
+	case modelV1.KindGlobalVariable:
+		return &globalVariable{
+			apiClient: apiClient.V1().GlobalVariable(),
+		}, nil
 	case modelV1.KindProject:
 		return &project{
 			apiClient: apiClient.V1().Project(),
+		}, nil
+	case modelV1.KindVariable:
+		return &variable{
+			apiClient: apiClient.V1().Variable(projectName),
 		}, nil
 	default:
 		return nil, fmt.Errorf("resource %q not supported by the command", kind)

--- a/internal/cli/service/variable.go
+++ b/internal/cli/service/variable.go
@@ -1,0 +1,70 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"github.com/perses/perses/internal/cli/output"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type variable struct {
+	Service
+	apiClient v1.VariableInterface
+}
+
+func (d *variable) CreateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Create(entity.(*modelV1.Variable))
+}
+
+func (d *variable) UpdateResource(entity modelAPI.Entity) (modelAPI.Entity, error) {
+	return d.apiClient.Update(entity.(*modelV1.Variable))
+}
+
+func (d *variable) ListResource(prefix string) ([]modelAPI.Entity, error) {
+	return convertToEntityIfNoError(d.apiClient.List(prefix))
+}
+
+func (d *variable) GetResource(name string) (modelAPI.Entity, error) {
+	return d.apiClient.Get(name)
+}
+
+func (d *variable) DeleteResource(name string) error {
+	return d.apiClient.Delete(name)
+}
+
+func (d *variable) BuildMatrix(hits []modelAPI.Entity) [][]string {
+	var data [][]string
+	for _, hit := range hits {
+		entity := hit.(*modelV1.Variable)
+		line := []string{
+			entity.Metadata.Name,
+			entity.Metadata.Project,
+			string(entity.Spec.Kind),
+			output.FormatTime(entity.Metadata.UpdatedAt),
+		}
+		data = append(data, line)
+	}
+	return data
+}
+
+func (d *variable) GetColumHeader() []string {
+	return []string{
+		"NAME",
+		"PROJECT",
+		"Variable_TYPE",
+		"AGE",
+	}
+}

--- a/pkg/client/api/v1/client.go
+++ b/pkg/client/api/v1/client.go
@@ -25,8 +25,10 @@ type ClientInterface interface {
 	Datasource(project string) DatasourceInterface
 	Folder(project string) FolderInterface
 	GlobalDatasource() GlobalDatasourceInterface
+	GlobalVariable() GlobalVariableInterface
 	Health() HealthInterface
 	Project() ProjectInterface
+	Variable(project string) VariableInterface
 }
 
 type client struct {
@@ -60,12 +62,20 @@ func (c *client) GlobalDatasource() GlobalDatasourceInterface {
 	return newGlobalDatasource(c.restClient)
 }
 
+func (c *client) GlobalVariable() GlobalVariableInterface {
+	return newGlobalVariable(c.restClient)
+}
+
 func (c *client) Health() HealthInterface {
 	return newHealth(c.restClient)
 }
 
 func (c *client) Project() ProjectInterface {
 	return newProject(c.restClient)
+}
+
+func (c *client) Variable(project string) VariableInterface {
+	return newVariable(c.restClient, project)
 }
 
 type query struct {

--- a/pkg/client/api/v1/globalvariable.go
+++ b/pkg/client/api/v1/globalvariable.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated. DO NOT EDIT
+
+package v1
+
+import (
+	"github.com/perses/perses/pkg/client/perseshttp"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+const globalVariableResource = "globalvariables"
+
+type GlobalVariableInterface interface {
+	Create(entity *v1.GlobalVariable) (*v1.GlobalVariable, error)
+	Update(entity *v1.GlobalVariable) (*v1.GlobalVariable, error)
+	Delete(name string) error
+	// Get is returning an unique GlobalVariable.
+	// As such name is the exact value of GlobalVariable.metadata.name. It cannot be empty.
+	// If you want to perform a research by prefix, please use the method List
+	Get(name string) (*v1.GlobalVariable, error)
+	// prefix is a prefix of the GlobalVariable.metadata.name to search for.
+	// It can be empty in case you want to get the full list of GlobalVariable available
+	List(prefix string) ([]*v1.GlobalVariable, error)
+}
+
+type globalVariable struct {
+	GlobalVariableInterface
+	client *perseshttp.RESTClient
+}
+
+func newGlobalVariable(client *perseshttp.RESTClient) GlobalVariableInterface {
+	return &globalVariable{
+		client: client,
+	}
+}
+
+func (c *globalVariable) Create(entity *v1.GlobalVariable) (*v1.GlobalVariable, error) {
+	result := &v1.GlobalVariable{}
+	err := c.client.Post().
+		Resource(globalVariableResource).
+		Body(entity).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *globalVariable) Update(entity *v1.GlobalVariable) (*v1.GlobalVariable, error) {
+	result := &v1.GlobalVariable{}
+	err := c.client.Put().
+		Resource(globalVariableResource).
+		Name(entity.Metadata.Name).
+		Body(entity).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *globalVariable) Delete(name string) error {
+	return c.client.Delete().
+		Resource(globalVariableResource).
+		Name(name).
+		Do().
+		Error()
+}
+
+func (c *globalVariable) Get(name string) (*v1.GlobalVariable, error) {
+	result := &v1.GlobalVariable{}
+	err := c.client.Get().
+		Resource(globalVariableResource).
+		Name(name).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *globalVariable) List(prefix string) ([]*v1.GlobalVariable, error) {
+	var result []*v1.GlobalVariable
+	err := c.client.Get().
+		Resource(globalVariableResource).
+		Query(&query{
+			name: prefix,
+		}).
+		Do().
+		Object(&result)
+	return result, err
+}

--- a/pkg/client/api/v1/variable.go
+++ b/pkg/client/api/v1/variable.go
@@ -1,0 +1,105 @@
+// Copyright 2021 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated. DO NOT EDIT
+
+package v1
+
+import (
+	"github.com/perses/perses/pkg/client/perseshttp"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+const variableResource = "variables"
+
+type VariableInterface interface {
+	Create(entity *v1.Variable) (*v1.Variable, error)
+	Update(entity *v1.Variable) (*v1.Variable, error)
+	Delete(name string) error
+	// Get is returning an unique Variable.
+	// As such name is the exact value of Variable.metadata.name. It cannot be empty.
+	// If you want to perform a research by prefix, please use the method List
+	Get(name string) (*v1.Variable, error)
+	// prefix is a prefix of the Variable.metadata.name to search for.
+	// It can be empty in case you want to get the full list of Variable available
+	List(prefix string) ([]*v1.Variable, error)
+}
+
+type variable struct {
+	VariableInterface
+	client  *perseshttp.RESTClient
+	project string
+}
+
+func newVariable(client *perseshttp.RESTClient, project string) VariableInterface {
+	return &variable{
+		client:  client,
+		project: project,
+	}
+}
+
+func (c *variable) Create(entity *v1.Variable) (*v1.Variable, error) {
+	result := &v1.Variable{}
+	err := c.client.Post().
+		Resource(variableResource).
+		Project(c.project).
+		Body(entity).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *variable) Update(entity *v1.Variable) (*v1.Variable, error) {
+	result := &v1.Variable{}
+	err := c.client.Put().
+		Resource(variableResource).
+		Name(entity.Metadata.Name).
+		Project(c.project).
+		Body(entity).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *variable) Delete(name string) error {
+	return c.client.Delete().
+		Resource(variableResource).
+		Name(name).
+		Project(c.project).
+		Do().
+		Error()
+}
+
+func (c *variable) Get(name string) (*v1.Variable, error) {
+	result := &v1.Variable{}
+	err := c.client.Get().
+		Resource(variableResource).
+		Name(name).
+		Project(c.project).
+		Do().
+		Object(result)
+	return result, err
+}
+
+func (c *variable) List(prefix string) ([]*v1.Variable, error) {
+	var result []*v1.Variable
+	err := c.client.Get().
+		Resource(variableResource).
+		Query(&query{
+			name: prefix,
+		}).
+		Project(c.project).
+		Do().
+		Object(&result)
+	return result, err
+}

--- a/pkg/model/api/v1/dashboard/variable_build_order_test.go
+++ b/pkg/model/api/v1/dashboard/variable_build_order_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,12 +37,12 @@ func TestBuildVariableDependencies(t *testing.T) {
 			title: "constant variable, no dep",
 			variables: []Variable{
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "myVariable",
 					},
 				},
 			},
@@ -51,17 +52,17 @@ func TestBuildVariableDependencies(t *testing.T) {
 			title: "query variable with no variable used",
 			variables: []Variable{
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "vector(1)",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "vector(1)",
+								},
 							},
 						},
+						Name: "myVariable",
 					},
 				},
 			},
@@ -71,54 +72,54 @@ func TestBuildVariableDependencies(t *testing.T) {
 			title: "query variable with variable used",
 			variables: []Variable{
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "sum by($doe) (rate($foo{label='$bar'}))",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "sum by($doe) (rate($foo{label='$bar'}))",
+								},
 							},
 						},
+						Name: "myVariable",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "foo",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "test",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "test",
+								},
 							},
 						},
+						Name: "foo",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "bar",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "vector($foo)",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "vector($foo)",
+								},
 							},
 						},
+						Name: "bar",
 					},
 				},
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "doe",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "doe",
 					},
 				},
 			},
@@ -135,57 +136,57 @@ func TestBuildVariableDependencies(t *testing.T) {
 			title: "query variable label_values with variable used",
 			variables: []Variable{
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
-								"label_name": "$foo",
-								"matchers": []interface{}{
-									"$foo{$bar='test'}",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusLabelValuesVariable",
+								Spec: map[string]interface{}{
+									"label_name": "$foo",
+									"matchers": []interface{}{
+										"$foo{$bar='test'}",
+									},
 								},
 							},
 						},
+						Name: "myVariable",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "foo",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "test",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "test",
+								},
 							},
 						},
+						Name: "foo",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "bar",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "vector($foo)",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "vector($foo)",
+								},
 							},
 						},
+						Name: "bar",
 					},
 				},
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "doe",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "doe",
 					},
 				},
 			},
@@ -202,54 +203,54 @@ func TestBuildVariableDependencies(t *testing.T) {
 			title: "multiple usage of the same variable",
 			variables: []Variable{
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+								},
 							},
 						},
+						Name: "myVariable",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "foo",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "test",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "test",
+								},
 							},
 						},
+						Name: "foo",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "bar",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "vector($foo)",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "vector($foo)",
+								},
 							},
 						},
+						Name: "bar",
 					},
 				},
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "doe",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "doe",
 					},
 				},
 			},
@@ -266,54 +267,54 @@ func TestBuildVariableDependencies(t *testing.T) {
 			title: "variable with only number is ignored",
 			variables: []Variable{
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "filter_platform",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "filter_platform",
 					},
 				},
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "PaaS",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "PaaS",
 					},
 				},
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "filter_kube_sts",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "filter_kube_sts",
 					},
 				},
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "extlabels_prometheus_namespace",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "extlabels_prometheus_namespace",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "foo",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr":       "group by(prometheus) (label_replace(kube_statefulset_labels{$filter_platform,stack=~\"$PaaS\",$filter_kube_sts,stack=~\"$PaaS\",namespace=~\"$extlabels_prometheus_namespace\"},\"prometheus\",\"$1\",\"label_app_kubernetes_io_instance\",\"([^-]+)-?.*\"))",
-								"label_name": "prometheus",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr":       "group by(prometheus) (label_replace(kube_statefulset_labels{$filter_platform,stack=~\"$PaaS\",$filter_kube_sts,stack=~\"$PaaS\",namespace=~\"$extlabels_prometheus_namespace\"},\"prometheus\",\"$1\",\"label_app_kubernetes_io_instance\",\"([^-]+)-?.*\"))",
+									"label_name": "prometheus",
+								},
 							},
 						},
+						Name: "foo",
 					},
 				},
 			},
@@ -346,17 +347,17 @@ func TestBuildVariableDependenciesError(t *testing.T) {
 			title: "variable used but not defined",
 			variables: []Variable{
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+								},
 							},
 						},
+						Name: "myVariable",
 					},
 				},
 			},
@@ -490,12 +491,12 @@ func TestBuildOrder(t *testing.T) {
 			title: "constant variable, no dep",
 			variables: []Variable{
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "myVariable",
 					},
 				},
 			},
@@ -505,54 +506,54 @@ func TestBuildOrder(t *testing.T) {
 			title: "multiple usage of same variable",
 			variables: []Variable{
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "myVariable",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
+								},
 							},
 						},
+						Name: "myVariable",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "foo",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "test",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "test",
+								},
 							},
 						},
+						Name: "foo",
 					},
 				},
 				{
-					Kind: ListVariable,
+					Kind: variable.KindList,
 					Spec: &ListVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "bar",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusPromQLVariable",
-							Spec: map[string]interface{}{
-								"expr": "vector($foo)",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]interface{}{
+									"expr": "vector($foo)",
+								},
 							},
 						},
+						Name: "bar",
 					},
 				},
 				{
-					Kind: TextVariable,
+					Kind: variable.KindText,
 					Spec: &TextVariableSpec{
-						CommonVariableSpec: CommonVariableSpec{
-							Name: "doe",
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
 						},
-						Value: "myConstant",
+						Name: "doe",
 					},
 				},
 			},

--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
@@ -41,12 +42,12 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 }
 `,
 			result: &Variable{
-				Kind: TextVariable,
+				Kind: variable.KindText,
 				Spec: &TextVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "SimpleText",
+					TextSpec: variable.TextSpec{
+						Value: "value",
 					},
-					Value: "value",
+					Name: "SimpleText",
 				},
 			},
 		},
@@ -68,19 +69,19 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 }
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelNamesVariable",
+							Spec: map[string]interface{}{},
+						},
 					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelNamesVariable",
-						Spec: map[string]interface{}{},
-					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -106,21 +107,21 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 }
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelNamesVariable",
-						Spec: map[string]interface{}{
-							"matchers": []interface{}{"up"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelNamesVariable",
+							Spec: map[string]interface{}{
+								"matchers": []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -148,22 +149,22 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 }
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: true,
 						},
-					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[string]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[string]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -191,23 +192,23 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 }
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					DefaultValue: &DefaultVariableValue{SingleValue: "default"},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[string]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						DefaultValue: &variable.DefaultValue{SingleValue: "default"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[string]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -236,24 +237,24 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 }
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					AllowMultiple: true,
-					DefaultValue:  &DefaultVariableValue{SliceValues: []string{"default1", "default2"}},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[string]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						AllowMultiple: true,
+						DefaultValue:  &variable.DefaultValue{SliceValues: []string{"default1", "default2"}},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[string]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -282,12 +283,12 @@ spec:
   value: "value"
 `,
 			result: &Variable{
-				Kind: TextVariable,
+				Kind: variable.KindText,
 				Spec: &TextVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "SimpleText",
+					TextSpec: variable.TextSpec{
+						Value: "value",
 					},
-					Value: "value",
+					Name: "SimpleText",
 				},
 			},
 		},
@@ -303,18 +304,18 @@ spec:
     kind: "PrometheusLabelNamesVariable"
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelNamesVariable",
+						},
 					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelNamesVariable",
-					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -333,21 +334,21 @@ spec:
         - "up"
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelNamesVariable",
-						Spec: map[interface{}]interface{}{
-							"matchers": []interface{}{"up"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelNamesVariable",
+							Spec: map[interface{}]interface{}{
+								"matchers": []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -368,22 +369,22 @@ spec:
         - "up"
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: true,
 						},
-					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[interface{}]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[interface{}]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -404,23 +405,23 @@ spec:
         - "up"
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					DefaultValue: &DefaultVariableValue{SingleValue: "default"},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[interface{}]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						DefaultValue: &variable.DefaultValue{SingleValue: "default"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[interface{}]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -444,24 +445,24 @@ spec:
         - "up"
 `,
 			result: &Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					AllowMultiple: true,
-					DefaultValue:  &DefaultVariableValue{SliceValues: []string{"default1", "default2"}},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[interface{}]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						AllowMultiple: true,
+						DefaultValue:  &variable.DefaultValue{SliceValues: []string{"default1", "default2"}},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[interface{}]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 		},
@@ -512,7 +513,7 @@ func TestUnmarshalVariableError(t *testing.T) {
   }
 }
 `,
-			err: fmt.Errorf(`value for the variable "hogwarts" cannot be empty`),
+			err: fmt.Errorf(`value for the text variable cannot be empty`),
 		},
 		{
 			title: "ListVariable with no name",
@@ -543,44 +544,43 @@ func TestMarshalListVariable(t *testing.T) {
 		{
 			title: "simple TextVariable",
 			variable: Variable{
-				Kind: TextVariable,
+				Kind: variable.KindText,
 				Spec: &TextVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "SimpleText",
+					TextSpec: variable.TextSpec{
+						Value: "value",
 					},
-					Value: "value",
+					Name: "SimpleText",
 				},
 			},
 			result: `{
   "kind": "TextVariable",
   "spec": {
-    "name": "SimpleText",
-    "value": "value"
+    "value": "value",
+    "name": "SimpleText"
   }
 }`,
 		},
 		{
 			title: "query variable by label_names",
 			variable: Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelNamesVariable",
+							Spec: map[string]interface{}{},
+						},
 					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelNamesVariable",
-						Spec: map[string]interface{}{},
-					},
+					Name: "MyList",
 				},
 			},
 			result: `{
   "kind": "ListVariable",
   "spec": {
-    "name": "MyList",
     "display": {
       "name": "my awesome variable",
       "hidden": false
@@ -590,34 +590,34 @@ func TestMarshalListVariable(t *testing.T) {
     "plugin": {
       "kind": "PrometheusLabelNamesVariable",
       "spec": {}
-    }
+    },
+    "name": "MyList"
   }
 }`,
 		},
 		{
 			title: "query variable by label_names with matcher",
 			variable: Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelNamesVariable",
-						Spec: map[string]interface{}{
-							"matchers": []interface{}{"up"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelNamesVariable",
+							Spec: map[string]interface{}{
+								"matchers": []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 			result: `{
   "kind": "ListVariable",
   "spec": {
-    "name": "MyList",
     "display": {
       "name": "my awesome variable",
       "hidden": false
@@ -631,35 +631,35 @@ func TestMarshalListVariable(t *testing.T) {
           "up"
         ]
       }
-    }
+    },
+    "name": "MyList"
   }
 }`,
 		},
 		{
 			title: "query variable with label_values and matcher",
 			variable: Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[string]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[string]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 			result: `{
   "kind": "ListVariable",
   "spec": {
-    "name": "MyList",
     "display": {
       "name": "my awesome variable",
       "hidden": false
@@ -674,36 +674,36 @@ func TestMarshalListVariable(t *testing.T) {
           "up"
         ]
       }
-    }
+    },
+    "name": "MyList"
   }
 }`,
 		},
 		{
 			title: "default value as a single string",
 			variable: Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					DefaultValue: &DefaultVariableValue{SingleValue: "default"},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[string]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						DefaultValue: &variable.DefaultValue{SingleValue: "default"},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[string]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 			result: `{
   "kind": "ListVariable",
   "spec": {
-    "name": "MyList",
     "display": {
       "name": "my awesome variable",
       "hidden": false
@@ -719,37 +719,37 @@ func TestMarshalListVariable(t *testing.T) {
           "up"
         ]
       }
-    }
+    },
+    "name": "MyList"
   }
 }`,
 		},
 		{
 			title: "default list of values",
 			variable: Variable{
-				Kind: ListVariable,
+				Kind: variable.KindList,
 				Spec: &ListVariableSpec{
-					CommonVariableSpec: CommonVariableSpec{
-						Name: "MyList",
-						Display: &VariableDisplay{
+					ListSpec: variable.ListSpec{
+						Display: &variable.Display{
 							Name:   "my awesome variable",
 							Hidden: false,
 						},
-					},
-					AllowMultiple: true,
-					DefaultValue:  &DefaultVariableValue{SliceValues: []string{"default1", "default2"}},
-					Plugin: common.Plugin{
-						Kind: "PrometheusLabelValuesVariable",
-						Spec: map[string]interface{}{
-							"label_name": "instance",
-							"matchers":   []interface{}{"up"},
+						AllowMultiple: true,
+						DefaultValue:  &variable.DefaultValue{SliceValues: []string{"default1", "default2"}},
+						Plugin: common.Plugin{
+							Kind: "PrometheusLabelValuesVariable",
+							Spec: map[string]interface{}{
+								"label_name": "instance",
+								"matchers":   []interface{}{"up"},
+							},
 						},
 					},
+					Name: "MyList",
 				},
 			},
 			result: `{
   "kind": "ListVariable",
   "spec": {
-    "name": "MyList",
     "display": {
       "name": "my awesome variable",
       "hidden": false
@@ -768,7 +768,8 @@ func TestMarshalListVariable(t *testing.T) {
           "up"
         ]
       }
-    }
+    },
+    "name": "MyList"
   }
 }`,
 		},

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -153,36 +154,36 @@ func TestMarshalDashboard(t *testing.T) {
 					Duration: model.Duration(6 * time.Hour),
 					Variables: []dashboard.Variable{
 						{
-							Kind: dashboard.ListVariable,
+							Kind: variable.KindList,
 							Spec: &dashboard.ListVariableSpec{
-								CommonVariableSpec: dashboard.CommonVariableSpec{
-									Name: "labelName",
-								},
-								Plugin: common.Plugin{
-									Kind: "PrometheusLabelNamesVariable",
-									Spec: map[string]interface{}{
-										"matchers": []string{
-											"up",
+								ListSpec: variable.ListSpec{
+									Plugin: common.Plugin{
+										Kind: "PrometheusLabelNamesVariable",
+										Spec: map[string]interface{}{
+											"matchers": []string{
+												"up",
+											},
 										},
 									},
 								},
+								Name: "labelName",
 							},
 						},
 						{
-							Kind: dashboard.ListVariable,
+							Kind: variable.KindList,
 							Spec: &dashboard.ListVariableSpec{
-								CommonVariableSpec: dashboard.CommonVariableSpec{
-									Name: "labelValue",
-								},
-								Plugin: common.Plugin{
-									Kind: "PrometheusLabelValuesVariable",
-									Spec: map[string]interface{}{
-										"label_name": "$labelName",
-										"matchers": []string{
-											"up",
+								ListSpec: variable.ListSpec{
+									Plugin: common.Plugin{
+										Kind: "PrometheusLabelValuesVariable",
+										Spec: map[string]interface{}{
+											"label_name": "$labelName",
+											"matchers": []string{
+												"up",
+											},
 										},
 									},
 								},
+								Name: "labelValue",
 							},
 						},
 					},
@@ -239,7 +240,6 @@ func TestMarshalDashboard(t *testing.T) {
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "labelName",
           "allow_all_value": false,
           "allow_multiple": false,
           "plugin": {
@@ -249,13 +249,13 @@ func TestMarshalDashboard(t *testing.T) {
                 "up"
               ]
             }
-          }
+          },
+          "name": "labelName"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "labelValue",
           "allow_all_value": false,
           "allow_multiple": false,
           "plugin": {
@@ -266,7 +266,8 @@ func TestMarshalDashboard(t *testing.T) {
                 "up"
               ]
             }
-          }
+          },
+          "name": "labelValue"
         }
       }
     ],
@@ -431,36 +432,36 @@ func TestUnmarshallDashboard(t *testing.T) {
 			Duration: model.Duration(6 * time.Hour),
 			Variables: []dashboard.Variable{
 				{
-					Kind: dashboard.ListVariable,
+					Kind: variable.KindList,
 					Spec: &dashboard.ListVariableSpec{
-						CommonVariableSpec: dashboard.CommonVariableSpec{
-							Name: "labelName",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusLabelNamesVariable",
-							Spec: map[string]interface{}{
-								"matchers": []interface{}{
-									"up",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusLabelNamesVariable",
+								Spec: map[string]interface{}{
+									"matchers": []interface{}{
+										"up",
+									},
 								},
 							},
 						},
+						Name: "labelName",
 					},
 				},
 				{
-					Kind: dashboard.ListVariable,
+					Kind: variable.KindList,
 					Spec: &dashboard.ListVariableSpec{
-						CommonVariableSpec: dashboard.CommonVariableSpec{
-							Name: "labelValue",
-						},
-						Plugin: common.Plugin{
-							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
-								"label_name": "$labelName",
-								"matchers": []interface{}{
-									"up",
+						ListSpec: variable.ListSpec{
+							Plugin: common.Plugin{
+								Kind: "PrometheusLabelValuesVariable",
+								Spec: map[string]interface{}{
+									"label_name": "$labelName",
+									"matchers": []interface{}{
+										"up",
+									},
 								},
 							},
 						},
+						Name: "labelValue",
 					},
 				},
 			},

--- a/pkg/model/api/v1/kind.go
+++ b/pkg/model/api/v1/kind.go
@@ -99,8 +99,12 @@ func GetStruct(kind Kind) (modelAPI.Entity, error) {
 		return &Folder{}, nil
 	case KindGlobalDatasource:
 		return &GlobalDatasource{}, nil
+	case KindGlobalVariable:
+		return &GlobalVariable{}, nil
 	case KindProject:
 		return &Project{}, nil
+	case KindVariable:
+		return &Variable{}, nil
 	default:
 		return nil, fmt.Errorf("%q has no associated struct", kind)
 	}

--- a/pkg/model/api/v1/kind.go
+++ b/pkg/model/api/v1/kind.go
@@ -27,7 +27,9 @@ const (
 	KindDatasource       Kind = "Datasource"
 	KindFolder           Kind = "Folder"
 	KindGlobalDatasource Kind = "GlobalDatasource"
+	KindGlobalVariable   Kind = "GlobalVariable"
 	KindProject          Kind = "Project"
+	KindVariable         Kind = "Variable"
 )
 
 var KindMap = map[Kind]bool{
@@ -35,7 +37,9 @@ var KindMap = map[Kind]bool{
 	KindDatasource:       true,
 	KindFolder:           true,
 	KindGlobalDatasource: true,
+	KindGlobalVariable:   true,
 	KindProject:          true,
+	KindVariable:         true,
 }
 
 var PluralKindMap = map[Kind]string{
@@ -43,7 +47,9 @@ var PluralKindMap = map[Kind]string{
 	KindDatasource:       "datasources",
 	KindFolder:           "folders",
 	KindGlobalDatasource: "globaldatasources",
+	KindGlobalVariable:   "globalvariables",
 	KindProject:          "projects",
+	KindVariable:         "variables",
 }
 
 func (k *Kind) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/variable.go
+++ b/pkg/model/api/v1/variable.go
@@ -66,6 +66,7 @@ func (v *VariableSpec) unmarshal(unmarshal func(interface{}) error, staticMarsha
 	return nil
 }
 
+// GlobalVariable is a global variable that be used everywhere regardless the project.
 type GlobalVariable struct {
 	Kind     Kind         `json:"kind" yaml:"kind"`
 	Metadata Metadata     `json:"metadata" yaml:"metadata"`
@@ -84,6 +85,8 @@ func (v *GlobalVariable) GetSpec() interface{} {
 	return v.Spec
 }
 
+// Variable is a global variable at project level.
+// If you are looking for the variable contained in a dashboard, take a look at dashboard.Variable
 type Variable struct {
 	Kind     Kind            `json:"kind" yaml:"kind"`
 	Metadata ProjectMetadata `json:"metadata" yaml:"metadata"`

--- a/pkg/model/api/v1/variable.go
+++ b/pkg/model/api/v1/variable.go
@@ -1,0 +1,55 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	"github.com/perses/perses/pkg/model/api/v1/dashboard"
+)
+
+type GlobalVariable struct {
+	Kind     Kind               `json:"kind" yaml:"kind"`
+	Metadata Metadata           `json:"metadata" yaml:"metadata"`
+	Spec     dashboard.Variable `json:"spec" yaml:"spec"`
+}
+
+func (v *GlobalVariable) GetMetadata() modelAPI.Metadata {
+	return &v.Metadata
+}
+
+func (v *GlobalVariable) GetKind() string {
+	return string(v.Kind)
+}
+
+func (v *GlobalVariable) GetSpec() interface{} {
+	return v.Spec
+}
+
+type Variable struct {
+	Kind     Kind               `json:"kind" yaml:"kind"`
+	Metadata ProjectMetadata    `json:"metadata" yaml:"metadata"`
+	Spec     dashboard.Variable `json:"spec" yaml:"spec"`
+}
+
+func (v *Variable) GetMetadata() modelAPI.Metadata {
+	return &v.Metadata
+}
+
+func (v *Variable) GetKind() string {
+	return string(v.Kind)
+}
+
+func (v *Variable) GetSpec() interface{} {
+	return v.Spec
+}

--- a/pkg/model/api/v1/variable.go
+++ b/pkg/model/api/v1/variable.go
@@ -85,8 +85,8 @@ func (v *GlobalVariable) GetSpec() interface{} {
 	return v.Spec
 }
 
-// Variable is a global variable at project level.
-// If you are looking for the variable contained in a dashboard, take a look at dashboard.Variable
+// Variable relates to variables defined at project level.
+// If you are looking for variable defined at dashboard level, see dashboard.Variable
 type Variable struct {
 	Kind     Kind            `json:"kind" yaml:"kind"`
 	Metadata ProjectMetadata `json:"metadata" yaml:"metadata"`

--- a/pkg/model/api/v1/variable/list.go
+++ b/pkg/model/api/v1/variable/list.go
@@ -1,0 +1,90 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package variable
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/perses/perses/pkg/model/api/v1/common"
+)
+
+type DefaultValue struct {
+	SingleValue string
+	SliceValues []string
+}
+
+func (v *DefaultValue) UnmarshalJSON(data []byte) error {
+	var s string
+	var slice []string
+	if unmarshalStringErr := json.Unmarshal(data, &s); unmarshalStringErr != nil {
+		if unmarshalSliceErr := json.Unmarshal(data, &slice); unmarshalSliceErr != nil {
+			return fmt.Errorf("unable to unmarshal default_value. Only string or array of string can be used")
+		}
+	}
+	v.SingleValue = s
+	v.SliceValues = slice
+	return nil
+}
+
+func (v *DefaultValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	var slice []string
+	if unmarshalStringErr := unmarshal(&s); unmarshalStringErr != nil {
+		if unmarshalSliceErr := unmarshal(&slice); unmarshalSliceErr != nil {
+			return fmt.Errorf("unable to unmarshal default_value. Only string or array of string can be used")
+		}
+	}
+	v.SingleValue = s
+	v.SliceValues = slice
+	return nil
+}
+
+func (v *DefaultValue) MarshalJSON() ([]byte, error) {
+	if len(v.SingleValue) > 0 {
+		return json.Marshal(v.SingleValue)
+	}
+	return json.Marshal(v.SliceValues)
+}
+
+func (v *DefaultValue) MarshalYAML() (interface{}, error) {
+	if len(v.SingleValue) > 0 {
+		return v.SingleValue, nil
+	}
+	return v.SliceValues, nil
+}
+
+type ListSpec struct {
+	Display       *Display      `json:"display,omitempty" yaml:"display,omitempty"`
+	DefaultValue  *DefaultValue `json:"default_value,omitempty" yaml:"default_value,omitempty"`
+	AllowAllValue bool          `json:"allow_all_value" yaml:"allow_all_value"`
+	AllowMultiple bool          `json:"allow_multiple" yaml:"allow_multiple"`
+	// CustomAllValue is a custom value that will be used if AllowAllValue is true and if then `all` is selected
+	CustomAllValue string `json:"custom_all_value,omitempty" yaml:"custom_all_value,omitempty"`
+	// CapturingRegexp is the regexp used to catch and filter the result of the query.
+	// If empty, then nothing is filtered. That's the equivalent of setting CapturingRegexp with (.*)
+	CapturingRegexp string        `json:"capturing_regexp,omitempty" yaml:"capturing_regexp,omitempty"`
+	Plugin          common.Plugin `json:"plugin" yaml:"plugin"`
+}
+
+func (v *ListSpec) Validate() error {
+	if len(v.CustomAllValue) > 0 && !v.AllowAllValue {
+		return fmt.Errorf("custom_all_value cannot be set if allow_all_value is not set to true")
+	}
+	if v.DefaultValue != nil && len(v.DefaultValue.SliceValues) > 0 && !v.AllowMultiple {
+		return fmt.Errorf("you can not use a list of default values if allow_multiple is set to false")
+	}
+
+	return nil
+}

--- a/pkg/model/api/v1/variable/text.go
+++ b/pkg/model/api/v1/variable/text.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package variable
+
+import (
+	"fmt"
+)
+
+type TextSpec struct {
+	Display *Display `json:"display,omitempty" yaml:"display,omitempty"`
+	Value   string   `json:"value" yaml:"value"`
+}
+
+func (v *TextSpec) Validate() error {
+	if len(v.Value) == 0 {
+		return fmt.Errorf("value for the text variable cannot be empty")
+	}
+	return nil
+}

--- a/pkg/model/api/v1/variable/variable.go
+++ b/pkg/model/api/v1/variable/variable.go
@@ -1,0 +1,106 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package variable
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Kind string
+
+const (
+	KindText Kind = "TextVariable"
+	KindList Kind = "ListVariable"
+)
+
+var KindMap = map[Kind]bool{
+	KindText: true,
+	KindList: true,
+}
+
+func (k *Kind) UnmarshalJSON(data []byte) error {
+	var tmp Kind
+	type plain Kind
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*k = tmp
+	return nil
+}
+
+func (k *Kind) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp Kind
+	type plain Kind
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*k = tmp
+	return nil
+}
+
+func (k *Kind) validate() error {
+	if len(*k) == 0 {
+		return fmt.Errorf("variable.kind cannot be empty")
+	}
+	if _, ok := KindMap[*k]; !ok {
+		return fmt.Errorf("unknown variable.kind %q used", *k)
+	}
+	return nil
+}
+
+type Display struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Hidden      bool   `json:"hidden" yaml:"hidden"`
+}
+
+func (d *Display) UnmarshalJSON(data []byte) error {
+	var tmp Display
+	type plain Display
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *Display) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp Display
+	type plain Display
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *Display) validate() error {
+	if len(d.Name) == 0 {
+		return fmt.Errorf("variables[].display.name cannot be empty")
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is adding two new resources in the backend : `GlobalVariable` and `ProjectVariable`. These variables can be then shared and used across different dashboard.

This is something coming up in the discussion https://github.com/perses/perses/discussions/226

For example:

```bash
curl -XGET https://perses.dev/api/v1/globalvariables
```
```json
[
{
  "kind": "GlobalVariable",
  "metadata": {
    "name": "MyList"
  },
  "spec": {
    "kind": "ListVariable",
    "spec": {
      "display": {
        "name": "my awesome variable",
        "hidden": false
      },
      "default_value": [
        "default1",
        "default2"
      ],
      "allow_all_value": false,
      "allow_multiple": true,
      "plugin": {
        "kind": "PrometheusLabelValuesVariable",
        "spec": {
          "label_name": "instance",
          "matchers": [
            "up"
          ]
        }
      }
    }
  }
}
]
```