### PR TITLE
[FEATURE] Injection of external variables

### DIFF
--- a/ui/app/src/model/variables.ts
+++ b/ui/app/src/model/variables.ts
@@ -1,0 +1,19 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The source type is limited in this part of the view. It can be:
+ * - 'project': variables defined for every dashboard of the current project.
+ * - 'global': variables defined for every dashboard of every project.
+ */
+export type ExternalVariableSource = 'project' | 'global';

--- a/ui/app/src/utils/variables.ts
+++ b/ui/app/src/utils/variables.ts
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ExternalVariableDefinition } from '@perses-dev/dashboards';
+import { VariableResource } from '@perses-dev/core';
+import { ExternalVariableSource } from '../model/variables';
+
+/**
+ * Build the definition of the external variables from the variable resources collected from the API.
+ * @param source the source of external variables. Used in view only, to display and discriminate from other sources.
+ * @param variables variable resources collected from the API
+ */
+export function buildExternalVariableDefinition(
+  source: ExternalVariableSource,
+  variables: VariableResource[]
+): ExternalVariableDefinition {
+  return {
+    source: source,
+    definitions: variables.map((v) => {
+      const definition = { ...v.spec };
+      // The name of the variable resource can be missing from the spec but present in the metadata.
+      // We ensure that the metadata.name is used.
+      // We do this only if not already defined as otherwise, it's readonly
+      if (!definition.spec.name) {
+        definition.spec.name = v.metadata.name;
+      }
+      return definition;
+    }),
+  };
+}

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -42,7 +42,9 @@ export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' 
     const isSavedDurationModified =
       isRelativeTimeRange(timeRange) && dashboard.spec.duration !== timeRange.pastDuration;
 
