### PR TITLE
[FEATURE] Resolve variables in prometheus legend formatter

### DIFF
--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
@@ -27,8 +27,12 @@ export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeri
     datasource: undefined,
   }),
   dependsOn: (spec) => {
+    // Variables can be used in the query and/or in the legend format string
+    const queryVariables = parseTemplateVariables(spec.query);
+    const legendVariables = parseTemplateVariables(spec.series_name_format || '');
+    const allVariables = [...new Set([...queryVariables, ...legendVariables])];
     return {
-      variables: parseTemplateVariables(spec.query),
+      variables: allVariables,
     };
   },
 };

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -51,6 +51,12 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   let query = spec.query.replace('$__rate_interval', `15s`);
   query = replaceTemplateVariables(query, context.variableState);
 
+  let seriesNameFormat = spec.series_name_format;
+  // if series name format is defined, replace template variable placeholders in series name format
+  if (seriesNameFormat) {
+    seriesNameFormat = replaceTemplateVariables(seriesNameFormat, context.variableState);
+  }
+
   // Get the datasource, using the default Prom Datasource if one isn't specified in the query
   const client: PrometheusClient = await context.datasourceStore.getDatasourceClient(spec.datasource ?? DEFAULT_PROM);
 
@@ -88,7 +94,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
       const { metric, values } = value;
 
       // Account for series_name_format from query editor when determining name to show in legend, tooltip, etc.
-      const { name, formattedName } = getFormattedPrometheusSeriesName(query, metric, spec.series_name_format);
+      const { name, formattedName } = getFormattedPrometheusSeriesName(query, metric, seriesNameFormat);
 
       return {
         name,

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -1,6 +1,9 @@
 import { TimeSeriesQueryContext } from '@perses-dev/plugin-system';
 import { PrometheusTimeSeriesQuery } from './';
 
+// TODO: This should be fixed globally in the test setup
+jest.mock('echarts/core');
+
 const stubTimeSeriesContext: TimeSeriesQueryContext = {
   datasourceStore: {
     getDatasource: jest.fn(),

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -79,9 +79,7 @@ describe('PrometheusTimeSeriesQuery', () => {
     expect(variables).toEqual(['job', 'instance', 'foo']);
   });
 
-  it('should replace variables in legend formatter', async () => {
-    if (!PrometheusTimeSeriesQuery.dependsOn) throw new Error('dependsOn is not defined');
-
+  it('should replace variables in series_name_format', async () => {
     const ctx = createStubContext();
     ctx.variableState = {
       foo: {

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { TimeSeriesQueryContext } from '@perses-dev/plugin-system';
 import { PrometheusTimeSeriesQuery } from './';
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -1,0 +1,30 @@
+import { TimeSeriesQueryContext } from '@perses-dev/plugin-system';
+import { PrometheusTimeSeriesQuery } from './';
+
+const stubTimeSeriesContext: TimeSeriesQueryContext = {
+  datasourceStore: {
+    getDatasource: jest.fn(),
+    getDatasourceClient: jest.fn(),
+    listDatasourceMetadata: jest.fn(),
+  },
+  refreshKey: 'test',
+  timeRange: {
+    end: new Date('01-01-2023'),
+    start: new Date('01-02-2023'),
+  },
+  variableState: {},
+};
+
+describe('PrometheusTimeSeriesQuery', () => {
+  it('should properly resolve variable dependencies', () => {
+    if (!PrometheusTimeSeriesQuery.dependsOn) throw new Error('dependsOn is not defined');
+    const { variables } = PrometheusTimeSeriesQuery.dependsOn(
+      {
+        query: 'sum(up{job="$job"}) by ($instance)',
+        series_name_format: `$foo - label`,
+      },
+      stubTimeSeriesContext
+    );
+    expect(variables).toEqual(['job', 'instance', 'foo']);
+  });
+});


### PR DESCRIPTION
Variables are now supported in the Prometheus legend formatter

<img width="909" alt="image" src="https://github.com/perses/perses/assets/6935733/5f5fa50d-f1e2-4383-9e8f-95172083305a">
<img width="1416" alt="image" src="https://github.com/perses/perses/assets/6935733/bbc0c717-d4cf-4df4-a933-77223f2dbd48">


<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
