### PR TITLE
[BUGFIX] avoid unnecessary horizontal scroll with table & legend

### DIFF
--- a/ui/components/src/Legend/ListLegend.tsx
+++ b/ui/components/src/Legend/ListLegend.tsx
@@ -46,9 +46,7 @@ export function ListLegend({ items, height, width, selectedItems, onLegendItemCl
             isVisuallySelected={isLegendItemVisuallySelected(item, selectedItems)}
             onClick={onLegendItemClick}
             sx={{
-              // Having an explicit width is important for the ellipsizing to
-              // work correctly. Subtract padding to simulate padding.
-              width: width,
+              width: '100%',
               wordBreak: 'break-word',
               overflow: 'hidden',
             }}

--- a/ui/components/src/Table/InnerTable.tsx
+++ b/ui/components/src/Table/InnerTable.tsx
@@ -32,7 +32,7 @@ const TABLE_DENSITY_CONFIG: Record<TableDensity, MuiTableProps['size']> = {
 };
 
 export const InnerTable = forwardRef<HTMLTableElement, InnerTableProps>(function InnerTable(
-  { density, width, ...otherProps },
+  { density, ...otherProps },
   ref
 ) {
   return (
@@ -42,7 +42,7 @@ export const InnerTable = forwardRef<HTMLTableElement, InnerTableProps>(function
       size={TABLE_DENSITY_CONFIG[density]}
       ref={ref}
       sx={{
-        width: width,
+        width: '100%',
       }}
     />
   );


### PR DESCRIPTION
Previously, the table and legend didn't properly account for spacing for the scrollbar causing unnecessary horizontal scroll, which is distracting when scrollbars are visible. It's easy to miss use cases like this as a mac user with a trackpad, because it hides the scrollbars by default. 😢 

This change should address cases where there is an unnecessary horizontal scroll in the table and legend caused by this. It does not address all cases of unwanted horizontal scrollbars.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

# Screenshots

All screenshots taken with my mac configured to always show scrollbars to make it very clear what the problem was and how it looks after a fix.

## Table

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="622" alt="image" src="https://github.com/perses/perses/assets/396962/2bf079cd-4e7f-4a32-931d-8ad271457cca">
</td>
		<td>
<img width="620" alt="image" src="https://github.com/perses/perses/assets/396962/07aa234b-edd2-4d43-a6e0-0e3a6d763c26">
</td>
	</tr>
</table>

## Legend

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="626" alt="image" src="https://github.com/perses/perses/assets/396962/1c62b903-0abb-4c2e-a77e-2a7df26e0643">
</td>
		<td>
<img width="635" alt="image" src="https://github.com/perses/perses/assets/396962/8fd038dc-1d66-40ae-b482-fa9f76828f37">
</td>
	</tr>
</table>

## Multiple examples with time series panel

Note that the bottom left panel still has an issue with an oversized item. I'm not trying to fix all scroll issues in this PR. Just the ones I introduced with some of my recent changes for table legend. 

<table>
	<tr>
		<th>before</th>
		<th>after</th>
	</tr>
	<tr>
		<td>
<img width="1381" alt="image" src="https://github.com/perses/perses/assets/396962/da01d428-1418-4f1c-abb8-a830ebc9b683">
</td>
		<td>
<img width="1372" alt="image" src="https://github.com/perses/perses/assets/396962/3e458b43-df8f-446b-bb0b-db2aeb14989e">
</td>
	</tr>
</table>

