### PR TITLE
[ENHANCEMENT] Add `noDataVariant` to `LineChart`

### DIFF
--- a/ui/components/src/LineChart/LineChart.stories.tsx
+++ b/ui/components/src/LineChart/LineChart.stories.tsx
@@ -14,6 +14,7 @@
 import { StoryObj, Meta } from '@storybook/react';
 import { LineChart } from '@perses-dev/components';
 import { waitForStableCanvas } from '@perses-dev/storybook';
+import { Stack, Typography } from '@mui/material';
 
 const meta: Meta<typeof LineChart> = {
   component: LineChart,
@@ -65,3 +66,45 @@ export default meta;
 type Story = StoryObj<typeof LineChart>;
 
 export const Primary: Story = {};
+
+export const NoData: Story = {
+  args: {
+    data: {
+      timeSeries: [],
+      xAxis: [1673784000000, 1673784060000, 1673784120000],
+      legendItems: [],
+      rangeMs: 21600000,
+    },
+  },
+  argTypes: {
+    // Remove from table because these values are managed in render.
+    data: {
+      table: {
+        disable: true,
+      },
+    },
+    noDataVariant: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  render: (args) => {
+    return (
+      <Stack>
+        <div>
+          <Typography variant="h3" gutterBottom align="center">
+            message
+          </Typography>
+          <LineChart {...args} noDataVariant="message" />
+        </div>
+        <div>
+          <Typography variant="h3" gutterBottom align="center">
+            chart
+          </Typography>
+          <LineChart {...args} noDataVariant="chart" />
+        </div>
+      </Stack>
+    );
+  },
+};

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -147,6 +147,9 @@ export function LineChart({
 
   const option: EChartsCoreOption = useMemo(() => {
     if (data.timeSeries === undefined) return {};
+
+    // The "chart" `noDataVariant` is only used when the `timeSeries` is an
+    // empty array because a `null` value will throw an error.
     if (data.timeSeries === null || (data.timeSeries.length === 0 && noDataVariant === 'message')) return noDataOption;
 
     // show symbols and axisPointer dashed line on hover

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -73,6 +73,7 @@ export interface LineChartProps {
   grid?: GridComponentOption;
   legend?: LegendComponentOption;
   tooltipConfig?: TooltipConfig;
+  noDataVariant?: 'chart' | 'message';
   onDataZoom?: (e: ZoomEventData) => void;
   onDoubleClick?: (e: MouseEvent) => void;
   __experimentalEChartsOptionsOverride?: (options: EChartsCoreOption) => EChartsCoreOption;
@@ -86,6 +87,7 @@ export function LineChart({
   grid,
   legend,
   tooltipConfig = { wrapLabels: true },
+  noDataVariant = 'message',
   onDataZoom,
   onDoubleClick,
   __experimentalEChartsOptionsOverride,
@@ -145,7 +147,7 @@ export function LineChart({
 
   const option: EChartsCoreOption = useMemo(() => {
     if (data.timeSeries === undefined) return {};
-    if (data.timeSeries === null || data.timeSeries.length === 0) return noDataOption;
+    if (data.timeSeries === null || (data.timeSeries.length === 0 && noDataVariant === 'message')) return noDataOption;
 
     // show symbols and axisPointer dashed line on hover
     const isOptimizedMode = data.timeSeries.length > OPTIMIZED_MODE_SERIES_LIMIT;

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -193,7 +193,7 @@ export function LineChart({
       return __experimentalEChartsOptionsOverride(option);
     }
     return option;
-  }, [data, yAxis, unit, grid, legend, noDataOption, timeZone, __experimentalEChartsOptionsOverride]);
+  }, [data, yAxis, unit, grid, legend, noDataOption, timeZone, __experimentalEChartsOptionsOverride, noDataVariant]);
 
   return (
     <Box


### PR DESCRIPTION
This new optional prop enables the user to choose one of two displays when the line chart does not have data:
- `message` (default): renders a simple "no data" message to the user. This was the prior behavior before the addition of this prop.
- `chart`: renders a very simple chart with the available information (e.g. x axis).

# Notes for reviewers

- This is yet another small PR in prep for the table legend. We want to show an empty chart (instead of a "no data" message) when the user unselects all the items in a table legend using the checkboxes.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

# Screenshots

This is only in storybook right now. Screenshot of the story that exercises this prop.

<img width="1173" alt="image" src="https://github.com/perses/perses/assets/396962/a4088973-5388-48df-882c-7e31792e114f">
