### PR TITLE
[BUGFIX] Revert allow echarts wrapper to default to fluid width and height

### DIFF
--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -16,7 +16,6 @@ import { ECharts, EChartsCoreOption, init } from 'echarts/core';
 import { Box, SxProps, Theme } from '@mui/material';
 import { isEqual, debounce } from 'lodash-es';
 import { EChartsTheme } from '../model';
-import { combineSx } from '../utils';
 
 // see docs for info about each property: https://echarts.apache.org/en/api.html#events
 export interface MouseEventsParameters<T> {
@@ -183,20 +182,7 @@ export const EChart = React.memo(function EChart<T>({
     updateSize();
   }, [sx]);
 
-  return (
-    <Box
-      ref={containerRef}
-      sx={combineSx(
-        {
-          // Ensures chart fills container and updates size correctly when resizing,
-          // combineSx allows this default behavior to be overriden from parent component
-          width: '100%',
-          height: '100%',
-        },
-        sx
-      )}
-    ></Box>
-  );
+  return <Box ref={containerRef} sx={sx}></Box>;
 });
 
 // Validate event config and bind custom events

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -232,7 +232,16 @@ export function LineChart({
             unit={unit}
           />
         )}
-      <EChart option={option} theme={chartsTheme.echartsTheme} onEvents={handleEvents} _instance={chartRef} />
+      <EChart
+        sx={{
+          width: '100%',
+          height: '100%',
+        }}
+        option={option}
+        theme={chartsTheme.echartsTheme}
+        onEvents={handleEvents}
+        _instance={chartRef}
+      />
     </Box>
   );
 }

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -126,7 +126,17 @@ export function StatChart(props: StatChartProps) {
       >
         {formattedValue}
       </Typography>
-      {sparkline !== undefined && <EChart option={option} theme={chartsTheme.echartsTheme} renderer="svg" />}
+      {sparkline !== undefined && (
+        <EChart
+          sx={{
+            width: '100%',
+            height: '100%',
+          }}
+          option={option}
+          theme={chartsTheme.echartsTheme}
+          renderer="svg"
+        />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
Reverts perses/perses#1115

Previous PR doesn't work since the sx prop is needed in the dependency array [here](https://github.com/perses/perses/blob/v0.29.1/ui/components/src/EChart/EChart.tsx#L178-L184)