### PR TITLE
[BREAKINGCHANGE] Move DEFAULT_ALL_VALUE to core since plugin-system requires MUI

### DIFF
--- a/ui/core/src/model/variables.ts
+++ b/ui/core/src/model/variables.ts
@@ -47,3 +47,5 @@ export interface ListVariableSpec<PluginSpec> extends VariableSpec {
 }
 
 export type VariableDefinition = TextVariableDefinition | ListVariableDefinition;
+
+export const DEFAULT_ALL_VALUE = '$__all' as const;

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -13,8 +13,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Select, FormControl, InputLabel, MenuItem, Box, LinearProgress, TextField } from '@mui/material';
-import { VariableName, ListVariableDefinition, VariableValue } from '@perses-dev/core';
-import { DEFAULT_ALL_VALUE } from '@perses-dev/plugin-system';
+import { DEFAULT_ALL_VALUE, ListVariableDefinition, VariableName, VariableValue } from '@perses-dev/core';
 import { useTemplateVariable, useTemplateVariableActions } from '../../context';
 import { useListVariablePluginValues } from './variable-model';
 type TemplateVariableProps = {

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -16,15 +16,8 @@ import { createStore, useStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { devtools } from 'zustand/middleware';
 import produce from 'immer';
-
-import {
-  TemplateVariableContext,
-  VariableStateMap,
-  VariableState,
-  VariableOption,
-  DEFAULT_ALL_VALUE as ALL_VALUE,
-} from '@perses-dev/plugin-system';
-import { VariableName, VariableValue, VariableDefinition } from '@perses-dev/core';
+import { TemplateVariableContext, VariableStateMap, VariableState, VariableOption } from '@perses-dev/plugin-system';
+import { DEFAULT_ALL_VALUE as ALL_VALUE, VariableName, VariableValue, VariableDefinition } from '@perses-dev/core';
 import { checkSavedDefaultVariableStatus } from './utils';
 import { hydrateTemplateVariableStates } from './hydrationUtils';
 import { useVariableQueryParams, getInitalValuesFromQueryParameters, getURLQueryParamName } from './query-params';

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { VariableDefinition } from '@perses-dev/core';
-import { DEFAULT_ALL_VALUE } from '@perses-dev/plugin-system';
+import { DEFAULT_ALL_VALUE, VariableDefinition } from '@perses-dev/core';
 import { hydrateTemplateVariableStates } from './hydrationUtils';
 
 describe('hydrateTemplateVariableStates', () => {

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { VariableValue, VariableDefinition } from '@perses-dev/core';
-import { VariableStateMap, VariableState, DEFAULT_ALL_VALUE } from '@perses-dev/plugin-system';
+import { DEFAULT_ALL_VALUE, VariableValue, VariableDefinition } from '@perses-dev/core';
+import { VariableStateMap, VariableState } from '@perses-dev/plugin-system';
 
 // TODO: move to TemplateVariableProvider/utils.ts
 function hydrateTemplateVariableState(variable: VariableDefinition, initialValue?: VariableValue) {

--- a/ui/plugin-system/src/runtime/template-variables.ts
+++ b/ui/plugin-system/src/runtime/template-variables.ts
@@ -15,7 +15,6 @@ import { createContext, useContext, useMemo } from 'react';
 import { VariableName, VariableValue } from '@perses-dev/core';
 import { VariableOption } from '../model';
 import { parseTemplateVariables, replaceTemplateVariables } from '../utils';
-export const DEFAULT_ALL_VALUE = '$__all' as const;
 
 export type VariableState = {
   value: VariableValue;


### PR DESCRIPTION
Move `DEFAULT_ALL_VALUE` const to core from plugin-system. Similar to #1265, in an effort to move helpful types and utils to `@perses-dev/core` this is a BREAKINGCHANGE, but will allow consumers to utilize this type without requiring the entire plugin-system (avoids the consumer having to install MUI)