### PR TITLE
BREAKING CHANGE: extract legend layout to reusable component

### DIFF
--- a/ui/components/src/ContentWithLegend/ContentWithLegend.stories.tsx
+++ b/ui/components/src/ContentWithLegend/ContentWithLegend.stories.tsx
@@ -1,0 +1,313 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { ContentWithLegend, LegendProps, LineChart, legendModes, legendPositions } from '@perses-dev/components';
+import { action } from '@storybook/addon-actions';
+import { red, orange, yellow, green, blue, indigo, purple } from '@mui/material/colors';
+import { Stack } from '@mui/material';
+import { StorySection } from '@perses-dev/storybook';
+
+const COLOR_SHADES = ['400', '800'] as const;
+const COLOR_NAMES = [red, orange, yellow, green, blue, indigo, purple];
+const MOCK_COLORS = COLOR_SHADES.reduce((results, colorShade) => {
+  COLOR_NAMES.map((colorName) => {
+    if (colorShade in colorName) {
+      results.push(colorName[colorShade]);
+    }
+  });
+  return results;
+}, [] as string[]);
+
+function generateMockLegendData(count: number, labelPrefix = 'legend item'): LegendProps['data'] {
+  const data: LegendProps['data'] = [];
+  for (let i = 0; i < count; i++) {
+    data.push({
+      id: `${i}`,
+      label: `${labelPrefix} ${i}`,
+      color: MOCK_COLORS[i % MOCK_COLORS.length] as string,
+      onClick: action(`onClick legendItem ${i}`),
+    });
+  }
+  return data;
+}
+
+const meta: Meta<typeof ContentWithLegend> = {
+  component: ContentWithLegend,
+  argTypes: {},
+  args: {
+    children: ({ height }) => (
+      <LineChart
+        height={height}
+        data={{
+          timeSeries: [
+            {
+              type: 'line' as const,
+              name: 'up{instance="demo.do.prometheus.io:3000",job="grafana"}',
+              data: [1, 1, 1],
+              color: 'hsla(158782136,50%,50%,0.8)',
+              sampling: 'lttb' as const,
+              progressiveThreshold: 1000,
+              symbolSize: 4,
+              lineStyle: { width: 1.5 },
+              emphasis: { lineStyle: { width: 2.5 } },
+            },
+          ],
+          xAxis: [1673784000000, 1673784060000, 1673784120000],
+          legendItems: [],
+          rangeMs: 21600000,
+        }}
+        yAxis={{
+          show: true,
+        }}
+        unit={{
+          kind: 'Decimal' as const,
+          decimal_places: 2,
+          abbreviate: true,
+        }}
+      />
+    ),
+    width: 600,
+    height: 300,
+    spacing: 10,
+    legendProps: {
+      data: generateMockLegendData(10),
+      options: {
+        position: 'Right',
+      },
+      selectedItems: {},
+      onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+    },
+  },
+  parameters: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ContentWithLegend>;
+
+export const Primary: Story = {
+  args: {},
+};
+
+/**
+ * The layout of the content alongside the legend is determined by
+ * `legendProps.options.position`.
+ */
+export const Position: Story = {
+  args: {},
+  render: (args) => {
+    return (
+      <Stack spacing={3}>
+        {legendPositions.map((position) => {
+          return (
+            <StorySection key={position} title={position} level="h3">
+              <ContentWithLegend
+                {...args}
+                legendProps={{
+                  data: generateMockLegendData(10),
+                  options: {
+                    position,
+                  },
+                  selectedItems: {},
+                  onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+                }}
+              />
+            </StorySection>
+          );
+        })}
+      </Stack>
+    );
+  },
+};
+
+export const Mode: Story = {
+  args: {},
+  render: (args) => {
+    return (
+      <Stack spacing={3}>
+        {legendModes.map((mode) => {
+          return (
+            <StorySection key={mode} title={mode} level="h3">
+              <ContentWithLegend
+                {...args}
+                legendProps={{
+                  data: generateMockLegendData(10),
+                  options: {
+                    position: 'Right',
+                    mode,
+                  },
+                  selectedItems: {},
+                  onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+                }}
+              />
+            </StorySection>
+          );
+        })}
+      </Stack>
+    );
+  },
+};
+
+/**
+ * Use the `children` prop to specify the content to be laid out alongside the
+ * legend. This prop can be one of the following:
+ * - React node
+ * - Function that returns a React node. The function provides the expected
+ *   height and width for the content, which can be useful for passing down
+ *   to chart components.
+ */
+export const Children: Story = {
+  args: {
+    legendProps: {
+      data: generateMockLegendData(10),
+      options: {
+        position: 'Right',
+      },
+      selectedItems: {},
+      onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+    },
+  },
+  argTypes: {
+    // Manage children inside the story, so do not make it customizable.
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  parameters: {
+    // Not a meaningful story to get visual diffs from.
+    happo: false,
+  },
+  render: (args) => {
+    return (
+      <Stack spacing={3}>
+        <ContentWithLegend {...args}>
+          {({ width, height }) => {
+            return (
+              <div
+                style={{
+                  background: 'lightgrey',
+                  width,
+                  height,
+                  padding: '20px',
+                  textAlign: 'center',
+                }}
+              >
+                content from function
+              </div>
+            );
+          }}
+        </ContentWithLegend>
+        <ContentWithLegend {...args}>
+          <div
+            style={{
+              background: 'lightgrey',
+              width: '100%',
+              height: '100%',
+              padding: '20px',
+              textAlign: 'center',
+            }}
+          >
+            content from react node
+          </div>
+        </ContentWithLegend>
+      </Stack>
+    );
+  },
+};
+
+/**
+ * If `legendProps` is not specified, the `children` will fill the entire
+ * content and no legend will be rendered.
+ */
+export const NoLegend: Story = {
+  args: {
+    legendProps: undefined,
+  },
+};
+
+/**
+ * Use the `minChildrenHeight` and `minChildrenWidth` props to manage responsive
+ * handling for bottom and right positioned legends. If the content specified
+ * by `children` will be smaller than these values, the legend will not be
+ * shown.
+ */
+export const Responsive: Story = {
+  args: {},
+  render: (args) => {
+    return (
+      <Stack spacing={3}>
+        <StorySection title="legend is hidden when it will not fit" level="h3">
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            <ContentWithLegend
+              {...args}
+              width={300}
+              legendProps={{
+                data: generateMockLegendData(10),
+                options: {
+                  position: 'Right',
+                },
+                selectedItems: {},
+                onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+              }}
+            />
+            <ContentWithLegend
+              {...args}
+              height={100}
+              legendProps={{
+                data: generateMockLegendData(10),
+                options: {
+                  position: 'Bottom',
+                },
+                selectedItems: {},
+                onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+              }}
+            />
+          </Stack>
+        </StorySection>
+        <StorySection title="size of bottom legend adjusts depending on the height" level="h3">
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            <ContentWithLegend
+              {...args}
+              width={400}
+              height={200}
+              legendProps={{
+                data: generateMockLegendData(10),
+                options: {
+                  position: 'Bottom',
+                },
+                selectedItems: {},
+                onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+              }}
+            />
+            <ContentWithLegend
+              {...args}
+              width={400}
+              height={300}
+              legendProps={{
+                data: generateMockLegendData(10),
+                options: {
+                  position: 'Bottom',
+                },
+                selectedItems: {},
+                onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+              }}
+            />
+          </Stack>
+        </StorySection>
+      </Stack>
+    );
+  },
+};

--- a/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
+++ b/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
@@ -1,0 +1,65 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { Box } from '@mui/material';
+import { Legend } from '../Legend';
+import { ContentWithLegendProps, getContentWithLegendLayout } from './model/content-with-legend-model';
+
+/**
+ * Component to help lay out content alongside a `Legend` component based on the
+ * configuration of the legend.
+ *
+ * See the documentation for the `Legend` component for more details about the
+ * features and configuration of the legend.
+ */
+export function ContentWithLegend({
+  children,
+  legendProps,
+  width,
+  height,
+  spacing = 0,
+  minChildrenWidth = 100,
+  minChildrenHeight = 100,
+}: ContentWithLegendProps) {
+  const { content, legend, margin } = getContentWithLegendLayout({
+    width,
+    height,
+    legendOptions: legendProps?.options,
+    minChildrenHeight,
+    minChildrenWidth,
+    spacing,
+  });
+
+  return (
+    <Box
+      sx={{
+        width,
+        height,
+        position: 'relative',
+      }}
+    >
+      <Box
+        sx={{
+          width: content.width,
+          height: content.height,
+          marginRight: margin.right,
+          marginBottom: margin.bottom,
+        }}
+      >
+        {typeof children === 'function' ? children({ width: content.width, height: content.height }) : children}
+      </Box>
+      {legendProps && legend.show && <Legend {...legendProps} height={legend.height} width={legend.width} />}
+    </Box>
+  );
+}

--- a/ui/components/src/ContentWithLegend/index.ts
+++ b/ui/components/src/ContentWithLegend/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './ContentWithLegend';

--- a/ui/components/src/ContentWithLegend/model/content-with-legend-model.test.ts
+++ b/ui/components/src/ContentWithLegend/model/content-with-legend-model.test.ts
@@ -1,0 +1,208 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ContentWithLegendLayoutOpts, getContentWithLegendLayout } from './content-with-legend-model';
+
+describe('getContentWithLegendLayout', () => {
+  describe('without legend options', () => {
+    const layoutOpts: ContentWithLegendLayoutOpts = {
+      width: 400,
+      height: 200,
+      spacing: 0,
+      minChildrenWidth: 0,
+      minChildrenHeight: 0,
+    };
+
+    test('does not show legend', () => {
+      const layout = getContentWithLegendLayout(layoutOpts);
+      expect(layout.legend.show).toBeFalsy();
+    });
+
+    test('gives content full width and height without a margin', () => {
+      const layout = getContentWithLegendLayout(layoutOpts);
+      expect(layout.content.width).toEqual(layoutOpts.width);
+      expect(layout.content.height).toEqual(layoutOpts.height);
+      expect(layout.margin).toEqual({ bottom: 0, right: 0 });
+    });
+  });
+
+  describe('with right oriented legend', () => {
+    describe('with spacing', () => {
+      const layoutOpts: ContentWithLegendLayoutOpts = {
+        width: 800,
+        height: 500,
+        spacing: 10,
+        minChildrenWidth: 0,
+        minChildrenHeight: 0,
+        legendOptions: {
+          position: 'Right',
+        },
+      };
+
+      test('shows legend', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.legend.show).toBeTruthy();
+      });
+
+      test('lays out the content, spacing, and legend horizontally', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.width + layout.margin.right + layout.legend.width).toEqual(layoutOpts.width);
+      });
+
+      test('content and legend use full height', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.height).toEqual(layoutOpts.height);
+        expect(layout.legend.height).toEqual(layoutOpts.height);
+      });
+    });
+
+    describe('without spacing', () => {
+      const layoutOpts: ContentWithLegendLayoutOpts = {
+        width: 800,
+        height: 500,
+        spacing: 0,
+        minChildrenWidth: 0,
+        minChildrenHeight: 0,
+        legendOptions: {
+          position: 'Right',
+        },
+      };
+
+      test('shows legend', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.legend.show).toBeTruthy();
+      });
+
+      test('lays out the content, spacing, and legend horizontally', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.width + layout.legend.width).toEqual(layoutOpts.width);
+      });
+
+      test('content and legend use full height', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.height).toEqual(layoutOpts.height);
+        expect(layout.legend.height).toEqual(layoutOpts.height);
+      });
+    });
+
+    describe('without enough horizontal space for the legend', () => {
+      const layoutOpts: ContentWithLegendLayoutOpts = {
+        width: 200,
+        height: 500,
+        spacing: 10,
+        minChildrenWidth: 200,
+        minChildrenHeight: 0,
+        legendOptions: {
+          position: 'Right',
+        },
+      };
+
+      test('does not show legend', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.legend.show).toBeFalsy();
+      });
+
+      test('gives content full width and height without a margin', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.width).toEqual(layoutOpts.width);
+        expect(layout.content.height).toEqual(layoutOpts.height);
+        expect(layout.margin).toEqual({ bottom: 0, right: 0 });
+      });
+    });
+  });
+
+  describe('with bottom oriented legend', () => {
+    describe('with spacing', () => {
+      const layoutOpts: ContentWithLegendLayoutOpts = {
+        width: 800,
+        height: 500,
+        spacing: 15,
+        minChildrenWidth: 0,
+        minChildrenHeight: 0,
+        legendOptions: {
+          position: 'Bottom',
+        },
+      };
+
+      test('shows legend', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.legend.show).toBeTruthy();
+      });
+
+      test('lays out the content, spacing, and legend vertically', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.height + layout.margin.bottom + layout.legend.height).toEqual(layoutOpts.height);
+      });
+
+      test('content and legend use full width', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.width).toEqual(layoutOpts.width);
+        expect(layout.legend.width).toEqual(layoutOpts.width);
+      });
+    });
+
+    describe('without spacing', () => {
+      const layoutOpts: ContentWithLegendLayoutOpts = {
+        width: 800,
+        height: 500,
+        spacing: 0,
+        minChildrenWidth: 0,
+        minChildrenHeight: 0,
+        legendOptions: {
+          position: 'Bottom',
+        },
+      };
+
+      test('shows legend', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.legend.show).toBeTruthy();
+      });
+
+      test('lays out the content, spacing, and legend horizontally', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.height + layout.legend.height).toEqual(layoutOpts.height);
+      });
+
+      test('content and legend use full width', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.width).toEqual(layoutOpts.width);
+        expect(layout.legend.width).toEqual(layoutOpts.width);
+      });
+    });
+
+    describe('without enough vertical space for the legend', () => {
+      const layoutOpts: ContentWithLegendLayoutOpts = {
+        width: 300,
+        height: 100,
+        spacing: 10,
+        minChildrenWidth: 0,
+        minChildrenHeight: 100,
+        legendOptions: {
+          position: 'Bottom',
+        },
+      };
+
+      test('does not show legend', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.legend.show).toBeFalsy();
+      });
+
+      test('gives content full width and height without a margin', () => {
+        const layout = getContentWithLegendLayout(layoutOpts);
+        expect(layout.content.width).toEqual(layoutOpts.width);
+        expect(layout.content.height).toEqual(layoutOpts.height);
+        expect(layout.margin).toEqual({ bottom: 0, right: 0 });
+      });
+    });
+  });
+});

