### PR TITLE
[BREAKINGCHANGE] Save dashboard type change for embed gql users

### DIFF
--- a/ui/core/src/model/dashboard.ts
+++ b/ui/core/src/model/dashboard.ts
@@ -38,5 +38,3 @@ export interface DashboardSelector {
   project: string;
   dashboard: string;
 }
-
-export type OnSaveDashboard = (dashboard: DashboardResource) => Promise<unknown>;

--- a/ui/core/src/model/dashboard.ts
+++ b/ui/core/src/model/dashboard.ts
@@ -38,3 +38,5 @@ export interface DashboardSelector {
   project: string;
   dashboard: string;
 }
+
+export type OnSaveDashboard = (dashboard: DashboardResource) => Promise<unknown>;

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -13,8 +13,7 @@
 
 import { Typography, Stack, Button, Box, useTheme, useMediaQuery, Alert } from '@mui/material';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
-import { OnSaveDashboard } from '@perses-dev/core';
-import { useEditMode } from '../../context';
+import { OnSaveDashboard, useEditMode } from '../../context';
 import { AddPanelButton } from '../AddPanelButton';
 import { AddGroupButton } from '../AddGroupButton';
 import { DownloadButton } from '../DownloadButton';

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import { Typography, Stack, Button, Box, useTheme, useMediaQuery, Alert } from '@mui/material';
-import { DashboardResource } from '@perses-dev/core';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
+import { OnSaveDashboard } from '@perses-dev/core';
 import { useEditMode } from '../../context';
 import { AddPanelButton } from '../AddPanelButton';
 import { AddGroupButton } from '../AddGroupButton';
