### PR TITLE
[BUGFIX] Fix y axis label positioning

### DIFF
--- a/ui/components/src/YAxisLabel.tsx
+++ b/ui/components/src/YAxisLabel.tsx
@@ -25,7 +25,7 @@ export function YAxisLabel({ name, height }: YAxisLabelProps) {
         display: 'inline-block',
         maxWidth: height, // allows rotated text to truncate instead of causing overlap
         position: 'absolute',
-        top: '45%',
+        top: `calc(${height}px / 2)`,
         transform: 'translateX(-50%) rotate(-90deg)',
         transformOrigin: 'top',
         textAlign: 'center',


### PR DESCRIPTION
Fix positioning of y axis label so that it doesn't overlap with the legend.

Before:
<img width="864" alt="Screen Shot 2023-06-09 at 11 13 59 AM" src="https://github.com/perses/perses/assets/22085207/4401dadf-8110-432d-a5da-4ea46b3164be">

After:
<img width="862" alt="Screen Shot 2023-06-09 at 11 13 15 AM" src="https://github.com/perses/perses/assets/22085207/3f788e18-b845-44f3-8416-8c1beecceb6c">

https://github.com/perses/perses/assets/22085207/188ee3ee-f201-449c-9814-bd3f7ff846db

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.