### PR TITLE
[IGNORE] Upgrade react-router from 6.3.0 to 6.11.2 

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -34,7 +34,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-error-boundary": "^3.1.4",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "^6.11.0",
     "use-immer": "^0.7.0",
     "use-query-params": "^2.1.1",
     "use-resize-observer": "^9.0.0"

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@perses-dev/internal-utils": "0.31.0",
     "@perses-dev/storybook": "0.31.0",
+    "history": "^5.3.0",
     "intersection-observer": "^0.12.2"
   },
   "peerDependencies": {

--- a/ui/dashboards/src/test/render.tsx
+++ b/ui/dashboards/src/test/render.tsx
@@ -27,6 +27,10 @@ interface CustomRouterProps {
   children: React.ReactNode;
 }
 
+/*
+ * Workaround for React router upgrade type errors.
+ * More details: https://stackoverflow.com/a/69948457/17575201
+ */
 const CustomRouter: React.FC<CustomRouterProps> = ({ history, children }) => {
   const [state, setState] = useState({
     action: history.action,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -83,7 +83,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-error-boundary": "^3.1.4",
-        "react-router-dom": "^6.3.0",
+        "react-router-dom": "^6.11.0",
         "use-immer": "^0.7.0",
         "use-query-params": "^2.1.1",
         "use-resize-observer": "^9.0.0"
@@ -187,6 +187,7 @@
       "devDependencies": {
         "@perses-dev/internal-utils": "0.31.0",
         "@perses-dev/storybook": "0.31.0",
+        "history": "^5.3.0",
         "intersection-observer": "^0.12.2"
       },
       "peerDependencies": {
@@ -4672,6 +4673,14 @@
       "peerDependencies": {
         "@lezer/highlight": "^1.1.2",
         "@lezer/lr": "^1.2.3"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sideway/address": {
@@ -16521,6 +16530,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -22682,23 +22692,29 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
       "dependencies": {
-        "history": "^5.2.0"
+        "@remix-run/router": "1.6.2"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
       "dependencies": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
+        "@remix-run/router": "1.6.2",
+        "react-router": "6.11.2"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -29769,7 +29785,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-error-boundary": "^3.1.4",
-        "react-router-dom": "^6.3.0",
+        "react-router-dom": "^6.11.0",
         "style-loader": "^3.3.1",
         "ts-loader": "^9.3.1",
         "ts-node": "^10.9.1",
@@ -29831,6 +29847,7 @@
         "@perses-dev/storybook": "0.31.0",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^2.28.0",
+        "history": "^5.3.0",
         "immer": "^9.0.15",
         "intersection-observer": "^0.12.2",
         "mdi-material-ui": "^7.4.0",
@@ -30066,6 +30083,11 @@
       "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.43.0.tgz",
       "integrity": "sha512-pETCiiJK24GotBytjNzE3tK+rGafl7F/Wxhd8l05T8a1hXR+kgelxyyfFCj/TxPqrQuzM24TW/mqFBKZZ0pSpQ==",
       "requires": {}
+    },
+    "@remix-run/router": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA=="
     },
     "@sideway/address": {
       "version": "4.1.4",
@@ -38909,6 +38931,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.6"
       }
@@ -43459,20 +43482,20 @@
       }
     },
     "react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
       "requires": {
-        "history": "^5.2.0"
+        "@remix-run/router": "1.6.2"
       }
     },
     "react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
       "requires": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
+        "@remix-run/router": "1.6.2",
+        "react-router": "6.11.2"
       }
     },
     "react-syntax-highlighter": {


### PR DESCRIPTION
Temp branch to hopefully upgrade react router without breaking a bunch of stuff 🤞 

Follow up to closed PR #1153 - I think this is safe to upgrade now, finally got RTL tests to pass again 