### PR TITLE
[ENHANCEMENT] Add size option for content with legend

### DIFF
--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -22,6 +22,7 @@ import (
 #legend: {
 	position: "Bottom" | "Right"
 	mode?:    "List" | "Table"
+	size?:    "Small" | "Medium"
 	values?: [...#legend_value]
 }
 

--- a/ui/components/src/ContentWithLegend/ContentWithLegend.stories.tsx
+++ b/ui/components/src/ContentWithLegend/ContentWithLegend.stories.tsx
@@ -18,7 +18,7 @@ import { red, orange, yellow, green, blue, indigo, purple } from '@mui/material/
 import { Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { StorySection } from '@perses-dev/storybook';
 import { useState } from 'react';
-import { LegendPositions, legendModes, legendPositions } from '@perses-dev/core';
+import { LegendPositions, legendModes, legendPositions, legendSizes } from '@perses-dev/core';
 
 const COLOR_SHADES = ['400', '800'] as const;
 const COLOR_NAMES = [red, orange, yellow, green, blue, indigo, purple];
@@ -133,6 +133,47 @@ export const Position: Story = {
                   onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
                 }}
               />
+            </StorySection>
+          );
+        })}
+      </Stack>
+    );
+  },
+};
+
+/**
+ * The amount of space the legend takes up is determined by the `legendSize`.
+ */
+export const LegendSize: Story = {
+  args: {},
+  render: (args) => {
+    return (
+      <Stack spacing={3}>
+        {legendSizes.map((size) => {
+          return (
+            <StorySection key={size} title={size} level="h3">
+              <Stack spacing={1} direction="row">
+                {legendPositions.map((position) => {
+                  return (
+                    <StorySection key={position} title={position} level="h4">
+                      <ContentWithLegend
+                        {...args}
+                        legendSize={size}
+                        legendProps={{
+                          data: generateMockLegendData(10),
+                          options: {
+                            position,
+                            mode: 'Table',
+                          },
+                          selectedItems: {},
+                          onSelectedItemsChange: (newSelectedItems) =>
+                            action('onSelectedItemsChange')(newSelectedItems),
+                        }}
+                      />
+                    </StorySection>
+                  );
+                })}
+              </Stack>
             </StorySection>
           );
         })}
@@ -369,6 +410,40 @@ export const Responsive: Story = {
                 options: {
                   position: 'Bottom',
                   mode: 'List',
+                },
+                selectedItems: {},
+                onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+              }}
+            />
+          </Stack>
+        </StorySection>
+        <StorySection title="size of bottom table legend will be shorter if the items do not fill the space" level="h3">
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            <ContentWithLegend
+              {...args}
+              width={400}
+              height={400}
+              legendProps={{
+                data: generateMockLegendData(2),
+                options: {
+                  position: 'Bottom',
+                  mode: 'Table',
+                  size: 'Small',
+                },
+                selectedItems: {},
+                onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),
+              }}
+            />
+            <ContentWithLegend
+              {...args}
+              width={400}
+              height={400}
+              legendProps={{
+                data: generateMockLegendData(10),
+                options: {
+                  position: 'Bottom',
+                  mode: 'Table',
+                  size: 'Small',
                 },
                 selectedItems: {},
                 onSelectedItemsChange: (newSelectedItems) => action('onSelectedItemsChange')(newSelectedItems),

--- a/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
+++ b/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
@@ -13,6 +13,7 @@
 
 import React from 'react';
 import { Box, useTheme } from '@mui/material';
+import { getLegendSize } from '@perses-dev/core';
 import { Legend } from '../Legend';
 import { ContentWithLegendProps, getContentWithLegendLayout } from './model/content-with-legend-model';
 
@@ -29,6 +30,7 @@ export function ContentWithLegend({
   width,
   height,
   spacing = 0,
+  legendSize,
   minChildrenWidth = 100,
   minChildrenHeight = 100,
 }: ContentWithLegendProps) {
@@ -41,6 +43,7 @@ export function ContentWithLegend({
     minChildrenWidth,
     spacing,
     theme,
+    legendSize: getLegendSize(legendSize),
   });
 
   return (

--- a/ui/components/src/ContentWithLegend/model/content-with-legend-model.test.ts
+++ b/ui/components/src/ContentWithLegend/model/content-with-legend-model.test.ts
@@ -12,12 +12,20 @@
 // limitations under the License.
 
 import { createTheme } from '@mui/material';
-import { legendModes } from '@perses-dev/core';
+import { legendModes, legendSizes } from '@perses-dev/core';
+import * as table from '../../Table';
 import {
   ContentWithLegendLayoutOpts,
   TABLE_LEGEND_SIZE,
   getContentWithLegendLayout,
 } from './content-with-legend-model';
+
+// Workaround to get spyOn to work without a cannot redefine property error.
+// https://github.com/microsoft/TypeScript/issues/43081#issuecomment-1352352654
+jest.mock('../../Table', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../Table'),
+}));
 
 const mockMuiTheme = createTheme({});
 
@@ -30,6 +38,7 @@ describe('getContentWithLegendLayout', () => {
       minChildrenWidth: 0,
       minChildrenHeight: 0,
       theme: mockMuiTheme,
+      legendSize: 'Medium',
     };
 
     test('does not show legend', () => {
@@ -46,40 +55,152 @@ describe('getContentWithLegendLayout', () => {
   });
 
   describe.each(legendModes)('%s mode legend', (mode) => {
-    describe('with right oriented legend', () => {
-      describe('with spacing', () => {
-        const layoutOpts: ContentWithLegendLayoutOpts = {
-          width: 800,
-          height: 500,
-          spacing: 10,
-          minChildrenWidth: 0,
-          minChildrenHeight: 0,
-          legendProps: {
-            options: {
-              position: 'Right',
-              mode: mode,
+    describe.each(legendSizes)('%s size legend', (size) => {
+      describe('with right oriented legend', () => {
+        describe('with spacing', () => {
+          const layoutOpts: ContentWithLegendLayoutOpts = {
+            width: 800,
+            height: 500,
+            spacing: 10,
+            minChildrenWidth: 0,
+            minChildrenHeight: 0,
+            legendProps: {
+              options: {
+                position: 'Right',
+                mode: mode,
+              },
+              data: [],
+              selectedItems: 'ALL',
+              onSelectedItemsChange: jest.fn(),
             },
-            data: [],
-            selectedItems: 'ALL',
-            onSelectedItemsChange: jest.fn(),
-          },
-          theme: mockMuiTheme,
-        };
+            legendSize: size,
+            theme: mockMuiTheme,
+          };
 
-        test('shows legend', () => {
-          const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.legend.show).toBeTruthy();
+          test('shows legend', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.legend.show).toBeTruthy();
+          });
+
+          test('lays out the content, spacing, and legend horizontally', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.content.width + layout.margin.right + layout.legend.width).toEqual(layoutOpts.width);
+          });
+
+          test('content and legend use full height', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.content.height).toEqual(layoutOpts.height);
+            expect(layout.legend.height).toEqual(layoutOpts.height);
+          });
         });
 
-        test('lays out the content, spacing, and legend horizontally', () => {
-          const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.content.width + layout.margin.right + layout.legend.width).toEqual(layoutOpts.width);
+        describe('without spacing', () => {
+          const layoutOpts: ContentWithLegendLayoutOpts = {
+            width: 800,
+            height: 500,
+            spacing: 0,
+            minChildrenWidth: 0,
+            minChildrenHeight: 0,
+            legendProps: {
+              options: {
+                position: 'Right',
+                mode: mode,
+              },
+              data: [],
+              selectedItems: 'ALL',
+              onSelectedItemsChange: jest.fn(),
+            },
+            legendSize: size,
+            theme: mockMuiTheme,
+          };
+
+          test('shows legend', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.legend.show).toBeTruthy();
+          });
+
+          test('lays out the content, spacing, and legend horizontally', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.content.width + layout.legend.width).toEqual(layoutOpts.width);
+          });
+
+          test('content and legend use full height', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.content.height).toEqual(layoutOpts.height);
+            expect(layout.legend.height).toEqual(layoutOpts.height);
+          });
         });
 
-        test('content and legend use full height', () => {
-          const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.content.height).toEqual(layoutOpts.height);
-          expect(layout.legend.height).toEqual(layoutOpts.height);
+        describe('without enough horizontal space for the legend', () => {
+          const layoutOpts: ContentWithLegendLayoutOpts = {
+            width: 200,
+            height: 500,
+            spacing: 10,
+            minChildrenWidth: 200,
+            minChildrenHeight: 0,
+            legendProps: {
+              options: {
+                position: 'Right',
+                mode: mode,
+              },
+              data: [],
+              selectedItems: 'ALL',
+              onSelectedItemsChange: jest.fn(),
+            },
+            legendSize: size,
+            theme: mockMuiTheme,
+          };
+
+          test('does not show legend', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.legend.show).toBeFalsy();
+          });
+
+          test('gives content full width and height without a margin', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.content.width).toEqual(layoutOpts.width);
+            expect(layout.content.height).toEqual(layoutOpts.height);
+            expect(layout.margin).toEqual({ bottom: 0, right: 0 });
+          });
+        });
+      });
+
+      describe('with bottom oriented legend', () => {
+        describe('with spacing', () => {
+          const layoutOpts: ContentWithLegendLayoutOpts = {
+            width: 800,
+            height: 500,
+            spacing: 15,
+            minChildrenWidth: 0,
+            minChildrenHeight: 0,
+            legendProps: {
+              options: {
+                position: 'Bottom',
+                mode: mode,
+              },
+              data: [],
+              selectedItems: 'ALL',
+              onSelectedItemsChange: jest.fn(),
+            },
+            legendSize: size,
+            theme: mockMuiTheme,
+          };
+
+          test('shows legend', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.legend.show).toBeTruthy();
+          });
+
+          test('lays out the content, spacing, and legend vertically', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.content.height + layout.margin.bottom + layout.legend.height).toEqual(layoutOpts.height);
+          });
+
+          test('content and legend use full width', () => {
+            const layout = getContentWithLegendLayout(layoutOpts);
+            expect(layout.content.width).toEqual(layoutOpts.width);
+            expect(layout.legend.width).toEqual(layoutOpts.width);
+          });
         });
       });
 