--- a/ui/components/src/ContentWithLegend/model/content-with-legend-model.ts
+++ b/ui/components/src/ContentWithLegend/model/content-with-legend-model.ts
@@ -1,0 +1,153 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LegendProps } from '../../Legend';
+
+type Dimensions = {
+  width: number;
+  height: number;
+};
+
+export interface ContentWithLegendProps {
+  /**
+   * Width of the overall component layout in pixels.
+   */
+  width: number;
+  /**
+   * Height of overall component layout in pixels.
+   */
+  height: number;
+  /**
+   * Child content to render next to the legend. May be a react node or a
+   * function that returns a react node. The function provides the expected
+   * height and width for the content, which can be useful for passing down
+   * to chart components.
+   */
+  children: React.ReactNode | (({ width, height }: Dimensions) => React.ReactNode);
+  /**
+   * Props to configure the legend. If not set, the content is rendered without
+   * a legend.
+   */
+  legendProps?: Omit<LegendProps, 'width' | 'height'>;
+  /**
+   * Space to put between the children and the legend in pixels.
+   */
+  spacing?: number;
+
+  /**
+   * Minimum width required for the content specified by the `children` prop.
+   * If this width cannot be maintained with a right positioned legend, the
+   * legend will not be shown.
+   */
+  minChildrenWidth?: number;
+
+  /**
+   * Minimum height required for the content specified by the `children` prop.
+   * If this width cannot be maintained with a bottom positioned legend, the
+   * legend will not be shown.
+   */
+  minChildrenHeight?: number;
+}
+
+export interface ContentWithLegendLayoutOpts
+  extends Required<Omit<ContentWithLegendProps, 'children' | 'legendProps'>> {
+  legendOptions?: LegendProps['options'];
+}
+
+export interface ContentWithLegendLayout {
+  legend: Dimensions & {
+    show: boolean;
+  };
+  content: Dimensions;
+  margin: {
+    right: number;
+    bottom: number;
+  };
+}
+
+const PANEL_HEIGHT_LG_BREAKPOINT = 300;
+const LEGEND_HEIGHT_SM = 40;
+const LEGEND_HEIGHT_LG = 100;
+
+/**
+ * Returns information for laying out content alongside a legend.
+ */
+export function getContentWithLegendLayout({
+  width,
+  height,
+  legendOptions,
+  minChildrenHeight,
+  minChildrenWidth,
+  spacing,
+}: ContentWithLegendLayoutOpts): ContentWithLegendLayout {
+  const hasLegend = !!legendOptions;
+
+  const noLegendLayout: ContentWithLegendLayout = {
+    legend: {
+      show: false,
+      width: 0,
+      height: 0,
+    },
+    content: {
+      width,
+      height,
+    },
+    margin: {
+      right: 0,
+      bottom: 0,
+    },
+  };
+
+  if (!hasLegend) {
+    return noLegendLayout;
+  }
+
+  const { position } = legendOptions;
+
+  const legendWidth = position === 'Right' ? 200 : width;
+
+  // TODO: account for number of legend items returned when adjusting legend spacing
+  let legendHeight = LEGEND_HEIGHT_SM;
+  if (position === 'Right') {
+    legendHeight = height;
+  } else if (height >= PANEL_HEIGHT_LG_BREAKPOINT) {
+    legendHeight = LEGEND_HEIGHT_LG;
+  }
+
+  const contentWidth = position === 'Right' ? width - legendWidth - spacing : width;
+  const contentHeight = position === 'Bottom' ? height - legendHeight - spacing : height;
+
+  if (
+    (position === 'Right' && contentWidth < minChildrenWidth) ||
+    (position === 'Bottom' && contentHeight < minChildrenHeight)
+  ) {
+    // Legend does not fit. Just show the content.
+    return noLegendLayout;
+  }
+
+  return {
+    legend: {
+      width: legendWidth,
+      height: legendHeight,
+      show: true,
+    },
+    content: {
+      width: contentWidth,
+      height: contentHeight,
+    },
+    margin: {
+      right: position === 'Right' ? spacing : 0,
+      bottom: position === 'Bottom' ? spacing : 0,
+    },
+  };
+}

