### PR TITLE
[ENHANCEMENT] make the whole panel group clickable for toggle/expand

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Icon, IconButton, Stack, Typography } from '@mui/material';
+import { Box, IconButton, Stack, Typography } from '@mui/material';
 import ExpandedIcon from 'mdi-material-ui/ChevronDown';
 import CollapsedIcon from 'mdi-material-ui/ChevronRight';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
@@ -43,39 +43,39 @@ export function GridTitle(props: GridTitleProps) {
   const { openDeletePanelGroupDialog } = useDeletePanelGroupDialog();
   const { isEditMode } = useEditMode();
 
-  const text = (
-    <Typography variant="h2" sx={{ marginLeft: collapse !== undefined ? 1 : undefined }}>
-      {title}
-    </Typography>
-  );
+  const text = <Typography variant="h2">{title}</Typography>;
 
   return (
     <Box
+      onClick={collapse ? collapse.onToggleOpen : undefined}
       sx={{
         display: 'flex',
         justifyContent: 'start',
         alignItems: 'center',
         padding: (theme) => theme.spacing(1),
+        cursor: collapse ? 'pointer' : 'auto',
         backgroundColor: ({ palette }) =>
           palette.mode === 'dark' ? palette.background.paper : palette.background.default,
       }}
       data-testid="panel-group-header"
-      onClick={collapse !== undefined ? collapse.onToggleOpen : undefined }
-      style={{ cursor: 'pointer' }}
     >
       {collapse ? (
         <>
-          {collapse.isOpen ? <ExpandedIcon style={{ margin: '8px' }}/> : <CollapsedIcon style={{ margin: '8px' }}/>}
+          <IconButton sx={{ marginRight: 1 }} aria-label={`${collapse.isOpen ? 'collapse' : 'expand'} group ${title}`}>
+            {collapse.isOpen ? <ExpandedIcon /> : <CollapsedIcon />}
+          </IconButton>
           {text}
           {isEditMode && (
             <Stack direction="row" marginLeft="auto">
               <InfoTooltip description={TOOLTIP_TEXT.addPanelToGroup}>
-                <IconButton 
+                <IconButton
                   aria-label={ARIA_LABEL_TEXT.addPanelToGroup(title)}
                   onClick={(e) => {
-                    {if (collapse.isOpen) e.stopPropagation()}; // set as expanded if not already
+                    // Don't trigger expand/collapse
+                    e.stopPropagation();
                     openAddPanel();
-                  }}>
+                  }}
+                >
                   <AddPanelIcon />
                 </IconButton>
               </InfoTooltip>
@@ -83,9 +83,11 @@ export function GridTitle(props: GridTitleProps) {
                 <IconButton
                   aria-label={ARIA_LABEL_TEXT.editGroup(title)}
                   onClick={(e) => {
-                    e.stopPropagation(); // to not trigger expand/collapse
+                    // Don't trigger expand/collapse
+                    e.stopPropagation();
                     openEditPanelGroup();
-                  }}>
+                  }}
+                >
                   <PencilIcon />
                 </IconButton>
               </InfoTooltip>
@@ -93,9 +95,11 @@ export function GridTitle(props: GridTitleProps) {
                 <IconButton
                   aria-label={ARIA_LABEL_TEXT.deleteGroup(title)}
                   onClick={(e) => {
-                    e.stopPropagation(); // to not trigger expand/collapse
+                    // Don't trigger expand/collapse
+                    e.stopPropagation();
                     openDeletePanelGroupDialog(panelGroupId);
-                  }}>
+                  }}
+                >
                   <DeleteIcon />
                 </IconButton>
               </InfoTooltip>
@@ -104,9 +108,11 @@ export function GridTitle(props: GridTitleProps) {
                   aria-label={ARIA_LABEL_TEXT.moveGroupDown(title)}
                   disabled={moveDown === undefined}
                   onClick={(e) => {
-                    e.stopPropagation(); // to not trigger expand/collapse
-                    {moveDown !== undefined ? moveDown() : undefined };
-                  }}>
+                    // Don't trigger expand/collapse
+                    e.stopPropagation();
+                    if (moveDown) moveDown();
+                  }}
+                >
                   <ArrowDownIcon />
                 </IconButton>
               </InfoTooltip>
@@ -115,9 +121,11 @@ export function GridTitle(props: GridTitleProps) {
                   aria-label={ARIA_LABEL_TEXT.moveGroupUp(title)}
                   disabled={moveUp === undefined}
                   onClick={(e) => {
-                    e.stopPropagation(); // to not trigger expand/collapse
-                    {moveUp !== undefined ? moveUp() : undefined };
-                  }}>
+                    // Don't trigger expand/collapse
+                    e.stopPropagation();
+                    if (moveUp) moveUp();
+                  }}
+                >
                   <ArrowUpIcon />
                 </IconButton>
               </InfoTooltip>