@@ -92,13 +213,14 @@ describe('getContentWithLegendLayout', () => {
           minChildrenHeight: 0,
           legendProps: {
             options: {
-              position: 'Right',
+              position: 'Bottom',
               mode: mode,
             },
             data: [],
             selectedItems: 'ALL',
             onSelectedItemsChange: jest.fn(),
           },
+          legendSize: size,
           theme: mockMuiTheme,
         };
 
@@ -109,32 +231,33 @@ describe('getContentWithLegendLayout', () => {
 
         test('lays out the content, spacing, and legend horizontally', () => {
           const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.content.width + layout.legend.width).toEqual(layoutOpts.width);
+          expect(layout.content.height + layout.legend.height).toEqual(layoutOpts.height);
         });
 
-        test('content and legend use full height', () => {
+        test('content and legend use full width', () => {
           const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.content.height).toEqual(layoutOpts.height);
-          expect(layout.legend.height).toEqual(layoutOpts.height);
+          expect(layout.content.width).toEqual(layoutOpts.width);
+          expect(layout.legend.width).toEqual(layoutOpts.width);
         });
       });
 
-      describe('without enough horizontal space for the legend', () => {
+      describe('without enough vertical space for the legend', () => {
         const layoutOpts: ContentWithLegendLayoutOpts = {
-          width: 200,
-          height: 500,
+          width: 300,
+          height: 100,
           spacing: 10,
-          minChildrenWidth: 200,
-          minChildrenHeight: 0,
+          minChildrenWidth: 0,
+          minChildrenHeight: 100,
           legendProps: {
             options: {
-              position: 'Right',
+              position: 'Bottom',
               mode: mode,
             },
             data: [],
             selectedItems: 'ALL',
             onSelectedItemsChange: jest.fn(),
           },
+          legendSize: size,
           theme: mockMuiTheme,
         };
 
@@ -151,115 +274,9 @@ describe('getContentWithLegendLayout', () => {
         });
       });
     });
-
-    describe('with bottom oriented legend', () => {
-      describe('with spacing', () => {
-        const layoutOpts: ContentWithLegendLayoutOpts = {
-          width: 800,
-          height: 500,
-          spacing: 15,
-          minChildrenWidth: 0,
-          minChildrenHeight: 0,
-          legendProps: {
-            options: {
-              position: 'Bottom',
-              mode: mode,
-            },
-            data: [],
-            selectedItems: 'ALL',
-            onSelectedItemsChange: jest.fn(),
-          },
-          theme: mockMuiTheme,
-        };
-
-        test('shows legend', () => {
-          const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.legend.show).toBeTruthy();
-        });
-
-        test('lays out the content, spacing, and legend vertically', () => {
-          const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.content.height + layout.margin.bottom + layout.legend.height).toEqual(layoutOpts.height);
-        });
-
-        test('content and legend use full width', () => {
-          const layout = getContentWithLegendLayout(layoutOpts);
-          expect(layout.content.width).toEqual(layoutOpts.width);
-          expect(layout.legend.width).toEqual(layoutOpts.width);
-        });
-      });
-    });
-
-    describe('without spacing', () => {
-      const layoutOpts: ContentWithLegendLayoutOpts = {
-        width: 800,
-        height: 500,
-        spacing: 0,
-        minChildrenWidth: 0,
-        minChildrenHeight: 0,
-        legendProps: {
-          options: {
-            position: 'Bottom',
-            mode: mode,
-          },
-          data: [],
-          selectedItems: 'ALL',
-          onSelectedItemsChange: jest.fn(),
-        },
-        theme: mockMuiTheme,
-      };
-
-      test('shows legend', () => {
-        const layout = getContentWithLegendLayout(layoutOpts);
-        expect(layout.legend.show).toBeTruthy();
-      });
-
-      test('lays out the content, spacing, and legend horizontally', () => {
-        const layout = getContentWithLegendLayout(layoutOpts);
-        expect(layout.content.height + layout.legend.height).toEqual(layoutOpts.height);
-      });
-
-      test('content and legend use full width', () => {
-        const layout = getContentWithLegendLayout(layoutOpts);
-        expect(layout.content.width).toEqual(layoutOpts.width);
-        expect(layout.legend.width).toEqual(layoutOpts.width);
-      });
-    });
-
-    describe('without enough vertical space for the legend', () => {
-      const layoutOpts: ContentWithLegendLayoutOpts = {
-        width: 300,
-        height: 100,
-        spacing: 10,
-        minChildrenWidth: 0,
-        minChildrenHeight: 100,
-        legendProps: {
-          options: {
-            position: 'Bottom',
-            mode: mode,
-          },
-          data: [],
-          selectedItems: 'ALL',
-          onSelectedItemsChange: jest.fn(),
-        },
-        theme: mockMuiTheme,
-      };
-
-      test('does not show legend', () => {
-        const layout = getContentWithLegendLayout(layoutOpts);
-        expect(layout.legend.show).toBeFalsy();
-      });
-
-      test('gives content full width and height without a margin', () => {
-        const layout = getContentWithLegendLayout(layoutOpts);
-        expect(layout.content.width).toEqual(layoutOpts.width);
-        expect(layout.content.height).toEqual(layoutOpts.height);
-        expect(layout.margin).toEqual({ bottom: 0, right: 0 });
-      });
-    });
   });
 