--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useTheme, Box } from '@mui/material';
 import { Virtuoso } from 'react-virtuoso';
 import { LegendItem, SelectedLegendItemState, isLegendItemVisuallySelected } from '../model';
 import { ListLegendItem, ListLegendItemProps } from './ListLegendItem';
@@ -31,14 +30,6 @@ export interface ListLegendProps {
  * large numbers of items when there is a single item per row.
  */
 export function ListLegend({ items, height, width, selectedItems, onLegendItemClick }: ListLegendProps) {
-  const theme = useTheme();
-  // Padding value used in the react virtuoso header/footer components to
-  // simulate top/bottom padding based on recommendation in this
-  // issue.
-  // https://github.com/petyosi/react-virtuoso/issues/238
-  const LIST_PADDING = parseInt(theme.spacing(1), 10);
-  const mockPadding = <Box sx={{ width: '100%', height: `${LIST_PADDING}px` }}></Box>;
-
   // show full labels on hover when there are many total series
   const truncateLabels = items.length > 5;
 
@@ -57,7 +48,7 @@ export function ListLegend({ items, height, width, selectedItems, onLegendItemCl
             sx={{
               // Having an explicit width is important for the ellipsizing to
               // work correctly. Subtract padding to simulate padding.
-              width: width - LIST_PADDING,
+              width: width,
               wordBreak: 'break-word',
               overflow: 'hidden',
             }}
@@ -65,14 +56,6 @@ export function ListLegend({ items, height, width, selectedItems, onLegendItemCl
         );
       }}
       role="list"
-      components={{
-        Header: () => {
-          return mockPadding;
-        },
-        Footer: () => {
-          return mockPadding;
-        },
-      }}
     />
   );
 }

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 export * from './ColorPicker';
+export * from './ContentWithLegend';
 export * from './DateTimeRangePicker';
 export * from './Dialog';
 export * from './Drawer';

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -21,21 +21,14 @@ import {
   DEFAULT_LEGEND,
   EChartsDataFormat,
   validateLegendSpec,
-  Legend,
   LineChart,
   YAxisLabel,
   ZoomEventData,
   useChartsTheme,
   SelectedLegendItemState,
+  ContentWithLegend,
 } from '@perses-dev/components';
-import {
-  TimeSeriesChartOptions,
-  DEFAULT_UNIT,
-  DEFAULT_VISUAL,
-  PANEL_HEIGHT_LG_BREAKPOINT,
-  LEGEND_HEIGHT_SM,
-  LEGEND_HEIGHT_LG,
-} from './time-series-chart-model';
+import { TimeSeriesChartOptions, DEFAULT_UNIT, DEFAULT_VISUAL } from './time-series-chart-model';
 import {
   getLineSeries,
   getThresholdSeries,
@@ -258,22 +251,12 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     }
   }
 
