### PR TITLE
[BUGFIX] Highlighted series not always cleared when cursor moved quickly

### DIFF
--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -42,7 +42,15 @@ import { useChartsTheme } from '../context/ChartsThemeProvider';
 import { TimeSeriesTooltip } from '../TimeSeriesTooltip';
 import { useTimeZone } from '../context/TimeZoneProvider';
 import { CursorCoordinates } from '../TimeSeriesTooltip/tooltip-model';
-import { enableDataZoom, getDateRange, getFormattedDate, getYAxes, restoreChart, ZoomEventData } from './utils';
+import {
+  clearHighlightedSeries,
+  enableDataZoom,
+  getDateRange,
+  getFormattedDate,
+  getYAxes,
+  restoreChart,
+  ZoomEventData,
+} from './utils';
 
 use([
   EChartsLineChart,
@@ -249,6 +257,9 @@ export function LineChart({
       onMouseLeave={() => {
         if (tooltipPinnedCoords === null) {
           setShowTooltip(false);
+        }
+        if (chartRef.current !== undefined) {
+          clearHighlightedSeries(chartRef.current, data.timeSeries.length);
         }
       }}
       onMouseEnter={() => {

--- a/ui/components/src/LineChart/utils.ts
+++ b/ui/components/src/LineChart/utils.ts
@@ -104,3 +104,18 @@ export function getYAxes(yAxis?: YAXisComponentOption, unit?: UnitOptions) {
   };
   return [merge(Y_AXIS_DEFAULT, yAxis)];
 }
+
+/*
+ * Clear all highlighted series when cursor exits canvas
+ * https://echarts.apache.org/en/api.html#action.downplay
+ */
+export function clearHighlightedSeries(chart: EChartsInstance, totalSeries: number) {
+  if (chart.dispatchAction !== undefined) {
+    for (let i = 0; i < totalSeries; i++) {
+      chart.dispatchAction({
+        type: 'downplay',
+        seriesIndex: i,
+      });
+    }
+  }
+}

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -202,16 +202,6 @@ export function getNearbySeriesData({
     }
   }
 
-  // clear all highlighted series when cursor exits canvas
-  // https://echarts.apache.org/en/api.html#action.downplay
-  for (let i = 0; i < totalSeries; i++) {
-    if (chart?.dispatchAction !== undefined) {
-      chart.dispatchAction({
-        type: 'downplay',
-        seriesIndex: i,
-      });
-    }
-  }
   return [];
 }
 


### PR DESCRIPTION
Move clear highlighted series function to onMouseLeave so it works even when cursor is moved quickly.

Before it could stay like this when leaving panel:
<img width="530" alt="image" src="https://github.com/perses/perses/assets/9369625/83ac8709-bbc4-4678-95dd-f902c46c2ea7">
