### PR TITLE
[BUGFIX] Fix save dashboard console warning and saved duration checkbox

### DIFF
--- a/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
@@ -19,13 +19,15 @@ import { Dialog } from '@perses-dev/components';
 import { useSaveChangesConfirmationDialog, useTemplateVariableActions } from '../../context';
 
 export const SaveChangesConfirmationDialog = () => {
-  const [saveDefaultTimeRange, setSaveDefaultTimeRange] = useState(true);
-  const [saveDefaultVariables, setSaveDefaultVariables] = useState(true);
+  const { saveChangesConfirmationDialog: dialog } = useSaveChangesConfirmationDialog();
+  const isSavedDurationModified = dialog?.isSavedDurationModified ?? true;
+  const isSavedVariableModified = dialog?.isSavedVariableModified ?? true;
+  const [saveDefaultTimeRange, setSaveDefaultTimeRange] = useState(isSavedDurationModified);
+  const [saveDefaultVariables, setSaveDefaultVariables] = useState(isSavedVariableModified);
 
   const { getSavedVariablesStatus } = useTemplateVariableActions();
-  const { isSavedVariableModified, modifiedVariableNames } = getSavedVariablesStatus();
+  const { modifiedVariableNames } = getSavedVariablesStatus();
 
-  const { saveChangesConfirmationDialog: dialog } = useSaveChangesConfirmationDialog();
   const isOpen = dialog !== undefined;
 
   const { timeRange } = useTimeRange();
@@ -51,8 +53,8 @@ export const SaveChangesConfirmationDialog = () => {
               <FormControlLabel
                 control={
                   <Checkbox
-                    disabled={!isRelativeTimeRange(timeRange)}
-                    checked={saveDefaultTimeRange && isRelativeTimeRange(timeRange)}
+                    disabled={!isSavedDurationModified || !isRelativeTimeRange(timeRange)}
+                    checked={saveDefaultTimeRange && isSavedDurationModified && isRelativeTimeRange(timeRange)}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSaveDefaultTimeRange(e.target.checked)}
                   />
                 }

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -74,7 +74,9 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
       } catch (error) {
         throw new Error(`An error occurred while saving the dashboard. ${error}`);
       } finally {
-        setSavingDashboard(false);
+        if (isSavingDashboard) {
+          setSavingDashboard(false);
+        }
       }
     } else {
       setEditMode(false);

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -31,7 +31,7 @@ export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'>
 
 export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' }: SaveDashboardButtonProps) => {
   const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
-  const { dashboard } = useDashboard();
+  const { dashboard, setDashboard } = useDashboard();
   const { getSavedVariablesStatus, setVariableDefaultValues } = useTemplateVariableActions();
   const { isSavedVariableModified } = getSavedVariablesStatus();
   const { timeRange } = useTimeRange();
@@ -53,11 +53,14 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
             const variables = setVariableDefaultValues();
             dashboard.spec.variables = variables;
           }
+          setDashboard(dashboard);
           saveDashboard();
         },
         onCancel: () => {
           closeSaveChangesConfirmationDialog();
         },
+        isSavedDurationModified,
+        isSavedVariableModified,
       });
     } else {
       saveDashboard();

--- a/ui/dashboards/src/context/DashboardProvider/save-changes-dialog-slice.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/save-changes-dialog-slice.tsx
@@ -23,6 +23,8 @@ export interface SaveChangesConfirmationDialogSlice {
 export interface SaveChangesConfirmationDialogState {
   onSaveChanges: (saveDefaultTimeRange: boolean, saveDefaultVariables: boolean) => void;
   onCancel: () => void;
+  isSavedDurationModified: boolean;
+  isSavedVariableModified: boolean;
   description?: string;
 }
 


### PR DESCRIPTION
## Overview

- Fix console warnings when saving using gql (these warnings were not shown in Perses app) 
- Disable saveDefaultTimeRange checkbox when saved default duration is not modified

## Screenshots
**After** isSavedDurationModified fix:
<img width="418" alt="image" src="https://github.com/perses/perses/assets/9369625/e3929704-b939-4303-8a50-2e709de17338">

**Before** console error fix:
![image](https://github.com/perses/perses/assets/9369625/60a06288-4a0a-4164-bee3-fcd6aa85f6b1)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