-  const legendWidth = legend && legend.position === 'Right' ? 200 : adjustedContentDimensions.width;
-
-  // TODO: account for number of time series returned when adjusting legend spacing
-  let legendHeight = LEGEND_HEIGHT_SM;
-  if (legend && legend.position === 'Right') {
-    legendHeight = contentDimensions?.height || adjustedContentDimensions.height;
-  } else if (adjustedContentDimensions.height >= PANEL_HEIGHT_LG_BREAKPOINT) {
-    legendHeight = LEGEND_HEIGHT_LG;
-  }
-
   // override default spacing, see: https://echarts.apache.org/en/option.html#grid
   const gridLeft = y_axis && y_axis.label ? 30 : 20;
   const gridOverrides: GridComponentOption = {
     left: !echartsYAxis.show ? 0 : gridLeft,
-    right: legend && legend.position === 'Right' ? legendWidth : 20,
-    bottom: legend && legend.position === 'Bottom' ? legendHeight : 0,
+    right: 20,
+    bottom: 0,
   };
 
   const handleDataZoom = (event: ZoomEventData) => {
@@ -282,29 +265,54 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   };
 
   return (
-    <Box sx={{ padding: `${contentPadding}px`, position: 'relative' }}>
-      {y_axis && y_axis.show && y_axis.label && (
-        <YAxisLabel name={y_axis.label} height={adjustedContentDimensions.height} />
-      )}
-      <LineChart
+    <Box sx={{ padding: `${contentPadding}px` }}>
+      <ContentWithLegend
+        width={adjustedContentDimensions.width}
         height={adjustedContentDimensions.height}
-        data={graphData}
-        yAxis={echartsYAxis}
-        unit={unit}
-        grid={gridOverrides}
-        tooltipConfig={{ wrapLabels: true }}
-        onDataZoom={handleDataZoom}
-      />
-      {legend && graphData.legendItems && (
-        <Legend
-          width={legendWidth}
-          height={legendHeight}
-          options={legend}
-          data={graphData.legendItems}
-          selectedItems={selectedLegendItems}
-          onSelectedItemsChange={setSelectedLegendItems}
-        />
-      )}
+        spacing={contentPadding}
+        legendProps={
+          legend && {
+            options: legend,
+            data: graphData.legendItems || [],
+            selectedItems: selectedLegendItems,
+            onSelectedItemsChange: setSelectedLegendItems,
+          }
+        }
+      >
+        {({ height, width }) => {
+          return (
+            <Box sx={{ height, width }}>
+              {y_axis && y_axis.show && y_axis.label && <YAxisLabel name={y_axis.label} height={height} />}
+              <LineChart
+                height={height}
+                data={graphData}
+                yAxis={echartsYAxis}
+                unit={unit}
+                grid={gridOverrides}
+                tooltipConfig={{ wrapLabels: true }}
+                onDataZoom={handleDataZoom}
+              />
+            </Box>
+          );
+        }}
+      </ContentWithLegend>
     </Box>
   );
