### PR TITLE
[ENHANCEMENT] Set y-axis min relative to data in stat chart

### DIFF
--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -87,6 +87,13 @@ export function StatChart(props: StatChartProps) {
       yAxis: {
         type: 'value',
         show: false,
+        min: (value: { min: number; max: number }) => {
+          if (value.min >= 0 && value.min <= 1) {
+            // helps with PercentDecimal units, or datasets that return 0 or 1 booleans
+            return 0;
+          }
+          return value.min;
+        },
       },
       tooltip: {
         show: false,


### PR DESCRIPTION
Right now y-axis min is calculated by echart, which causes the sparkline in stat chart to be rather flat in some cases. 

To fix this, we are now setting y-axis min to the minimum value of the data.

**BEFORE**
![image](https://github.com/perses/perses/assets/9817826/acd0821d-5bb4-4c35-9ee3-21a5fd5de0d0)
![image](https://github.com/perses/perses/assets/9817826/08345092-e16f-499f-b57f-fd0c9d19ae74)


**AFTER**
![image](https://github.com/perses/perses/assets/9817826/9ad72624-d93f-4f8e-a2cf-5009628d7591)

![image](https://github.com/perses/perses/assets/9817826/22ec0356-a835-4d60-8cc6-dd44a2b77e70)