--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -47,7 +47,7 @@ export function GridTitle(props: GridTitleProps) {
 
   return (
     <Box
-      onClick={collapse ? collapse.onToggleOpen : undefined}
+      onClick={collapse?.onToggleOpen}
       sx={{
         display: 'flex',
         justifyContent: 'start',
@@ -110,7 +110,7 @@ export function GridTitle(props: GridTitleProps) {
                   onClick={(e) => {
                     // Don't trigger expand/collapse
                     e.stopPropagation();
-                    if (moveDown) moveDown();
+                    moveDown && moveDown();
                   }}
                 >
                   <ArrowDownIcon />
@@ -123,7 +123,7 @@ export function GridTitle(props: GridTitleProps) {
                   onClick={(e) => {
                     // Don't trigger expand/collapse
                     e.stopPropagation();
-                    if (moveUp) moveUp();
+                    moveUp && moveUp();
                   }}
                 >
                   <ArrowUpIcon />

--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, IconButton, Stack, Typography } from '@mui/material';
+import { Box, Icon, IconButton, Stack, Typography } from '@mui/material';
 import ExpandedIcon from 'mdi-material-ui/ChevronDown';
 import CollapsedIcon from 'mdi-material-ui/ChevronRight';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
@@ -60,33 +60,42 @@ export function GridTitle(props: GridTitleProps) {
           palette.mode === 'dark' ? palette.background.paper : palette.background.default,
       }}
       data-testid="panel-group-header"
+      onClick={collapse !== undefined ? collapse.onToggleOpen : undefined }
+      style={{ cursor: 'pointer' }}
     >
       {collapse ? (
         <>
-          <IconButton
-            onClick={collapse.onToggleOpen}
-            aria-label={`${collapse.isOpen ? 'collapse' : 'expand'} group ${title}`}
-          >
-            {collapse.isOpen ? <ExpandedIcon /> : <CollapsedIcon />}
-          </IconButton>
+          {collapse.isOpen ? <ExpandedIcon style={{ margin: '8px' }}/> : <CollapsedIcon style={{ margin: '8px' }}/>}
           {text}
           {isEditMode && (
             <Stack direction="row" marginLeft="auto">
               <InfoTooltip description={TOOLTIP_TEXT.addPanelToGroup}>
-                <IconButton aria-label={ARIA_LABEL_TEXT.addPanelToGroup(title)} onClick={openAddPanel}>
+                <IconButton 
+                  aria-label={ARIA_LABEL_TEXT.addPanelToGroup(title)}
+                  onClick={(e) => {
+                    {if (collapse.isOpen) e.stopPropagation()}; // set as expanded if not already
+                    openAddPanel();
+                  }}>
                   <AddPanelIcon />
                 </IconButton>
               </InfoTooltip>
               <InfoTooltip description={TOOLTIP_TEXT.editGroup}>
-                <IconButton aria-label={ARIA_LABEL_TEXT.editGroup(title)} onClick={openEditPanelGroup}>
+                <IconButton
+                  aria-label={ARIA_LABEL_TEXT.editGroup(title)}
+                  onClick={(e) => {
+                    e.stopPropagation(); // to not trigger expand/collapse
+                    openEditPanelGroup();
+                  }}>
                   <PencilIcon />
                 </IconButton>
               </InfoTooltip>
               <InfoTooltip description={TOOLTIP_TEXT.deleteGroup}>
                 <IconButton
                   aria-label={ARIA_LABEL_TEXT.deleteGroup(title)}
-                  onClick={() => openDeletePanelGroupDialog(panelGroupId)}
-                >
+                  onClick={(e) => {
+                    e.stopPropagation(); // to not trigger expand/collapse
+                    openDeletePanelGroupDialog(panelGroupId);
+                  }}>
                   <DeleteIcon />
                 </IconButton>
               </InfoTooltip>
@@ -94,8 +103,10 @@ export function GridTitle(props: GridTitleProps) {
                 <IconButton
                   aria-label={ARIA_LABEL_TEXT.moveGroupDown(title)}
                   disabled={moveDown === undefined}
-                  onClick={moveDown}
-                >
+                  onClick={(e) => {
+                    e.stopPropagation(); // to not trigger expand/collapse
+                    {moveDown !== undefined ? moveDown() : undefined };
+                  }}>
                   <ArrowDownIcon />
                 </IconButton>
               </InfoTooltip>
@@ -103,8 +114,10 @@ export function GridTitle(props: GridTitleProps) {
                 <IconButton
                   aria-label={ARIA_LABEL_TEXT.moveGroupUp(title)}
                   disabled={moveUp === undefined}
-                  onClick={moveUp}
-                >
+                  onClick={(e) => {
+                    e.stopPropagation(); // to not trigger expand/collapse
+                    {moveUp !== undefined ? moveUp() : undefined };
+                  }}>
                   <ArrowUpIcon />
                 </IconButton>
               </InfoTooltip>


### PR DESCRIPTION
This is a proposal for (imho) better usability of panel groups.

Currently to toggle/expand a panel group, you have to click on the (little) chevron button at the left:
![panel_group_before](https://github.com/perses/perses/assets/7058693/ce9ab30f-807b-4ba6-a195-fc1be9001870)

This PR makes the whole panel group clickable instead:
![panel_group_after](https://github.com/perses/perses/assets/7058693/72bc2e3f-49aa-4388-8f4f-f778298e3964)

Let me know if you agree or not with this change. Also this is my first attempt at doing some React so don't hesitate to point anything wrong/dirty in the code.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
