### PR TITLE
[IGNORE] upgrade and fix typedoc generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,29 +79,24 @@ jobs:
           name: storybook
           path: ui/storybook/storybook-static
   
-  # Temporarily disabling the typedoc run in CI because it is causing OOM
-  # errors. There also appear to be some other issues with typedoc that need
-  # addressing (error on a potentialy valid typing that is fine when running
-  # type-check, breaking changes in the latest minor release we need to handle).
-  # TODO: uncomment and re-enable this when those issues are addressed.
-  # build-typedoc:
-  #   name: "build-typedoc"
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - uses: ./.github/actions/setup_environment
-  #       with:
-  #         enable_npm: true
-  #     - name: Install UI deps
-  #       run: cd ./ui && npm install
-  #     - name: Build the typedoc docs
-  #       run: cd ./ui && npm run build && npm run typedoc
-  #     - name: store typedoc build
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: typedoc
-  #         path: ui/typedoc
+  build-typedoc:
+    name: "build-typedoc"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_environment
+        with:
+          enable_npm: true
+      - name: Install UI deps
+        run: cd ./ui && npm install
+      - name: Build the typedoc docs
+        run: cd ./ui && npm run build && npm run typedoc
+      - name: store typedoc build
+        uses: actions/upload-artifact@v3
+        with:
+          name: typedoc
+          path: ui/typedoc
   
   libs-release:
     name: "libs-release"

--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -60,8 +60,5 @@
   },
   "files": [
     "dist"
-  ],
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
-  }
+  ]
 }

--- a/ui/components/typedoc.json
+++ b/ui/components/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -42,8 +42,5 @@
   },
   "files": [
     "dist"
-  ],
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
-  }
+  ]
 }

--- a/ui/core/typedoc.json
+++ b/ui/core/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -57,8 +57,5 @@
   },
   "files": [
     "dist"
-  ],
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
-  }
+  ]
 }

--- a/ui/dashboards/typedoc.json
+++ b/ui/dashboards/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -52,7 +52,7 @@
         "rimraf": "^3.0.2",
         "swc-loader": "^0.2.3",
         "turbo": "^1.7.0",
-        "typedoc": "^0.23.28",
+        "typedoc": "^0.24.8",
         "typescript": "^4.7.4",
         "wait-on": "^7.0.1"
       }
@@ -19563,9 +19563,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -25245,14 +25245,14 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "bin": {
@@ -25262,7 +25262,7 @@
         "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -25275,15 +25275,15 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -41230,9 +41230,9 @@
       "requires": {}
     },
     "marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "mathjs": {
       "version": "10.6.4",
@@ -45461,14 +45461,14 @@
       }
     },
     "typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "dependencies": {
@@ -45482,9 +45482,9 @@
           }
         },
         "minimatch": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-          "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+          "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.2",
     "swc-loader": "^0.2.3",
     "turbo": "^1.7.0",
-    "typedoc": "^0.23.28",
+    "typedoc": "^0.24.8",
     "typescript": "^4.7.4",
     "wait-on": "^7.0.1"
   }

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -54,8 +54,5 @@
     "@types/color-hash": "^1.0.2",
     "@types/dompurify": "^2.3.4",
     "@types/marked": "^4.0.7"
-  },
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
   }
 }

--- a/ui/panels-plugin/typedoc.json
+++ b/ui/panels-plugin/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -45,8 +45,5 @@
   },
   "files": [
     "dist"
-  ],
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
-  }
+  ]
 }

--- a/ui/plugin-system/typedoc.json
+++ b/ui/plugin-system/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -45,8 +45,5 @@
   "files": [
     "dist",
     "plugin.json"
-  ],
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
-  }
+  ]
 }

--- a/ui/prometheus-plugin/typedoc.json
+++ b/ui/prometheus-plugin/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/ui/typedoc.base.json
+++ b/ui/typedoc.base.json
@@ -1,0 +1,3 @@
+{
+  "includeVersion": true
+}

--- a/ui/typedoc.json
+++ b/ui/typedoc.json
@@ -1,7 +1,12 @@
 {
   "entryPointStrategy": "packages",
   "entryPoints": [
-    "."
+    "components",
+    "core",
+    "dashboards",
+    "panels-plugin",
+    "plugin-system",
+    "prometheus-plugin"
   ],
   "out": "typedoc"
 }


### PR DESCRIPTION
This commit:
- Upgrades typedoc to the latest release. I think they've fixed some of the issues that may have led to the OOM errors we saw before, but we'll need to keep an eye on it.
- Handles some breaking changes in the latest typedoc release related to generating docs for monorepos.
- Re-enables typedoc generation in CI.

Fixes https://github.com/perses/perses/issues/1200.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

# Screenshots

Typedoc assets again available after the CI run, which did not throw any memory errors.
<img width="634" alt="image" src="https://github.com/perses/perses/assets/396962/44cab95c-9b6f-451d-8eab-d8384ea1b9f9">

Examples of what the docs look like now. They've changed the layout a little, but it's still very similar.
<img width="1220" alt="image" src="https://github.com/perses/perses/assets/396962/e6c7fefc-e333-495e-bae9-6b50ad836f3c">
<img width="1220" alt="image" src="https://github.com/perses/perses/assets/396962/c292db57-73fe-4dba-8d46-47966287c29b">

