### PR TITLE
[BUGFIX] avoiding screen reload on theme toggle

### DIFF
--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -131,9 +131,9 @@ export default function Header(): JSX.Element {
   const navigate = useNavigate();
   const { exceptionSnackbar } = useSnackbar();
   const { isDarkModeEnabled, setDarkMode } = useDarkMode();
-  const handleDarkModeChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleDarkModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     try {
-      await setDarkMode(e.target.checked);
+      setDarkMode(e.target.checked);
     } catch (e) {
       exceptionSnackbar(e);
     }

--- a/ui/app/src/context/DarkMode.tsx
+++ b/ui/app/src/context/DarkMode.tsx
@@ -24,7 +24,7 @@ const DARK_MODE_PREFERENCE_KEY = 'PERSES_ENABLE_DARK_MODE';
 
 interface DarkModeContext {
   isDarkModeEnabled: boolean;
-  setDarkMode: (pref: boolean) => Promise<void>;
+  setDarkMode: (pref: boolean) => void;
 }
 
 export const DarkModeContext = createContext<DarkModeContext | undefined>(undefined);
@@ -35,18 +35,15 @@ export const DarkModeContext = createContext<DarkModeContext | undefined>(undefi
 export function DarkModeContextProvider(props: { children: React.ReactNode }) {
   const browserPrefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
-  const [isDarkModeEnabled] = useLocalStorage<boolean>(DARK_MODE_PREFERENCE_KEY, browserPrefersDarkMode);
+  const [isDarkModeEnabled, setDarkMode] = useLocalStorage<boolean>(DARK_MODE_PREFERENCE_KEY, browserPrefersDarkMode);
 
   // store the dark mode preference in local storage
   const darkModeContext: DarkModeContext = useMemo(
     () => ({
       isDarkModeEnabled,
-      setDarkMode: async (preference: boolean) => {
-        window.localStorage.setItem(DARK_MODE_PREFERENCE_KEY, preference.toString());
-        location.reload();
-      },
+      setDarkMode,
     }),
-    [isDarkModeEnabled]
+    [isDarkModeEnabled, setDarkMode]
   );
 
   const theme = useMemo(() => getTheme(isDarkModeEnabled ? 'dark' : 'light'), [isDarkModeEnabled]);

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -148,6 +148,7 @@ export class DashboardPage {
 
   async toggleTheme() {
     await this.themeToggle.click();
+    await this.page.mouse.move(-200, -200);
   }
 
   /**

--- a/ui/e2e/src/pages/PanelEditor.ts
+++ b/ui/e2e/src/pages/PanelEditor.ts
@@ -81,7 +81,7 @@ export class PanelEditor {
   }
 
   async editThreshold(label: string, value: string) {
-    const input = this.container.getByLabel(label);
+    const input = this.container.getByLabel(label, { exact: true });
     await input.clear();
     await input.type(value);
   }

--- a/ui/e2e/src/tests/gaugeChartPanel.spec.ts
+++ b/ui/e2e/src/tests/gaugeChartPanel.spec.ts
@@ -50,21 +50,21 @@ test.describe('Dashboard: Gauge Chart Panel', () => {
 
   test.describe('Thresholds', () => {
     test('should be able to add absolute threshold', async ({ page, dashboardPage, mockNow }) => {
+      await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
+
+      await dashboardPage.startEditing();
+      await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
+        await panelEditor.selectTab('Settings');
+        await panelEditor.addThreshold();
+        await panelEditor.editThreshold('T2', '40');
+        await panelEditor.addThreshold();
+      });
+      const panel = dashboardPage.getPanelByName('Single Gauge');
+      await panel.isLoaded();
+      // Wait for gauge animation to finish before taking a screenshot.
+      await waitForStableCanvas(panel.canvas);
+
       await dashboardPage.forEachTheme(async (themeName) => {
-        await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
-
-        await dashboardPage.startEditing();
-        await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
-          await panelEditor.selectTab('Settings');
-          await panelEditor.addThreshold();
-          await panelEditor.editThreshold('T2', '40');
-          await panelEditor.addThreshold();
-        });
-        const panel = dashboardPage.getPanelByName('Single Gauge');
-        await panel.isLoaded();
-        // Wait for gauge animation to finish before taking a screenshot.
-        await waitForStableCanvas(panel.canvas);
-
         await happoPlaywright.screenshot(page, panel.parent, {
           component: 'Gauge Chart Panel',
           variant: `Single Gauge with Absolute Thresholds [${themeName}]`,
@@ -73,20 +73,19 @@ test.describe('Dashboard: Gauge Chart Panel', () => {
     });
 
     test('should be able to add percent threshold', async ({ page, dashboardPage, mockNow }) => {
+      await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
+      await dashboardPage.startEditing();
+      await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
+        await panelEditor.selectTab('Settings');
+        await panelEditor.toggleThresholdModes('Percent');
+        await panelEditor.editThreshold('T1', '50');
+        await panelEditor.container.getByLabel('Max').fill('200');
+      });
+      const panel = dashboardPage.getPanelByName('Single Gauge');
+      await panel.isLoaded();
+      // Wait for gauge animation to finish before taking a screenshot.
+      await waitForStableCanvas(panel.canvas);
       await dashboardPage.forEachTheme(async (themeName) => {
-        await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
-        await dashboardPage.startEditing();
-        await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
-          await panelEditor.selectTab('Settings');
-          await panelEditor.toggleThresholdModes('Percent');
-          await panelEditor.editThreshold('T1', '50');
-          await panelEditor.container.getByLabel('Max').fill('200');
-        });
-        const panel = dashboardPage.getPanelByName('Single Gauge');
-        await panel.isLoaded();
-        // Wait for gauge animation to finish before taking a screenshot.
-        await waitForStableCanvas(panel.canvas);
-
         await happoPlaywright.screenshot(page, panel.parent, {
           component: 'Gauge Chart Panel',
           variant: `Single Gauge with Percent Thresholds [${themeName}]`,
@@ -109,24 +108,23 @@ test.describe('Dashboard: Gauge Chart Panel', () => {
     });
 
     test('should be able to change threshold color to purple', async ({ page, dashboardPage, mockNow }) => {
+      await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
+      await dashboardPage.startEditing();
+      await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
+        await panelEditor.selectTab('Settings');
+        await panelEditor.openThresholdColorPicker('T1');
+        const colorPicker = dashboardPage.page.getByTestId('threshold color picker');
+        await colorPicker.isVisible();
+        const colorInput = colorPicker.getByRole('textbox', { name: 'enter hex color' });
+        await colorInput.clear();
+        await colorInput.type('8457c2', { delay: 100 });
+        await page.keyboard.press('Escape');
+      });
+      const panel = dashboardPage.getPanelByName('Single Gauge');
+      await panel.isLoaded();
+      // Wait for gauge animation to finish before taking a screenshot.
+      await waitForStableCanvas(panel.canvas);
       await dashboardPage.forEachTheme(async (themeName) => {
-        await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
-        await dashboardPage.startEditing();
-        await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
-          await panelEditor.selectTab('Settings');
-          await panelEditor.openThresholdColorPicker('T1');
-          const colorPicker = dashboardPage.page.getByTestId('threshold color picker');
-          await colorPicker.isVisible();
-          const colorInput = colorPicker.getByRole('textbox', { name: 'enter hex color' });
-          await colorInput.clear();
-          await colorInput.type('8457c2', { delay: 100 });
-          await page.keyboard.press('Escape');
-        });
-        const panel = dashboardPage.getPanelByName('Single Gauge');
-        await panel.isLoaded();
-        // Wait for gauge animation to finish before taking a screenshot.
-        await waitForStableCanvas(panel.canvas);
-
         await happoPlaywright.screenshot(page, panel.parent, {
           component: 'Gauge Chart Panel',
           variant: `Single Gauge with Purple Threshold [${themeName}]`,
@@ -135,24 +133,23 @@ test.describe('Dashboard: Gauge Chart Panel', () => {
     });
 
     test('should be able to change default threshold color', async ({ page, dashboardPage, mockNow }) => {
+      await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
+      await dashboardPage.startEditing();
+      await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
+        await panelEditor.selectTab('Settings');
+        await panelEditor.openThresholdColorPicker('default');
+        const colorPicker = dashboardPage.page.getByTestId('threshold color picker');
+        await colorPicker.isVisible();
+        const colorInput = colorPicker.getByRole('textbox', { name: 'enter hex color' });
+        await colorInput.clear();
+        await colorInput.type('e3abab', { delay: 100 });
+        await page.keyboard.press('Escape');
+      });
+      const panel = dashboardPage.getPanelByName('Single Gauge');
+      await panel.isLoaded();
+      // Wait for gauge animation to finish before taking a screenshot.
+      await waitForStableCanvas(panel.canvas);
       await dashboardPage.forEachTheme(async (themeName) => {
-        await mockGaugeChartQueryRangeRequest(dashboardPage, mockNow);
-        await dashboardPage.startEditing();
-        await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
-          await panelEditor.selectTab('Settings');
-          await panelEditor.openThresholdColorPicker('default');
-          const colorPicker = dashboardPage.page.getByTestId('threshold color picker');
-          await colorPicker.isVisible();
-          const colorInput = colorPicker.getByRole('textbox', { name: 'enter hex color' });
-          await colorInput.clear();
-          await colorInput.type('e3abab', { delay: 100 });
-          await page.keyboard.press('Escape');
-        });
-        const panel = dashboardPage.getPanelByName('Single Gauge');
-        await panel.isLoaded();
-        // Wait for gauge animation to finish before taking a screenshot.
-        await waitForStableCanvas(panel.canvas);
-
         await happoPlaywright.screenshot(page, panel.parent, {
           component: 'Gauge Chart Panel',
           variant: `Single Gauge with New Default Threshold Color [${themeName}]`,


### PR DESCRIPTION
Changing the Theme Provider to not reload the entire screen when switch between themes.

This PR will fix https://github.com/perses/perses/issues/1173

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for the loading to complete.

## Screenshots

https://github.com/perses/perses/assets/8205546/d7eb91b6-c717-43cc-9d7a-0318b5bd2f12
