### PR TITLE
[IGNORE] Temporarily disable typedoc in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,24 +79,29 @@ jobs:
           name: storybook
           path: ui/storybook/storybook-static
   
-  build-typedoc:
-    name: "build-typedoc"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: ./.github/actions/setup_environment
-        with:
-          enable_npm: true
-      - name: Install UI deps
-        run: cd ./ui && npm install
-      - name: Build the typedoc docs
-        run: cd ./ui && npm run build && npm run typedoc
-      - name: store typedoc build
-        uses: actions/upload-artifact@v3
-        with:
-          name: typedoc
-          path: ui/typedoc
+  # Temporarily disabling the typedoc run in CI because it is causing OOM
+  # errors. There also appear to be some other issues with typedoc that need
+  # addressing (error on a potentialy valid typing that is fine when running
+  # type-check, breaking changes in the latest minor release we need to handle).
+  # TODO: uncomment and re-enable this when those issues are addressed.
+  # build-typedoc:
+  #   name: "build-typedoc"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - uses: ./.github/actions/setup_environment
+  #       with:
+  #         enable_npm: true
+  #     - name: Install UI deps
+  #       run: cd ./ui && npm install
+  #     - name: Build the typedoc docs
+  #       run: cd ./ui && npm run build && npm run typedoc
+  #     - name: store typedoc build
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: typedoc
+  #         path: ui/typedoc
   
   libs-release:
     name: "libs-release"


### PR DESCRIPTION
It's causing issues that aren't a super-quick fix, and it is not a mission critical part of the project at this time. Temporarily disabling it in CI to avoid confusion with the intent to re-enable after we fix those issues.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
