### PR TITLE
[BREAKINGCHANGE] Clean up refresh_interval in dashboard spec

### DIFF
--- a/ui/core/src/model/dashboard.ts
+++ b/ui/core/src/model/dashboard.ts
@@ -29,7 +29,7 @@ export interface DashboardSpec {
   display?: Display;
   datasources?: Record<string, DatasourceSpec>;
   duration: DurationString;
-  refreshInterval: DurationString;
+  refresh_interval?: DurationString;
   variables: VariableDefinition[];
   layouts: LayoutDefinition[];
   panels: Record<string, PanelDefinition>;

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -105,7 +105,7 @@ function initStore(props: DashboardProviderProps) {
   } = props;
 
   const {
-    spec: { display, duration, refreshInterval },
+    spec: { display, duration, refresh_interval },
     metadata,
   } = dashboardResource;
 
@@ -138,10 +138,13 @@ function initStore(props: DashboardProviderProps) {
           metadata,
           display,
           duration,
-          refreshInterval,
+          refreshInterval: refresh_interval,
           isEditMode: !!isEditMode,
           setEditMode: (isEditMode: boolean) => set({ isEditMode }),
-          setDashboard: ({ metadata, spec: { display, panels = {}, layouts = [], duration, refreshInterval } }) => {
+          setDashboard: ({
+            metadata,
+            spec: { display, panels = {}, layouts = [], duration, refresh_interval = '0s' },
+          }) => {
             set((state) => {
               state.metadata = metadata;
               state.display = display;
@@ -150,7 +153,7 @@ function initStore(props: DashboardProviderProps) {
               state.panelGroups = panelGroups;
               state.panelGroupOrder = panelGroupOrder;
               state.duration = duration;
-              state.refreshInterval = refreshInterval;
+              state.refreshInterval = refresh_interval;
             });
           },
         };

--- a/ui/dashboards/src/stories/decorators/constants.ts
+++ b/ui/dashboards/src/stories/decorators/constants.ts
@@ -24,7 +24,7 @@ export const EMPTY_DASHBOARD_RESOURCE: DashboardResource = {
   },
   spec: {
     duration: '1h',
-    refreshInterval: '0s',
+    refresh_interval: '0s',
     variables: [],
     layouts: [],
     panels: {},

--- a/ui/dashboards/src/test/testDashboard.ts
+++ b/ui/dashboards/src/test/testDashboard.ts
@@ -24,7 +24,7 @@ const testDashboard: DashboardResource = {
   },
   spec: {
     duration: '30m',
-    refreshInterval: '0s',
+    refresh_interval: '0s',
     variables: [
       {
         kind: 'TextVariable',

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.stories.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.stories.tsx
@@ -52,7 +52,7 @@ export const ViewEmptyState: Story = {
         version: 0,
       },
       spec: {
-        refreshInterval: '0s',
+        refresh_interval: '0s',
         duration: '1h',
         variables: [],
         layouts: [],
@@ -76,7 +76,7 @@ export const EditEmptyState: Story = {
       },
       spec: {
         duration: '1h',
-        refreshInterval: '0s',
+        refresh_interval: '0s',
         variables: [],
         layouts: [],
         panels: {},
@@ -104,7 +104,7 @@ export const CustomEmptyState: Story = {
       },
       spec: {
         duration: '1h',
-        refreshInterval: '0s',
+        refresh_interval: '0s',
         variables: [],
         layouts: [],
         panels: {},


### PR DESCRIPTION
I usually prefer camelCase but for consistency, I don't want some dashboard spec properties snake_case and others camelCase. Discussion up here if anyone has strong feelings: https://github.com/perses/perses/discussions/1243