### PR TITLE
[ENHANCEMENT] Refactor time series chart panel selection

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -105,14 +105,14 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   // convert Perses dashboard format to be ECharts compatible
   const echartsYAxis = convertPanelYAxis(y_axis);
 
-  const [selectedSeriesNames, setSelectedSeriesNames] = useState<SelectedSeriesState>('ALL');
+  const [selectedSeries, setSelectedSeries] = useState<SelectedSeriesState>('ALL');
 
   const { setTimeRange } = useTimeRange();
 
   const onLegendItemClick = (e: React.MouseEvent<HTMLElement, MouseEvent>, seriesId: string) => {
     const isModifiedClick = e.metaKey || e.shiftKey;
 
-    setSelectedSeriesNames((current) => {
+    setSelectedSeries((current) => {
       return produce(current, (draft) => {
         if (draft === 'ALL') {
           return {
@@ -217,8 +217,8 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
         // When we initially load the chart, we want to show all series, but
         // DO NOT want to visualy highlight all the items in the legend.
-        const isSelectAll = selectedSeriesNames === 'ALL';
-        const isSelected = !isSelectAll && !!selectedSeriesNames[seriesId];
+        const isSelectAll = selectedSeries === 'ALL';
+        const isSelected = !isSelectAll && !!selectedSeries[seriesId];
         const showTimeSeries = isSelected || isSelectAll;
 
         if (showTimeSeries) {
@@ -264,7 +264,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     return {
       graphData,
     };
-  }, [queryResults, thresholds, selectedSeriesNames, legend, visual, isFetching, isLoading, y_axis?.max, y_axis?.min]);
+  }, [queryResults, thresholds, selectedSeries, legend, visual, isFetching, isLoading, y_axis?.max, y_axis?.min]);
 
   if (adjustedContentDimensions === undefined) {
     return null;

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -217,9 +217,9 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
         // When we initially load the chart, we want to show all series, but
         // DO NOT want to visualy highlight all the items in the legend.
-        const isInitAll = selectedSeriesNames === 'ALL';
-        const isSelected = !isInitAll && !!selectedSeriesNames[seriesId];
-        const showTimeSeries = isSelected || isInitAll;
+        const isSelectAll = selectedSeriesNames === 'ALL';
+        const isSelected = !isSelectAll && !!selectedSeriesNames[seriesId];
+        const showTimeSeries = isSelected || isSelectAll;
 
         if (showTimeSeries) {
           graphData.timeSeries.push(lineSeries);

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -13,7 +13,12 @@
 
 import type { YAXisComponentOption } from 'echarts';
 import { StepOptions, TimeScale, getCommonTimeScale } from '@perses-dev/core';
-import { OPTIMIZED_MODE_SERIES_LIMIT, EChartsTimeSeries, EChartsValues } from '@perses-dev/components';
+import {
+  OPTIMIZED_MODE_SERIES_LIMIT,
+  EChartsTimeSeries,
+  EChartsValues,
+  EChartsDataFormat,
+} from '@perses-dev/components';
 import { useTimeSeriesQueries, UseDataQueryResults } from '@perses-dev/plugin-system';
 import {
   DEFAULT_AREA_OPACITY,
@@ -29,7 +34,7 @@ import {
 
 export type RunningQueriesState = ReturnType<typeof useTimeSeriesQueries>;
 
-export const EMPTY_GRAPH_DATA = {
+export const EMPTY_GRAPH_DATA: EChartsDataFormat = {
   timeSeries: [],
   xAxis: [],
   legendItems: [],


### PR DESCRIPTION
This commit refactors the time series chart panel selection mechanisms in the following ways:
- Switch from tracking selected items using `name` to using a unique `id` to avoid unintentionally setting multiple items if they have the same label.
- Switch from storing selected items using an array of names to a record of ids and booleans. This should make some operations more performant with large data sets and is more aligned with how we'll want to manage checkbox-based selection with the in progress table legend work.


# Notes for code reviewers

- This is another refactor in service to the in flight work I'm doing on the table legend to avoid that initial PR being super large and nasty to review. 
- I played around with some larger refactoring while doing this that I think would benefit the time series chart panel, but it made the diffs in git really nasty. I'll try to come back to it in a follow-up, so it's a cleaner change.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

# Screenshots

This should ideally be a noop from a user experience perspective. Below is a video showing a combo of single and modified clicks.

https://github.com/perses/perses/assets/396962/13e99a70-c6d2-4c0f-b79a-931548f617c6