-    // Save dashboard if active timeRange from plugin-system is relative and different than currently saved
+    // Save dashboard
+    // - if active timeRange from plugin-system is relative and different from currently saved
+    // - or if the saved variables are different from currently saved
     if (isSavedDurationModified || isSavedVariableModified) {
       openSaveChangesConfirmationDialog({
         onSaveChanges: (saveDefaultTimeRange, saveDefaultVariables) => {

--- a/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
+++ b/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
@@ -18,7 +18,12 @@ import { Drawer, InfoTooltip } from '@perses-dev/components';
 import { VariableDefinition } from '@perses-dev/core';
 
 import { TOOLTIP_TEXT } from '../../constants';
-import { useTemplateVariableDefinitions, useTemplateVariableActions } from '../../context';
+import {
+  ExternalVariableDefinition,
+  useTemplateExternalVariableDefinitions,
+  useTemplateVariableActions,
+  useTemplateVariableDefinitions,
+} from '../../context';
 import { VariableEditor } from './VariableEditor';
 
 export interface EditVariablesButtonProps extends Pick<ButtonProps, 'fullWidth'> {
@@ -46,6 +51,7 @@ export function EditVariablesButton({
 }: EditVariablesButtonProps) {
   const [isVariableEditorOpen, setIsVariableEditorOpen] = useState(false);
   const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
+  const externalVariableDefinitions: ExternalVariableDefinition[] = useTemplateExternalVariableDefinitions();
   const { setVariableDefinitions } = useTemplateVariableActions();
 
   const openVariableEditor = () => {
@@ -79,6 +85,7 @@ export function EditVariablesButton({
       >
         <VariableEditor
           variableDefinitions={variableDefinitions}
+          externalVariableDefinitions={externalVariableDefinitions}
           onCancel={closeVariableEditor}
           onChange={(variables: VariableDefinition[]) => {
             setVariableDefinitions(variables);

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -19,23 +19,24 @@ import { useTemplateVariable, useTemplateVariableActions } from '../../context';
 
 type TemplateVariableProps = {
   name: VariableName;
+  source?: string;
 };
 
-export function TemplateVariable({ name }: TemplateVariableProps) {
-  const ctx = useTemplateVariable(name);
+export function TemplateVariable({ name, source }: TemplateVariableProps) {
+  const ctx = useTemplateVariable(name, source);
   const kind = ctx.definition?.kind;
   switch (kind) {
     case 'TextVariable':
-      return <TextVariable name={name} />;
+      return <TextVariable name={name} source={source} />;
     case 'ListVariable':
-      return <ListVariable name={name} />;
+      return <ListVariable name={name} source={source} />;
   }
 
   return <div>Unsupported Variable Kind: ${kind}</div>;
 }
 
-function ListVariable({ name }: TemplateVariableProps) {
-  const ctx = useTemplateVariable(name);
+function ListVariable({ name, source }: TemplateVariableProps) {
+  const ctx = useTemplateVariable(name, source);
   const definition = ctx.definition as ListVariableDefinition;
   const variablesOptionsQuery = useListVariablePluginValues(definition);
   const { setVariableValue, setVariableLoading, setVariableOptions } = useTemplateVariableActions();
@@ -45,11 +46,11 @@ function ListVariable({ name }: TemplateVariableProps) {
   const title = definition?.spec.display?.name ?? name;
 
   useEffect(() => {
-    setVariableLoading(name, variablesOptionsQuery.isFetching);
+    setVariableLoading(name, variablesOptionsQuery.isFetching, source);
     if (variablesOptionsQuery.data) {
-      setVariableOptions(name, variablesOptionsQuery.data);
+      setVariableOptions(name, variablesOptionsQuery.data, source);
     }
-  }, [variablesOptionsQuery, name, setVariableLoading, setVariableOptions]);
+  }, [variablesOptionsQuery, name, setVariableLoading, setVariableOptions, source]);
 
   let value = ctx.state?.value;
   const options = ctx.state?.options;
@@ -93,9 +94,9 @@ function ListVariable({ name }: TemplateVariableProps) {
 
     // If there is no value but there are options, set the value to the first option.
     if (!value && firstOption) {
-      setVariableValue(name, firstOption.value);
+      setVariableValue(name, firstOption.value, source);
     }
-  }, [finalOptions, setVariableValue, value, name, allowMultiple]);
+  }, [finalOptions, setVariableValue, value, name, allowMultiple, source]);
 
   return (
     <Box display={'flex'}>
@@ -110,11 +111,11 @@ function ListVariable({ name }: TemplateVariableProps) {
             // Must be selected
             if (e.target.value === null || e.target.value.length === 0) {
               if (allowAllValue) {
-                setVariableValue(name, DEFAULT_ALL_VALUE);
+                setVariableValue(name, DEFAULT_ALL_VALUE, source);
               }
               return;
             }
-            setVariableValue(name, e.target.value as VariableValue);
+            setVariableValue(name, e.target.value as VariableValue, source);
           }}
           multiple={allowMultiple}
         >
@@ -141,8 +142,8 @@ function ListVariable({ name }: TemplateVariableProps) {
   );
 }
 
-function TextVariable({ name }: TemplateVariableProps) {
-  const { state, definition } = useTemplateVariable(name);
+function TextVariable({ name, source }: TemplateVariableProps) {
+  const { state, definition } = useTemplateVariable(name, source);
   const [tempValue, setTempValue] = useState(state?.value ?? '');
   const { setVariableValue } = useTemplateVariableActions();
 
@@ -154,7 +155,7 @@ function TextVariable({ name }: TemplateVariableProps) {
     <TextField
       value={tempValue}
       onChange={(e) => setTempValue(e.target.value)}
-      onBlur={() => setVariableValue(name, tempValue)}
+      onBlur={() => setVariableValue(name, tempValue, source)}
       placeholder={name}
       label={definition?.spec.display?.name ?? name}
     />

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -28,6 +28,7 @@ import {
   Alert,
   styled,
   capitalize,
+  Tooltip,
 } from '@mui/material';
 import AddIcon from 'mdi-material-ui/Plus';
 import { VariableDefinition } from '@perses-dev/core';
@@ -36,6 +37,7 @@ import PencilIcon from 'mdi-material-ui/Pencil';
 import TrashIcon from 'mdi-material-ui/TrashCan';
 import ArrowUp from 'mdi-material-ui/ArrowUp';
 import ArrowDown from 'mdi-material-ui/ArrowDown';
+import ContentDuplicate from 'mdi-material-ui/ContentDuplicate';
 import { Action, VariableEditForm, VariableState, VARIABLE_TYPES } from '@perses-dev/plugin-system';
 import { ExternalVariableDefinition, useDiscardChangesConfirmationDialog } from '../../context';
 import { hydrateTemplateVariableStates } from '../../context/TemplateVariableProvider/hydrationUtils';
@@ -156,6 +158,12 @@ export function VariableEditor(props: {
         draft[index + 1] = currentElement;
         draft[index] = nextElement;
       }
+    });
+  };
+
+  const overrideVariable = (v: VariableDefinition) => {
+    setVariableDefinitions((draft) => {
+      draft.push(v);
     });
   };
 
@@ -295,6 +303,14 @@ export function VariableEditor(props: {
                           </TableCell>
                           <TableCell>{getVariableLabelByKind(v.kind) ?? v.kind}</TableCell>
                           <TableCell align="right">
+                            <Tooltip title="Override">
+                              <IconButton
+                                onClick={() => overrideVariable(v)}
+                                disabled={!!variableState.get({ name: v.spec.name })}
+                              >
+                                <ContentDuplicate />
+                              </IconButton>
+                            </Tooltip>
                             <IconButton disabled>
                               <ArrowUp />
                             </IconButton>

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -27,6 +27,7 @@ import {
   IconButton,
   Alert,
   styled,
+  capitalize,
 } from '@mui/material';
 import AddIcon from 'mdi-material-ui/Plus';
 import { VariableDefinition } from '@perses-dev/core';
@@ -35,8 +36,9 @@ import PencilIcon from 'mdi-material-ui/Pencil';
 import TrashIcon from 'mdi-material-ui/TrashCan';
 import ArrowUp from 'mdi-material-ui/ArrowUp';
 import ArrowDown from 'mdi-material-ui/ArrowDown';
-import { Action, VariableEditForm, VARIABLE_TYPES } from '@perses-dev/plugin-system';
-import { useDiscardChangesConfirmationDialog } from '../../context';
+import { Action, VariableEditForm, VariableState, VARIABLE_TYPES } from '@perses-dev/plugin-system';
+import { ExternalVariableDefinition, useDiscardChangesConfirmationDialog } from '../../context';
+import { hydrateTemplateVariableStates } from '../../context/TemplateVariableProvider/hydrationUtils';
 
 function getVariableLabelByKind(kind: string) {
   return VARIABLE_TYPES.find((variableType) => variableType.kind === kind)?.label;
@@ -59,6 +61,7 @@ function getValidation(variableDefinitions: VariableDefinition[]) {
 
 export function VariableEditor(props: {
   variableDefinitions: VariableDefinition[];
+  externalVariableDefinitions: ExternalVariableDefinition[];
   onChange: (variableDefinitions: VariableDefinition[]) => void;
   onCancel: () => void;
 }) {
@@ -66,7 +69,11 @@ export function VariableEditor(props: {
   const [variableEditIdx, setVariableEditIdx] = useState<number | null>(null);
   const [variableFormAction, setVariableFormAction] = useState<Action>('update');
 
+  const externalVariableDefinitions = props.externalVariableDefinitions;
   const validation = useMemo(() => getValidation(variableDefinitions), [variableDefinitions]);
+  const [variableState] = useMemo(() => {
+    return [hydrateTemplateVariableStates(variableDefinitions, {}, externalVariableDefinitions)];
+  }, [externalVariableDefinitions, variableDefinitions]);
   const currentEditingVariableDefinition = typeof variableEditIdx === 'number' && variableDefinitions[variableEditIdx];
 
   const { openDiscardChangesConfirmationDialog, closeDiscardChangesConfirmationDialog } =
@@ -182,7 +189,7 @@ export function VariableEditor(props: {
               borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
             }}
           >
-            <Typography variant="h2">Variables</Typography>
+            <Typography variant="h2">Dashboard Variables</Typography>
             <Stack direction="row" spacing={1} marginLeft="auto">
               <Button
                 disabled={props.variableDefinitions === variableDefinitions || !validation.isValid}
@@ -228,7 +235,7 @@ export function VariableEditor(props: {
                           />
                         </TableCell>
                         <TableCell component="th" scope="row" sx={{ fontWeight: 'bold' }}>
-                          {v.spec.name}
+                          <VariableName name={v.spec.name} state={variableState.get({ name: v.spec.name })} />
                         </TableCell>
                         <TableCell>{getVariableLabelByKind(v.kind) ?? v.kind}</TableCell>
                         <TableCell align="right">
@@ -260,6 +267,54 @@ export function VariableEditor(props: {
                 </Button>
               </Box>
             </Stack>
+
+            {externalVariableDefinitions.map((extVar) => (
+              <Stack key={extVar.source}>
+                <Typography variant="h2">{capitalize(extVar.source)} Variables</Typography>
+                <TableContainer>
+                  <Table sx={{ minWidth: 650 }} aria-label="table of variables">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Visibility</TableCell>
+                        <TableCell>Name</TableCell>
+                        <TableCell>Type</TableCell>
+                        <TableCell align="right" />
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {extVar.definitions.map((v) => (
+                        <TableRow key={v.spec.name}>
+                          <TableCell component="th" scope="row">
+                            <Switch checked={v.spec.display?.hidden !== true} disabled />
+                          </TableCell>
+                          <TableCell component="th" scope="row" sx={{ fontWeight: 'bold' }}>
+                            <VariableName
+                              name={v.spec.name}
+                              state={variableState.get({ name: v.spec.name, source: extVar.source })}
+                            />
+                          </TableCell>
+                          <TableCell>{getVariableLabelByKind(v.kind) ?? v.kind}</TableCell>
+                          <TableCell align="right">
+                            <IconButton disabled>
+                              <ArrowUp />
+                            </IconButton>
+                            <IconButton disabled>
+                              <ArrowDown />
+                            </IconButton>
+                            <IconButton disabled>
+                              <PencilIcon />
+                            </IconButton>
+                            <IconButton disabled>
+                              <TrashIcon />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Stack>
+            ))}
           </Box>
         </>
       )}
@@ -270,3 +325,25 @@ export function VariableEditor(props: {
 const TableCell = styled(MuiTableCell)(({ theme }) => ({
   borderBottom: `solid 1px ${theme.palette.divider}`,
 }));
+
+export function VariableName(props: { name: string; state: VariableState | undefined }) {
+  const { name, state } = props;
+  return (
+    <>
+      {!state?.overridden && `${name} `}
+      {!state?.overridden && state?.overriding && (
+        <Box fontWeight="normal" color={(theme) => theme.palette.primary.main}>
+          (overriding)
+        </Box>
+      )}
+      {state?.overridden && (
+        <>
+          <Box color={(theme) => theme.palette.grey[500]}>{name}</Box>
+          <Box fontWeight="normal" color={(theme) => theme.palette.grey[500]}>
+            (overridden)
+          </Box>
+        </>
+      )}
+    </>
+  );
+}

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -12,8 +12,13 @@
 // limitations under the License.
 
 import { Box } from '@mui/material';
-import { VariableDefinition } from '@perses-dev/core';
-import { useTemplateVariableDefinitions } from '../../context';
+import { VariableDefinition, VariableSpec } from '@perses-dev/core';
+import {
+  ExternalVariableDefinition,
+  useTemplateExternalVariableDefinitions,
+  useTemplateVariable,
+  useTemplateVariableDefinitions,
+} from '../../context';
 import { TemplateVariable } from './TemplateVariable';
 
 const VARIABLE_INPUT_MIN_WIDTH = '120px';
@@ -21,22 +26,38 @@ const VARIABLE_INPUT_MAX_WIDTH = '240px';
 
 export function TemplateVariableList() {
   const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
+  const externalVariableDefinitions: ExternalVariableDefinition[] = useTemplateExternalVariableDefinitions();
 
   return (
     <>
+      {externalVariableDefinitions
+        .slice()
+        .reverse() // We reverse to have the most prioritized on top
+        .map((def) =>
+          def.definitions.map((v) => (
+            <TemplateVariableListItem key={v.spec.name + def.source} spec={v.spec} source={def.source} />
+          ))
+        )}
       {variableDefinitions.map((v) => (
-        <Box
-          key={v.spec.name}
-          display={v.spec.display?.hidden ? 'none' : undefined}
-          minWidth={VARIABLE_INPUT_MIN_WIDTH}
-          maxWidth={VARIABLE_INPUT_MAX_WIDTH}
-          marginBottom={1}
-          marginRight={1}
-          data-testid="template-variable"
-        >
-          <TemplateVariable key={v.spec.name} name={v.spec.name} />
-        </Box>
+        <TemplateVariableListItem key={v.spec.name} spec={v.spec} />
       ))}
     </>
+  );
+}
+
+export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec; source?: string }) {
+  const ctx = useTemplateVariable(spec.name, source);
+  return (
+    <Box
+      key={spec.name + source ?? ''}
+      display={ctx.state?.overridden || spec.display?.hidden ? 'none' : undefined}
+      minWidth={VARIABLE_INPUT_MIN_WIDTH}
+      maxWidth={VARIABLE_INPUT_MAX_WIDTH}
+      marginBottom={1}
+      marginRight={1}
+      data-testid="template-variable"
+    >
+      <TemplateVariable key={spec.name + source ?? ''} name={spec.name} source={source} />
+    </Box>
   );
 }

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -16,18 +16,25 @@ import { createStore, useStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { devtools } from 'zustand/middleware';
 import produce from 'immer';
-import { TemplateVariableContext, VariableStateMap, VariableState, VariableOption } from '@perses-dev/plugin-system';
+import {
+  TemplateVariableContext,
+  VariableStateMap,
+  VariableState,
+  VariableStoreStateMap,
+  VariableOption,
+} from '@perses-dev/plugin-system';
 import { DEFAULT_ALL_VALUE as ALL_VALUE, VariableName, VariableValue, VariableDefinition } from '@perses-dev/core';
-import { checkSavedDefaultVariableStatus } from './utils';
+import { checkSavedDefaultVariableStatus, findVariableDefinitionByName, mergeVariableDefinitions } from './utils';
 import { hydrateTemplateVariableStates } from './hydrationUtils';
-import { useVariableQueryParams, getInitalValuesFromQueryParameters, getURLQueryParamName } from './query-params';
+import { getInitalValuesFromQueryParameters, getURLQueryParamName, useVariableQueryParams } from './query-params';
 
 type TemplateVariableStore = {
   variableDefinitions: VariableDefinition[];
-  variableState: VariableStateMap;
-  setVariableValue: (variableName: VariableName, value: VariableValue) => void;
-  setVariableOptions: (name: VariableName, options: VariableOption[]) => void;
-  setVariableLoading: (name: VariableName, loading: boolean) => void;
+  externalVariableDefinitions: ExternalVariableDefinition[];
+  variableState: VariableStoreStateMap;
+  setVariableValue: (variableName: VariableName, value: VariableValue, source?: string) => void;
+  setVariableOptions: (name: VariableName, options: VariableOption[], source?: string) => void;
+  setVariableLoading: (name: VariableName, loading: boolean, source?: string) => void;
   setVariableDefinitions: (definitions: VariableDefinition[]) => void;
   setVariableDefaultValues: () => VariableDefinition[];
   getSavedVariablesStatus: () => { isSavedVariableModified: boolean; modifiedVariableNames: string[] };
@@ -36,7 +43,7 @@ type TemplateVariableStore = {
 const TemplateVariableStoreContext = createContext<ReturnType<typeof createTemplateVariableSrvStore> | undefined>(
   undefined
 );
-function useTemplateVariableStoreCtx() {
+export function useTemplateVariableStoreCtx() {
   const context = useContext(TemplateVariableStoreContext);
   if (!context) {
     throw new Error('TemplateVariableStoreContext not initialized');
@@ -46,36 +53,57 @@ function useTemplateVariableStoreCtx() {
 
 export function useTemplateVariableValues(variableNames?: string[]) {
   const store = useTemplateVariableStoreCtx();
-  const state = useStore(
+  return useStore(
     store,
     (s) => {
-      const names = variableNames ?? Object.keys(s.variableState);
       const vars: VariableStateMap = {};
+
+      // Collect values of local variables, from the variable state
+      const names = variableNames ?? s.variableDefinitions.map((value) => value.spec.name);
       names.forEach((name) => {
-        const varState = s.variableState[name];
-        if (!varState) {
+        const varState = s.variableState.get({ name });
+        if (!varState || varState.overridden) {
           return;
         }
         vars[name] = varState;
       });
+
+      // Collect values of external variables, from the variable state
+      s.externalVariableDefinitions.forEach((d) => {
+        const source = d.source;
+        d.definitions.forEach((value) => {
+          const name = value.spec.name;
+          const varState = s.variableState.get({ name, source });
+          if (!varState || varState.overridden) {
+            return;
+          }
+          vars[name] = varState;
+        });
+      });
+
       return vars;
     },
     (left, right) => {
       return JSON.stringify(left) === JSON.stringify(right);
     }
   );
-  return state;
 }
 
-export function useTemplateVariable(name: string) {
+/**
+ * Get the state and definition of a variable from the Template variables context.
+ * @param name name of the variable
+ * @param source if given, it searches in the external variables
+ */
+export function useTemplateVariable(name: string, source?: string) {
   const store = useTemplateVariableStoreCtx();
   return useStore(store, (s) => {
-    const variableState = s.variableState[name];
-    const definition = s.variableDefinitions.find((v) => v.spec.name === name);
-    return {
-      state: variableState,
-      definition,
-    };
+    const state = s.variableState.get({ name, source });
+    const definitions = source
+      ? s.externalVariableDefinitions.find((v) => v.source === source)?.definitions
+      : s.variableDefinitions;
+    const definition = (definitions || []).find((v) => v.spec.name === name);
+
+    return { state, definition };
   });
 }
 
@@ -98,6 +126,11 @@ export function useTemplateVariableDefinitions() {
   return useStore(store, (s) => s.variableDefinitions);
 }
 
+export function useTemplateExternalVariableDefinitions() {
+  const store = useTemplateVariableStoreCtx();
+  return useStore(store, (s) => s.externalVariableDefinitions);
+}
+
 export function useTemplateVariableStore() {
   const store = useTemplateVariableStoreCtx();
   return useStore(store);
@@ -106,6 +139,7 @@ export function useTemplateVariableStore() {
 function PluginProvider({ children }: { children: React.ReactNode }) {
   const originalValues = useTemplateVariableValues();
   const definitions = useTemplateVariableDefinitions();
+  const externalDefinitions = useTemplateExternalVariableDefinitions();
 
   const values = useMemo(() => {
     const contextValues: VariableStateMap = {};
@@ -117,7 +151,7 @@ function PluginProvider({ children }: { children: React.ReactNode }) {
       const v = { ...originalValues[name] } as VariableState;
 
       if (v.value === ALL_VALUE) {
-        const definition = definitions.find((d) => d.spec.name === name);
+        const definition = findVariableDefinitionByName(name, definitions, externalDefinitions);
         // If the variable is a list variable and has a custom all value, then use that value instead
         if (definition?.kind === 'ListVariable' && definition.spec.custom_all_value) {
           v.value = definition.spec.custom_all_value;
@@ -128,37 +162,51 @@ function PluginProvider({ children }: { children: React.ReactNode }) {
       contextValues[name] = v;
     });
     return contextValues;
-  }, [originalValues, definitions]);
+  }, [originalValues, definitions, externalDefinitions]);
 
   return <TemplateVariableContext.Provider value={{ state: values }}>{children}</TemplateVariableContext.Provider>;
 }
 
 interface TemplateVariableSrvArgs {
   initialVariableDefinitions?: VariableDefinition[];
+  externalVariableDefinitions?: ExternalVariableDefinition[];
   queryParams?: ReturnType<typeof useVariableQueryParams>;
 }
 
-function createTemplateVariableSrvStore({ initialVariableDefinitions = [], queryParams }: TemplateVariableSrvArgs) {
+function createTemplateVariableSrvStore({
+  initialVariableDefinitions = [],
+  externalVariableDefinitions = [],
+  queryParams,
+}: TemplateVariableSrvArgs) {
   const initialParams = getInitalValuesFromQueryParameters(queryParams ? queryParams[0] : {});
   const store = createStore<TemplateVariableStore>()(
     devtools(
       immer((set, get) => ({
-        variableState: hydrateTemplateVariableStates(initialVariableDefinitions, initialParams),
+        variableState: hydrateTemplateVariableStates(
+          initialVariableDefinitions,
+          initialParams,
+          externalVariableDefinitions
+        ),
         variableDefinitions: initialVariableDefinitions,
+        externalVariableDefinitions: externalVariableDefinitions,
         setVariableDefinitions(definitions: VariableDefinition[]) {
           set(
             (state) => {
               state.variableDefinitions = definitions;
-              state.variableState = hydrateTemplateVariableStates(definitions, initialParams);
+              state.variableState = hydrateTemplateVariableStates(
+                definitions,
+                initialParams,
+                externalVariableDefinitions
+              );
             },
             false,
             '[Variables] setVariableDefinitions' // Used for action name in Redux devtools
           );
         },
-        setVariableOptions(name, options) {
+        setVariableOptions(name, options, source?: string) {
           set(
             (state) => {
-              const varState = state.variableState[name];
+              const varState = state.variableState.get({ name, source });
               if (!varState) {
                 return;
               }
@@ -168,10 +216,10 @@ function createTemplateVariableSrvStore({ initialVariableDefinitions = [], query
             '[Variables] setVariableOptions'
           );
         },
-        setVariableLoading(name, loading) {
+        setVariableLoading(name, loading, source?: string) {
           set(
             (state) => {
-              const varState = state.variableState[name];
+              const varState = state.variableState.get({ name, source });
               if (!varState) {
                 return;
               }
@@ -181,11 +229,11 @@ function createTemplateVariableSrvStore({ initialVariableDefinitions = [], query
             '[Variables] setVariableLoading'
           );
         },
-        setVariableValue: (name, value) =>
+        setVariableValue: (name, value, source?: string) =>
           set(
             (state) => {
               let val = value;
-              const varState = state.variableState[name];
+              const varState = state.variableState.get({ name, source });
               if (!varState) {
                 return;
               }
@@ -212,8 +260,9 @@ function createTemplateVariableSrvStore({ initialVariableDefinitions = [], query
           const variableState = get().variableState;
           const updatedVariables = produce(variableDefinitions, (draft) => {
             draft.forEach((variable, index) => {
+              const name = variable.spec.name;
               if (variable.kind === 'ListVariable') {
-                const currentVariable = variableState[variable.spec.name];
+                const currentVariable = variableState.get({ name });
                 if (currentVariable?.value !== undefined) {
                   draft[index] = {
                     kind: 'ListVariable',
@@ -223,7 +272,7 @@ function createTemplateVariableSrvStore({ initialVariableDefinitions = [], query
                   };
                 }
               } else if (variable.kind === 'TextVariable') {
-                const currentVariable = variableState[variable.spec.name];
+                const currentVariable = variableState.get({ name });
                 const currentVariableValue = typeof currentVariable?.value === 'string' ? currentVariable.value : '';
                 if (currentVariable?.value !== undefined) {
                   draft[index] = {
@@ -255,14 +304,35 @@ function createTemplateVariableSrvStore({ initialVariableDefinitions = [], query
   return store;
 }
 
+export type ExternalVariableDefinition = {
+  source: string;
+  definitions: VariableDefinition[];
+};
+
 export interface TemplateVariableProviderProps {
   children: React.ReactNode;
   initialVariableDefinitions?: VariableDefinition[];
+  /**
+   * The external variables allow you to give to the provider some additional variables, not defined in the dashboard and static.
+   * It means that you won´t be able to update them from the dashboard itself, but you will see them appear and will be able
+   * to modify their runtime value as any other variable.
+   * If one of the external variable has the same name as a local one, it will be marked as overridden.
+   * You can define one list of variable definition by source and as many source as you want.
+   * The order of the sources is important as first one will take precedence on the following ones, in case they have same names.
+   */
+  externalVariableDefinitions?: ExternalVariableDefinition[];
 }
 
-export function TemplateVariableProvider({ children, initialVariableDefinitions = [] }: TemplateVariableProviderProps) {
-  const queryParams = useVariableQueryParams(initialVariableDefinitions);
-  const [store] = useState(createTemplateVariableSrvStore({ initialVariableDefinitions, queryParams }));
+export function TemplateVariableProvider({
+  children,
+  initialVariableDefinitions = [],
+  externalVariableDefinitions = [],
+}: TemplateVariableProviderProps) {
+  const allVariableDefs = mergeVariableDefinitions(initialVariableDefinitions, externalVariableDefinitions);
+  const queryParams = useVariableQueryParams(allVariableDefs);
+  const [store] = useState(
+    createTemplateVariableSrvStore({ initialVariableDefinitions, externalVariableDefinitions, queryParams })
+  );
 
   return (
     <TemplateVariableStoreContext.Provider value={store}>

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { DEFAULT_ALL_VALUE, VariableDefinition } from '@perses-dev/core';
+import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 import { hydrateTemplateVariableStates } from './hydrationUtils';
 
 describe('hydrateTemplateVariableStates', () => {
@@ -38,6 +39,113 @@ describe('hydrateTemplateVariableStates', () => {
       },
     ];
     const result = hydrateTemplateVariableStates(definitions, {});
-    expect(result?.instance?.value).toEqual(DEFAULT_ALL_VALUE);
+    expect(result?.get({ name: 'instance' })?.value).toEqual(DEFAULT_ALL_VALUE);
+  });
+  test('external definitions overridden and overriding', () => {
+    const definitions: VariableDefinition[] = [
+      {
+        kind: 'TextVariable',
+        spec: {
+          name: 'project_var',
+          value: 'something',
+        },
+      },
+      {
+        kind: 'TextVariable',
+        spec: {
+          name: 'greetings',
+          value: 'something',
+        },
+      },
+    ];
+
+    const externalDefinitions: ExternalVariableDefinition[] = [
+      {
+        source: 'project',
+        definitions: [
+          {
+            kind: 'TextVariable',
+            spec: {
+              name: 'greetings',
+              display: {
+                name: 'Greetings(project)',
+              },
+              value: 'hello',
+            },
+          },
+          {
+            kind: 'TextVariable',
+            spec: {
+              name: 'project_var',
+              value: 'something',
+            },
+          },
+        ],
+      },
+      {
+        source: 'global',
+        definitions: [
+          {
+            kind: 'TextVariable',
+            spec: {
+              name: 'greetings',
+              display: {
+                name: 'Greetings(global)',
+              },
+              value: 'hello',
+            },
+          },
+          {
+            kind: 'TextVariable',
+            spec: {
+              name: 'global_var',
+              value: 'global scope value',
+            },
+          },
+        ],
+      },
+    ];
+
+    const localStateResult = hydrateTemplateVariableStates(definitions, {}, externalDefinitions);
+
+    // Verify hydration of local variable state
+    expect(localStateResult.get({ name: 'project_var' })).toEqual({
+      value: 'something',
+      loading: false,
+      overriding: true,
+      overridden: false,
+    });
+    expect(localStateResult.get({ name: 'greetings' })).toEqual({
+      value: 'something',
+      loading: false,
+      overriding: true,
+      overridden: false,
+    });
+
+    // Verify hydration of external variable state
+    expect(localStateResult.get({ source: 'project', name: 'greetings' })).toEqual({
+      value: 'hello',
+      loading: false,
+      overriding: true,
+      overridden: true,
+    });
+    expect(localStateResult.get({ source: 'project', name: 'project_var' })).toEqual({
+      value: 'something',
+      loading: false,
+      overriding: false,
+      overridden: true,
+    });
+    expect(localStateResult.get({ source: 'global', name: 'greetings' })).toEqual({
+      value: 'hello',
+      loading: false,
+      overriding: false,
+      overridden: true,
+    });
+    expect(localStateResult.get({ source: 'global', name: 'global_var' })).toEqual({
+      value: 'global scope value',
+      loading: false,
+      overriding: false,
+      overridden: false,
+    });
   });
 });

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
@@ -12,13 +12,16 @@
 // limitations under the License.
 
 import { DEFAULT_ALL_VALUE, VariableValue, VariableDefinition } from '@perses-dev/core';
-import { VariableStateMap, VariableState } from '@perses-dev/plugin-system';
+import { VariableStoreStateMap, VariableState } from '@perses-dev/plugin-system';
+import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 
 // TODO: move to TemplateVariableProvider/utils.ts
-function hydrateTemplateVariableState(variable: VariableDefinition, initialValue?: VariableValue) {
+function hydrateTemplateVariableState(variable: VariableDefinition, initialValue?: VariableValue): VariableState {
   const varState: VariableState = {
     value: null,
     loading: false,
+    overriding: false,
+    overridden: false,
   };
   switch (variable.kind) {
     case 'TextVariable':
@@ -51,17 +54,76 @@ function hydrateTemplateVariableState(variable: VariableDefinition, initialValue
   return varState;
 }
 
+/**
+ * Build the local variable states according to the given definitions
+ * @param localDefinitions local variable definitions. Dynamic part.
+ * @param externalDefinitions external variables definitions. Static part.
+ * @param initialValues values coming from query parameters
+ */
 export function hydrateTemplateVariableStates(
-  definitions: VariableDefinition[],
-  initialValues: Record<string, VariableValue>
-): VariableStateMap {
-  const state: VariableStateMap = {};
-  definitions.forEach((v) => {
+  localDefinitions: VariableDefinition[],
+  initialValues: Record<string, VariableValue>,
+  externalDefinitions: ExternalVariableDefinition[] = []
+): VariableStoreStateMap {
+  const state: VariableStoreStateMap = new VariableStoreStateMap();
+
+  // Collect the names used by local definitions
+  let overridingNames: Record<string, boolean> = {};
+  localDefinitions.forEach((v) => {
+    overridingNames[v.spec.name] = true;
+  }, {} as Record<string, boolean>);
+
+  // Then populate the external variables state,
+  // taking care of well flagging each name as used, so the overridden state can be filled accordingly.
+  const overriddenNames: Record<string, boolean> = {};
+  externalDefinitions.forEach((externalDef) => {
+    const source = externalDef.source;
+    externalDef.definitions.forEach((v) => {
+      const name = v.spec.name;
+      const param = initialValues[name];
+      const initialValue = param ? param : null;
+      state.set(
+        { source, name },
+        {
+          ...hydrateTemplateVariableState(v, initialValue),
+          overridden: !!overridingNames[name],
+        }
+      );
+
+      overridingNames[name] = true;
+      overriddenNames[v.spec.name] = true;
+    });
+  }, {} as Record<string, boolean>);
+
+  // Then populate the local variables state,
+  // taking care the overriding state is filled according to the names used in external variables.
+  localDefinitions.forEach((v) => {
     const name = v.spec.name;
     const param = initialValues[name];
     const initialValue = param ? param : null;
-    state[name] = hydrateTemplateVariableState(v, initialValue);
+    state.set(
+      { name },
+      {
+        ...hydrateTemplateVariableState(v, initialValue),
+        overriding: !!overriddenNames[name],
+      }
+    );
   });
 
+  overridingNames = {};
+  externalDefinitions
+    .slice()
+    .reverse()
+    .forEach((externalDef) => {
+      const source = externalDef.source;
+      externalDef.definitions.forEach((v) => {
+        const name = v.spec.name;
+        const value = state.get({ source, name });
+        if (value) {
+          value.overriding = !!overridingNames[name];
+        }
+        overridingNames[name] = true;
+      });
+    });
   return state;
 }

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
@@ -12,29 +12,86 @@
 // limitations under the License.
 
 import { VariableDefinition } from '@perses-dev/core';
-import { VariableStateMap } from '@perses-dev/plugin-system';
+import { VariableStoreStateMap } from '@perses-dev/plugin-system';
+import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 
 /*
  * Check whether saved variable definitions are out of date with current default list values in Zustand store
  */
-export function checkSavedDefaultVariableStatus(definitions: VariableDefinition[], varState: VariableStateMap) {
+export function checkSavedDefaultVariableStatus(definitions: VariableDefinition[], varState: VariableStoreStateMap) {
   let isSavedVariableModified = false;
   const modifiedVariableNames: string[] = [];
   for (const savedVariable of definitions) {
+    const name = savedVariable.spec.name;
     if (savedVariable.kind === 'ListVariable') {
-      const currentVariable = varState[savedVariable.spec.name];
+      const currentVariable = varState.get({ name });
       if (currentVariable?.value !== null && currentVariable?.value !== savedVariable.spec.default_value) {
-        modifiedVariableNames.push(savedVariable.spec.name);
+        modifiedVariableNames.push(name);
         isSavedVariableModified = true;
       }
     } else if (savedVariable.kind === 'TextVariable') {
-      const currentVariable = varState[savedVariable.spec.name];
+      const currentVariable = varState.get({ name });
       const currentVariableValue = typeof currentVariable?.value === 'string' ? currentVariable.value : '';
       if (savedVariable.spec.value !== currentVariableValue) {
-        modifiedVariableNames.push(savedVariable.spec.name);
+        modifiedVariableNames.push(name);
         isSavedVariableModified = true;
       }
     }
   }
   return { isSavedVariableModified, modifiedVariableNames };
+}
+
+/**
+ * Merge the different kind of variable definition into a list without any duplicates (same name).
+ * Respects the order of priority explained in {@link forEachVariableDefinition}
+ * @param locals
+ * @param externals
+ */
+export function mergeVariableDefinitions(
+  locals: VariableDefinition[],
+  externals: ExternalVariableDefinition[]
+): VariableDefinition[] {
+  const pushed: Record<string, boolean> = {};
+  const result: VariableDefinition[] = [];
+
+  // Append the value only if it's not already appended
+  forEachVariableDefinition(locals, externals, (value: VariableDefinition, name: string) => {
+    if (!pushed[name]) {
+      result.push(value);
+      pushed[name] = true;
+    }
+  });
+  return result;
+}
+
+/**
+ * Find a definition by its name.
+ * Respects the order of priority explained in {@link forEachVariableDefinition}
+ * @param name
+ * @param localDefinitions
+ * @param externalDefinitions
+ */
+export function findVariableDefinitionByName(
+  name: string,
+  localDefinitions: VariableDefinition[],
+  externalDefinitions: ExternalVariableDefinition[]
+): VariableDefinition | undefined {
+  return mergeVariableDefinitions(localDefinitions, externalDefinitions).find((d) => d.spec.name === name);
+}
+
+/**
+ * Loop on local and external variable definitions, respecting the order of priority:
+ * - local var defs override external var defs of same name
+ * - each external var defs override the external var defs coming after.
+ * @param locals
+ * @param externals
+ * @param callbackFn
+ */
+export function forEachVariableDefinition(
+  locals: VariableDefinition[],
+  externals: ExternalVariableDefinition[],
+  callbackFn: (varDef: VariableDefinition, name: string, source?: string) => void
+) {
+  locals.forEach((v) => callbackFn(v, v.spec.name));
+  externals.forEach((ext) => ext.definitions.forEach((v) => callbackFn(v, v.spec.name, ext.source)));
 }

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -20,11 +20,13 @@ import {
   DashboardProvider,
   DatasourceStoreProviderProps,
   DatasourceStoreProvider,
+  TemplateVariableProviderProps,
 } from '../../context';
 import { DashboardApp, DashboardAppProps } from './DashboardApp';
 
 export interface ViewDashboardProps extends Omit<BoxProps, 'children'>, DashboardAppProps {
   datasourceApi: DatasourceStoreProviderProps['datasourceApi'];
+  externalVariableDefinitions?: TemplateVariableProviderProps['externalVariableDefinitions'];
   isEditing?: boolean;
 }
 
@@ -35,6 +37,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
   const {
     dashboardResource,
     datasourceApi,
+    externalVariableDefinitions,
     dashboardTitleComponent,
     emptyDashboardProps,
     onSave,
@@ -47,9 +50,9 @@ export function ViewDashboard(props: ViewDashboardProps) {
   } = props;
   const { spec } = dashboardResource;
   const dashboardDuration = spec.duration ?? DEFAULT_DASHBOARD_DURATION;
-  const dashhboardRefreshInterval = spec.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
+  const dashboardRefreshInterval = spec.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
   const initialTimeRange = useInitialTimeRange(dashboardDuration);
-  const initialRefreshInterval = useInitialRefreshInterval(dashhboardRefreshInterval);
+  const initialRefreshInterval = useInitialRefreshInterval(dashboardRefreshInterval);
 
   return (
     <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>
@@ -59,7 +62,10 @@ export function ViewDashboard(props: ViewDashboardProps) {
           initialRefreshInterval={initialRefreshInterval}
           enabledURLParams={true}
         >
-          <TemplateVariableProvider initialVariableDefinitions={spec.variables}>
+          <TemplateVariableProvider
+            initialVariableDefinitions={spec.variables}
+            externalVariableDefinitions={externalVariableDefinitions}
+          >
             <Box
               sx={combineSx(
                 {

--- a/ui/plugin-system/src/runtime/template-variable.test.ts
+++ b/ui/plugin-system/src/runtime/template-variable.test.ts
@@ -1,0 +1,54 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { VariableStoreStateMap } from '@perses-dev/plugin-system';
+
+describe('VariableStoreStateMap', function () {
+  let sut: VariableStoreStateMap;
+
+  beforeEach(() => {
+    sut = new VariableStoreStateMap();
+    sut.set({ name: 'varA', source: 'srcA' }, { value: 'value1', loading: false });
+    sut.set({ name: 'varA' }, { value: 'value2', loading: false });
+  });
+
+  test('check the update of the reference', function () {
+    const ref = sut.get({ name: 'varA', source: 'srcA' });
+    if (ref) {
+      ref.loading = true;
+    }
+    expect(sut.get({ name: 'varA', source: 'srcA' })).toEqual({ value: 'value1', loading: true });
+  });
+
+  test('check has/get methods', function () {
+    expect(sut.has({ name: 'varA' })).toEqual(true);
+    expect(sut.get({ name: 'varA' })).toEqual({ value: 'value2', loading: false });
+
+    expect(sut.has({ name: 'varA', source: '' })).toEqual(true);
+    expect(sut.get({ name: 'varA', source: '' })).toEqual({ value: 'value2', loading: false });
+
+    expect(sut.has({ name: 'varA', source: 'srcA' })).toEqual(true);
+    expect(sut.get({ name: 'varA', source: 'srcA' })).toEqual({ value: 'value1', loading: false });
+
+    expect(sut.has({ name: 'varB', source: 'srcA' })).toEqual(false);
+    expect(sut.get({ name: 'varB', source: 'srcA' })).toEqual(undefined);
+  });
+
+  test('check delete methods', function () {
+    expect(sut.delete({ name: 'varA' })).toEqual(true);
+    expect(sut.delete({ name: 'varA', source: 'srcA' })).toEqual(true);
+
+    expect(sut.has({ name: 'varA' })).toEqual(false);
+    expect(sut.has({ name: 'varA', source: 'srcA' })).toEqual(false);
+  });
+});

--- a/ui/plugin-system/src/runtime/template-variables.ts
+++ b/ui/plugin-system/src/runtime/template-variables.ts
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import { createContext, useContext, useMemo } from 'react';
-import { VariableName, VariableValue } from '@perses-dev/core';
+import { VariableValue } from '@perses-dev/core';
+import { immerable } from 'immer';
 import { VariableOption } from '../model';
 import { parseTemplateVariables, replaceTemplateVariables } from '../utils';
 
@@ -21,9 +22,106 @@ export type VariableState = {
   options?: VariableOption[];
   loading: boolean;
   error?: Error;
+  /**
+   * If a local variable is overriding an external variable, local var will have the flag ``overriding=true``.
+   */
+  overriding?: boolean;
+  /**
+   * If a local variable is overriding an external variable, external var will have the flag ``overridden=true``.
+   */
+  overridden?: boolean;
+  default_value?: VariableValue;
 };
 
-export type VariableStateMap = Record<VariableName, VariableState>;
+export type VariableStateMap = Record<string, VariableState>;
+
+/**
+ * Structure used as key in the {@link VariableStoreStateMap}.
+ */
+export type VariableStateKey = {
+  /**
+   * name of the variable we want to access in the state.
+   */
+  name: string;
+  /**
+   * source of the variable we want to access in the state.
+   * Defined only for external variables.
+   */
+  source?: string;
+};
+
+/**
+ * A state map with two entry keys, materialized by {@link VariableStateKey} structure.
+ */
+export class VariableStoreStateMap {
+  /**
+   * "Immerable" is mandatory to be able to use this class in an immer context.
+   * Ref: https://docs.pmnd.rs/zustand/integrations/immer-middleware#gotchas
+   */
+  [immerable] = true;
+
+  private readonly DEFAULT_LOCAL_SOURCE_NAME = '';
+  private readonly _state: Record<string, Record<string, VariableState>> = {};
+
+  /**
+   * Get variable state by key.
+   * @param key
+   */
+  get(key: VariableStateKey): VariableState | undefined {
+    return this._sourceStatesOrEmpty(key.source)[key.name];
+  }
+
+  /**
+   * Set variable state by key.
+   * @param key
+   * @param value
+   */
+  set(key: VariableStateKey, value: VariableState): VariableState | undefined {
+    const sourceName = this._sourceName(key.source);
+    if (!this._state[sourceName]) {
+      this._state[sourceName] = {};
+    }
+    this._sourceStatesOrEmpty(key.source)[key.name] = value;
+    return value;
+  }
+
+  /**
+   * Check presence of variable state by key.
+   * @param key
+   */
+  has(key: VariableStateKey): boolean {
+    return this._sourceStatesOrEmpty(key.source)[key.name] !== undefined;
+  }
+
+  /**
+   * Delete variable state by key.
+   * @param key
+   */
+  delete(key: VariableStateKey): boolean {
+    const result = this.has(key);
+    const sourceName = this._sourceName(key.source);
+    const sourceStates = this._state[sourceName];
+
+    // Delete var from source state
+    if (sourceStates) {
+      delete sourceStates[key.name];
+    }
+
+    // Delete source state from state if empty
+    if (Object.keys(sourceStates ?? {})?.length === 0) {
+      delete this._state[sourceName];
+    }
+    return result;
+  }
+
+  private _sourceName(source: string | undefined): string {
+    return source ?? this.DEFAULT_LOCAL_SOURCE_NAME;
+  }
+
+  private _sourceStatesOrEmpty(source: string | undefined): Record<string, VariableState> {
+    return this._state[this._sourceName(source)] ?? {};
+  }
+}
 
 export type TemplateVariableSrv = {
   state: VariableStateMap;


### PR DESCRIPTION
This PR introduce the logic to take into account a new type of variables into the dashboards. I call them here "external" and they contains all the variables that are not defined inside the Dashboard itself. 
Spoiler alert, in the Perses UI, it would describe the new "project scope" and "global scope" variables. 

The idea here is to include them as specific variables in the store, so they would be taken in account into the view, but not in the backend requests. 

> **Disclaimer from a react newbie**
> Despite the fact that it works well, I am not sure I'm using the store as I should. In particular, I put the ``overridden``/``overriding`` booleans inside the state object(s) of the store, but I need to recompute them in the drawer (see VariableEditor.tsx) as the store is not used there while we don´t save changes. 
> **I'm open to suggestions**.

Visually it would render the following type of screenshot, where we can see
- the external variables disabled as we cannot edit them;
- the overridden/overriding information alongside each variable in the drawer. They are dynamically updated if we add/remove a variable in the list;
- the overridden variables does not appear in the variable list behind.

> NB: the override mechanism means that a variable definition is used in place of another of same name
> local variable overrides all external variables of any source
> external variable from project source overrides external variable from global sources.

![MicrosoftTeams-image](https://github.com/perses/perses/assets/10258608/ff4aaecd-e198-41ff-9acb-b4bcd3e8e276)
![MicrosoftTeams-image (1)](https://github.com/perses/perses/assets/10258608/4e212cc8-7dca-4d85-a9c9-2ea25219ba80)

### Proposal for the display of overridden/overriding variables
![image](https://github.com/perses/perses/assets/10258608/99353f00-5864-41b4-acd5-7636a3b384a2)

### Proposal for a shortcut to override easily an external variable
![override_external_var_shortcut](https://github.com/perses/perses/assets/10258608/99aedb5f-e8b0-4959-86e5-803e6d773217)


<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