+
+  // return (
+  //   <Box sx={{ padding: `${contentPadding}px` }}>
+  //     {y_axis && y_axis.show && y_axis.label && (
+  //       <YAxisLabel name={y_axis.label} height={adjustedContentDimensions.height} />
+  //     )}
+  //     <LineChart
+  //       height={adjustedContentDimensions.height}
+  //       data={graphData}
+  //       yAxis={echartsYAxis}
+  //       unit={unit}
+  //       grid={gridOverrides}
+  //       tooltipConfig={{ wrapLabels: true }}
+  //       onDataZoom={handleDataZoom}
+  //     />
+  //   </Box>
+  // );
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -136,10 +136,6 @@ export const STACK_OPTIONS = Object.entries(STACK_CONFIG).map(([id, config]) => 
   };
 });
 
-export const PANEL_HEIGHT_LG_BREAKPOINT = 300;
-export const LEGEND_HEIGHT_SM = 40;
-export const LEGEND_HEIGHT_LG = 100;
-
 // Both of these constants help produce a value that is LESS THAN the initial value.
 // For positive values, we multiply by a number less than 1 to get this outcome.
 // For negative values, we multiply to a number greater than 1 to get this outcome.


### PR DESCRIPTION
This commit:
- Extracts the layout and spacing of content alongside a legend from the time series panel plugin into a ContentWithLegend component that can be used by both the time series plugin panel and other use cases.
- Adjustments to the styling of the layout and spacing of content alongside a legend and the legend itself to better match guidance from design. Primarily this impacts some margins and padding.

BREAKING CHANGE: this change makes some styling adjustments to the Legend component that existed to support the previous layout in the time series panel plugin. Consumers who were using the Legend outside of the time series panel, may need to adjust their styling to handle the change.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