@@ -32,7 +32,7 @@ export interface DashboardToolbarProps {
   isReadonly: boolean;
   onEditButtonClick: () => void;
   onCancelButtonClick: () => void;
-  onSave?: (dashboard: DashboardResource) => Promise<unknown>;
+  onSave?: OnSaveDashboard;
 }
 
 export const DashboardToolbar = (props: DashboardToolbarProps) => {

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -13,8 +13,7 @@
 
 import { Typography, Stack, Button, Box, useTheme, useMediaQuery, Alert } from '@mui/material';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
-import { DashboardResource } from '@perses-dev/core';
-import { useEditMode } from '../../context';
+import { OnSaveDashboard, useEditMode } from '../../context';
 import { AddPanelButton } from '../AddPanelButton';
 import { AddGroupButton } from '../AddGroupButton';
 import { DownloadButton } from '../DownloadButton';
@@ -32,7 +31,7 @@ export interface DashboardToolbarProps {
   isReadonly: boolean;
   onEditButtonClick: () => void;
   onCancelButtonClick: () => void;
-  onSave?: (entity: DashboardResource) => Promise<DashboardResource>;
+  onSave?: OnSaveDashboard;
 }
 
 export const DashboardToolbar = (props: DashboardToolbarProps) => {

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -12,8 +12,9 @@
 // limitations under the License.
 
 import { Typography, Stack, Button, Box, useTheme, useMediaQuery, Alert } from '@mui/material';
+import { DashboardResource } from '@perses-dev/core';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
-import { OnSaveDashboard, useEditMode } from '../../context';
+import { useEditMode } from '../../context';
 import { AddPanelButton } from '../AddPanelButton';
 import { AddGroupButton } from '../AddGroupButton';
 import { DownloadButton } from '../DownloadButton';
@@ -31,7 +32,7 @@ export interface DashboardToolbarProps {
   isReadonly: boolean;
   onEditButtonClick: () => void;
   onCancelButtonClick: () => void;
-  onSave?: OnSaveDashboard;
+  onSave?: (dashboard: DashboardResource) => Promise<unknown>;
 }
 
 export const DashboardToolbar = (props: DashboardToolbarProps) => {

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -13,9 +13,15 @@
 
 import { useState } from 'react';
 import { Button, ButtonProps } from '@mui/material';
-import { OnSaveDashboard, isRelativeTimeRange } from '@perses-dev/core';
+import { isRelativeTimeRange } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
-import { useDashboard, useEditMode, useSaveChangesConfirmationDialog, useTemplateVariableActions } from '../../context';
+import {
+  OnSaveDashboard,
+  useDashboard,
+  useEditMode,
+  useSaveChangesConfirmationDialog,
+  useTemplateVariableActions,
+} from '../../context';
 
 export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'> {
   onSave?: OnSaveDashboard;

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -14,18 +14,13 @@
 import { useState } from 'react';
 import { Button, ButtonProps } from '@mui/material';
 import { useSnackbar } from '@perses-dev/components';
-import { isRelativeTimeRange } from '@perses-dev/core';
+import { DashboardResource, isRelativeTimeRange } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
-import {
-  OnSaveDashboard,
-  useDashboard,
-  useEditMode,
-  useSaveChangesConfirmationDialog,
-  useTemplateVariableActions,
-} from '../../context';
+import { useDashboard, useEditMode, useSaveChangesConfirmationDialog, useTemplateVariableActions } from '../../context';
 
 export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'> {
-  onSave?: OnSaveDashboard;
+  onSave?: (dashboard: DashboardResource) => Promise<unknown>;
+  onUnsavedChanges?: () => void;
   isDisabled: boolean;
   variant?: 'contained' | 'text' | 'outlined';
 }

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -14,12 +14,12 @@
 import { useState } from 'react';
 import { Button, ButtonProps } from '@mui/material';
 import { useSnackbar } from '@perses-dev/components';
-import { DashboardResource, isRelativeTimeRange } from '@perses-dev/core';
+import { OnSaveDashboard, isRelativeTimeRange } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { useDashboard, useEditMode, useSaveChangesConfirmationDialog, useTemplateVariableActions } from '../../context';
 
 export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'> {
-  onSave?: (dashboard: DashboardResource) => Promise<unknown>;
+  onSave?: OnSaveDashboard;
   onUnsavedChanges?: () => void;
   isDisabled: boolean;
   variant?: 'contained' | 'text' | 'outlined';

--- a/ui/dashboards/src/context/DashboardProvider/common.ts
+++ b/ui/dashboards/src/context/DashboardProvider/common.ts
@@ -11,7 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PanelDefinition, UnknownSpec } from '@perses-dev/core';
+import { DashboardResource, PanelDefinition, UnknownSpec } from '@perses-dev/core';
+
+export type OnSaveDashboard = (dashboard: DashboardResource) => Promise<unknown>;
 
 /**
  * The middleware applied to the DashboardStore (can be used as generic argument in StateCreator).

--- a/ui/dashboards/src/context/DashboardProvider/common.ts
+++ b/ui/dashboards/src/context/DashboardProvider/common.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DashboardResource, PanelDefinition, UnknownSpec } from '@perses-dev/core';
+import { PanelDefinition, UnknownSpec } from '@perses-dev/core';
 
 /**
  * The middleware applied to the DashboardStore (can be used as generic argument in StateCreator).
@@ -50,9 +50,3 @@ export function createPanelDefinition(defaultPanelKind?: string, defaultPanelSpe
     },
   };
 }
-
-export type OnSaveDashboardRest = (dashboard: DashboardResource) => Promise<DashboardResource>;
-
-export type OnSaveDashboardGql = (dashboard: DashboardResource) => Promise<void>;
-
-export type OnSaveDashboard = OnSaveDashboardRest | OnSaveDashboardGql;

--- a/ui/dashboards/src/context/DashboardProvider/common.ts
+++ b/ui/dashboards/src/context/DashboardProvider/common.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PanelDefinition, UnknownSpec } from '@perses-dev/core';
+import { DashboardResource, PanelDefinition, UnknownSpec } from '@perses-dev/core';
 
 /**
  * The middleware applied to the DashboardStore (can be used as generic argument in StateCreator).
@@ -50,3 +50,9 @@ export function createPanelDefinition(defaultPanelKind?: string, defaultPanelSpe
     },
   };
 }
+
+export type OnSaveDashboardRest = (dashboard: DashboardResource) => Promise<DashboardResource>;
+
+export type OnSaveDashboardGql = (dashboard: DashboardResource) => Promise<void>;
+
+export type OnSaveDashboard = OnSaveDashboardRest | OnSaveDashboardGql;

--- a/ui/dashboards/src/context/DashboardProvider/index.ts
+++ b/ui/dashboards/src/context/DashboardProvider/index.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export * from './common';
 export * from './dashboard-provider-api';
 export * from './DashboardProvider';
 export type {

--- a/ui/dashboards/src/context/DashboardProvider/index.ts
+++ b/ui/dashboards/src/context/DashboardProvider/index.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './common';
 export * from './dashboard-provider-api';
 export * from './DashboardProvider';
 export type {

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -14,7 +14,7 @@
 import { useState } from 'react';
 import { Box } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { DashboardResource, OnSaveDashboard } from '@perses-dev/core';
+import { DashboardResource } from '@perses-dev/core';
 import {
   PanelDrawer,
   Dashboard,
@@ -27,7 +27,7 @@ import {
   EditJsonDialog,
   SaveChangesConfirmationDialog,
 } from '../../components';
-import { useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '../../context';
+import { OnSaveDashboard, useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '../../context';
 
 export interface DashboardAppProps {
   emptyDashboardProps?: Partial<EmptyDashboardProps>;

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -27,14 +27,14 @@ import {
   EditJsonDialog,
   SaveChangesConfirmationDialog,
 } from '../../components';
-import { useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '../../context';
+import { OnSaveDashboard, useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '../../context';
 
 export interface DashboardAppProps {
   emptyDashboardProps?: Partial<EmptyDashboardProps>;
   dashboardResource: DashboardResource;
   dashboardTitleComponent?: JSX.Element;
 
-  onSave?: (entity: DashboardResource) => Promise<DashboardResource>;
+  onSave?: OnSaveDashboard;
   onDiscard?: (entity: DashboardResource) => void;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -14,7 +14,7 @@
 import { useState } from 'react';
 import { Box } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { DashboardResource } from '@perses-dev/core';
+import { DashboardResource, OnSaveDashboard } from '@perses-dev/core';
 import {
   PanelDrawer,
   Dashboard,
@@ -33,8 +33,7 @@ export interface DashboardAppProps {
   emptyDashboardProps?: Partial<EmptyDashboardProps>;
   dashboardResource: DashboardResource;
   dashboardTitleComponent?: JSX.Element;
-
-  onSave?: (dashboard: DashboardResource) => Promise<unknown>;
+  onSave?: OnSaveDashboard;
   onDiscard?: (entity: DashboardResource) => void;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -27,14 +27,14 @@ import {
   EditJsonDialog,
   SaveChangesConfirmationDialog,
 } from '../../components';
-import { OnSaveDashboard, useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '../../context';
+import { useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '../../context';
 
 export interface DashboardAppProps {
   emptyDashboardProps?: Partial<EmptyDashboardProps>;
   dashboardResource: DashboardResource;
   dashboardTitleComponent?: JSX.Element;
 
-  onSave?: OnSaveDashboard;
+  onSave?: (dashboard: DashboardResource) => Promise<unknown>;
   onDiscard?: (entity: DashboardResource) => void;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;


### PR DESCRIPTION
Not all embed users implement saving dashboards using REST, this type change will allow `SaveDashboardButton` to be used in cases where our consumers use GraphQL