-  describe('right positioned table legend with additional columns', () => {
+  describe.each(legendSizes)('right positioned, size %s table legend with additional columns', (size) => {
     const layoutOpts: ContentWithLegendLayoutOpts = {
       width: 800,
       height: 500,
@@ -289,6 +306,7 @@ describe('getContentWithLegendLayout', () => {
         selectedItems: 'ALL',
         onSelectedItemsChange: jest.fn(),
       },
+      legendSize: size,
       theme: mockMuiTheme,
     };
 
@@ -304,7 +322,52 @@ describe('getContentWithLegendLayout', () => {
 
     test('legend width accounts for columns', () => {
       const layout = getContentWithLegendLayout(layoutOpts);
-      expect(layout.legend.width).toEqual(TABLE_LEGEND_SIZE['Right'] + 50);
+      expect(layout.legend.width).toEqual(TABLE_LEGEND_SIZE[size]['Right'] + 50);
+    });
+  });
+
+  describe('bottom positioned table legend with less items than size calls for', () => {
+    test('reduces the size of the legend based on the number of items', () => {
+      const layoutOpts: ContentWithLegendLayoutOpts = {
+        width: 800,
+        height: 500,
+        spacing: 15,
+        minChildrenWidth: 0,
+        minChildrenHeight: 0,
+        legendProps: {
+          options: {
+            position: 'Bottom',
+            mode: 'Table',
+          },
+          data: [
+            {
+              id: '1',
+              label: 'one',
+              color: '#ff0000',
+            },
+            {
+              id: '2',
+              label: 'two',
+              color: '#00FF00',
+            },
+          ],
+          selectedItems: 'ALL',
+          onSelectedItemsChange: jest.fn(),
+        },
+        legendSize: 'Medium',
+        theme: mockMuiTheme,
+      };
+
+      const MOCK_TABLE_CELL_HEIGHT = 20;
+      jest.spyOn(table, 'getTableCellLayout').mockReturnValue({
+        height: MOCK_TABLE_CELL_HEIGHT,
+      });
+
+      const layout = getContentWithLegendLayout(layoutOpts);
+      expect(layout.legend.height).toBeLessThan(TABLE_LEGEND_SIZE['Medium']['Bottom'] * MOCK_TABLE_CELL_HEIGHT);
+
+      // Height is for 3 rows because there are 2 legend items + 1 header row.
+      expect(layout.legend.height).toEqual(3 * MOCK_TABLE_CELL_HEIGHT);
     });
   });
 });

--- a/ui/components/src/ContentWithLegend/model/content-with-legend-model.ts
+++ b/ui/components/src/ContentWithLegend/model/content-with-legend-model.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Theme } from '@mui/material';
-import { LegendPositions, getLegendMode } from '@perses-dev/core';
+import { LegendPositions, getLegendMode, LegendSize } from '@perses-dev/core';
 import { LegendProps } from '../../Legend';
 import { getTableCellLayout } from '../../Table';
 
@@ -37,11 +37,20 @@ export interface ContentWithLegendProps {
    * to chart components.
    */
   children: React.ReactNode | (({ width, height }: Dimensions) => React.ReactNode);
+
+  /**
+   * Size used for the legend.
+   *
+   * @default 'Medium'
+   */
+  legendSize?: LegendSize;
+
   /**
    * Props to configure the legend. If not set, the content is rendered without
    * a legend.
    */
   legendProps?: Omit<LegendProps, 'width' | 'height'>;
+
   /**
    * Space to put between the children and the legend in pixels.
    */
@@ -79,14 +88,23 @@ export interface ContentWithLegendLayout {
   };
 }
 
-type LegendSizeConfig = Record<LegendPositions, number>;
+type LegendSizeConfig = Record<LegendSize, Record<LegendPositions, number>>;
 
 export const TABLE_LEGEND_SIZE: LegendSizeConfig = {
-  // 5 rows plus header. Value to be multiplied by row height in pixels.
-  Bottom: 6,
+  Medium: {
+    // 5 rows plus header. Value to be multiplied by row height in pixels.
+    Bottom: 6,
 
-  // Pixel value
-  Right: 250,
+    // Pixel value
+    Right: 250,
+  },
+  Small: {
+    // 3 rows plus header. Value to be multiplied by row height in pixels.
+    Bottom: 4,
+
+    // Pixel value
+    Right: 150,
+  },
 };
 
 const PANEL_HEIGHT_LG_BREAKPOINT = 300;
@@ -100,6 +118,7 @@ export function getContentWithLegendLayout({
   width,
   height,
   legendProps,
+  legendSize,
   minChildrenHeight,
   minChildrenWidth,
   spacing,
@@ -159,8 +178,11 @@ export function getContentWithLegendLayout({
       return total;
     }, 0);
 
-    legendWidth = position === 'Right' ? TABLE_LEGEND_SIZE['Right'] + columnsWidth : width;
-    legendHeight = position === 'Bottom' ? TABLE_LEGEND_SIZE['Bottom'] * tableLayout.height : height;
+    legendWidth = position === 'Right' ? TABLE_LEGEND_SIZE[legendSize]['Right'] + columnsWidth : width;
+
+    // Use the smaller of the size-based row count or the number of legend items + 1 for the header.
+    const rowsToShow = Math.min(TABLE_LEGEND_SIZE[legendSize]['Bottom'], legendProps.data.length + 1);
+    legendHeight = position === 'Bottom' ? rowsToShow * tableLayout.height : height;
   }
 
   const contentWidth = position === 'Right' ? width - legendWidth - spacing : width;

--- a/ui/core/src/model/legend.ts
+++ b/ui/core/src/model/legend.ts
@@ -22,10 +22,14 @@ export type LegendPositions = (typeof legendPositions)[number];
 export const legendModes = ['List', 'Table'] as const;
 export type LegendMode = (typeof legendModes)[number];
 
+export const legendSizes = ['Small', 'Medium'] as const;
+export type LegendSize = (typeof legendSizes)[number];
+
 // Common legend options used across some UI components and panel specifications
 export interface LegendOptionsBase {
   position: LegendPositions;
   mode?: LegendMode;
+  size?: LegendSize;
 }
 
 export function isValidLegendPosition(position: LegendPositions) {
@@ -36,9 +40,14 @@ export function isValidLegendMode(mode: LegendMode) {
   return (legendModes as readonly string[]).includes(mode);
 }
 
+export function isValidLegendSize(size: LegendSize) {
+  return (legendSizes as readonly string[]).includes(size);
+}
+
 export const DEFAULT_LEGEND: Required<LegendOptionsBase> = {
   position: 'Bottom',
   mode: 'List',
+  size: 'Medium',
 };
 
 export function getLegendPosition(position?: LegendPositions) {
@@ -57,4 +66,12 @@ export function getLegendMode(mode?: LegendMode) {
   }
 
   return mode;
+}
+
+export function getLegendSize(size?: LegendSize) {
+  if (!size || !isValidLegendSize(size)) {
+    return DEFAULT_LEGEND.size;
+  }
+
+  return size;
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -324,6 +324,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         // Making this small enough that the medium size doesn't get
         // responsive-handling-ed away when in the panel options editor.
         minChildrenHeight={50}
+        legendSize={legend?.size}
         legendProps={
           legend && {
             options: legend,

--- a/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Switch, SwitchProps } from '@mui/material';
-import { DEFAULT_LEGEND, getLegendMode, getLegendPosition } from '@perses-dev/core';
+import { DEFAULT_LEGEND, getLegendMode, getLegendPosition, getLegendSize } from '@perses-dev/core';
 import { ErrorAlert, OptionsEditorControl, SettingsAutocomplete } from '@perses-dev/components';
 import {
   LEGEND_MODE_CONFIG,
@@ -22,6 +22,7 @@ import {
   validateLegendSpec,
   LEGEND_VALUE_CONFIG,
   LegendValue,
+  LEGEND_SIZE_CONFIG,
 } from '../../model';
 
 type LegendPositionOption = LegendSingleSelectConfig & { id: LegendSpecOptions['position'] };
@@ -38,6 +39,15 @@ type LegendModeOption = LegendSingleSelectConfig & { id: Required<LegendSpecOpti
 const MODE_OPTIONS: LegendModeOption[] = Object.entries(LEGEND_MODE_CONFIG).map(([id, config]) => {
   return {
     id: id as Required<LegendSpecOptions>['mode'],
+    ...config,
+  };
+});
+
+type LegendSizeOption = LegendSingleSelectConfig & { id: Required<LegendSpecOptions>['size'] };
+
+const SIZE_OPTIONS: LegendSizeOption[] = Object.entries(LEGEND_SIZE_CONFIG).map(([id, config]) => {
+  return {
+    id: id as Required<LegendSpecOptions>['size'],
     ...config,
   };
 });
@@ -77,6 +87,14 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
     });
   };
 
+  const handleLegendSizeChange = (_: unknown, newValue: LegendSizeOption) => {
+    onChange({
+      ...value,
+      position: currentPosition,
+      size: newValue.id,
+    });
+  };
+
   const handleLegendValueChange = (_: unknown, newValue: LegendValueOption[]) => {
     onChange({
       ...value,
@@ -93,6 +111,9 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
 
   const currentMode = getLegendMode(value?.mode);
   const legendModeConfig = LEGEND_MODE_CONFIG[currentMode];
+
+  const currentSize = getLegendSize(value?.size);
+  const legendSizeConfig = LEGEND_SIZE_CONFIG[currentSize];
 
   const currentValues = value?.values || [];
   const legendValuesConfig = currentValues.reduce((result, item) => {
@@ -141,8 +162,24 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
         }
       />
       <OptionsEditorControl
+        label="Size"
+        control={
+          <SettingsAutocomplete
+            value={{
+              ...legendSizeConfig,
+              id: currentSize,
+            }}
+            options={SIZE_OPTIONS}
+            onChange={handleLegendSizeChange}
+            // TODO: enable sizes for list mode when we normalize the layout of
+            // lists to more closely match tables.
+            disabled={value === undefined || currentMode !== 'Table'}
+            disableClearable
+          ></SettingsAutocomplete>
+        }
+      />
+      <OptionsEditorControl
         label="Values"
-        description="Computed values ignore nulls."
         control={
           // For some reason, the inferred option type doesn't always seem to work
           // quite right when `multiple` is true. Explicitly setting the generics

--- a/ui/plugin-system/src/model/legend.ts
+++ b/ui/plugin-system/src/model/legend.ts
@@ -19,6 +19,8 @@ import {
   LegendPositions,
   isValidLegendMode,
   isValidLegendPosition,
+  LegendSize,
+  isValidLegendSize,
 } from '@perses-dev/core';
 
 // This file contains legend-related model code specific to panel plugin specs.
@@ -63,6 +65,11 @@ export const LEGEND_MODE_CONFIG: Readonly<Record<LegendMode, LegendSingleSelectC
   Table: { label: 'Table' },
 };
 
+export const LEGEND_SIZE_CONFIG: Readonly<Record<LegendSize, LegendSingleSelectConfig>> = {
+  Small: { label: 'Small' },
+  Medium: { label: 'Medium' },
+};
+
 export const LEGEND_VALUE_CONFIG = legendValues.reduce((config, value) => {
   config[value] = CALCULATIONS_CONFIG[value];
 
@@ -78,6 +85,9 @@ export function validateLegendSpec(legend?: LegendOptionsBase) {
     return false;
   }
   if (legend.mode && !isValidLegendMode(legend.mode)) {
+    return false;
+  }
+  if (legend.size && !isValidLegendSize(legend.size)) {
     return false;
   }
 


### PR DESCRIPTION
This change impacts the following:
- `ContentWithLegend` component.
- `TimeSeriesChartPanel` panel plugin.

Sizes currently include: small and medium.

This change also includes an adjustment to the sized height of bottom positioned table legends to be smaller if there are not enough legend items to fill the specified space.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Notes for reviewers

I'm intentionally not tackling the grafana migration piece in this PR because this one is a trickier case because there's not a 1:1 mapping between the two, and I don't want to block the basic behavior on the complex migration logic.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

# Screenshots

## Content with legend

<img width="1516" alt="image" src="https://github.com/perses/perses/assets/396962/665f4373-9de9-48ff-812c-439c5a577dbd">
<img width="1148" alt="image" src="https://github.com/perses/perses/assets/396962/5a08bc90-6b06-4dc0-9457-9217eca949c7">


## Time Series chart panel

<img width="1527" alt="image" src="https://github.com/perses/perses/assets/396962/3479a48e-ec1d-4c41-8096-9edcf3afdae1">

<img width="1533" alt="image" src="https://github.com/perses/perses/assets/396962/87ec13b3-f503-435c-86b1-ce409c8164dd">


https://github.com/perses/perses/assets/396962/1d8f60b4-1328-4081-862e-12c53fec6b8e


