### PR TITLE
[BUGFIX] Fix useTimeSeriesQueries return type

### DIFF
--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -119,13 +119,13 @@ export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], o
   );
 
   return useQueries({
-    queries: definitions.map<QueryObserverOptions>((definition, idx) => {
+    queries: definitions.map((definition, idx) => {
       const plugin = pluginLoaderResponse[idx]?.data;
       const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
       return {
         enabled: queryEnabled,
         queryKey: queryKey,
-        refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : false,
+        refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : undefined,
         queryFn: async () => {
           // Keep options out of query key so we don't re-run queries because suggested step changes
           const ctx: TimeSeriesQueryContext = { ...context, suggestedStepMs: options?.suggestedStepMs };

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -11,15 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  useQuery,
-  useQueries,
-  useQueryClient,
-  Query,
-  QueryCache,
-  QueryKey,
-  QueryObserverOptions,
-} from '@tanstack/react-query';
+import { useQuery, useQueries, useQueryClient, Query, QueryCache, QueryKey } from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec, TimeSeriesData } from '@perses-dev/core';
 import { TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryPlugin } from '../model';
 import { VariableStateMap, useTemplateVariableValues } from './template-variables';


### PR DESCRIPTION
This PR fixes a type error `Type unknown is not assignable to type TimeSeriesData` by removing the type cast to `QueryObserverOptions` in useTimeSeriesQueries 