### PR TITLE
[BUGFIX] Ensure pinned tooltip shows behind modals / sticky header

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -96,7 +96,7 @@ export const TimeSeriesTooltip = memo(function TimeSeriesTooltip({
           visibility: 'visible',
           opacity: 1,
           transition: 'all 0.1s ease-out',
-          zIndex: theme.zIndex.tooltip,
+          zIndex: pinnedPos !== null ? 'auto' : theme.zIndex.tooltip, // Ensure pinned tooltip shows behind sticky header
           overflow: 'hidden',
           '&:hover': {
             overflowY: 'auto',

--- a/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -96,7 +96,8 @@ export const TimeSeriesTooltip = memo(function TimeSeriesTooltip({
           visibility: 'visible',
           opacity: 1,
           transition: 'all 0.1s ease-out',
-          zIndex: pinnedPos !== null ? 'auto' : theme.zIndex.tooltip, // Ensure pinned tooltip shows behind sticky header
+          // Ensure pinned tooltip shows behind edit panel drawer and sticky header
+          zIndex: pinnedPos !== null ? 'auto' : theme.zIndex.tooltip,
           overflow: 'hidden',
           '&:hover': {
             overflowY: 'auto',


### PR DESCRIPTION
Pinned tooltip fixed to not show above edit panel drawer and sticky header.

## Before
![edit_panel_overlap_bug](https://github.com/perses/perses/assets/9369625/7ca130c7-f7b5-4d60-96db-7ca9b82cd347)

![sticky_header_overlap_bug](https://github.com/perses/perses/assets/9369625/64ff8c9b-6fa0-474e-aa70-766c19552a0b)

## After

<img width="927" alt="image" src="https://github.com/perses/perses/assets/9369625/40adee37-4a02-42a4-a4ae-3a3312f55e07">
