### PR TITLE
[BUGFIX] Saving defaults error adjustments and account for Empty StaticListVariable

### DIFF
--- a/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelDrawer.test.tsx
@@ -14,6 +14,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
+import { TimeRangeProvider } from '@perses-dev/plugin-system';
 import { createDashboardProviderSpy, getTestDashboard, renderWithContext } from '../../test';
 import { DashboardProvider } from '../../context/DashboardProvider';
 import { PanelDrawer } from './PanelDrawer';
@@ -24,8 +25,10 @@ describe('Panel Drawer', () => {
 
     renderWithContext(
       <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
-        <DashboardProviderSpy />
-        <PanelDrawer />
+        <TimeRangeProvider initialTimeRange={{ pastDuration: '30m' }}>
+          <DashboardProviderSpy />
+          <PanelDrawer />
+        </TimeRangeProvider>
       </DashboardProvider>
     );
 

--- a/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
@@ -16,11 +16,14 @@ import { Checkbox, FormGroup, FormControlLabel, Typography } from '@mui/material
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { isRelativeTimeRange, SAVE_DEFAULTS_DIALOG_TEXT } from '@perses-dev/core';
 import { Dialog } from '@perses-dev/components';
-import { useSaveChangesConfirmationDialog } from '../../context';
+import { useSaveChangesConfirmationDialog, useTemplateVariableActions } from '../../context';
 
 export const SaveChangesConfirmationDialog = () => {
   const [saveDefaultTimeRange, setSaveDefaultTimeRange] = useState(true);
   const [saveDefaultVariables, setSaveDefaultVariables] = useState(true);
+
+  const { getSavedVariablesStatus } = useTemplateVariableActions();
+  const { isSavedVariableModified, modifiedVariableNames } = getSavedVariablesStatus();
 
   const { saveChangesConfirmationDialog: dialog } = useSaveChangesConfirmationDialog();
   const isOpen = dialog !== undefined;
@@ -30,7 +33,11 @@ export const SaveChangesConfirmationDialog = () => {
     ? `(Last ${timeRange.pastDuration})`
     : '(Absolute time ranges can not be saved)';
 
-  const timeRangeInfoText = `Save current time range as new default ${currentTimeRangeText}`;
+  const saveTimeRangeText = `Save current time range as new default ${currentTimeRangeText}`;
+
+  const saveVariablesText = `Save current variable values as new default (${
+    modifiedVariableNames.length > 0 ? modifiedVariableNames.join(', ') : 'No modified variables'
+  })`;
 
   return (
     <Dialog open={isOpen}>
@@ -49,16 +56,17 @@ export const SaveChangesConfirmationDialog = () => {
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSaveDefaultTimeRange(e.target.checked)}
                   />
                 }
-                label={timeRangeInfoText}
+                label={saveTimeRangeText}
               />
               <FormControlLabel
                 control={
                   <Checkbox
+                    disabled={!isSavedVariableModified}
                     checked={saveDefaultVariables}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSaveDefaultVariables(e.target.checked)}
                   />
                 }
-                label="Save current variable values as new default."
+                label={saveVariablesText}
               />
             </FormGroup>
           </Dialog.Content>

--- a/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
@@ -62,7 +62,7 @@ export const SaveChangesConfirmationDialog = () => {
                 control={
                   <Checkbox
                     disabled={!isSavedVariableModified}
-                    checked={saveDefaultVariables}
+                    checked={saveDefaultVariables && isSavedVariableModified}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSaveDefaultVariables(e.target.checked)}
                   />
                 }

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -31,7 +31,7 @@ export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'>
 
 export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' }: SaveDashboardButtonProps) => {
   const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
-  const { dashboard, setDashboard } = useDashboard();
+  const { dashboard } = useDashboard();
   const { getSavedVariablesStatus, setVariableDefaultValues } = useTemplateVariableActions();
   const { isSavedVariableModified } = getSavedVariablesStatus();
   const { timeRange } = useTimeRange();
@@ -71,7 +71,6 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
         await onSave(dashboard);
         closeSaveChangesConfirmationDialog();
         setEditMode(false);
-        setDashboard(dashboard);
       } catch (error) {
         throw new Error(`An error occurred while saving the dashboard. ${error}`);
       } finally {

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -13,6 +13,7 @@
 
 import { useState } from 'react';
 import { Button, ButtonProps } from '@mui/material';
+import { useSnackbar } from '@perses-dev/components';
 import { isRelativeTimeRange } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import {
@@ -32,6 +33,7 @@ export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'>
 export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' }: SaveDashboardButtonProps) => {
   const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
   const { dashboard } = useDashboard();
+  const { exceptionSnackbar } = useSnackbar();
   const { getSavedVariablesStatus, setVariableDefaultValues } = useTemplateVariableActions();
   const isSavedVariableModified = getSavedVariablesStatus();
   const { timeRange } = useTimeRange();
@@ -64,18 +66,18 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
     }
   };
 
-  const saveDashboard = () => {
-    if (onSave !== undefined) {
-      setSavingDashboard(true);
-      onSave(dashboard)
-        .then(() => {
-          setSavingDashboard(false);
-          closeSaveChangesConfirmationDialog();
-          setEditMode(false);
-        })
-        .catch(() => {
-          setSavingDashboard(false);
-        });
+  const saveDashboard = async () => {
+    if (onSave) {
+      try {
+        setSavingDashboard(true);
+        await onSave(dashboard);
+        setSavingDashboard(false);
+        closeSaveChangesConfirmationDialog();
+        setEditMode(false);
+      } catch (error) {
+        setSavingDashboard(false);
+        exceptionSnackbar(error);
+      }
     } else {
       setEditMode(false);
     }

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -13,7 +13,6 @@
 
 import { useState } from 'react';
 import { Button, ButtonProps } from '@mui/material';
-import { useSnackbar } from '@perses-dev/components';
 import { isRelativeTimeRange } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import {
@@ -27,19 +26,12 @@ import {
 export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'> {
   onSave?: OnSaveDashboard;
   isDisabled: boolean;
-  showErrorSnackbar?: boolean;
   variant?: 'contained' | 'text' | 'outlined';
 }
 
-export const SaveDashboardButton = ({
-  onSave,
-  isDisabled,
-  showErrorSnackbar = false,
-  variant = 'contained',
-}: SaveDashboardButtonProps) => {
+export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' }: SaveDashboardButtonProps) => {
   const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
   const { dashboard } = useDashboard();
-  const { exceptionSnackbar } = useSnackbar();
   const { getSavedVariablesStatus, setVariableDefaultValues } = useTemplateVariableActions();
   const isSavedVariableModified = getSavedVariablesStatus();
   const { timeRange } = useTimeRange();
@@ -82,9 +74,6 @@ export const SaveDashboardButton = ({
         setEditMode(false);
       } catch (error) {
         setSavingDashboard(false);
-        if (showErrorSnackbar) {
-          exceptionSnackbar(error);
-        }
       }
     } else {
       setEditMode(false);

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -27,10 +27,16 @@ import {
 export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'> {
   onSave?: OnSaveDashboard;
   isDisabled: boolean;
+  showErrorSnackbar?: boolean;
   variant?: 'contained' | 'text' | 'outlined';
 }
 
-export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' }: SaveDashboardButtonProps) => {
+export const SaveDashboardButton = ({
+  onSave,
+  isDisabled,
+  showErrorSnackbar = false,
+  variant = 'contained',
+}: SaveDashboardButtonProps) => {
   const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
   const { dashboard } = useDashboard();
   const { exceptionSnackbar } = useSnackbar();
@@ -76,7 +82,9 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
         setEditMode(false);
       } catch (error) {
         setSavingDashboard(false);
-        exceptionSnackbar(error);
+        if (showErrorSnackbar) {
+          exceptionSnackbar(error);
+        }
       }
     } else {
       setEditMode(false);

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -69,13 +69,13 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
       try {
         setSavingDashboard(true);
         await onSave(dashboard);
-        setSavingDashboard(false);
         closeSaveChangesConfirmationDialog();
         setEditMode(false);
         setDashboard(dashboard);
       } catch (error) {
-        setSavingDashboard(false);
         throw new Error(`An error occurred while saving the dashboard. ${error}`);
+      } finally {
+        setSavingDashboard(false);
       }
     } else {
       setEditMode(false);

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -74,6 +74,7 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
         setEditMode(false);
       } catch (error) {
         setSavingDashboard(false);
+        throw new Error(`An error occurred while saving the dashboard. ${error}`);
       }
     } else {
       setEditMode(false);

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -31,9 +31,9 @@ export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'>
 
 export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' }: SaveDashboardButtonProps) => {
   const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
-  const { dashboard } = useDashboard();
+  const { dashboard, setDashboard } = useDashboard();
   const { getSavedVariablesStatus, setVariableDefaultValues } = useTemplateVariableActions();
-  const isSavedVariableModified = getSavedVariablesStatus();
+  const { isSavedVariableModified } = getSavedVariablesStatus();
   const { timeRange } = useTimeRange();
   const { setEditMode } = useEditMode();
   const { openSaveChangesConfirmationDialog, closeSaveChangesConfirmationDialog } = useSaveChangesConfirmationDialog();
@@ -72,6 +72,7 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
         setSavingDashboard(false);
         closeSaveChangesConfirmationDialog();
         setEditMode(false);
+        setDashboard(dashboard);
       } catch (error) {
         setSavingDashboard(false);
         throw new Error(`An error occurred while saving the dashboard. ${error}`);

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -25,7 +25,7 @@ import {
   DEFAULT_ALL_VALUE as ALL_VALUE,
 } from '@perses-dev/plugin-system';
 import { VariableName, VariableValue, VariableDefinition } from '@perses-dev/core';
-import { isSavedVariableModified } from './utils';
+import { checkSavedDefaultVariableStatus } from './utils';
 import { hydrateTemplateVariableStates } from './hydrationUtils';
 import { useVariableQueryParams, getInitalValuesFromQueryParameters, getURLQueryParamName } from './query-params';
 
@@ -245,7 +245,7 @@ function createTemplateVariableSrvStore({ initialVariableDefinitions = [], query
           return updatedVariables;
         },
         getSavedVariablesStatus: () => {
-          return isSavedVariableModified(get().variableDefinitions, get().variableState);
+          return checkSavedDefaultVariableStatus(get().variableDefinitions, get().variableState);
         },
       }))
     )

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -37,7 +37,7 @@ type TemplateVariableStore = {
   setVariableLoading: (name: VariableName, loading: boolean) => void;
   setVariableDefinitions: (definitions: VariableDefinition[]) => void;
   setVariableDefaultValues: () => VariableDefinition[];
-  getSavedVariablesStatus: () => boolean;
+  getSavedVariablesStatus: () => { isSavedVariableModified: boolean; modifiedVariableNames: string[] };
 };
 
 const TemplateVariableStoreContext = createContext<ReturnType<typeof createTemplateVariableSrvStore> | undefined>(

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 import { VariableDefinition } from '@perses-dev/core';
-import { isSavedVariableModified } from './utils';
+import { checkSavedDefaultVariableStatus } from './utils';
 
-describe('isSavedVariableModified', () => {
+describe('checkSavedDefaultVariableStatus', () => {
   it('should check whether saved variable definitions are out of date with current default values state', () => {
     const savedVariables: VariableDefinition[] = [
       {
@@ -115,7 +115,8 @@ describe('isSavedVariableModified', () => {
         loading: false,
       },
     };
-    expect(isSavedVariableModified(savedVariables, variableState)).toBe(true);
+    const { isSavedVariableModified } = checkSavedDefaultVariableStatus(savedVariables, variableState);
+    expect(isSavedVariableModified).toBe(true);
   });
 
   it('should confirm list variable default value was not modified', () => {
@@ -153,7 +154,8 @@ describe('isSavedVariableModified', () => {
         ],
       },
     };
-    expect(isSavedVariableModified(savedVariables, variableState)).toBe(false);
+    const { isSavedVariableModified } = checkSavedDefaultVariableStatus(savedVariables, variableState);
+    expect(isSavedVariableModified).toBe(false);
   });
 
   it('should confirm null list variable was not modified', () => {
@@ -180,7 +182,8 @@ describe('isSavedVariableModified', () => {
         options: [],
       },
     };
-    expect(isSavedVariableModified(savedVariables, variableState)).toBe(false);
+    const { isSavedVariableModified } = checkSavedDefaultVariableStatus(savedVariables, variableState);
+    expect(isSavedVariableModified).toBe(false);
   });
 
   it('should confirm text variable value was not modified', () => {
@@ -203,7 +206,8 @@ describe('isSavedVariableModified', () => {
         loading: false,
       },
     };
-    expect(isSavedVariableModified(savedVariables, variableState)).toBe(false);
+    const { isSavedVariableModified } = checkSavedDefaultVariableStatus(savedVariables, variableState);
+    expect(isSavedVariableModified).toBe(false);
   });
 
   it('should confirm text variable value was modified', () => {
@@ -222,6 +226,7 @@ describe('isSavedVariableModified', () => {
         loading: false,
       },
     };
-    expect(isSavedVariableModified(savedVariables, variableState)).toBe(true);
+    const { isSavedVariableModified } = checkSavedDefaultVariableStatus(savedVariables, variableState);
+    expect(isSavedVariableModified).toBe(true);
   });
 });

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
@@ -156,6 +156,33 @@ describe('isSavedVariableModified', () => {
     expect(isSavedVariableModified(savedVariables, variableState)).toBe(false);
   });
 
+  it('should confirm null list variable was not modified', () => {
+    const savedVariables: VariableDefinition[] = [
+      {
+        kind: 'ListVariable',
+        spec: {
+          allow_all_value: false,
+          allow_multiple: false,
+          plugin: {
+            kind: 'StaticListVariable',
+            spec: {
+              values: [],
+            },
+          },
+          name: 'EmptyListVariableTest',
+        },
+      },
+    ];
+    const variableState = {
+      EmptyListVariableTest: {
+        value: null,
+        loading: false,
+        options: [],
+      },
+    };
+    expect(isSavedVariableModified(savedVariables, variableState)).toBe(false);
+  });
+
   it('should confirm text variable value was not modified', () => {
     const savedVariables: VariableDefinition[] = [
       {

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
@@ -21,7 +21,7 @@ export function isSavedVariableModified(definitions: VariableDefinition[], varSt
   for (const savedVariable of definitions) {
     if (savedVariable.kind === 'ListVariable') {
       const currentVariable = varState[savedVariable.spec.name];
-      if (savedVariable.spec.default_value !== currentVariable?.value) {
+      if (currentVariable?.value !== null && currentVariable?.value !== savedVariable.spec.default_value) {
         return true;
       }
     } else if (savedVariable.kind === 'TextVariable') {

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
@@ -18,19 +18,23 @@ import { VariableStateMap } from '@perses-dev/plugin-system';
  * Check whether saved variable definitions are out of date with current default list values in Zustand store
  */
 export function isSavedVariableModified(definitions: VariableDefinition[], varState: VariableStateMap) {
+  let isSavedVariableModified = false;
+  const modifiedVariableNames: string[] = [];
   for (const savedVariable of definitions) {
     if (savedVariable.kind === 'ListVariable') {
       const currentVariable = varState[savedVariable.spec.name];
       if (currentVariable?.value !== null && currentVariable?.value !== savedVariable.spec.default_value) {
-        return true;
+        modifiedVariableNames.push(savedVariable.spec.name);
+        isSavedVariableModified = true;
       }
     } else if (savedVariable.kind === 'TextVariable') {
       const currentVariable = varState[savedVariable.spec.name];
       const currentVariableValue = typeof currentVariable?.value === 'string' ? currentVariable.value : '';
       if (savedVariable.spec.value !== currentVariableValue) {
-        return true;
+        modifiedVariableNames.push(savedVariable.spec.name);
+        isSavedVariableModified = true;
       }
     }
   }
-  return false;
+  return { isSavedVariableModified, modifiedVariableNames };
 }

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
@@ -17,7 +17,7 @@ import { VariableStateMap } from '@perses-dev/plugin-system';
 /*
  * Check whether saved variable definitions are out of date with current default list values in Zustand store
  */
-export function isSavedVariableModified(definitions: VariableDefinition[], varState: VariableStateMap) {
+export function checkSavedDefaultVariableStatus(definitions: VariableDefinition[], varState: VariableStateMap) {
   let isSavedVariableModified = false;
   const modifiedVariableNames: string[] = [];
   for (const savedVariable of definitions) {

--- a/ui/dashboards/src/test/render.tsx
+++ b/ui/dashboards/src/test/render.tsx
@@ -18,7 +18,7 @@ import { createMemoryHistory, MemoryHistory } from 'history';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ChartsThemeProvider, testChartsTheme } from '@perses-dev/components';
+import { ChartsThemeProvider, SnackbarProvider, testChartsTheme } from '@perses-dev/components';
 import { mockPluginRegistry, PluginRegistry } from '@perses-dev/plugin-system';
 import { MOCK_PLUGINS } from './plugin-registry';
 
@@ -63,9 +63,11 @@ export function renderWithContext(
     <CustomRouter history={customHistory}>
       <QueryClientProvider client={queryClient}>
         <QueryParamProvider adapter={ReactRouter6Adapter}>
-          <ChartsThemeProvider chartsTheme={testChartsTheme}>
-            <PluginRegistry {...mockPluginRegistry(...MOCK_PLUGINS)}>{ui}</PluginRegistry>
-          </ChartsThemeProvider>
+          <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
+            <ChartsThemeProvider chartsTheme={testChartsTheme}>
+              <PluginRegistry {...mockPluginRegistry(...MOCK_PLUGINS)}>{ui}</PluginRegistry>
+            </ChartsThemeProvider>
+          </SnackbarProvider>
         </QueryParamProvider>
       </QueryClientProvider>
     </CustomRouter>

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.stories.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.stories.tsx
@@ -16,12 +16,12 @@ import { Button } from '@mui/material';
 import { ViewDashboard } from '@perses-dev/dashboards';
 import { action } from '@storybook/addon-actions';
 import { WithPluginRegistry } from '@perses-dev/plugin-system/src/stories/shared-utils';
-import { WithQueryClient, WithQueryParams } from '@perses-dev/storybook';
+import { WithErrorSnackbar, WithQueryClient, WithQueryParams } from '@perses-dev/storybook';
 import { WithDashboard } from '../../stories/decorators';
 
 const meta: Meta<typeof ViewDashboard> = {
   component: ViewDashboard,
-  decorators: [WithDashboard, WithQueryParams, WithPluginRegistry, WithQueryClient],
+  decorators: [WithDashboard, WithErrorSnackbar, WithQueryParams, WithPluginRegistry, WithQueryClient],
   parameters: {
     // Overriding the default on* regex for actions becaues we expose a LOT
     // of these by exposing the MUI BoxProps, and it was making the storybook

--- a/ui/e2e/src/tests/variables.spec.ts
+++ b/ui/e2e/src/tests/variables.spec.ts
@@ -63,8 +63,6 @@ test.describe('Dashboard: Variables', () => {
     // TODO: add helper for saving and confirming in defaults dialog
     const toolbarSaveButton = await dashboardPage.page.getByRole('button', { name: 'Save' });
     await toolbarSaveButton.click();
-    const dialogSaveButton = await dashboardPage.page.getByRole('button', { name: 'Save Changes' });
-    await dialogSaveButton.click();
 
     await expect(dashboardPage.variableListItems).toHaveCount(1);
     await expect(dashboardPage.variableListItems).toContainText([/List Var/]);

--- a/ui/storybook/src/decorators/WithErrorSnackbar.tsx
+++ b/ui/storybook/src/decorators/WithErrorSnackbar.tsx
@@ -11,6 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './WithErrorSnackbar';
-export * from './WithQueryClient';
-export * from './WithQueryParams';
+import { StoryFn } from '@storybook/react';
+import { SnackbarProvider } from '@perses-dev/components';
+
+export const WithErrorSnackbar = (Story: StoryFn) => {
+  return (
+    <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
+      <Story />
+    </SnackbarProvider>
+  );
+};


### PR DESCRIPTION
## Summary

- Fixes issue where empty StaticListVariable was triggering save default dialog unnecessarily
- Refactor error handling in SaveDashboardButton and change to async await
- RTL test setup adjustments to include SnackbarProvider
- Reduce Jest warnings in dashboards package by adding TimeRangeProvider in PanelDrawer.test.tsx (still a decent number of warnings though)