### PR TITLE
[FEATURE]: SettingsAutocomplete component

### DIFF
--- a/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.stories.tsx
+++ b/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.stories.tsx
@@ -1,0 +1,232 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { SettingsAutocomplete, SettingsAutocompleteProps, SettingsAutocompleteOption } from '@perses-dev/components';
+import { action } from '@storybook/addon-actions';
+import { useState } from 'react';
+
+const meta: Meta<typeof SettingsAutocomplete> = {
+  component: SettingsAutocomplete,
+  argTypes: {},
+  args: {
+    onChange: (...args) => {
+      action('onChange')(...args);
+    },
+  },
+  parameters: {
+    // Overriding the default on* regex for actions becaues we expose a LOT
+    // of these by exposing the MUI BoxProps, and it was making the storybook
+    // and browser hang from the numerous actions happening when you interacted
+    // with the page.
+    actions: { argTypesRegex: '' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SettingsAutocomplete>;
+
+/**
+ * Include a `label` property on options to specify the text that will be
+ * displayed to the user for that option. If the `label` is not set, the
+ * required `id` property will be displayed.
+ */
+export const OptionWithLabel: Story = {
+  args: {
+    options: [
+      {
+        id: 'top',
+        label: 'Top',
+      },
+      {
+        id: 'right',
+        label: 'Right',
+      },
+      {
+        id: 'bottom',
+        label: 'Bottom',
+      },
+      {
+        id: 'left',
+        label: 'Left',
+      },
+    ],
+  },
+};
+
+/**
+ * Use the `value` prop to set the currently selected value (or values(s) when
+ * `multiple` is true) of the autocomplete. The value should use the same type
+ * as the `options`. Values are checked for equality with options using the
+ * required `id` value for options which should be a unique identifier.
+ */
+export const Value: StoryObj<SettingsAutocompleteProps<SettingsAutocompleteOption, false, false>> = {
+  args: {
+    value: {
+      id: 'top',
+      label: 'Top',
+    },
+    options: [
+      {
+        id: 'top',
+        label: 'Top',
+      },
+      {
+        id: 'right',
+        label: 'Right',
+      },
+      {
+        id: 'bottom',
+        label: 'Bottom',
+      },
+      {
+        id: 'left',
+        label: 'Left',
+      },
+    ],
+  },
+  render: (props) => {
+    // This rule doesn't understand storybook's `render` prop.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState<SettingsAutocompleteOption | null | undefined>(props.value);
+
+    return (
+      <SettingsAutocomplete
+        {...props}
+        value={value}
+        onChange={(event, value, ...otherArgs) => {
+          action('onChange')(event, value, ...otherArgs);
+          setValue(value);
+        }}
+      />
+    );
+  },
+};
+
+/**
+ * Include a `description` property on options to display additional context
+ * about the option below the label.
+ */
+export const OptionWithDescription: Story = {
+  args: {
+    options: [
+      {
+        id: 'min',
+        label: 'Min',
+        description: 'Minimum value.',
+      },
+      {
+        id: 'max',
+        label: 'Max',
+        description: 'Maximum value.',
+      },
+      {
+        id: 'mean',
+        label: 'Mean',
+        description: 'Average value.',
+      },
+    ],
+  },
+};
+
+export const SelectMultiple: StoryObj<SettingsAutocompleteProps<SettingsAutocompleteOption, true, false>> = {
+  args: {
+    options: [
+      {
+        id: 'first',
+        label: 'First',
+      },
+      {
+        id: 'last',
+        label: 'Last',
+      },
+      {
+        id: 'min',
+        label: 'Min',
+      },
+      {
+        id: 'max',
+        label: 'Max',
+      },
+    ],
+    value: [
+      {
+        id: 'last',
+        label: 'Last',
+      },
+    ],
+    multiple: true,
+  },
+  render: (props) => {
+    // This rule doesn't understand storybook's `render` prop.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState<SettingsAutocompleteOption[] | undefined>(props.value);
+
+    return (
+      <SettingsAutocomplete
+        {...props}
+        value={value}
+        onChange={(event, value, ...otherArgs) => {
+          action('onChange')(event, value, ...otherArgs);
+          setValue(value);
+        }}
+      />
+    );
+  },
+};
+
+interface GroupedStoryOption extends SettingsAutocompleteOption {
+  group: string;
+}
+
+/**
+ * Options can be grouped using the `groupBy` property.
+ */
+export const GroupedOptions: StoryObj<SettingsAutocompleteProps<GroupedStoryOption, false, false>> = {
+  args: {
+    groupBy: (option) => option.group,
+    options: [
+      {
+        id: 'apple',
+        label: 'Apple',
+        group: 'Fruit',
+      },
+      {
+        id: 'banana',
+        label: 'Banana',
+        group: 'Fruit',
+      },
+      {
+        id: 'orange',
+        label: 'Orange',
+        group: 'Fruit',
+      },
+      {
+        id: 'broccoli',
+        label: 'Broccoli',
+        group: 'Vegetable',
+      },
+      {
+        id: 'carrot',
+        label: 'Carrot',
+        group: 'Vegetable',
+      },
+      {
+        id: 'onion',
+        label: 'Onion',
+        group: 'Vegetable',
+      },
+    ],
+  },
+};

--- a/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.test.tsx
+++ b/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.test.tsx
@@ -1,0 +1,152 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { SettingsAutocomplete } from './SettingsAutocomplete';
+
+describe('SettingsAutocomplete', () => {
+  test('determines `isOptionEqualToValue` using `id` attr', () => {
+    const options = [
+      {
+        id: '1',
+        label: 'One',
+      },
+      {
+        id: '2',
+        label: 'Two',
+      },
+    ];
+    render(
+      <SettingsAutocomplete
+        options={options}
+        value={{
+          id: '2',
+          label: 'Two',
+        }}
+      />
+    );
+
+    const dropdown = screen.getByRole('combobox');
+    expect(dropdown).toHaveValue('Two');
+
+    userEvent.click(dropdown);
+
+    const dropdownOptions = screen.getAllByRole('option');
+    expect(dropdownOptions[0]).not.toHaveAttribute('aria-selected', 'true');
+    expect(dropdownOptions[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('options show the `label` prop when available', () => {
+    const options = [
+      {
+        id: '1',
+        label: 'One',
+      },
+    ];
+    render(<SettingsAutocomplete options={options} />);
+
+    const dropdown = screen.getByRole('combobox');
+    userEvent.click(dropdown);
+
+    expect(screen.getByRole('option')).toHaveTextContent('One');
+    expect(screen.getByRole('option')).not.toHaveTextContent('1');
+  });
+
+  test('options show the `id` prop when `label` is not set', () => {
+    const options = [
+      {
+        id: '2',
+      },
+    ];
+    render(<SettingsAutocomplete options={options} />);
+
+    const dropdown = screen.getByRole('combobox');
+    userEvent.click(dropdown);
+
+    expect(screen.getByRole('option')).toHaveTextContent('2');
+  });
+
+  describe('when options include a description', () => {
+    const options = [
+      {
+        id: '1',
+        label: 'One',
+        description: 'The first description',
+      },
+      {
+        id: '2',
+        label: 'Two',
+        description: 'Second description.',
+      },
+    ];
+
+    test('dropdown options show label and description', () => {
+      render(<SettingsAutocomplete options={options} />);
+
+      const dropdown = screen.getByRole('combobox');
+      userEvent.click(dropdown);
+
+      const dropdownOptions = screen.getAllByRole('option');
+      expect(dropdownOptions).toHaveLength(options.length);
+
+      dropdownOptions.forEach((dropdownOption, i) => {
+        const option = options[i];
+
+        if (!option) {
+          throw new Error(`Could not find option for ${i}`);
+        }
+
+        expect(dropdownOption).toHaveTextContent(option.label);
+        expect(dropdownOption).toHaveTextContent(option.description);
+      });
+    });
+
+    test('filtering includes the label', () => {
+      render(<SettingsAutocomplete options={options} />);
+
+      const dropdown = screen.getByRole('combobox');
+      userEvent.type(dropdown, 'One');
+
+      const filteredOption = screen.getByRole('option');
+      expect(filteredOption).toHaveTextContent('One');
+    });
+
+    test('filtering includes the description', () => {
+      render(<SettingsAutocomplete options={options} />);
+
+      const dropdown = screen.getByRole('combobox');
+      userEvent.type(dropdown, 'second');
+
+      const filteredOption = screen.getByRole('option');
+      expect(filteredOption).toHaveTextContent('Second description');
+    });
+  });
+
+  describe('when options are disabled', () => {
+    const options = [
+      {
+        id: '1',
+        label: 'Active',
+      },
+      {
+        id: '2',
+        label: 'Inactive',
+        disabled: true,
+      },
+    ];
+
+    test('the associated dropdown option is disabled', () => {
+      render(<SettingsAutocomplete options={options} />);
+
+      const dropdown = screen.getByRole('combobox');
+      userEvent.click(dropdown);
+
+      const dropdownOptions = screen.getAllByRole('option');
+      expect(dropdownOptions).toHaveLength(options.length);
+
+      // .toBeDisabled didn't work for this. It may not be properly checking
+      // for the aria-disabled attr.
+      expect(dropdownOptions[1]).toHaveAttribute('aria-disabled', 'true');
+
+      expect(dropdownOptions[0]).not.toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+});

--- a/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.test.tsx
+++ b/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.test.tsx
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { SettingsAutocomplete } from './SettingsAutocomplete';

--- a/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.tsx
+++ b/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.tsx
@@ -82,6 +82,10 @@ export function SettingsAutocomplete<
     return option.label ?? option.id;
   };
 
+  // Note: this component currently is not virtualized because it is specific
+  // to being used for settings, which generally have a pretty small list of
+  // options. If this changes to include values with many options, virtualization
+  // should be added using react-virtuoso.
   return (
     <Autocomplete
       isOptionEqualToValue={(option, value) => option.id === value.id}

--- a/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.tsx
+++ b/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.tsx
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   Autocomplete,
   AutocompleteProps,

--- a/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.tsx
+++ b/ui/components/src/SettingsAutocomplete/SettingsAutocomplete.tsx
@@ -1,0 +1,102 @@
+import {
+  Autocomplete,
+  AutocompleteProps,
+  TextField,
+  Typography,
+  UseAutocompleteProps,
+  createFilterOptions,
+} from '@mui/material';
+import { ReactNode } from 'react';
+
+/**
+ * Interface to extend from for `options` when using `SettingsAutocomplete`.
+ */
+export interface SettingsAutocompleteOption {
+  /**
+   * Unique identifier for the option.
+   */
+  id: string;
+
+  /**
+   * Optional value that is presented to the user for each option. If not set,
+   * the `id` will be used instead.
+   */
+  label?: string;
+
+  /**
+   * Optional description that will be rendered below the `label` to provide the
+   * user with additional information about the option.
+   */
+  description?: ReactNode;
+
+  /**
+   * When `true`, the option will be disabled.
+   */
+  disabled?: boolean;
+}
+
+export interface SettingsAutocompleteProps<
+  OptionType extends SettingsAutocompleteOption,
+  Multiple extends boolean | undefined,
+  DisableClearable extends boolean | undefined
+  // Note that the last `false` in the generic arguments sets the `freeSolo` option to `false`.
+  // This component is intended to be used with a discrete list of options, so `freeSolo` never
+  // needs to be `true`.
+> extends Omit<AutocompleteProps<OptionType, Multiple, DisableClearable, false>, 'renderInput'> {
+  // Modifying this to optional, so we can define a sensible default below that
+  // is used in many of the simple cases.
+  renderInput?: AutocompleteProps<OptionType, Multiple, DisableClearable, false>['renderInput'];
+}
+
+/**
+ * Opinionated autocomplete component useful for providing users with a dropdown
+ * for settings that require selecting one or more options from a list.
+ *
+ * **Note: This component is currently experimental and is likely to have significant breaking changes in the near future. Use with caution outside of the core Perses codebase.**
+ */
+export function SettingsAutocomplete<
+  OptionType extends SettingsAutocompleteOption,
+  Multiple extends boolean | undefined = false,
+  DisableClearable extends boolean | undefined = false
+>({
+  options,
+  renderInput = (params) => <TextField {...params} />,
+  ...otherProps
+}: SettingsAutocompleteProps<OptionType, Multiple, DisableClearable>) {
+  const getOptionLabel: UseAutocompleteProps<OptionType, undefined, boolean, undefined>['getOptionLabel'] = (
+    option
+  ) => {
+    return option.label ?? option.id;
+  };
+
+  return (
+    <Autocomplete
+      isOptionEqualToValue={(option, value) => option.id === value.id}
+      getOptionDisabled={(option) => !!option.disabled}
+      getOptionLabel={getOptionLabel}
+      options={options}
+      renderInput={renderInput}
+      renderOption={(props, option) => {
+        return (
+          <li {...props}>
+            <div>
+              <Typography variant="body1" component="div">
+                {getOptionLabel(option)}
+              </Typography>
+              {option.description && (
+                <Typography variant="body2" component="div" color={(theme) => theme.palette.text.secondary}>
+                  {option.description}
+                </Typography>
+              )}
+            </div>
+          </li>
+        );
+      }}
+      filterOptions={createFilterOptions({
+        // Include the label and the description in search.
+        stringify: (option) => `${getOptionLabel(option)} ${option.description || ''}`,
+      })}
+      {...otherProps}
+    />
+  );
+}

--- a/ui/components/src/SettingsAutocomplete/index.ts
+++ b/ui/components/src/SettingsAutocomplete/index.ts
@@ -1,1 +1,14 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from './SettingsAutocomplete';

--- a/ui/components/src/SettingsAutocomplete/index.ts
+++ b/ui/components/src/SettingsAutocomplete/index.ts
@@ -1,0 +1,1 @@
+export * from './SettingsAutocomplete';

--- a/ui/components/src/UnitSelector/UnitSelector.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.tsx
@@ -14,6 +14,7 @@ import { Box, Switch, TextField, Autocomplete, SwitchProps } from '@mui/material
 import { UnitOptions, UNIT_CONFIG, UnitConfig, isUnitWithDecimalPlaces, isUnitWithAbbreviate } from '../model';
 import { shouldAbbreviate } from '../model/units/utils';
 import { OptionsEditorControl } from '../OptionsEditorLayout';
+import { SettingsAutocomplete } from '../SettingsAutocomplete';
 
 export interface UnitSelectorProps {
   value: UnitOptions;
@@ -32,12 +33,12 @@ const KIND_OPTIONS: AutocompleteKindOption[] = Object.entries(UNIT_CONFIG)
   .filter((config) => !config.disableSelectorOption);
 
 const DECIMAL_PLACES_OPTIONS = [
-  { label: 'Default', decimal_places: undefined },
-  { label: '0', decimal_places: 0 },
-  { label: '1', decimal_places: 1 },
-  { label: '2', decimal_places: 2 },
-  { label: '3', decimal_places: 3 },
-  { label: '4', decimal_places: 4 },
+  { id: 'default', label: 'Default', decimal_places: undefined },
+  { id: '0', label: '0', decimal_places: 0 },
+  { id: '1', label: '1', decimal_places: 1 },
+  { id: '2', label: '2', decimal_places: 2 },
+  { id: '3', label: '3', decimal_places: 3 },
+  { id: '4', label: '4', decimal_places: 4 },
 ];
 
 function getOptionByDecimalPlaces(decimal_places?: number) {
@@ -89,35 +90,22 @@ export function UnitSelector({ value, onChange }: UnitSelectorProps) {
       <OptionsEditorControl
         label="Unit"
         control={
-          <Autocomplete
+          <SettingsAutocomplete
             value={{ id: value.kind, ...kindConfig }}
             options={KIND_OPTIONS}
-            isOptionEqualToValue={(option, value) => option.id === value.id}
             groupBy={(option) => option.group}
-            renderInput={(params) => <TextField {...params} />}
-            renderOption={(renderOptsProps, option) => {
-              // Custom option needed to get some increased left padding to make
-              // the items more distinct from the group label.
-              return (
-                <li {...renderOptsProps}>
-                  <Box paddingLeft={(theme) => theme.spacing(1)}>{option.label}</Box>
-                </li>
-              );
-            }}
             onChange={handleKindChange}
             disableClearable
-          ></Autocomplete>
+          ></SettingsAutocomplete>
         }
       />
       <OptionsEditorControl
         label="Decimals"
         control={
-          <Autocomplete
+          <SettingsAutocomplete
             value={getOptionByDecimalPlaces(value.decimal_places)}
             options={DECIMAL_PLACES_OPTIONS}
             getOptionLabel={(o) => o.label}
-            isOptionEqualToValue={(option, value) => option.label === value.label}
-            renderInput={(params) => <TextField {...params} />}
             onChange={handleDecimalPlacesChange}
             disabled={!hasDecimalPlaces}
             disableClearable

--- a/ui/components/src/UnitSelector/UnitSelector.tsx
+++ b/ui/components/src/UnitSelector/UnitSelector.tsx
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Box, Switch, TextField, Autocomplete, SwitchProps } from '@mui/material';
+import { Switch, SwitchProps } from '@mui/material';
 import { UnitOptions, UNIT_CONFIG, UnitConfig, isUnitWithDecimalPlaces, isUnitWithAbbreviate } from '../model';
 import { shouldAbbreviate } from '../model/units/utils';
 import { OptionsEditorControl } from '../OptionsEditorLayout';

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -25,6 +25,7 @@ export * from './JSONEditor';
 export * from './Legend';
 export * from './LineChart';
 export * from './OptionsEditorLayout';
+export * from './SettingsAutocomplete';
 export * from './StatChart';
 export * from './Table';
 export * from './ThresholdsEditor';

--- a/ui/core/src/model/calculations.ts
+++ b/ui/core/src/model/calculations.ts
@@ -29,22 +29,28 @@ export type CalculationType = keyof typeof CalculationsMap;
 
 export type CalculationConfig = {
   label: string;
+  description: string;
 };
 export const CALCULATIONS_CONFIG: Readonly<Record<CalculationType, CalculationConfig>> = {
   First: {
     label: 'First',
+    description: 'First value',
   },
   Last: {
     label: 'Last',
+    description: 'Last value',
   },
   LastNumber: {
     label: 'Last number',
+    description: 'Last numeric value',
   },
   Mean: {
     label: 'Mean',
+    description: 'Average value',
   },
   Sum: {
     label: 'Sum',
+    description: 'The sum of all values',
   },
 } as const;
 

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.test.tsx
@@ -66,7 +66,7 @@ describe('GaugeChartOptionsEditorSettings', () => {
     const calcSelector = screen.getByRole('combobox', { name: 'Calculation' });
     userEvent.click(calcSelector);
     const meanOption = screen.getByRole('option', {
-      name: 'Mean',
+      name: /Mean/,
     });
     userEvent.click(meanOption);
     expect(onChange).toHaveBeenCalledWith(

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanelOptionsEditor.stories.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanelOptionsEditor.stories.tsx
@@ -1,0 +1,85 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { GaugeChart, GaugeChartOptions } from '@perses-dev/panels-plugin';
+import { useState } from 'react';
+import { OptionsEditorTabs } from '@perses-dev/plugin-system';
+import { PanelDefinition } from '@perses-dev/core';
+import { produce } from 'immer';
+import { action } from '@storybook/addon-actions';
+
+type PanelOptionsEditorWrapperProps = {
+  /**
+   * Panel definition used to initialize the options editor in storybook.
+   */
+  initialPanelDefinition: PanelDefinition<GaugeChartOptions>;
+};
+
+const PanelOptionsEditorWrapper = ({ initialPanelDefinition }: PanelOptionsEditorWrapperProps) => {
+  const [panelDefinition, setPanelDefinition] = useState<PanelDefinition<GaugeChartOptions>>(initialPanelDefinition);
+
+  function handleChange(newChartOptions: GaugeChartOptions) {
+    action('onChange')(newChartOptions);
+    setPanelDefinition(
+      produce(panelDefinition, (draft) => {
+        draft.spec.plugin.spec = newChartOptions;
+      })
+    );
+  }
+
+  const tabs =
+    GaugeChart.panelOptionsEditorComponents?.map(({ label, content: OptionsEditorComponent }) => ({
+      label,
+      content: <OptionsEditorComponent value={panelDefinition.spec.plugin.spec} onChange={handleChange} />,
+    })) || [];
+
+  return <OptionsEditorTabs tabs={tabs} />;
+};
+
+/**
+ * The panel options editor for the `GaugeChart` panel plugin.
+ *
+ * This component is not intended to be used directly. It is documented in storybook
+ * to provide an example of what the plugin settings look like.
+ */
+const meta: Meta<typeof PanelOptionsEditorWrapper> = {
+  component: PanelOptionsEditorWrapper,
+  args: {
+    initialPanelDefinition: {
+      kind: 'Panel',
+      spec: {
+        display: {
+          name: 'Gauge Chart Panel',
+        },
+        plugin: {
+          kind: 'GaugeChart',
+          spec: {
+            calculation: 'First',
+          },
+        },
+      },
+    },
+  },
+  argTypes: {},
+  parameters: {
+    docs: {},
+  },
+  decorators: [],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PanelOptionsEditorWrapper>;
+
+export const Primary: Story = {};

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.test.tsx
@@ -66,7 +66,7 @@ describe('StatChartOptionsEditorSettings', () => {
     const calcSelector = screen.getByRole('combobox', { name: 'Calculation' });
     userEvent.click(calcSelector);
     const firstOption = screen.getByRole('option', {
-      name: 'First',
+      name: /First/,
     });
     userEvent.click(firstOption);
     expect(onChange).toHaveBeenCalledWith(

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanelOptionsEditor.stories.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanelOptionsEditor.stories.tsx
@@ -1,0 +1,88 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatChart, StatChartOptions } from '@perses-dev/panels-plugin';
+import { useState } from 'react';
+import { OptionsEditorTabs } from '@perses-dev/plugin-system';
+import { PanelDefinition } from '@perses-dev/core';
+import { produce } from 'immer';
+import { action } from '@storybook/addon-actions';
+
+type PanelOptionsEditorWrapperProps = {
+  /**
+   * Panel definition used to initialize the options editor in storybook.
+   */
+  initialPanelDefinition: PanelDefinition<StatChartOptions>;
+};
+
+const PanelOptionsEditorWrapper = ({ initialPanelDefinition }: PanelOptionsEditorWrapperProps) => {
+  const [panelDefinition, setPanelDefinition] = useState<PanelDefinition<StatChartOptions>>(initialPanelDefinition);
+
+  function handleChange(newChartOptions: StatChartOptions) {
+    action('onChange')(newChartOptions);
+    setPanelDefinition(
+      produce(panelDefinition, (draft) => {
+        draft.spec.plugin.spec = newChartOptions;
+      })
+    );
+  }
+
+  const tabs =
+    StatChart.panelOptionsEditorComponents?.map(({ label, content: OptionsEditorComponent }) => ({
+      label,
+      content: <OptionsEditorComponent value={panelDefinition.spec.plugin.spec} onChange={handleChange} />,
+    })) || [];
+
+  return <OptionsEditorTabs tabs={tabs} />;
+};
+
+/**
+ * The panel options editor for the `StatChart` panel plugin.
+ *
+ * This component is not intended to be used directly. It is documented in storybook
+ * to provide an example of what the plugin settings look like.
+ */
+const meta: Meta<typeof PanelOptionsEditorWrapper> = {
+  component: PanelOptionsEditorWrapper,
+  args: {
+    initialPanelDefinition: {
+      kind: 'Panel',
+      spec: {
+        display: {
+          name: 'Stat Chart Panel',
+        },
+        plugin: {
+          kind: 'StatChart',
+          spec: {
+            calculation: 'First',
+            unit: {
+              kind: 'Decimal',
+            },
+          },
+        },
+      },
+    },
+  },
+  argTypes: {},
+  parameters: {
+    docs: {},
+  },
+  decorators: [],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PanelOptionsEditorWrapper>;
+
+export const Primary: Story = {};

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Autocomplete, Slider, Switch, TextField } from '@mui/material';
-import { OptionsEditorControl, OptionsEditorGroup } from '@perses-dev/components';
+import { OptionsEditorControl, OptionsEditorGroup, SettingsAutocomplete } from '@perses-dev/components';
 import {
   DEFAULT_AREA_OPACITY,
   DEFAULT_CONNECT_NULLS,
@@ -88,15 +88,12 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
       <OptionsEditorControl
         label={VISUAL_CONFIG.stack.label}
         control={
-          <Autocomplete
+          <SettingsAutocomplete
             value={{
               ...stackConfig,
               id: currentStack,
             }}
             options={STACK_OPTIONS}
-            getOptionDisabled={(option) => option.label === 'Percent'} // TODO: enable option after 'Percent' implemented
-            isOptionEqualToValue={(option, value) => option.id === value.id}
-            renderInput={(params) => <TextField {...params} />}
             onChange={(__, newValue) => {
               const updatedValue: TimeSeriesChartVisualOptions = {
                 ...value,
@@ -110,7 +107,7 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             }}
             disabled={value === undefined}
             disableClearable
-          ></Autocomplete>
+          ></SettingsAutocomplete>
         }
       />
       <OptionsEditorControl

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Autocomplete, Slider, Switch, TextField } from '@mui/material';
+import { Slider, Switch } from '@mui/material';
 import { OptionsEditorControl, OptionsEditorGroup, SettingsAutocomplete } from '@perses-dev/components';
 import {
   DEFAULT_AREA_OPACITY,

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -130,7 +130,9 @@ export type StackOptions = 'None' | 'All' | 'Percent'; // TODO: add Percent opti
 export const STACK_CONFIG = {
   None: { label: 'None' },
   All: { label: 'All' },
-  Percent: { label: 'Percent' }, // temporarily disabled
+
+  // TODO: enable option after 'Percent' implemented
+  Percent: { label: 'Percent', disabled: true }, // temporarily disabled
 };
 
 export const STACK_OPTIONS = Object.entries(STACK_CONFIG).map(([id, config]) => {

--- a/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.test.tsx
+++ b/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.test.tsx
@@ -36,7 +36,7 @@ describe('CalculationSelector', () => {
     const calcSelector = getCalculationSelector();
     userEvent.click(calcSelector);
     const sumOption = screen.getByRole('option', {
-      name: 'Sum',
+      name: /Sum/,
     });
     userEvent.click(sumOption);
 
@@ -54,7 +54,7 @@ describe('CalculationSelector', () => {
     userEvent.clear(calcSelector);
     userEvent.keyboard('first');
     screen.getByRole('option', {
-      name: 'First',
+      name: /First/,
     });
 
     userEvent.keyboard('{arrowup}{enter}');

--- a/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.tsx
+++ b/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.tsx
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TextField, Autocomplete } from '@mui/material';
-import { OptionsEditorControl } from '@perses-dev/components';
+import { OptionsEditorControl, SettingsAutocomplete } from '@perses-dev/components';
 import { CALCULATIONS_CONFIG, CalculationConfig, CalculationType } from '@perses-dev/core';
 
 type AutocompleteCalculationOption = CalculationConfig & { id: CalculationType };
@@ -39,17 +38,15 @@ export function CalculationSelector({ value, onChange }: CalculationSelectorProp
     <OptionsEditorControl
       label="Calculation"
       control={
-        <Autocomplete
+        <SettingsAutocomplete
           value={{
             ...calcConfig,
             id: value,
           }}
           options={CALC_OPTIONS}
-          isOptionEqualToValue={(option, value) => option.id === value.id}
-          renderInput={(params) => <TextField {...params} />}
           onChange={handleCalculationChange}
           disableClearable
-        ></Autocomplete>
+        ></SettingsAutocomplete>
       }
     />
   );

--- a/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Autocomplete, Switch, SwitchProps, TextField } from '@mui/material';
+import { Switch, SwitchProps } from '@mui/material';
 import { DEFAULT_LEGEND, getLegendMode, getLegendPosition } from '@perses-dev/core';
-import { ErrorAlert, OptionsEditorControl } from '@perses-dev/components';
+import { ErrorAlert, OptionsEditorControl, SettingsAutocomplete } from '@perses-dev/components';
 import {
   LEGEND_MODE_CONFIG,
   LEGEND_POSITIONS_CONFIG,
@@ -31,11 +31,11 @@ const POSITION_OPTIONS: LegendPositionOption[] = Object.entries(LEGEND_POSITIONS
   };
 });
 
-type LegendModeOption = LegendSingleSelectConfig & { id: LegendSpecOptions['mode'] };
+type LegendModeOption = LegendSingleSelectConfig & { id: Required<LegendSpecOptions>['mode'] };
 
 const MODE_OPTIONS: LegendModeOption[] = Object.entries(LEGEND_MODE_CONFIG).map(([id, config]) => {
   return {
-    id: id as LegendSpecOptions['mode'],
+    id: id as Required<LegendSpecOptions>['mode'],
     ...config,
   };
 });
@@ -84,35 +84,31 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
       <OptionsEditorControl
         label="Position"
         control={
-          <Autocomplete
+          <SettingsAutocomplete
             value={{
               ...legendPositionConfig,
               id: currentPosition,
             }}
             options={POSITION_OPTIONS}
-            isOptionEqualToValue={(option, value) => option.id === value.id}
-            renderInput={(params) => <TextField {...params} />}
             onChange={handleLegendPositionChange}
             disabled={value === undefined}
             disableClearable
-          ></Autocomplete>
+          ></SettingsAutocomplete>
         }
       />
       <OptionsEditorControl
         label="Mode"
         control={
-          <Autocomplete
+          <SettingsAutocomplete
             value={{
               ...legendModeConfig,
               id: currentMode,
             }}
             options={MODE_OPTIONS}
-            isOptionEqualToValue={(option, value) => option.id === value.id}
-            renderInput={(params) => <TextField {...params} />}
             onChange={handleLegendModeChange}
             disabled={value === undefined}
             disableClearable
-          ></Autocomplete>
+          ></SettingsAutocomplete>
         }
       />
     </>


### PR DESCRIPTION
The purpose of this component is to normalize the rendering of settings within the panel options editors and other similar use cases.

This is a first draft of this component to make incremental progress. It is very likely the designs and some behaviors may change after syncing with designers

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Notes for reviewers

- I know we have some more work to do on the designs for this component. I have some time scheduled with design to work on that. However, I don't want to block incremental progress on this component (in service of getting table legend to have values) on those design adjustments, especially since this isn't making anything worse than it was before and in some cases is making an incremental improvement.
- Marking the component as "experimental" until the designs are more finalized.
- I'm writing pretty minimal tests here focused on the added logic because the vast majority of this component is MUI's `Autocomplete` and I don't want to exercise all the edge cases for the underlying library.
- I added some quick stories for the stat and gauge options editors to make it easier to test those changes.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

# Screenshots

<img width="1190" alt="image" src="https://github.com/perses/perses/assets/396962/f1a4a5b7-2b97-42ba-91ab-b6024d966e2d">
<img width="899" alt="image" src="https://github.com/perses/perses/assets/396962/dc6569b2-c080-4c5a-98e5-bd40a0a2bbb1">

<img width="926" alt="image" src="https://github.com/perses/perses/assets/396962/bc4212dd-9223-4a77-a10c-548b9c984dfc">
<img width="926" alt="image" src="https://github.com/perses/perses/assets/396962/f41c8339-c82a-4e2b-b7f3-ab6ba51d8e86">
<img width="926" alt="image" src="https://github.com/perses/perses/assets/396962/b9dac5e2-c97e-48f2-ba2a-45d4d6bb60e3">

<img width="886" alt="image" src="https://github.com/perses/perses/assets/396962/29880ad8-ab82-47b6-92ce-8b6ca958f1ef">


