### PR TITLE
[BREAKINGCHANGE]: move legend interactions to legend

### DIFF
--- a/ui/components/src/Legend/CompactLegend.tsx
+++ b/ui/components/src/Legend/CompactLegend.tsx
@@ -12,12 +12,14 @@
 // limitations under the License.
 
 import { Box } from '@mui/material';
-import { LegendItem } from '../model';
-import { ListLegendItem } from './ListLegendItem';
+import { LegendItem, SelectedLegendItemState, isLegendItemHighlighted } from '../model';
+import { ListLegendItem, ListLegendItemProps } from './ListLegendItem';
 
-interface CompactLegendProps {
+export interface CompactLegendProps {
   height: number;
   items: LegendItem[];
+  selectedItems: SelectedLegendItemState;
+  onLegendItemClick: ListLegendItemProps['onClick'];
 }
 
 /**
@@ -26,13 +28,15 @@ interface CompactLegendProps {
  * number of items. The `ListLegend` is used for cases with large numbers of items
  * because it is virtualized.
  */
-export function CompactLegend({ height, items }: CompactLegendProps) {
+export function CompactLegend({ height, items, selectedItems, onLegendItemClick }: CompactLegendProps) {
   return (
     <Box component="ul" sx={{ width: '100%', height, padding: [0, 1, 0, 0], overflowY: 'scroll', margin: 0 }}>
       {items.map((item) => (
         <ListLegendItem
           key={item.id}
           item={item}
+          isHighlighted={isLegendItemHighlighted(item, selectedItems)}
+          onClick={onLegendItemClick}
           sx={{
             width: 'auto',
             float: 'left',

--- a/ui/components/src/Legend/CompactLegend.tsx
+++ b/ui/components/src/Legend/CompactLegend.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Box } from '@mui/material';
-import { LegendItem, SelectedLegendItemState, isLegendItemHighlighted } from '../model';
+import { LegendItem, SelectedLegendItemState, isLegendItemVisuallySelected } from '../model';
 import { ListLegendItem, ListLegendItemProps } from './ListLegendItem';
 
 export interface CompactLegendProps {
@@ -35,7 +35,7 @@ export function CompactLegend({ height, items, selectedItems, onLegendItemClick 
         <ListLegendItem
           key={item.id}
           item={item}
-          isHighlighted={isLegendItemHighlighted(item, selectedItems)}
+          isVisuallySelected={isLegendItemVisuallySelected(item, selectedItems)}
           onClick={onLegendItemClick}
           sx={{
             width: 'auto',

--- a/ui/components/src/Legend/Legend.stories.tsx
+++ b/ui/components/src/Legend/Legend.stories.tsx
@@ -294,6 +294,16 @@ export const SelectedItems: StoryObj<LegendProps> = {
         disable: true,
       },
     },
+    selectedItems: {
+      table: {
+        disable: true,
+      },
+    },
+    onSelectedItemsChange: {
+      table: {
+        disable: true,
+      },
+    },
   },
   args: {},
   parameters: {

--- a/ui/components/src/Legend/Legend.stories.tsx
+++ b/ui/components/src/Legend/Legend.stories.tsx
@@ -306,9 +306,6 @@ export const SelectedItems: StoryObj<LegendProps> = {
     },
   },
   args: {},
-  parameters: {
-    happo: false,
-  },
   render: (args) => {
     return (
       <Stack spacing={3}>

--- a/ui/components/src/Legend/Legend.stories.tsx
+++ b/ui/components/src/Legend/Legend.stories.tsx
@@ -16,6 +16,7 @@ import { Legend, LegendProps } from '@perses-dev/components';
 import { action } from '@storybook/addon-actions';
 import { Box, Stack, Typography } from '@mui/material';
 import { red, orange, yellow, green, blue, indigo, purple } from '@mui/material/colors';
+import { useState } from 'react';
 
 const COLOR_SHADES = ['400', '800'] as const;
 const COLOR_NAMES = [red, orange, yellow, green, blue, indigo, purple];
@@ -34,7 +35,6 @@ function generateMockLegendData(count: number, labelPrefix = 'legend item'): Leg
     data.push({
       id: `${i}`,
       label: `${labelPrefix} ${i}`,
-      isSelected: false,
       color: MOCK_COLORS[i % MOCK_COLORS.length] as string,
       onClick: action(`onClick legendItem ${i}`),
     });
@@ -45,9 +45,16 @@ function generateMockLegendData(count: number, labelPrefix = 'legend item'): Leg
 // Simple wrapper to try to help visualize that the legend is positioned absolutely
 // inside a relative ancestor.
 const LegendWrapper = (props: LegendProps) => {
+  const [selectedItems, setSelectedItems] = useState<LegendProps['selectedItems']>('ALL');
+
   const {
     options: { position },
   } = props;
+
+  const handleSelectedItemsChange: LegendProps['onSelectedItemsChange'] = (newSelectedItems) => {
+    action('onSelectedItemsChange')(newSelectedItems);
+    setSelectedItems(newSelectedItems);
+  };
 
   // The legend does not look very interesting by itself in stories, especially
   // when considering the positioning. This wrapper puts a box with a border
@@ -68,14 +75,23 @@ const LegendWrapper = (props: LegendProps) => {
         boxSizing: 'content-box',
       }}
     >
-      <Legend {...props} />
+      <Legend {...props} selectedItems={selectedItems} onSelectedItemsChange={handleSelectedItemsChange} />
     </Box>
   );
 };
 
 const meta: Meta<typeof Legend> = {
   component: Legend,
-  argTypes: {},
+  argTypes: {
+    // Disabling the controls for these types because they are managed inside
+    // LegendWrapper for the purpose of stories.
+    selectedItems: {
+      control: false,
+    },
+    onSelectedItemsChange: {
+      control: false,
+    },
+  },
   args: {
     width: 400,
     height: 100,

--- a/ui/components/src/Legend/Legend.test.tsx
+++ b/ui/components/src/Legend/Legend.test.tsx
@@ -1,0 +1,181 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { VirtuosoMockContext } from 'react-virtuoso';
+import { Legend, LegendProps } from './Legend';
+
+const mockItems = [
+  {
+    id: '1',
+    label: 'One',
+    color: 'red',
+  },
+  {
+    id: '2',
+    label: 'Two',
+    color: 'green',
+  },
+  {
+    id: '3',
+    label: 'Three',
+    color: 'blue',
+  },
+];
+
+type RenderLegendOpts = Partial<Pick<LegendProps, 'onSelectedItemsChange' | 'selectedItems'>> & {
+  position?: LegendProps['options']['position'];
+};
+
+const renderLegend = (
+  { onSelectedItemsChange = jest.fn(), selectedItems = 'ALL' }: RenderLegendOpts = {},
+  position = 'Bottom' as const
+) => {
+  return render(
+    <VirtuosoMockContext.Provider value={{ viewportHeight: 600, itemHeight: 100 }}>
+      <Legend
+        height={300}
+        width={400}
+        data={mockItems}
+        options={{
+          position: position,
+        }}
+        selectedItems={selectedItems}
+        onSelectedItemsChange={onSelectedItemsChange}
+      />
+    </VirtuosoMockContext.Provider>
+  );
+};
+
+describe('Legend', () => {
+  describe.each(['Right', 'Bottom'] as const)('positioned %s', (position) => {
+    test('renders items in a list', () => {
+      renderLegend({ position });
+
+      const listItems = screen.getAllByRole('listitem');
+      expect(listItems).toHaveLength(mockItems.length);
+      listItems.forEach((listItem, i) => {
+        const mockItem = mockItems[i];
+        if (!mockItem) {
+          // This check exists to appease typescript.
+          throw new Error('List item does not have matching item');
+        }
+
+        expect(listItem).toHaveTextContent(mockItem.label);
+      });
+    });
+
+    test('highlights selected items when partial selection', () => {
+      const selectedItems: LegendProps['selectedItems'] = { '1': true };
+      renderLegend({
+        position,
+        selectedItems,
+      });
+
+      const listItems = screen.getAllByRole('listitem');
+      expect(listItems).toHaveLength(mockItems.length);
+      listItems.forEach((listItem, i) => {
+        const mockItem = mockItems[i];
+        if (!mockItem) {
+          // This check exists to appease typescript.
+          throw new Error('List item does not have matching item');
+        }
+
+        const shouldBeHighlighted = !!selectedItems[mockItem.id];
+
+        expect(listItem).toHaveTextContent(mockItem.label);
+        if (shouldBeHighlighted) {
+          expect(listItem).toHaveClass('Mui-selected');
+        } else {
+          expect(listItem).not.toHaveClass('Mui-selected');
+        }
+      });
+    });
+
+    test('does not highlight selected items when select "ALL"', () => {
+      renderLegend({
+        position,
+        selectedItems: 'ALL',
+      });
+
+      const listItems = screen.getAllByRole('listitem');
+      expect(listItems).toHaveLength(mockItems.length);
+      listItems.forEach((listItem, i) => {
+        const mockItem = mockItems[i];
+        if (!mockItem) {
+          // This check exists to appease typescript.
+          throw new Error('List item does not have matching item');
+        }
+
+        expect(listItem).toHaveTextContent(mockItem.label);
+        expect(listItem).not.toHaveClass('Mui-selected');
+      });
+    });
+
+    test('selects unselected item on click', () => {
+      const mockOnSelectedItemsChange = jest.fn();
+      renderLegend({
+        onSelectedItemsChange: mockOnSelectedItemsChange,
+        position,
+      });
+
+      const listItems = screen.getAllByRole('listitem');
+      const itemToClick = listItems[1];
+      if (!itemToClick) {
+        throw new Error('Missing item to click');
+      }
+
+      userEvent.click(itemToClick);
+      expect(mockOnSelectedItemsChange).toHaveBeenCalledWith({
+        '2': true,
+      });
+    });
+
+    test.each(['shiftKey', 'metaKey'])(`adds/removes selected items on click modified with %s`, (modifierKey) => {
+      const mockOnSelectedItemsChange = jest.fn();
+      renderLegend({
+        onSelectedItemsChange: mockOnSelectedItemsChange,
+        selectedItems: {
+          '1': true,
+          '2': true,
+        },
+        position,
+      });
+
+      const listItems = screen.getAllByRole('listitem');
+      const unselectedItem = listItems[2];
+      if (!unselectedItem) {
+        throw new Error('Missing item to click');
+      }
+
+      userEvent.click(unselectedItem, { [modifierKey]: true });
+      expect(mockOnSelectedItemsChange).toHaveBeenCalledWith({ '1': true, '2': true, '3': true });
+
+      const selectedItem = listItems[0];
+      if (!selectedItem) {
+        throw new Error('Missing item to click');
+      }
+      userEvent.click(selectedItem, { [modifierKey]: true });
+      expect(mockOnSelectedItemsChange).toHaveBeenCalledWith({ '2': true });
+    });
+
+    test('reverts to select "ALL" on simple click of selected item', () => {
+      const mockOnSelectedItemsChange = jest.fn();
+      renderLegend({
+        onSelectedItemsChange: mockOnSelectedItemsChange,
+        selectedItems: {
+          '2': true,
+          '3': true,
+        },
+        position,
+      });
+
+      const listItems = screen.getAllByRole('listitem');
+      const itemToClick = listItems[2];
+      if (!itemToClick) {
+        throw new Error('Missing item to click');
+      }
+
+      userEvent.click(itemToClick);
+      expect(mockOnSelectedItemsChange).toHaveBeenCalledWith('ALL');
+    });
+  });
+});

--- a/ui/components/src/Legend/Legend.test.tsx
+++ b/ui/components/src/Legend/Legend.test.tsx
@@ -38,10 +38,11 @@ type RenderLegendOpts = Partial<Pick<LegendProps, 'onSelectedItemsChange' | 'sel
   position?: LegendProps['options']['position'];
 };
 
-const renderLegend = (
-  { onSelectedItemsChange = jest.fn(), selectedItems = 'ALL' }: RenderLegendOpts = {},
-  position = 'Bottom' as const
-) => {
+const renderLegend = ({
+  onSelectedItemsChange = jest.fn(),
+  selectedItems = 'ALL',
+  position = 'Bottom',
+}: RenderLegendOpts = {}) => {
   return render(
     <VirtuosoMockContext.Provider value={{ viewportHeight: 600, itemHeight: 100 }}>
       <Legend

--- a/ui/components/src/Legend/Legend.test.tsx
+++ b/ui/components/src/Legend/Legend.test.tsx
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { VirtuosoMockContext } from 'react-virtuoso';

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -13,13 +13,15 @@
 
 import { useTheme, Box } from '@mui/material';
 import { Virtuoso } from 'react-virtuoso';
-import { LegendItem } from '../model';
-import { ListLegendItem } from './ListLegendItem';
+import { LegendItem, SelectedLegendItemState, isLegendItemHighlighted } from '../model';
+import { ListLegendItem, ListLegendItemProps } from './ListLegendItem';
 
 export interface ListLegendProps {
   items: LegendItem[];
   height: number;
   width: number;
+  selectedItems: SelectedLegendItemState;
+  onLegendItemClick: ListLegendItemProps['onClick'];
 }
 
 /**
@@ -28,7 +30,7 @@ export interface ListLegendProps {
  * large number of items because it is virtualized and easier to visually scan
  * large numbers of items when there is a single item per row.
  */
-export function ListLegend({ items, height, width }: ListLegendProps) {
+export function ListLegend({ items, height, width, selectedItems, onLegendItemClick }: ListLegendProps) {
   const theme = useTheme();
   // Padding value used in the react virtuoso header/footer components to
   // simulate top/bottom padding based on recommendation in this
@@ -50,6 +52,8 @@ export function ListLegend({ items, height, width }: ListLegendProps) {
             key={item.id}
             item={item}
             truncateLabel={truncateLabels}
+            isHighlighted={isLegendItemHighlighted(item, selectedItems)}
+            onClick={onLegendItemClick}
             sx={{
               // Having an explicit width is important for the ellipsizing to
               // work correctly. Subtract padding to simulate padding.

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -13,7 +13,7 @@
 
 import { useTheme, Box } from '@mui/material';
 import { Virtuoso } from 'react-virtuoso';
-import { LegendItem, SelectedLegendItemState, isLegendItemHighlighted } from '../model';
+import { LegendItem, SelectedLegendItemState, isLegendItemVisuallySelected } from '../model';
 import { ListLegendItem, ListLegendItemProps } from './ListLegendItem';
 
 export interface ListLegendProps {
@@ -52,7 +52,7 @@ export function ListLegend({ items, height, width, selectedItems, onLegendItemCl
             key={item.id}
             item={item}
             truncateLabel={truncateLabels}
-            isHighlighted={isLegendItemHighlighted(item, selectedItems)}
+            isVisuallySelected={isLegendItemVisuallySelected(item, selectedItems)}
             onClick={onLegendItemClick}
             sx={{
               // Having an explicit width is important for the ellipsizing to

--- a/ui/components/src/Legend/ListLegendItem.tsx
+++ b/ui/components/src/Legend/ListLegendItem.tsx
@@ -17,8 +17,15 @@ import { LegendItem } from '../model';
 import { combineSx } from '../utils';
 import { LegendColorBadge } from './LegendColorBadge';
 
-interface ListLegendItemProps extends ListItemProps<'div'> {
+export interface ListLegendItemProps extends Omit<ListItemProps<'div'>, 'onClick'> {
   item: LegendItem;
+
+  /**
+   * When true, the item is visually highlighted to communicate it is selected.
+   */
+  isHighlighted?: boolean;
+
+  onClick: (e: React.MouseEvent<HTMLElement, MouseEvent>, seriesId: string) => void;
 
   /**
    * When `true`, will keep labels to a single line with overflow ellipsized. The
@@ -30,7 +37,7 @@ interface ListLegendItemProps extends ListItemProps<'div'> {
 }
 
 const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(function ListLegendItem(
-  { item, sx, truncateLabel, ...others },
+  { item, sx, truncateLabel, onClick, isHighlighted, ...others },
   ref
 ) {
   const [noWrap, setNoWrap] = useState(truncateLabel);
@@ -47,6 +54,11 @@ const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(funct
     }
   }
 
+  const handleClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    onClick(e, item.id);
+    item.onClick?.(e);
+  };
+
   return (
     <ListItem
       {...others}
@@ -61,8 +73,8 @@ const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(funct
       )}
       dense={true}
       key={item.id}
-      onClick={item.onClick}
-      selected={item.isSelected}
+      onClick={handleClick}
+      selected={isHighlighted}
       ref={ref}
     >
       <Box sx={{ display: 'flex', alignItems: 'center' }}>

--- a/ui/components/src/Legend/ListLegendItem.tsx
+++ b/ui/components/src/Legend/ListLegendItem.tsx
@@ -21,9 +21,10 @@ export interface ListLegendItemProps extends Omit<ListItemProps<'div'>, 'onClick
   item: LegendItem;
 
   /**
-   * When true, the item is visually highlighted to communicate it is selected.
+   * When true, the item is rendered differently to visually communicate it is
+   * selected.
    */
-  isHighlighted?: boolean;
+  isVisuallySelected?: boolean;
 
   onClick: (e: React.MouseEvent<HTMLElement, MouseEvent>, seriesId: string) => void;
 
@@ -37,7 +38,7 @@ export interface ListLegendItemProps extends Omit<ListItemProps<'div'>, 'onClick
 }
 
 const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(function ListLegendItem(
-  { item, sx, truncateLabel, onClick, isHighlighted, ...others },
+  { item, sx, truncateLabel, onClick, isVisuallySelected, ...others },
   ref
 ) {
   const [noWrap, setNoWrap] = useState(truncateLabel);
@@ -74,7 +75,7 @@ const ListLegendItemBase = forwardRef<HTMLDivElement, ListLegendItemProps>(funct
       dense={true}
       key={item.id}
       onClick={handleClick}
-      selected={isHighlighted}
+      selected={isVisuallySelected}
       ref={ref}
     >
       <Box sx={{ display: 'flex', alignItems: 'center' }}>

--- a/ui/components/src/model/legend.test.ts
+++ b/ui/components/src/model/legend.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { LegendOptions, validateLegendSpec } from './legend';
+import { LegendOptions, validateLegendSpec, isLegendItemHighlighted } from './legend';
 
 describe('validateLegendSpec', () => {
   it('should check if a legend spec is valid', () => {
@@ -19,5 +19,67 @@ describe('validateLegendSpec', () => {
     expect(validateLegendSpec(invalidLegend as LegendOptions)).toEqual(false);
     expect(validateLegendSpec({ position: 'Bottom' })).toEqual(true);
     expect(validateLegendSpec(undefined)).toEqual(true);
+  });
+});
+
+describe('isLegendItemHighlighted', () => {
+  it('does not highlight the item when "ALL" selected', () => {
+    expect(
+      isLegendItemHighlighted(
+        {
+          id: 'one',
+          label: 'One',
+          color: 'red',
+        },
+        'ALL'
+      )
+    ).toBeFalsy();
+  });
+
+  it('does not highlight the item when it is not in the selected object', () => {
+    expect(
+      isLegendItemHighlighted(
+        {
+          id: 'one',
+          label: 'One',
+          color: 'red',
+        },
+        {
+          two: true,
+        }
+      )
+    ).toBeFalsy();
+  });
+
+  it('does not highlight the item when it is false in the selected object', () => {
+    expect(
+      isLegendItemHighlighted(
+        {
+          id: 'one',
+          label: 'One',
+          color: 'red',
+        },
+        {
+          one: false,
+          two: true,
+        }
+      )
+    ).toBeFalsy();
+  });
+
+  it('highlights the item when it is true in the selected object', () => {
+    expect(
+      isLegendItemHighlighted(
+        {
+          id: 'one',
+          label: 'One',
+          color: 'red',
+        },
+        {
+          one: true,
+          two: true,
+        }
+      )
+    ).toBeTruthy();
   });
 });

--- a/ui/components/src/model/legend.test.ts
+++ b/ui/components/src/model/legend.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { LegendOptions, validateLegendSpec, isLegendItemHighlighted } from './legend';
+import { LegendOptions, validateLegendSpec, isLegendItemVisuallySelected } from './legend';
 
 describe('validateLegendSpec', () => {
   it('should check if a legend spec is valid', () => {
@@ -22,10 +22,10 @@ describe('validateLegendSpec', () => {
   });
 });
 
-describe('isLegendItemHighlighted', () => {
+describe('isLegendItemVisuallySelected', () => {
   it('does not highlight the item when "ALL" selected', () => {
     expect(
-      isLegendItemHighlighted(
+      isLegendItemVisuallySelected(
         {
           id: 'one',
           label: 'One',
@@ -38,7 +38,7 @@ describe('isLegendItemHighlighted', () => {
 
   it('does not highlight the item when it is not in the selected object', () => {
     expect(
-      isLegendItemHighlighted(
+      isLegendItemVisuallySelected(
         {
           id: 'one',
           label: 'One',
@@ -53,7 +53,7 @@ describe('isLegendItemHighlighted', () => {
 
   it('does not highlight the item when it is false in the selected object', () => {
     expect(
-      isLegendItemHighlighted(
+      isLegendItemVisuallySelected(
         {
           id: 'one',
           label: 'One',
@@ -69,7 +69,7 @@ describe('isLegendItemHighlighted', () => {
 
   it('highlights the item when it is true in the selected object', () => {
     expect(
-      isLegendItemHighlighted(
+      isLegendItemVisuallySelected(
         {
           id: 'one',
           label: 'One',

--- a/ui/components/src/model/legend.ts
+++ b/ui/components/src/model/legend.ts
@@ -24,14 +24,22 @@ export interface LegendOptions {
 export interface LegendItem {
   id: string;
   label: string;
-  isSelected: boolean;
   color: string;
-  onClick: MouseEventHandler<HTMLElement>;
+  onClick?: MouseEventHandler<HTMLElement>;
 }
 
 export type LegendPositionConfig = {
   label: string;
 };
+
+/**
+ * State of selected items in the legend.
+ * - When "ALL", all legend items are selected, but not visually highlighted.
+ * - Otherwise, it is a Record that associates legend item ids with a boolean
+ *   value. When the associated entry for a legend item is `true`, that item
+ *   will be treated as selected and visually highlighted.
+ */
+export type SelectedLegendItemState = Record<LegendItem['id'], boolean> | 'ALL';
 
 export const LEGEND_POSITIONS_CONFIG: Readonly<Record<LegendPositions, LegendPositionConfig>> = {
   Bottom: { label: 'Bottom' },
@@ -65,4 +73,10 @@ export function validateLegendSpec(legend?: LegendOptions) {
     return false;
   }
   return true;
+}
+
+export function isLegendItemHighlighted(item: LegendItem, selectedItems: SelectedLegendItemState) {
+  // In the "ALL" case, technically all legend items are selected, but we do
+  // not visually highlight them.
+  return selectedItems !== 'ALL' && !!selectedItems[item.id];
 }

--- a/ui/components/src/model/legend.ts
+++ b/ui/components/src/model/legend.ts
@@ -75,8 +75,8 @@ export function validateLegendSpec(legend?: LegendOptions) {
   return true;
 }
 
-export function isLegendItemHighlighted(item: LegendItem, selectedItems: SelectedLegendItemState) {
+export function isLegendItemVisuallySelected(item: LegendItem, selectedItems: SelectedLegendItemState) {
   // In the "ALL" case, technically all legend items are selected, but we do
-  // not visually highlight them.
+  // not render them differently.
   return selectedItems !== 'ALL' && !!selectedItems[item.id];
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -56,7 +56,6 @@ export type TimeSeriesChartProps = PanelProps<TimeSeriesChartOptions>;
 // currently require significantly more refactoring of this component.
 // TODO: simplify this if we switch the list-based legend UI to use checkboxes,
 // where we *would* want to visually select all items in this case.
-// type SelectedSeriesState = Record<string, boolean> | 'ALL';
 
 export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   const {
@@ -191,9 +190,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
           graphData.legendItems.push({
             id: seriesId, // Avoids duplicate key console errors when there are duplicate series names
             label: formattedSeriesName,
-            // isSelected,
             color: seriesColor,
-            // onClick: (e) => onLegendItemClick(e, seriesId),
           });
         }
       }


### PR DESCRIPTION
Prior to this change, much of the legend selection interactions were managed inside `TimeSeriesChartPanel`, requiring consumers to duplicate this logic when using the legend in other use cases.

After this change, the legend selection interactions are managed inside `Legend` and its child components, so that it can be used wherever the legend is. The selection state remains "controlled."

BREAKINGCHANGE: Refactoring `Legend` to manage legend interactions includes the following breaking changes:
- The `Legend` component now requires the following props to control the selected state of the items: `selectedItems`, `onSelectedItemsChange`.
- The `LegendItem` type no longer allows the `isSelected` property. The selected state of items are now managed by the `selectedItems` prop on the `Legend` component.
- The `onClick` property on the `LegendItem` type is now optional because it is no longer used to manage the selected state of items. Instead use the `onSelectedItemsChange` prop on the `Legend` component if you need to listen for selection changes.

# Notes for reviewers

- This is yet another improvement I'm making as part of the lead-up to table legends landing, but it's also a good refactor to move the logic closer to the component that should own it.
- This is a no-op from a UX perspective for the time series panel, but does include some breaking changes in the props for Legend as noted above.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

# Screenshots

This is a no-op for the time series panel. Below is a video showing the interactions are still the same.


https://github.com/perses/perses/assets/396962/9d8e8326-b878-4dc5-9b6c-5df74e66f2f0



The visuals of the legend are the same now, but the interaction patterns for selection are now more tightly baked in. You can see that in the stories.



https://github.com/perses/perses/assets/396962/2f508e3f-d64c-41b3-b6e4-640ff08e11cf


Added a story to the legend to show the selection options.
<img width="1348" alt="image" src="https://github.com/perses/perses/assets/396962/f4c948e4-2b63-4ebf-b90a-b22d3016b56b">


