### PR TITLE
[IGNORE] StatChart add threshold e2e fix

### DIFF
--- a/ui/e2e/src/tests/statChartPanel.spec.ts
+++ b/ui/e2e/src/tests/statChartPanel.spec.ts
@@ -47,25 +47,24 @@ test.describe('Dashboard: Stat Chart Panel', () => {
   });
 
   test('should be able to add and edit threshold', async ({ page, dashboardPage, mockNow }) => {
+    await mockStatChartQueryRangeRequest(dashboardPage, mockNow);
+    await dashboardPage.startEditing();
+    await dashboardPage.editPanel('Simple Stat', async (panelEditor) => {
+      await panelEditor.selectTab('Settings');
+      await panelEditor.addThreshold();
+      await panelEditor.editThreshold('T1', '5');
+      await panelEditor.openThresholdColorPicker('T1');
+      const colorPicker = dashboardPage.page.getByTestId('threshold color picker');
+      await colorPicker.isVisible();
+      const colorInput = colorPicker.getByRole('textbox', { name: 'enter hex color' });
+      await colorInput.clear();
+      await colorInput.type('ed6bd4', { delay: 100 });
+      await page.keyboard.press('Escape');
+    });
+    const panel = dashboardPage.getPanelByName('Simple Stat');
+    await panel.isLoaded();
+    await waitForStableCanvas(panel.canvas);
     await dashboardPage.forEachTheme(async (themeName) => {
-      await mockStatChartQueryRangeRequest(dashboardPage, mockNow);
-      await dashboardPage.startEditing();
-      await dashboardPage.editPanel('Simple Stat', async (panelEditor) => {
-        await panelEditor.selectTab('Settings');
-        await panelEditor.addThreshold();
-        await panelEditor.editThreshold('T1', '5');
-        await panelEditor.openThresholdColorPicker('T1');
-        const colorPicker = dashboardPage.page.getByTestId('threshold color picker');
-        await colorPicker.isVisible();
-        const colorInput = colorPicker.getByRole('textbox', { name: 'enter hex color' });
-        await colorInput.clear();
-        await colorInput.type('ed6bd4', { delay: 100 });
-        await page.keyboard.press('Escape');
-      });
-      const panel = dashboardPage.getPanelByName('Simple Stat');
-      await panel.isLoaded();
-      await waitForStableCanvas(panel.canvas);
-
       await happoPlaywright.screenshot(page, panel.parent, {
         component: 'Stat Chart Panel',
         variant: `Single Stat with Threshold [${themeName}]`,


### PR DESCRIPTION
Follow up to #1198 (see issue #1173) to fix unrelated e2e failures

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
