### PR TITLE
[FEATURE] Respect custom all value in list variables

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -296,7 +296,25 @@ export function VariableEditForm(props: VariableEditFormProps) {
                   }
                   label="Allow All option"
                 />
-                <Typography variant="caption">Enables an option to include all variable values</Typography>
+                <Typography mb={1} variant="caption">
+                  Enables an option to include all variable values
+                </Typography>
+                {state.listVariableFields.allowAll && (
+                  <TextField
+                    label="Custom All Value"
+                    value={state.listVariableFields.customAllValue}
+                    onChange={(e) => {
+                      setState((draft) => {
+                        if (e.target.value) {
+                          draft.listVariableFields.customAllValue = e.target.value;
+                        } else {
+                          draft.listVariableFields.customAllValue = undefined;
+                        }
+                      });
+                    }}
+                    helperText="When All is selected, this value will be used"
+                  />
+                )}
               </Stack>
             </Stack>
           </>

--- a/ui/dashboards/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/dashboards/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -26,12 +26,14 @@ export function getInitialState(initialVariableDefinition: VariableDefinition) {
       kind: '',
       spec: {},
     },
+    customAllValue: undefined as string | undefined,
   };
   if (initialVariableDefinition.kind === 'ListVariable') {
     listVariableFields.allowMultiple = initialVariableDefinition.spec.allow_all_value ?? false;
     listVariableFields.allowAll = initialVariableDefinition.spec.allow_all_value ?? false;
     listVariableFields.capturing_regexp = initialVariableDefinition.spec.capturing_regexp;
     listVariableFields.plugin = initialVariableDefinition.spec.plugin;
+    listVariableFields.customAllValue = initialVariableDefinition.spec.custom_all_value;
   }
 
   return {
@@ -72,6 +74,7 @@ export function getVariableDefinitionFromState(state: VariableEditorState): Vari
         allow_all_value: state.listVariableFields.allowAll,
         capturing_regexp: state.listVariableFields.capturing_regexp,
         plugin: state.listVariableFields.plugin,
+        custom_all_value: state.listVariableFields.customAllValue,
       },
     };
   }


### PR DESCRIPTION
This fixes ListVariables to use `spec.custom_all_value` if present when the All value (`$__all`) is selected
Demo:
https://www.loom.com/share/8f87895829dc469f983f1d95cfeaba24
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
