### PR TITLE
[FEATURE] Shared crosshair for all time series panels on a dashboard

### DIFF
--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -128,6 +128,7 @@ export const EChart = React.memo(function EChart<T>({
   useLayoutEffect(() => {
     if (containerRef.current === null || chartElement.current !== null) return;
     chartElement.current = init(containerRef.current, theme, { renderer: renderer ?? 'canvas' });
+    if (chartElement.current === undefined) return;
     chartElement.current.setOption(initialOption.current, true);
     onChartInitialized?.(chartElement.current);
     if (_instance !== undefined) {
@@ -140,8 +141,8 @@ export const EChart = React.memo(function EChart<T>({
     };
   }, [_instance, onChartInitialized, theme, renderer]);
 
+  // When syncGroup is explicitly set, charts within same group share interactions such as crosshair
   useEffect(() => {
-    // When syncGroup is explicitly set, charts within same group share interactions such as crosshair
     if (!chartElement.current || !syncGroup) return;
     chartElement.current.group = syncGroup;
     connect([chartElement.current]); // more info: https://echarts.apache.org/en/api.html#echarts.connect

--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
-import { ECharts, EChartsCoreOption, init } from 'echarts/core';
+import { ECharts, EChartsCoreOption, init, connect } from 'echarts/core';
 import { Box, SxProps, Theme } from '@mui/material';
 import { isEqual, debounce } from 'lodash-es';
 import { EChartsTheme } from '../model';
@@ -127,6 +127,9 @@ export const EChart = React.memo(function EChart<T>({
     if (containerRef.current === null || chartElement.current !== null) return;
     chartElement.current = init(containerRef.current, theme, { renderer: renderer ?? 'canvas' });
     if (chartElement.current === undefined) return;
+    // https://echarts.apache.org/en/api.html#echarts.connect
+    chartElement.current.group = 'dashboard';
+    connect([chartElement.current]);
     chartElement.current.setOption(initialOption.current, true);
     onChartInitialized?.(chartElement.current);
     if (_instance !== undefined) {

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -75,6 +75,7 @@ export interface LineChartProps {
   legend?: LegendComponentOption;
   tooltipConfig?: TooltipConfig;
   noDataVariant?: 'chart' | 'message';
+  syncGroup?: string;
   onDataZoom?: (e: ZoomEventData) => void;
   onDoubleClick?: (e: MouseEvent) => void;
   __experimentalEChartsOptionsOverride?: (options: EChartsCoreOption) => EChartsCoreOption;
@@ -89,6 +90,7 @@ export function LineChart({
   legend,
   tooltipConfig = { wrapLabels: true },
   noDataVariant = 'message',
+  syncGroup,
   onDataZoom,
   onDoubleClick,
   __experimentalEChartsOptionsOverride,
@@ -291,6 +293,7 @@ export function LineChart({
         theme={chartsTheme.echartsTheme}
         onEvents={handleEvents}
         _instance={chartRef}
+        syncGroup={syncGroup}
       />
     </Box>
   );

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -129,6 +129,7 @@ export function checkforNearbySeries(
         type: 'highlight',
         seriesIndex: emphasizedSeriesIndexes,
         notBlur: false,
+        escapeConnect: true,
       });
     } else {
       // When no emphasized series with bold text, notBlur allows opacity fadeout to not trigger.
@@ -136,6 +137,7 @@ export function checkforNearbySeries(
         type: 'highlight',
         seriesIndex: nearbySeriesIndexes,
         notBlur: true,
+        escapeConnect: true,
       });
     }
   }

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -128,16 +128,16 @@ export function checkforNearbySeries(
       chart.dispatchAction({
         type: 'highlight',
         seriesIndex: emphasizedSeriesIndexes,
-        notBlur: false,
-        escapeConnect: true,
+        notBlur: false, // ensure blur IS triggered, this is default but setting so it is explicit
+        escapeConnect: true, // shared crosshair should not emphasize series on adjacent charts
       });
     } else {
       // When no emphasized series with bold text, notBlur allows opacity fadeout to not trigger.
       chart.dispatchAction({
         type: 'highlight',
         seriesIndex: nearbySeriesIndexes,
-        notBlur: true,
-        escapeConnect: true,
+        notBlur: true, // do not trigger blur state when cursor is not immediately close to any series
+        escapeConnect: true, // shared crosshair should not emphasize series on adjacent charts
       });
     }
   }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -292,6 +292,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
                 unit={unit}
                 grid={gridOverrides}
                 tooltipConfig={{ wrapLabels: true }}
+                syncGroup="default-panel-group"
                 onDataZoom={handleDataZoom}
                 //  Show an empty chart when there is no data because the user unselected all items in
                 // the legend. Otherwise, show a "no data" message.

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -292,7 +292,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
                 unit={unit}
                 grid={gridOverrides}
                 tooltipConfig={{ wrapLabels: true }}
-                syncGroup="default-panel-group"
+                syncGroup="default-panel-group" // TODO: make configurable from dashboard settings and per panel-group overrides
                 onDataZoom={handleDataZoom}
                 //  Show an empty chart when there is no data because the user unselected all items in
                 // the legend. Otherwise, show a "no data" message.


### PR DESCRIPTION
## Overview
Support shared crosshair for all charts on a dashboard. This is only on for panel use-cases where `syncGroup` is set explicitly. Embed users of LineChart.tsx or EChart.tsx will have to explicitly set a `syncGroup` to opt-in to this feature.

See ECharts docs:
- https://echarts.apache.org/en/api.html#echarts.connect

## Recording / Screenshots
https://github.com/perses/perses/assets/9369625/b9c46df3-2306-4521-990c-e3c31cdf31da

![image](https://github.com/perses/perses/assets/9369625/599168f3-e989-49fb-8483-f63f03adc8b5)
