### PR TITLE
[WIP] Bold closest series to cursor in tooltip, fix highlight lines flicker

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/SeriesInfo.tsx
+++ b/ui/components/src/TimeSeriesTooltip/SeriesInfo.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { SeriesMarker } from './SeriesMarker';
 import { SeriesLabelsStack } from './SeriesLabelsStack';
 import { TOOLTIP_LABELS_MAX_WIDTH } from './tooltip-model';
@@ -22,11 +22,12 @@ export interface SeriesInfoProps {
   formattedY: string;
   markerColor: string;
   totalSeries: number;
+  emphasizeText?: boolean;
   wrapLabels?: boolean;
 }
 
 export function SeriesInfo(props: SeriesInfoProps) {
-  const { seriesName, formattedY, markerColor, totalSeries, wrapLabels = true } = props;
+  const { seriesName, formattedY, markerColor, totalSeries, emphasizeText = false, wrapLabels = true } = props;
 
   // metric __name__ comes before opening curly brace, ignore if not populated
   // ex with metric name: node_load15{env="demo",job="node"}
@@ -77,6 +78,7 @@ export function SeriesInfo(props: SeriesInfoProps) {
             maxWidth: TOOLTIP_LABELS_MAX_WIDTH,
             overflow: 'hidden',
             color: theme.palette.common.white,
+            fontWeight: emphasizeText ? theme.typography.fontWeightBold : theme.typography.fontWeightRegular,
             textOverflow: 'ellipsis',
             whiteSpace: wrapLabels ? 'normal' : 'nowrap',
           })}
