### PR TITLE
[BREAKINGCHANGE] Adjust MUI bg tokens to simplify theming

### DIFF
--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -24,8 +24,7 @@ function App() {
         display: 'flex',
         flexDirection: 'column',
         minHeight: '100vh',
-        backgroundColor: ({ palette }) =>
-          palette.mode === 'dark' ? palette.background.default : palette.background.paper,
+        backgroundColor: ({ palette }) => palette.background.default,
       }}
     >
       <Header />

--- a/ui/components/src/theme/component-overrides/paper.ts
+++ b/ui/components/src/theme/component-overrides/paper.ts
@@ -1,0 +1,9 @@
+import { Components, Theme } from '@mui/material';
+
+export const MuiPaper: Components<Theme>['MuiPaper'] = {
+  styleOverrides: {
+    root: ({ theme }) => ({
+      backgroundColor: theme.palette.background.default,
+    }),
+  },
+};

--- a/ui/components/src/theme/palette/background.ts
+++ b/ui/components/src/theme/palette/background.ts
@@ -21,8 +21,8 @@ export const background = (mode: PaletteMode): PaletteOptions['background'] => {
     ? {
         navigation,
         overlay,
-        default: grey[50],
-        paper: white,
+        default: white,
+        paper: grey[50],
         tooltip: grey[100],
         border: grey[100],
       }

--- a/ui/components/src/theme/theme.ts
+++ b/ui/components/src/theme/theme.ts
@@ -13,6 +13,7 @@
 
 import { createTheme, PaletteMode, ThemeOptions, Theme } from '@mui/material';
 import { MuiAlert } from './component-overrides/alert';
+import { MuiPaper } from './component-overrides/paper';
 import { getPaletteOptions } from './palette/palette-options';
 import { typography } from './typography';
 
@@ -57,6 +58,7 @@ const components: ThemeOptions['components'] = {
       size: 'small',
     },
   },
+  MuiPaper,
   MuiTextField: {
     defaultProps: {
       size: 'small',

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -88,8 +88,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}
                 sx={{
-                  backgroundColor: ({ palette }) =>
-                    palette.mode === 'dark' ? palette.background.default : palette.background.paper,
+                  backgroundColor: ({ palette }) => palette.background.default,
                 }}
               />
             </ErrorBoundary>
@@ -135,8 +134,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}
                 sx={{
-                  backgroundColor: ({ palette }) =>
-                    palette.mode === 'dark' ? palette.background.default : palette.background.paper,
+                  backgroundColor: ({ palette }) => palette.background.default,
                 }}
               />
             </ErrorBoundary>

--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -54,8 +54,7 @@ export function GridTitle(props: GridTitleProps) {
         alignItems: 'center',
         padding: (theme) => theme.spacing(1),
         cursor: collapse ? 'pointer' : 'auto',
-        backgroundColor: ({ palette }) =>
-          palette.mode === 'dark' ? palette.background.paper : palette.background.default,
+        backgroundColor: ({ palette }) => palette.background.paper,
       }}
       data-testid="panel-group-header"
     >

--- a/ui/storybook/src/config/preview.ts
+++ b/ui/storybook/src/config/preview.ts
@@ -62,10 +62,10 @@ export const globalTypes = {
   bgColor: {
     name: 'Background',
     description: 'Background color',
-    defaultValue: 'paper',
+    defaultValue: 'default',
     toolbar: {
       icon: 'photo',
-      items: ['paper', 'default', 'overlay', 'navigation', 'tooltip'],
+      items: ['default', 'paper', 'overlay', 'navigation', 'tooltip'],
       // Change title based on selected value
       dynamicTitle: true,
     },


### PR DESCRIPTION
Prior to this change, chunks of the codebase would have to switch between `paper` and `default` depending on if the theme was in `light` or `dark` mode. After this change, consistent values can be used for each.

BREAKINGCHANGE: This change modifies the MUI theme design tokens for the `paper` and `default` background colors and some related components that use these tokens. Consumers may need to make some associated theming changes to handle this.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
