### PR TITLE
[BREAKINGCHANGE] Optional metadata, remove `unknown` DashboardResource type assertion

### DIFF
--- a/ui/app/src/views/ViewDashboard.tsx
+++ b/ui/app/src/views/ViewDashboard.tsx
@@ -96,7 +96,7 @@ function ViewDashboard() {
           layouts: [],
           panels: {},
         },
-      } as unknown as DashboardResource;
+      };
       isEditing = true;
     }
   }

--- a/ui/core/src/model/resource.ts
+++ b/ui/core/src/model/resource.ts
@@ -12,10 +12,10 @@
 // limitations under the License.
 
 export interface Metadata {
-  name: string;
-  created_at: string;
-  updated_at: string;
-  version: number;
+  name?: string;
+  created_at?: string;
+  updated_at?: string;
+  version?: number;
 }
 
 export interface ProjectMetadata extends Metadata {

--- a/ui/core/src/model/resource.ts
+++ b/ui/core/src/model/resource.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 export interface Metadata {
-  name?: string;
+  name: string;
   created_at?: string;
   updated_at?: string;
   version?: number;


### PR DESCRIPTION
Make certain metadata fields optional (see PR #939) and comment [here](https://github.com/perses/perses/pull/939#discussion_r1094774589) about using `unknown`. 

created_at, updated_at, and version are now optional 

These fields are set by the BE and shouldn't be required, this allows us to use the DashboardResource from @perses-dev/core without using type assertion as a workaround.  

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