@@ -85,13 +87,13 @@ export function SeriesInfo(props: SeriesInfoProps) {
         </Box>
       </Box>
       <Box
-        sx={{
+        sx={(theme) => ({
           display: 'table-cell',
           paddingLeft: 1.5,
           textAlign: 'right',
           verticalAlign: 'top',
-          fontWeight: '700',
-        }}
+          fontWeight: emphasizeText ? theme.typography.fontWeightBold : theme.typography.fontWeightRegular,
+        })}
       >
         {formattedY}
       </Box>

--- a/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -48,14 +48,7 @@ export const TimeSeriesTooltip = React.memo(function TimeSeriesTooltip({
   const chart = chartRef.current;
   const focusedSeries = getFocusedSeriesData(mousePos, chartData, pinnedPos, chart, unit);
   const chartWidth = chart?.getWidth() ?? 750;
-  const cursorTransform = assembleTransform(
-    mousePos,
-    focusedSeries.length,
-    chartWidth,
-    pinnedPos,
-    height ?? 0,
-    width ?? 0
-  );
+  const cursorTransform = assembleTransform(mousePos, chartWidth, pinnedPos, height ?? 0, width ?? 0);
 
   if (focusedSeries.length === 0) {
     return null;

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
@@ -52,8 +52,22 @@ export function TooltipContent(props: TooltipContentProps) {
   };
 
   const sortedFocusedSeries = useMemo(() => {
-    if (focusedSeries === null) return null;
-    return focusedSeries.sort((a, b) => (a.y > b.y ? -1 : 1));
+    if (focusedSeries === null) {
+      return null;
+    }
+    return focusedSeries.sort((a, b) => {
+      // // if (focusedSeries.length > TOOLTIP_MAX_ITEMS && !a.isClosestToCursor) {
+      // //   return 1;
+      // // }
+      // if (a.isClosestToCursor) {
+      //   return -1;
+      // }
+      if (a.y > b.y) {
+        return -1;
+      } else {
+        return 1;
+      }
+    });
   }, [focusedSeries]);
 
   // TODO: use react-virtuoso to improve performance
@@ -71,25 +85,28 @@ export function TooltipContent(props: TooltipContentProps) {
             display: 'table',
           }}
         >
-          {sortedFocusedSeries.map(({ datumIdx, seriesIdx, seriesName, y, formattedY, markerColor }, index) => {
-            if (index > TOOLTIP_MAX_ITEMS) {
-              return null;
-            }
-            if (datumIdx === null || seriesIdx === null) return null;
-            const key = seriesIdx.toString() + datumIdx.toString();
+          {sortedFocusedSeries.map(
+            ({ datumIdx, seriesIdx, seriesName, y, formattedY, markerColor, isClosestToCursor }, index) => {
+              // if (index > TOOLTIP_MAX_ITEMS) {
+              //   return null;
+              // }
+              if (datumIdx === null || seriesIdx === null) return null;
+              const key = seriesIdx.toString() + datumIdx.toString();
 
-            return (
-              <SeriesInfo
-                key={key}
-                seriesName={seriesName}
-                y={y}
-                formattedY={formattedY}
-                markerColor={markerColor}
-                totalSeries={sortedFocusedSeries.length}
-                wrapLabels={wrapLabels}
-              />
-            );
-          })}
+              return (
+                <SeriesInfo
+                  key={key}
+                  seriesName={seriesName}
+                  y={y}
+                  formattedY={formattedY}
+                  markerColor={markerColor}
+                  totalSeries={sortedFocusedSeries.length}
+                  wrapLabels={wrapLabels}
+                  emphasizeText={isClosestToCursor}
+                />
+              );
+            }
+          )}
         </Box>
       </Stack>
     );

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
@@ -15,7 +15,6 @@ import { useMemo } from 'react';
 import { Box, Divider, Stack, Typography } from '@mui/material';
 import { useTimeZone } from '../context/TimeZoneProvider';
 import { FocusedSeriesArray } from './focused-series';
-import { TOOLTIP_MAX_ITEMS } from './tooltip-model';
 import { SeriesInfo } from './SeriesInfo';
 
 export interface TooltipContentProps {
@@ -52,22 +51,8 @@ export function TooltipContent(props: TooltipContentProps) {
   };
 
   const sortedFocusedSeries = useMemo(() => {
-    if (focusedSeries === null) {
-      return null;
-    }
-    return focusedSeries.sort((a, b) => {
-      // // if (focusedSeries.length > TOOLTIP_MAX_ITEMS && !a.isClosestToCursor) {
-      // //   return 1;
-      // // }
-      // if (a.isClosestToCursor) {
-      //   return -1;
-      // }
-      if (a.y > b.y) {
-        return -1;
-      } else {
-        return 1;
-      }
-    });
+    if (focusedSeries === null) return null;
+    return focusedSeries.sort((a, b) => (a.y > b.y ? -1 : 1));
   }, [focusedSeries]);
 
   // TODO: use react-virtuoso to improve performance
@@ -86,10 +71,7 @@ export function TooltipContent(props: TooltipContentProps) {
           }}
         >
           {sortedFocusedSeries.map(
-            ({ datumIdx, seriesIdx, seriesName, y, formattedY, markerColor, isClosestToCursor }, index) => {
-              // if (index > TOOLTIP_MAX_ITEMS) {
-              //   return null;
-              // }
+            ({ datumIdx, seriesIdx, seriesName, y, formattedY, markerColor, isClosestToCursor }) => {
               if (datumIdx === null || seriesIdx === null) return null;
               const key = seriesIdx.toString() + datumIdx.toString();
 

--- a/ui/components/src/TimeSeriesTooltip/focused-series.test.ts
+++ b/ui/components/src/TimeSeriesTooltip/focused-series.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { EChartsDataFormat, UnitOptions } from '../model';
-import { getNearbySeries } from './focused-series';
+import { getNearbySeries, isWithinPercentageRange } from './focused-series';
 
 describe('getNearbySeries', () => {
   const chartData: EChartsDataFormat = {
@@ -48,6 +48,7 @@ describe('getNearbySeries', () => {
     {
       date: 1654007895000,
       datumIdx: 2,
+      isClosestToCursor: true,
       markerColor: 'hsla(286664040,50%,50%,0.8)',
       seriesName: 'env="demo", instance="demo.do.prometheus", job="node", mode="test alt"',
       seriesIdx: 1,
@@ -77,5 +78,23 @@ describe('getNearbySeries', () => {
     expect(getNearbySeries(chartData, pointInGrid, yBuffer, undefined, percentFormattedUnit)).toEqual(
       percentFormattedOutput
     );
+  });
+});
+
+describe('isWithinPercentageRange', () => {
+  it('should return true when focusedY is within the specified percentage range of yValue', () => {
+    const focusedY = 256250000;
+    const yValue = 261353472;
+    const percentage = 5;
+    const result = isWithinPercentageRange(focusedY, yValue, percentage);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when focusedY is outside the specified percentage range of yValue', () => {
+    const focusedY = 200;
+    const yValue = 100;
+    const percentage = 5;
+    const result = isWithinPercentageRange(focusedY, yValue, percentage);
+    expect(result).toBe(false);
   });
 });

--- a/ui/components/src/TimeSeriesTooltip/focused-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/focused-series.ts
@@ -53,10 +53,7 @@ export function getNearbySeries(
     return currentFocusedData;
   }
 
-  const allSeriesNames: string[] = [];
-  const focusedSeriesNames: string[] = [];
   const focusedSeriesIndexes: number[] = [];
-  const nonFocusedSeriesNames: string[] = [];
   const nonFocusedSeriesIndexes: number[] = [];
 
   if (Array.isArray(data.xAxis) && Array.isArray(data.timeSeries)) {
@@ -65,7 +62,6 @@ export function getNearbySeries(
       if (currentFocusedData.length >= OPTIMIZED_MODE_SERIES_LIMIT) break;
       if (currentSeries !== undefined) {
         const currentSeriesName = currentSeries.name ? currentSeries.name.toString() : '';
-        allSeriesNames.push(currentSeriesName);
         const markerColor = currentSeries.color ?? '#000';
         if (Array.isArray(currentSeries.data)) {
           for (let datumIdx = 0; datumIdx < currentSeries.data.length; datumIdx++) {
@@ -91,10 +87,8 @@ export function getNearbySeries(
                   markerColor: markerColor.toString(),
                   isClosestToCursor: isWithinPercentageRange(focusedY, yValue, percentRangeToCheck),
                 });
-                focusedSeriesNames.push(currentSeriesName);
                 focusedSeriesIndexes.push(seriesIdx);
               } else {
-                nonFocusedSeriesNames.push(currentSeriesName);
                 nonFocusedSeriesIndexes.push(seriesIdx);
               }
             }
@@ -112,11 +106,14 @@ export function getNearbySeries(
 
     // trigger emphasis state of nearby series so tooltip matches highlighted lines
     // https://echarts.apache.org/en/api.html#action.highlight
-    chart.dispatchAction({
-      type: 'highlight',
-      seriesIndex: focusedSeriesIndexes,
-    });
+    // chart.dispatchAction({
+    //   type: 'highlight',
+    //   seriesIndex: focusedSeriesIndexes,
+    //   // notBlur: true,
+    //   // isFired: true,
+    // });
   }
+
   return currentFocusedData;
 }
 

--- a/ui/components/src/TimeSeriesTooltip/focused-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/focused-series.ts
@@ -72,6 +72,26 @@ export function getNearbySeries(
               if (yValue !== '-' && focusedY <= yValue + yBuffer && focusedY >= yValue - yBuffer) {
                 // show fewer bold series in tooltip when many total series
                 const percentRangeToCheck = data.timeSeries.length > 50 ? 1 : 5;
+                const isClosestToCursor = isWithinPercentageRange(focusedY, yValue, percentRangeToCheck);
+                if (isClosestToCursor) {
+                  if (chart?.dispatchAction !== undefined) {
+                    chart.dispatchAction({
+                      type: 'highlight',
+                      seriesIndex: seriesIdx,
+                      // notBlur: true,
+                      // isFired: true,
+                    });
+                  }
+                } else {
+                  if (chart?.dispatchAction !== undefined) {
+                    chart.dispatchAction({
+                      type: 'downplay',
+                      seriesIndex: seriesIdx,
+                      // notBlur: true,
+                      // isFired: true,
+                    });
+                  }
+                }
 
                 // determine whether to convert timestamp to ms, see: https://stackoverflow.com/a/23982005/17575201
                 const xValueMilliSeconds = xValue > 99999999999 ? xValue : xValue * 1000;
@@ -85,7 +105,7 @@ export function getNearbySeries(
                   y: yValue,
                   formattedY: formattedY,
                   markerColor: markerColor.toString(),
-                  isClosestToCursor: isWithinPercentageRange(focusedY, yValue, percentRangeToCheck),
+                  isClosestToCursor,
                 });
                 focusedSeriesIndexes.push(seriesIdx);
               } else {
@@ -98,19 +118,34 @@ export function getNearbySeries(
     }
   }
   if (chart?.dispatchAction !== undefined) {
-    // clears emphasis state of lines that are not focused
-    chart.dispatchAction({
-      type: 'downplay',
-      seriesIndex: nonFocusedSeriesIndexes,
-    });
-
+    // // clears emphasis state of lines that are not focused
+    // chart.dispatchAction({
+    //   type: 'downplay',
+    //   seriesIndex: nonFocusedSeriesIndexes,
+    // });
     // trigger emphasis state of nearby series so tooltip matches highlighted lines
     // https://echarts.apache.org/en/api.html#action.highlight
     // chart.dispatchAction({
     //   type: 'highlight',
     //   seriesIndex: focusedSeriesIndexes,
     //   // notBlur: true,
-    //   // isFired: true,
+    //   isFired: true,
+    // });
+    //
+    // chart.dispatchAction({
+    //   // type: 'select',
+    //   type: 'toggleSelect',
+    //   seriesIndex: focusedSeriesIndexes,
+    //   // seriesIndex: nonFocusedSeriesIndexes,
+    // });
+    // chart.dispatchAction({
+    //   type: 'selectDataRange',
+    //   // // optional; index of visualMap component; useful for are multiple visualMap components; 0 by default
+    //   // visualMapIndex: number,
+    //   // // continuous visualMap is different from discrete one
+    //   // // continuous visualMap is an array representing range of data values.
+    //   // // discrete visualMap is an object, whose key is category or piece index; value is `true` or `false`
+    //   // selected: Object|Array
     // });
   }
 

--- a/ui/components/src/TimeSeriesTooltip/focused-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/focused-series.ts
@@ -54,6 +54,8 @@ export function getNearbySeries(
   }
 
   const focusedSeriesIndexes: number[] = [];
+  const emphasizedSeriesIndexes: number[] = [];
+  const nonEmphasizedSeriesIndexes: number[] = [];
   const nonFocusedSeriesIndexes: number[] = [];
 
   if (Array.isArray(data.xAxis) && Array.isArray(data.timeSeries)) {
@@ -74,23 +76,25 @@ export function getNearbySeries(
                 const percentRangeToCheck = Math.max(2, 200 / data.timeSeries.length);
                 const isClosestToCursor = isWithinPercentageRange(focusedY, yValue, percentRangeToCheck);
                 if (isClosestToCursor) {
-                  if (chart?.dispatchAction !== undefined) {
-                    chart.dispatchAction({
-                      type: 'highlight',
-                      seriesIndex: seriesIdx,
-                      // notBlur: true,
-                      // isFired: true,
-                    });
-                  }
+                  emphasizedSeriesIndexes.push(seriesIdx);
+                  // if (chart?.dispatchAction !== undefined) {
+                  //   chart.dispatchAction({
+                  //     type: 'highlight',
+                  //     seriesIndex: seriesIdx,
+                  //     // notBlur: true,
+                  //     // isFired: true,
+                  //   });
+                  // }
                 } else {
-                  if (chart?.dispatchAction !== undefined) {
-                    chart.dispatchAction({
-                      type: 'downplay',
-                      seriesIndex: seriesIdx,
-                      // notBlur: true,
-                      // isFired: true,
-                    });
-                  }
+                  nonEmphasizedSeriesIndexes.push(seriesIdx);
+                  // if (chart?.dispatchAction !== undefined) {
+                  //   chart.dispatchAction({
+                  //     type: 'downplay',
+                  //     seriesIndex: seriesIdx,
+                  //     // notBlur: true,
+                  //     // isFired: true,
+                  //   });
+                  // }
                 }
 
                 // determine whether to convert timestamp to ms, see: https://stackoverflow.com/a/23982005/17575201
@@ -118,19 +122,21 @@ export function getNearbySeries(
     }
   }
   if (chart?.dispatchAction !== undefined) {
-    // // clears emphasis state of lines that are not focused
+    // clears emphasis state of lines that are not focused
     chart.dispatchAction({
       type: 'downplay',
-      seriesIndex: nonFocusedSeriesIndexes,
+      seriesIndex: nonEmphasizedSeriesIndexes,
+      // seriesIndex: nonFocusedSeriesIndexes,
     });
     // trigger emphasis state of nearby series so tooltip matches highlighted lines
     // https://echarts.apache.org/en/api.html#action.highlight
-    // chart.dispatchAction({
-    //   type: 'highlight',
-    //   seriesIndex: focusedSeriesIndexes,
-    //   // notBlur: true,
-    //   isFired: true,
-    // });
+    chart.dispatchAction({
+      type: 'highlight',
+      seriesIndex: emphasizedSeriesIndexes,
+      // seriesIndex: focusedSeriesIndexes,
+      // notBlur: true,
+      // isFired: true,
+    });
     //
     // chart.dispatchAction({
     //   // type: 'select',

--- a/ui/components/src/TimeSeriesTooltip/focused-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/focused-series.ts
@@ -17,8 +17,7 @@ import { CursorData } from './tooltip-model';
 
 // increase multipliers to show more series in tooltip
 export const INCREASE_FOCUSED_SERIES_MULTIPLIER = 5.5; // adjusts how many focused series show in tooltip (higher == more series shown)
-// export const REDUCE_FOCUSED_SERIES_MULTIPLIER = 1.75; // used to reduce number of focused series for heavy queries
-export const REDUCE_FOCUSED_SERIES_MULTIPLIER = 20;
+export const REDUCE_FOCUSED_SERIES_MULTIPLIER = 30;
 export const SHOW_FEWER_SERIES_LIMIT = 5;
 
 export interface FocusedSeriesInfo {
@@ -159,12 +158,15 @@ export function getFocusedSeriesData(
   const yAxisInterval = chartModel.getComponent('yAxis').axis.scale._interval;
 
   const seriesNum = chartData.timeSeries.length;
+  console.log(seriesNum);
 
   // tooltip trigger area gets smaller with more series, increase yAxisInterval multiplier to expand nearby series range
   const yBuffer =
     seriesNum > SHOW_FEWER_SERIES_LIMIT
       ? (yAxisInterval * REDUCE_FOCUSED_SERIES_MULTIPLIER) / seriesNum
       : yAxisInterval * INCREASE_FOCUSED_SERIES_MULTIPLIER;
+
+  console.log('yBuffer: ', yBuffer);
 
   const pointInPixel = [mousePos.plotCanvas.x ?? 0, mousePos.plotCanvas.y ?? 0];
   if (chart.containPixel('grid', pointInPixel)) {

--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -18,9 +18,6 @@ export const TOOLTIP_MAX_WIDTH = 650;
 export const TOOLTIP_MAX_HEIGHT = 600;
 export const TOOLTIP_LABELS_MAX_WIDTH = TOOLTIP_MAX_WIDTH - 150;
 
-// TODO: increase after virtualizing TooltipContent
-export const TOOLTIP_MAX_ITEMS = 10;
-
 export const TOOLTIP_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
   month: 'short',

--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react';
 import { FocusedSeriesArray } from './focused-series';
 
 export const TOOLTIP_MAX_WIDTH = 650;
-export const TOOLTIP_MAX_HEIGHT = 400;
+export const TOOLTIP_MAX_HEIGHT = 600;
 export const TOOLTIP_LABELS_MAX_WIDTH = TOOLTIP_MAX_WIDTH - 150;
 
 // TODO: increase after virtualizing TooltipContent

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -18,7 +18,6 @@ import { CursorCoordinates, CursorData, TOOLTIP_MAX_WIDTH } from './tooltip-mode
  */
 export function assembleTransform(
   mousePos: CursorData['coords'],
-  seriesNum: number,
   chartWidth: number,
   pinnedPos: CursorCoordinates | null,
   tooltipHeight: number,
@@ -43,7 +42,7 @@ export function assembleTransform(
 
   // adjust so tooltip does not get cut off at bottom of chart
   if (mousePos.client.y + tooltipHeight + cursorPaddingY > window.innerHeight) {
-    y = mousePos.page.y - tooltipHeight;
+    y = mousePos.page.y - tooltipHeight * 0.75;
   }
 
   // use tooltip width to determine when to repos from right to left

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -738,6 +738,34 @@ const TIMESERIES_ALT_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
           ],
         },
       },
+      TwoThousandSeries: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'Two Thousand Series' },
+          plugin: {
+            kind: 'TimeSeriesChart',
+            spec: {
+              legend: {
+                position: 'Right',
+              },
+            },
+          },
+          queries: [
+            {
+              kind: 'TimeSeriesQuery',
+              spec: {
+                plugin: {
+                  kind: 'PrometheusTimeSeriesQuery',
+                  spec: {
+                    datasource: { kind: 'PrometheusDatasource', name: 'PrometheusDemo' },
+                    query: 'fake_query_with_two_thousand_series',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
     },
     layouts: [
       {
@@ -748,7 +776,7 @@ const TIMESERIES_ALT_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
             { x: 0, y: 0, width: 12, height: 8, content: { $ref: '#/spec/panels/TwentySeries' } },
             { x: 12, y: 0, width: 12, height: 8, content: { $ref: '#/spec/panels/FiftySeries' } },
             { x: 0, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/OneHundredSeries' } },
-            { x: 12, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/FiveHundredSeries' } },
+            { x: 12, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/TwoThousandSeries' } },
           ],
         },
       },
@@ -826,6 +854,16 @@ export const ExampleWithManySeries: Story = {
                   startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
                   endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
                   totalSeries: 500,
+                }),
+              },
+            },
+            {
+              query: 'fake_query_with_two_thousand_series',
+              response: {
+                body: mockTimeSeriesResponseWithManySeries({
+                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
+                  endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
+                  totalSeries: 2000,
                 }),
               },
             },

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -469,7 +469,7 @@ const TIMESERIES_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
                   kind: 'PrometheusTimeSeriesQuery',
                   spec: {
                     datasource: { kind: 'PrometheusDatasource', name: 'PrometheusDemo' },
-                    query: 'fake_query_with_many_series',
+                    query: 'fake_query_with_twenty_series',
                   },
                 },
               },
@@ -597,12 +597,235 @@ export const ExampleWithTimeSeriesPanels: Story = {
               },
             },
             {
-              query: 'fake_query_with_many_series',
+              query: 'fake_query_with_twenty_series',
+              response: {
+                body: mockTimeSeriesResponseWithManySeries({
+                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
+                  endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
+                  totalSeries: 100,
+                }),
+              },
+            },
+          ],
+        }),
+      },
+    },
+  },
+};
+
+const TIMESERIES_ALT_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
+  kind: 'Dashboard',
+  metadata: {
+    name: 'TimeSeriesChartPanel',
+    created_at: '2022-12-21T00:00:00Z',
+    updated_at: '2023-01-25T17:43:56.745494Z',
+    version: 3,
+    project: 'testing',
+  },
+  spec: {
+    duration: '6h',
+    variables: [],
+    panels: {
+      TwentySeries: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'Twenty Series' },
+          plugin: {
+            kind: 'TimeSeriesChart',
+            spec: {
+              legend: {
+                position: 'Right',
+              },
+            },
+          },
+          queries: [
+            {
+              kind: 'TimeSeriesQuery',
+              spec: {
+                plugin: {
+                  kind: 'PrometheusTimeSeriesQuery',
+                  spec: {
+                    datasource: { kind: 'PrometheusDatasource', name: 'PrometheusDemo' },
+                    query: 'fake_query_with_twenty_series',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      FiftySeries: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'Fifty Series' },
+          plugin: {
+            kind: 'TimeSeriesChart',
+            spec: {
+              legend: {
+                position: 'Right',
+              },
+            },
+          },
+          queries: [
+            {
+              kind: 'TimeSeriesQuery',
+              spec: {
+                plugin: {
+                  kind: 'PrometheusTimeSeriesQuery',
+                  spec: {
+                    datasource: { kind: 'PrometheusDatasource', name: 'PrometheusDemo' },
+                    query: 'fake_query_with_fifty_series',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      OneHundredSeries: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'One Hundred Series' },
+          plugin: {
+            kind: 'TimeSeriesChart',
+            spec: {
+              legend: {
+                position: 'Right',
+              },
+            },
+          },
+          queries: [
+            {
+              kind: 'TimeSeriesQuery',
+              spec: {
+                plugin: {
+                  kind: 'PrometheusTimeSeriesQuery',
+                  spec: {
+                    datasource: { kind: 'PrometheusDatasource', name: 'PrometheusDemo' },
+                    query: 'fake_query_with_one_hundred_series',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      FiveHundredSeries: {
+        kind: 'Panel',
+        spec: {
+          display: { name: 'Five Hundred Series' },
+          plugin: {
+            kind: 'TimeSeriesChart',
+            spec: {
+              legend: {
+                position: 'Right',
+              },
+            },
+          },
+          queries: [
+            {
+              kind: 'TimeSeriesQuery',
+              spec: {
+                plugin: {
+                  kind: 'PrometheusTimeSeriesQuery',
+                  spec: {
+                    datasource: { kind: 'PrometheusDatasource', name: 'PrometheusDemo' },
+                    query: 'fake_query_with_five_hundred_series',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    layouts: [
+      {
+        kind: 'Grid',
+        spec: {
+          display: { title: 'Row 1', collapse: { open: true } },
+          items: [
+            { x: 0, y: 0, width: 12, height: 8, content: { $ref: '#/spec/panels/TwentySeries' } },
+            { x: 12, y: 0, width: 12, height: 8, content: { $ref: '#/spec/panels/FiftySeries' } },
+            { x: 0, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/OneHundredSeries' } },
+            { x: 12, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/FiveHundredSeries' } },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const TIMESERIES_ALT_EXAMPLE_MOCK_START = TIMESERIES_EXAMPLE_MOCK_END - 2 * 60 * 60 * 1000;
+export const ExampleWithManySeries: Story = {
+  parameters: {
+    ...formatProviderParameters(TIMESERIES_ALT_EXAMPLE_DASHBOARD_RESOURCE),
+    withTimeRange: {
+      props: {
+        initialTimeRange: {
+          start: new Date(TIMESERIES_ALT_EXAMPLE_MOCK_START),
+          end: new Date(TIMESERIES_EXAMPLE_MOCK_END),
+        },
+      },
+    },
+    happo: {
+      beforeScreenshot: async () => {
+        await waitForStableCanvas('canvas', {
+          expectedCount: 8,
+        });
+      },
+    },
+    msw: {
+      handlers: {
+        queryRange: mockQueryRangeRequests({
+          queries: [
+            {
+              query: 'fake_query_with_few_series',
+              response: {
+                body: mockTimeSeriesResponseWithManySeries({
+                  startTimeMs: TIMESERIES_ALT_EXAMPLE_MOCK_START,
+                  endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
+                  totalSeries: 7,
+                }),
+              },
+            },
+            {
+              query: 'fake_query_with_twenty_series',
               response: {
                 body: mockTimeSeriesResponseWithManySeries({
                   startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
                   endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
                   totalSeries: 20,
+                }),
+              },
+            },
+            {
+              query: 'fake_query_with_fifty_series',
+              response: {
+                body: mockTimeSeriesResponseWithManySeries({
+                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
+                  endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
+                  totalSeries: 50,
+                }),
+              },
+            },
+            {
+              query: 'fake_query_with_one_hundred_series',
+              response: {
+                body: mockTimeSeriesResponseWithManySeries({
+                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
+                  endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
+                  totalSeries: 100,
+                }),
+              },
+            },
+            {
+              query: 'fake_query_with_five_hundred_series',
+              response: {
+                body: mockTimeSeriesResponseWithManySeries({
+                  startTimeMs: TIMESERIES_EXAMPLE_MOCK_START,
+                  endTimeMs: TIMESERIES_EXAMPLE_MOCK_END,
+                  totalSeries: 500,
                 }),
               },
             },

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -776,8 +776,15 @@ const TIMESERIES_ALT_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
             { x: 0, y: 0, width: 12, height: 8, content: { $ref: '#/spec/panels/TwentySeries' } },
             { x: 12, y: 0, width: 12, height: 8, content: { $ref: '#/spec/panels/FiftySeries' } },
             { x: 0, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/OneHundredSeries' } },
-            { x: 12, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/TwoThousandSeries' } },
+            { x: 12, y: 8, width: 12, height: 8, content: { $ref: '#/spec/panels/FiveHundredSeries' } },
           ],
+        },
+      },
+      {
+        kind: 'Grid',
+        spec: {
+          display: { title: 'Row 2', collapse: { open: false } },
+          items: [{ x: 0, y: 0, width: 24, height: 12, content: { $ref: '#/spec/panels/TwoThousandSeries' } }],
         },
       },
     ],

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -78,19 +78,31 @@ export function getLineSeries(
     showSymbol: showPoints,
     showAllSymbol: true,
     symbolSize: pointRadius,
+    // selectedMode: false,
+    // triggerLineEvent: true,
     lineStyle: {
       width: lineWidth,
-      opacity: 0.7,
+      opacity: 0.9,
     },
     areaStyle: {
       opacity: visual.area_opacity ?? DEFAULT_AREA_OPACITY,
     },
     // https://echarts.apache.org/en/option.html#series-line.emphasis
     emphasis: {
-      disabled: visual.area_opacity !== undefined && visual.area_opacity > 0, // prevents flicker when moving cursor between shaded regions
+      // focus: 'series',
+      focus: 'self',
+      blurScope: 'series',
+      // disabled: true,
+      // disabled: visual.area_opacity !== undefined && visual.area_opacity > 0, // prevents flicker when moving cursor between shaded regions
       lineStyle: {
-        width: lineWidth + 1,
+        width: lineWidth + 10,
         opacity: 1,
+      },
+    },
+    blur: {
+      lineStyle: {
+        width: 0,
+        opacity: 0,
       },
     },
   };

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -78,8 +78,8 @@ export function getLineSeries(
     showSymbol: showPoints,
     showAllSymbol: true,
     symbolSize: pointRadius,
-    selectedMode: true,
-    triggerLineEvent: true,
+    // selectedMode: true,
+    // triggerLineEvent: true,
     lineStyle: {
       width: lineWidth,
       opacity: 0.9,
@@ -89,10 +89,10 @@ export function getLineSeries(
     },
     // https://echarts.apache.org/en/option.html#series-line.emphasis
     emphasis: {
-      // focus: 'series',
-      // // focus: 'self',
-      // blurScope: 'global',
-      disabled: true,
+      focus: 'series',
+      // // // focus: 'self',
+      // blurScope: 'series',
+      // disabled: true,
       // disabled: visual.area_opacity !== undefined && visual.area_opacity > 0, // prevents flicker when moving cursor between shaded regions
       lineStyle: {
         width: lineWidth + 10,

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -78,11 +78,9 @@ export function getLineSeries(
     showSymbol: showPoints,
     showAllSymbol: true,
     symbolSize: pointRadius,
-    // selectedMode: true,
-    // triggerLineEvent: true,
     lineStyle: {
       width: lineWidth,
-      opacity: 0.9,
+      opacity: 0.8,
     },
     areaStyle: {
       opacity: visual.area_opacity ?? DEFAULT_AREA_OPACITY,
@@ -90,19 +88,16 @@ export function getLineSeries(
     // https://echarts.apache.org/en/option.html#series-line.emphasis
     emphasis: {
       focus: 'series',
-      // // // focus: 'self',
-      // blurScope: 'series',
-      // disabled: true,
-      // disabled: visual.area_opacity !== undefined && visual.area_opacity > 0, // prevents flicker when moving cursor between shaded regions
+      disabled: visual.area_opacity !== undefined && visual.area_opacity > 0, // prevents flicker when moving cursor between shaded regions
       lineStyle: {
-        width: lineWidth + 10,
+        width: lineWidth + 1,
         opacity: 1,
       },
     },
     blur: {
       lineStyle: {
-        width: 0,
-        opacity: 0,
+        width: lineWidth,
+        opacity: 0.4,
       },
     },
   };
@@ -131,8 +126,14 @@ export function getThresholdSeries(
       width: 2,
     },
     emphasis: {
+      focus: 'series',
       lineStyle: {
         width: 2.5,
+      },
+    },
+    blur: {
+      lineStyle: {
+        opacity: 0.4,
       },
     },
   };

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -78,8 +78,8 @@ export function getLineSeries(
     showSymbol: showPoints,
     showAllSymbol: true,
     symbolSize: pointRadius,
-    // selectedMode: false,
-    // triggerLineEvent: true,
+    selectedMode: true,
+    triggerLineEvent: true,
     lineStyle: {
       width: lineWidth,
       opacity: 0.9,
@@ -90,9 +90,9 @@ export function getLineSeries(
     // https://echarts.apache.org/en/option.html#series-line.emphasis
     emphasis: {
       // focus: 'series',
-      focus: 'self',
-      blurScope: 'series',
-      // disabled: true,
+      // // focus: 'self',
+      // blurScope: 'global',
+      disabled: true,
       // disabled: visual.area_opacity !== undefined && visual.area_opacity > 0, // prevents flicker when moving cursor between shaded regions
       lineStyle: {
         width: lineWidth + 10,


### PR DESCRIPTION
Follow up to #1112 with a fix for flickering of lines by refactoring downplay logic and additional bold names for the series that are closest to your cursor.

Demo: https://www.loom.com/share/cd5e2bbb2cc046eea380f8420a94e99a

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
