### PR TITLE
[BREAKINGCHANGE] Variables spec snake_case -> camelCase 

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -31,8 +31,8 @@
           "kind": "ListVariable",
           "spec": {
             "name": "job",
-            "allow_multiple": false,
-            "allow_all_value": false,
+            "allowMultiple": false,
+            "allowAllValue": false,
             "plugin": {
               "kind": "PrometheusLabelValuesVariable",
               "spec": {
@@ -45,8 +45,8 @@
           "kind": "ListVariable",
           "spec": {
             "name": "instance",
-            "allow_multiple": false,
-            "allow_all_value": false,
+            "allowMultiple": false,
+            "allowAllValue": false,
             "plugin": {
               "kind": "PrometheusLabelValuesVariable",
               "spec": {
@@ -782,9 +782,9 @@
           "kind": "ListVariable",
           "spec": {
             "name": "job",
-            "allow_multiple": false,
-            "allow_all_value": true,
-            "default_value": "node",
+            "allowMultiple": false,
+            "allowAllValue": true,
+            "defaultValue": "node",
             "plugin": {
               "kind": "PrometheusLabelValuesVariable",
               "spec": {
@@ -797,9 +797,9 @@
           "kind": "ListVariable",
           "spec": {
             "name": "instance",
-            "allow_multiple": false,
-            "allow_all_value": false,
-            "default_value": "demo.do.prometheus.io:9100",
+            "allowMultiple": false,
+            "allowAllValue": false,
+            "defaultValue": "demo.do.prometheus.io:9100",
             "plugin": {
               "kind": "PrometheusLabelValuesVariable",
               "spec": {
@@ -3008,8 +3008,8 @@
           "kind": "ListVariable",
           "spec": {
             "name": "interval",
-            "allow_multiple": false,
-            "allow_all_value": false,
+            "allowMultiple": false,
+            "allowAllValue": false,
             "plugin": {
               "kind": "StaticListVariable",
               "spec": {
@@ -3032,9 +3032,9 @@
           "spec": {
             "name": "NewListVariable",
             "display": { "name": "Test display name", "hidden": false },
-            "default_value": "second value",
-            "allow_all_value": true,
-            "allow_multiple": false,
+            "defaultValue": "second value",
+            "allowAllValue": true,
+            "allowMultiple": false,
             "plugin": {
               "kind": "StaticListVariable",
               "spec": {
@@ -3110,8 +3110,8 @@
           "kind": "ListVariable",
           "spec": {
             "name": "interval",
-            "allow_multiple": false,
-            "allow_all_value": false,
+            "allowMultiple": false,
+            "allowAllValue": false,
             "plugin": {
               "kind": "StaticListVariable",
               "spec": {
@@ -3134,9 +3134,9 @@
           "spec": {
             "name": "NewListVariable",
             "display": { "name": "Test display name", "hidden": false },
-            "default_value": "second value",
-            "allow_all_value": true,
-            "allow_multiple": false,
+            "defaultValue": "second value",
+            "allowAllValue": true,
+            "allowMultiple": false,
             "plugin": {
               "kind": "StaticListVariable",
               "spec": {
@@ -3279,14 +3279,14 @@
               "kind": "TimeSeriesChart",
               "spec": {
                 "legend": {
-                  "mode": "table",
-                  "position": "bottom",
+                  "mode": "Table",
+                  "position": "Bottom",
                   "values": [
-                    "mean",
-                    "first-number",
-                    "last-number",
-                    "min",
-                    "max"
+                    "Mean",
+                    "FirstNumber",
+                    "LastNumber",
+                    "Min",
+                    "Max"
                   ]
                 }
               }
@@ -3316,10 +3316,13 @@
               "kind": "TimeSeriesChart",
               "spec": {
                 "legend": {
-                  "mode": "table",
-                  "position": "right",
-                  "size": "small",
-                  "values": ["mean", "last-number"]
+                  "mode": "Table",
+                  "position": "Right",
+                  "size": "Small",
+                  "values": [
+                    "Mean",
+                    "LastNumber"
+                  ]
                 }
               }
             },

--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -3279,14 +3279,14 @@
               "kind": "TimeSeriesChart",
               "spec": {
                 "legend": {
-                  "mode": "Table",
-                  "position": "Bottom",
+                  "mode": "table",
+                  "position": "bottom",
                   "values": [
-                    "Mean",
-                    "FirstNumber",
-                    "LastNumber",
-                    "Min",
-                    "Max"
+                    "mean",
+                    "first-number",
+                    "last-number",
+                    "min",
+                    "max"
                   ]
                 }
               }
@@ -3316,13 +3316,10 @@
               "kind": "TimeSeriesChart",
               "spec": {
                 "legend": {
-                  "mode": "Table",
-                  "position": "Right",
-                  "size": "Small",
-                  "values": [
-                    "Mean",
-                    "LastNumber"
-                  ]
+                  "mode": "table",
+                  "position": "right",
+                  "size": "small",
+                  "values": ["mean", "last-number"]
                 }
               }
             },
@@ -3417,8 +3414,8 @@
               "name": "Job",
               "hidden": false
             },
-            "allow_all_value": false,
-            "allow_multiple": false,
+            "allowAllValue": false,
+            "allowMultiple": false,
             "plugin": {
               "kind": "PrometheusLabelValuesVariable",
               "spec": {
@@ -3436,8 +3433,8 @@
               "name": "Host:",
               "hidden": false
             },
-            "allow_all_value": false,
-            "allow_multiple": false,
+            "allowAllValue": false,
+            "allowMultiple": false,
             "plugin": {
               "kind": "PrometheusLabelValuesVariable",
               "spec": {
@@ -3455,8 +3452,8 @@
               "name": "diskdevices",
               "hidden": true
             },
-            "allow_all_value": false,
-            "allow_multiple": false,
+            "allowAllValue": false,
+            "allowMultiple": false,
             "plugin": {
               "kind": "StaticListVariable",
               "spec": {
@@ -3469,9 +3466,9 @@
         {
           "kind": "ListVariable",
           "spec": {
-            "default_value": "1m",
-            "allow_all_value": false,
-            "allow_multiple": false,
+            "defaultValue": "1m",
+            "allowAllValue": false,
+            "allowMultiple": false,
             "plugin": {
               "kind": "StaticListVariable",
               "spec": { "values": ["1m", "5m"] }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -261,9 +261,9 @@ has two mode:
 
 1. An online mode that requires an active connection to a remote Perses server that holds the translation logic.
 2. An offline mode that requires three different folders:
-   * charts folders
-   * queries folders
-   * variables folders
+   - charts folders
+   - queries folders
+   - variables folders
 
 Each of the above folders should contain files, named `mig.cuepart` that holds the logic of the migration for each
 plugin. For more information about these files please read the documentation about [cue](./cue.md)
@@ -292,8 +292,8 @@ spec:
       display:
         name: datasource
         hidden: false
-      allow_all_value: false
-      allow_multiple: false
+      allowAllValue: false
+      allowMultiple: false
       plugin:
         kind: StaticListVariable
         spec:
@@ -308,8 +308,8 @@ spec:
       display:
         name: Job
         hidden: false
-      allow_all_value: false
-      allow_multiple: false
+      allowAllValue: false
+      allowMultiple: false
       plugin:
         kind: PrometheusLabelValuesVariable
         spec:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -16,9 +16,9 @@ syntax. A dashboard like others documents is composed by three different section
 }
 ```
 
-* `kind`: like others documents is the type of the document. Here the onlue accepted is `Dashboard`
-* `metadata`: contains the name of the document, the data of the creation and so on.
-* `spec`: contains the specification of the document such as the different panels contained in the Dashboard.
+- `kind`: like others documents is the type of the document. Here the onlue accepted is `Dashboard`
+- `metadata`: contains the name of the document, the data of the creation and so on.
+- `spec`: contains the specification of the document such as the different panels contained in the Dashboard.
 
 ### Metadata
 
@@ -36,13 +36,13 @@ the project could be associated to the folder you could find in Grafana. For exa
 
 There are three mandatory things to provide here:
 
-* `datasource` is the name of the datasource. It's the direct reference of the document of type `Datasource`. The
+- `datasource` is the name of the datasource. It's the direct reference of the document of type `Datasource`. The
   datasource linked must exist in the database. Otherwise, the API will reject the creation of the Dashboard
-* `duration` is the default time you would like to use to looking in the past when getting data to fill the dashboard
-* `panels` is the list of the panel.
-* `layouts` is the list of layout. A layout is the object you can use to describe how to display the list of the panel.
-* `entrypoint` is the json reference to one particular layout.
-* `variables` is a map where the key is the reference of the variable defined as a value. The key cannot contain any
+- `duration` is the default time you would like to use to looking in the past when getting data to fill the dashboard
+- `panels` is the list of the panel.
+- `layouts` is the list of layout. A layout is the object you can use to describe how to display the list of the panel.
+- `entrypoint` is the json reference to one particular layout.
+- `variables` is a map where the key is the reference of the variable defined as a value. The key cannot contain any
   special characters or spaces. The key is used in the different variables / panels when they need to use it. Finally,
   you can define some variables that would be used then in the different panel.
 
@@ -62,19 +62,19 @@ Example:
 Variables is a map where the key is the reference of the variable. The value is the actual variable definition that
 contains the following attribute:
 
-* `kind` is the type of the variable. It's an enum and each value is conditioning what you can put in the
+- `kind` is the type of the variable. It's an enum and each value is conditioning what you can put in the
   attribute `parameter`. Possible values are :
-  * `PromQLQuery`. In order to get the value for this variable, a PromQL query will be performed
-  * `LabelNamesQuery`. The list of value for this variable will be calculated using the Prometheus
+  - `PromQLQuery`. In order to get the value for this variable, a PromQL query will be performed
+  - `LabelNamesQuery`. The list of value for this variable will be calculated using the Prometheus
     endpoint `/api/v1/labels`
-  * `LabelValuesQuery`. The list of value for this variable will be calculated using the Prometheus
+  - `LabelValuesQuery`. The list of value for this variable will be calculated using the Prometheus
     endpoint `/api/v1/label/<label_name>/values`
-  * `Constant`. The variable has a defined list of value.
-* `displayed_name` is the name that would be displayed by the UI. It should be filled only if `hide` is set to `false`.
-* `hide` is a boolean that will be used by the UI to decide if the variable has to be displayed. By default,
+  - `Constant`. The variable has a defined list of value.
+- `displayed_name` is the name that would be displayed by the UI. It should be filled only if `hide` is set to `false`.
+- `hide` is a boolean that will be used by the UI to decide if the variable has to be displayed. By default,
   it's `false`
-* `selected` is the variable selected by default if it exists. (Not mandatory)
-* `parameter` is a document, and the different attributes that defined it, are conditioned by the value of the
+- `selected` is the variable selected by default if it exists. (Not mandatory)
+- `parameter` is a document, and the different attributes that defined it, are conditioned by the value of the
   attribute `kind` described above
 
 Example:
@@ -93,7 +93,7 @@ Example:
 
 ##### Parameter
 
-* kind = "Constant"
+- kind = "Constant"
 
 In this case, `parameter` has only one attribute `values` which is a list of string
 
@@ -102,26 +102,23 @@ Example:
 ```json
 {
   "parameter": {
-    "values": [
-      "myValue",
-      "anotherValue"
-    ]
+    "values": ["myValue", "anotherValue"]
   }
 }
 ```
 
-* kind = "PromQLQuery"
+- kind = "PromQLQuery"
 
 In this case, `parameter` will contain
 
-* a PromQL expression (`expr`)
-* a `label_name` that is the name of the label which is used once the PromQL query is performed to select the
+- a PromQL expression (`expr`)
+- a `label_name` that is the name of the label which is used once the PromQL query is performed to select the
   labelValue.
-* a `capturing_regexp` which is a Golang regular expression used to capture potentially a sub part of the value.
+- a `capturingRegexp` which is a Golang regular expression used to capture potentially a sub part of the value.
 
-Note that if the `capturing_regexp` doesn't contain any group, it won't catch any value, and you will have an empty list
+Note that if the `capturingRegexp` doesn't contain any group, it won't catch any value, and you will have an empty list
 for the variable. So for example if you want to catch every value with no specific filter/prefix pattern,
-then `capturing_regexp` would be `(.*)` and not just `.*`
+then `capturingRegexp` would be `(.*)` and not just `.*`
 
 Example:
 
@@ -130,14 +127,14 @@ Example:
   "parameter": {
     "expr": "max by(stack) (thanos_build_info)",
     "label_name": "stack",
-    "capturing_regexp": "(.*)"
+    "capturingRegexp": "(.*)"
   }
 }
 ```
 
-* kind = "LabelNamesQuery"
+- kind = "LabelNamesQuery"
 
-In this case `parameter` must only define the attribute `capturing_regexp`. It will be used to filter the list / catch a
+In this case `parameter` must only define the attribute `capturingRegexp`. It will be used to filter the list / catch a
 subset of the value like for the `PromQLQuery` described above.
 
 Optionally you can define a list of matcher that corresponds to the parameter `match[]` like it is described in the
@@ -149,17 +146,15 @@ Example:
 ```json
 {
   "parameter": {
-    "capturing_regexp": "(.*)",
-    "matchers": [
-      "go"
-    ]
+    "capturingRegexp": "(.*)",
+    "matchers": ["go"]
   }
 }
 ```
 
-* kind = "LabelValuesQuery"
+- kind = "LabelValuesQuery"
 
-In this case `parameter` must define the attribute `label_name` and `capturing_regexp`. `capturing_regexp` is used to
+In this case `parameter` must define the attribute `label_name` and `capturingRegexp`. `capturingRegexp` is used to
 filter the list / catch a subset of the value like for the `PromQLQuery` described above. `label_name` is the name of
 the label you want to get the list of the values.
 
@@ -173,10 +168,8 @@ Example:
 {
   "parameter": {
     "label_name": "instance",
-    "capturing_regexp": "(.*)",
-    "matchers": [
-      "go"
-    ]
+    "capturingRegexp": "(.*)",
+    "matchers": ["go"]
   }
 }
 ```
@@ -188,13 +181,13 @@ what kind of chart you will display. One panel can only hold one chart.
 
 Here is the different attribute available:
 
-* `displayed_name` is the name of the panel that would be displayed by the UI.
-* `kind` is the type of chart displayed. It is an enum, and it conditions what contains the attribute `chart`. Possible
+- `displayed_name` is the name of the panel that would be displayed by the UI.
+- `kind` is the type of chart displayed. It is an enum, and it conditions what contains the attribute `chart`. Possible
   values are :
-  * `TimeSeriesChart`. It is a simple graph
-  * `GaugeChart`. It is the way to display a single number with different threshold. It can be used to show with
+  - `TimeSeriesChart`. It is a simple graph
+  - `GaugeChart`. It is the way to display a single number with different threshold. It can be used to show with
     different color if it's ok or not to have the current value displayed
-* `chart` contains the different parameters that describe a chart. It will depend on the `kind` value
+- `chart` contains the different parameters that describe a chart. It will depend on the `kind` value
 
 Example:
 
@@ -235,13 +228,13 @@ how the different panels are positioned in the UI
 
 Here is the different attribute available:
 
-* `kind` is the type of layout. It is an enum, and it conditions what contains the attribute `parameter`. Possible value
+- `kind` is the type of layout. It is an enum, and it conditions what contains the attribute `parameter`. Possible value
   are:
-  * `Expand`: It's a layout that can be expanded. It can be used for example if you want to hide panel by default.
-  * `Grid`: It's the layout tha defines a grid. Useful when you want to give different size for your different panels
+  - `Expand`: It's a layout that can be expanded. It can be used for example if you want to hide panel by default.
+  - `Grid`: It's the layout tha defines a grid. Useful when you want to give different size for your different panels
     and to position them precisely.
 
-*`parameter` contains the different parameters of the layout. It will depend on the `kind` value
+\*`parameter` contains the different parameters of the layout. It will depend on the `kind` value
 
 Example:
 
@@ -258,8 +251,8 @@ Example:
 
 ##### Expand
 
-* `open` : a boolean used by the UI to decide if the children should be displayed or not
-* `children`: a list of json reference. Each element can be a reference to another layout or to a panel.
+- `open` : a boolean used by the UI to decide if the children should be displayed or not
+- `children`: a list of json reference. Each element can be a reference to another layout or to a panel.
 
 Example:
 
@@ -324,7 +317,7 @@ example.
 #### Simple dashboard
 
 ```json
-  {
+{
   "kind": "Dashboard",
   "metadata": {
     "name": "SimpleLineChart",
@@ -372,8 +365,8 @@ This part is more dedicated to developer that would like to consume the API in o
 
 The API is providing two different endpoint for that:
 
-* `POST /api/v1/feed/variables` that should be used to get the value of the different variable defined
-* `POST /api/v1/feed/panels` that should be used to get the value for a set of panels
+- `POST /api/v1/feed/variables` that should be used to get the value of the different variable defined
+- `POST /api/v1/feed/panels` that should be used to get the value for a set of panels
 
 ### How to get the value of the variables.
 
@@ -395,20 +388,20 @@ curl -XPOST http://localhost:8080/api/v1/feed/variables -d '
             "parameter": {
                 "expr": "prometheus_build_info",
                 "label_name": "branch",
-                "capturing_regexp": "(.*)"
+                "capturingRegexp": "(.*)"
             }
         },
         "bar": {
             "kind" :"LabelValuesQuery",
             "parameter":{
                 "label_name": "$foo",
-                "capturing_regexp" : "(.*)"
+                "capturingRegexp" : "(.*)"
             }
         },
         "foo": {
             "kind" : "LabelNamesQuery",
             "parameter":{
-                "capturing_regexp" : "(alert.*)"
+                "capturingRegexp" : "(alert.*)"
             }
         }
     }
@@ -423,25 +416,17 @@ Result:
   {
     "name": "foo",
     "selected": "alertmanager",
-    "values": [
-      "alertmanager",
-      "alertname",
-      "alertstate"
-    ]
+    "values": ["alertmanager", "alertname", "alertstate"]
   },
   {
     "name": "do",
     "selected": "HEAD",
-    "values": [
-      "HEAD"
-    ]
+    "values": ["HEAD"]
   },
   {
     "name": "bar",
     "selected": "http://demo.do.prometheus.io:9093/api/v2/alerts",
-    "values": [
-      "http://demo.do.prometheus.io:9093/api/v2/alerts"
-    ]
+    "values": ["http://demo.do.prometheus.io:9093/api/v2/alerts"]
   }
 ]
 ```
@@ -453,9 +438,9 @@ Once the dashboard is properly initialized, the user will likely change the valu
 As the backend need to know which variable should be recalculated (following the changes of the selected value), the
 front-end should:
 
-* re-send all variables definitions to the backend.
-* Send the previous selected value for each variable
-* Send the current selected value for each variable. Thanks to the previous and the current selected value, the backend
+- re-send all variables definitions to the backend.
+- Send the previous selected value for each variable
+- Send the current selected value for each variable. Thanks to the previous and the current selected value, the backend
   is able to calculate which variable value changed. Then it compares to the build order to know exactly which variable
   should be recalculated and which one should not.
 
@@ -478,20 +463,20 @@ curl -XPOST http://localhost:8080/api/v1/feed/variables -d '
             "parameter": {
                 "expr": "prometheus_build_info",
                 "label_name": "branch",
-                "capturing_regexp": "(.*)"
+                "capturingRegexp": "(.*)"
             }
         },
         "bar": {
             "kind" :"LabelValuesQuery",
             "parameter":{
                 "label_name": "$foo",
-                "capturing_regexp" : "(.*)"
+                "capturingRegexp" : "(.*)"
             }
         },
         "foo": {
             "kind" : "LabelNamesQuery",
             "parameter":{
-                "capturing_regexp" : "(alert.*)"
+                "capturingRegexp" : "(alert.*)"
             }
         }
     }
@@ -506,16 +491,12 @@ Result:
   {
     "name": "do",
     "selected": "HEAD",
-    "values": [
-      "HEAD"
-    ]
+    "values": ["HEAD"]
   },
   {
     "name": "bar",
     "selected": "Watchdog",
-    "values": [
-      "Watchdog"
-    ]
+    "values": ["Watchdog"]
   }
 ]
 ```
@@ -558,7 +539,7 @@ curl -XPOST http://localhost:8080/api/v1/feed/panels -d '
 
 Note:
 
-* Panels is a map (exactly like in the dashboard definition). Like that, the frontend won't have to transform the panel
+- Panels is a map (exactly like in the dashboard definition). Like that, the frontend won't have to transform the panel
   definitions when requesting the backend to get the data.
-* After getting the values of the variables, the frontend need to get the data for the different panels displayed. For
+- After getting the values of the variables, the frontend need to get the data for the different panels displayed. For
   optimization purpose, the frontend shouldn't ask the data for the panels not displayed.

--- a/internal/api/shared/migrate/mapping.cuepart
+++ b/internal/api/shared/migrate/mapping.cuepart
@@ -84,9 +84,9 @@ spec: {
                         }
                     }
                 }
-                allow_all_value: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
-                allow_multiple: *grafanaVar.multi | false       // the default value tackles the case of variables of type `interval` that don't have such field
-                // default_value: nothing to map to this field
+                allowAllValue: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
+                allowMultiple: *grafanaVar.multi | false       // the default value tackles the case of variables of type `interval` that don't have such field
+                // defaultValue: nothing to map to this field
                 #var: grafanaVar
                 plugin: [ // switch
                     %(conditional_variables)

--- a/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -21,8 +21,8 @@
             "name": "PaaS",
             "hidden": true
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -17,8 +17,8 @@
         "kind": "ListVariable",
         "spec": {
           "name": "listVar",
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
@@ -38,8 +38,8 @@
         "kind": "ListVariable",
         "spec": {
           "name": "firstNames",
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
@@ -57,8 +57,8 @@
             "description": "Label values, 1rst flavor",
             "hidden": false
           },
-          "allow_all_value": true,
-          "allow_multiple": false,
+          "allowAllValue": true,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -77,8 +77,8 @@
             "description": "Label values, 2nd flavor",
             "hidden": false
           },
-          "allow_all_value": true,
-          "allow_multiple": false,
+          "allowAllValue": true,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -97,8 +97,8 @@
             "description": "Label values, 3rd flavor",
             "hidden": false
           },
-          "allow_all_value": true,
-          "allow_multiple": false,
+          "allowAllValue": true,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -117,8 +117,8 @@
             "description": "Label values, 4th flavor",
             "hidden": false
           },
-          "allow_all_value": true,
-          "allow_multiple": false,
+          "allowAllValue": true,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -137,8 +137,8 @@
             "description": "ad hoc filter",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
@@ -167,8 +167,8 @@
             "description": "adHocFilter",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
@@ -181,8 +181,8 @@
         "kind": "ListVariable",
         "spec": {
           "name": "LabelNamesTest",
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelNamesVariable",
             "spec": {
@@ -200,8 +200,8 @@
             "description": "variable using query_result clause",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
@@ -220,8 +220,8 @@
             "description": "query result var for volatile series (relies $__range global var)",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
@@ -240,8 +240,8 @@
             "description": "query result var with no <aggr> by clause",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {

--- a/internal/api/shared/validate/testdata/variable_with_regex_dashboard.json
+++ b/internal/api/shared/validate/testdata/variable_with_regex_dashboard.json
@@ -21,15 +21,13 @@
             "name": "IaaS location",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
               "label_name": "stack",
-              "matchers": [
-                "thanos_build_info{stack=~\"\\\\w{4}\"}"
-              ]
+              "matchers": ["thanos_build_info{stack=~\"\\\\w{4}\"}"]
             }
           }
         }
@@ -42,15 +40,13 @@
             "name": "Stack (label_values)",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
               "label_name": "stack",
-              "matchers": [
-                "thanos_build_info{stack=~\"$iaas_loc.*\"}"
-              ]
+              "matchers": ["thanos_build_info{stack=~\"$iaas_loc.*\"}"]
             }
           }
         }
@@ -63,8 +59,8 @@
             "name": "Stack (query_result)",
             "hidden": false
           },
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {

--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -178,7 +178,7 @@ func TestUnmarshalJSONVariable(t *testing.T) {
     "display": {
       "name": "my awesome variable"
     },
-    "default_value": "default",
+    "defaultValue": "default",
     "plugin": {
       "kind": "PrometheusLabelValuesVariable",
       "spec": {
@@ -222,8 +222,8 @@ func TestUnmarshalJSONVariable(t *testing.T) {
     "display": {
       "name": "my awesome variable"
     },
-    "allow_multiple" : true,
-    "default_value": ["default1", "default2"],
+    "allowMultiple" : true,
+    "defaultValue": ["default1", "default2"],
     "plugin": {
       "kind": "PrometheusLabelValuesVariable",
       "spec": {
@@ -396,7 +396,7 @@ spec:
   name: "MyList"
   display:
     name: "my awesome variable"
-  default_value: "default"
+  defaultValue: "default"
   plugin:
     kind: "PrometheusLabelValuesVariable"
     spec:
@@ -433,8 +433,8 @@ spec:
   name: "MyList"
   display:
     name: "my awesome variable"
-  allow_multiple: true
-  default_value:
+  allowMultiple: true
+  defaultValue:
     - "default1"
     - "default2"
   plugin:
@@ -585,8 +585,8 @@ func TestMarshalListVariable(t *testing.T) {
       "name": "my awesome variable",
       "hidden": false
     },
-    "allow_all_value": false,
-    "allow_multiple": false,
+    "allowAllValue": false,
+    "allowMultiple": false,
     "plugin": {
       "kind": "PrometheusLabelNamesVariable",
       "spec": {}
@@ -622,8 +622,8 @@ func TestMarshalListVariable(t *testing.T) {
       "name": "my awesome variable",
       "hidden": false
     },
-    "allow_all_value": false,
-    "allow_multiple": false,
+    "allowAllValue": false,
+    "allowMultiple": false,
     "plugin": {
       "kind": "PrometheusLabelNamesVariable",
       "spec": {
@@ -664,8 +664,8 @@ func TestMarshalListVariable(t *testing.T) {
       "name": "my awesome variable",
       "hidden": false
     },
-    "allow_all_value": false,
-    "allow_multiple": false,
+    "allowAllValue": false,
+    "allowMultiple": false,
     "plugin": {
       "kind": "PrometheusLabelValuesVariable",
       "spec": {
@@ -708,9 +708,9 @@ func TestMarshalListVariable(t *testing.T) {
       "name": "my awesome variable",
       "hidden": false
     },
-    "default_value": "default",
-    "allow_all_value": false,
-    "allow_multiple": false,
+    "defaultValue": "default",
+    "allowAllValue": false,
+    "allowMultiple": false,
     "plugin": {
       "kind": "PrometheusLabelValuesVariable",
       "spec": {
@@ -754,12 +754,12 @@ func TestMarshalListVariable(t *testing.T) {
       "name": "my awesome variable",
       "hidden": false
     },
-    "default_value": [
+    "defaultValue": [
       "default1",
       "default2"
     ],
-    "allow_all_value": false,
-    "allow_multiple": true,
+    "allowAllValue": false,
+    "allowMultiple": true,
     "plugin": {
       "kind": "PrometheusLabelValuesVariable",
       "spec": {

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -242,8 +242,8 @@ func TestMarshalDashboard(t *testing.T) {
       {
         "kind": "ListVariable",
         "spec": {
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelNamesVariable",
             "spec": {
@@ -258,8 +258,8 @@ func TestMarshalDashboard(t *testing.T) {
       {
         "kind": "ListVariable",
         "spec": {
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {

--- a/pkg/model/api/v1/variable/list.go
+++ b/pkg/model/api/v1/variable/list.go
@@ -30,7 +30,7 @@ func (v *DefaultValue) UnmarshalJSON(data []byte) error {
 	var slice []string
 	if unmarshalStringErr := json.Unmarshal(data, &s); unmarshalStringErr != nil {
 		if unmarshalSliceErr := json.Unmarshal(data, &slice); unmarshalSliceErr != nil {
-			return fmt.Errorf("unable to unmarshal default_value. Only string or array of string can be used")
+			return fmt.Errorf("unable to unmarshal defaultValue. Only string or array of string can be used")
 		}
 	}
 	v.SingleValue = s
@@ -43,7 +43,7 @@ func (v *DefaultValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var slice []string
 	if unmarshalStringErr := unmarshal(&s); unmarshalStringErr != nil {
 		if unmarshalSliceErr := unmarshal(&slice); unmarshalSliceErr != nil {
-			return fmt.Errorf("unable to unmarshal default_value. Only string or array of string can be used")
+			return fmt.Errorf("unable to unmarshal defaultValue. Only string or array of string can be used")
 		}
 	}
 	v.SingleValue = s
@@ -67,23 +67,23 @@ func (v *DefaultValue) MarshalYAML() (interface{}, error) {
 
 type ListSpec struct {
 	Display       *Display      `json:"display,omitempty" yaml:"display,omitempty"`
-	DefaultValue  *DefaultValue `json:"default_value,omitempty" yaml:"default_value,omitempty"`
-	AllowAllValue bool          `json:"allow_all_value" yaml:"allow_all_value"`
-	AllowMultiple bool          `json:"allow_multiple" yaml:"allow_multiple"`
+	DefaultValue  *DefaultValue `json:"defaultValue,omitempty" yaml:"defaultValue,omitempty"`
+	AllowAllValue bool          `json:"allowAllValue" yaml:"allowAllValue"`
+	AllowMultiple bool          `json:"allowMultiple" yaml:"allowMultiple"`
 	// CustomAllValue is a custom value that will be used if AllowAllValue is true and if then `all` is selected
-	CustomAllValue string `json:"custom_all_value,omitempty" yaml:"custom_all_value,omitempty"`
+	CustomAllValue string `json:"customAllValue,omitempty" yaml:"customAllValue,omitempty"`
 	// CapturingRegexp is the regexp used to catch and filter the result of the query.
 	// If empty, then nothing is filtered. That's the equivalent of setting CapturingRegexp with (.*)
-	CapturingRegexp string        `json:"capturing_regexp,omitempty" yaml:"capturing_regexp,omitempty"`
+	CapturingRegexp string        `json:"capturingRegexp,omitempty" yaml:"capturingRegexp,omitempty"`
 	Plugin          common.Plugin `json:"plugin" yaml:"plugin"`
 }
 
 func (v *ListSpec) Validate() error {
 	if len(v.CustomAllValue) > 0 && !v.AllowAllValue {
-		return fmt.Errorf("custom_all_value cannot be set if allow_all_value is not set to true")
+		return fmt.Errorf("customAllValue cannot be set if allowAllValue is not set to true")
 	}
 	if v.DefaultValue != nil && len(v.DefaultValue.SliceValues) > 0 && !v.AllowMultiple {
-		return fmt.Errorf("you can not use a list of default values if allow_multiple is set to false")
+		return fmt.Errorf("you can not use a list of default values if allowMultiple is set to false")
 	}
 
 	return nil

--- a/ui/core/src/model/variables.ts
+++ b/ui/core/src/model/variables.ts
@@ -39,11 +39,11 @@ export interface ListVariableDefinition<PluginSpec = UnknownSpec> extends Defini
 }
 
 export interface ListVariableSpec<PluginSpec> extends VariableSpec {
-  default_value?: VariableValue;
-  allow_multiple?: boolean;
-  allow_all_value?: boolean;
-  custom_all_value?: string;
-  capturing_regexp?: string;
+  defaultValue?: VariableValue;
+  allowMultiple?: boolean;
+  allowAllValue?: boolean;
+  customAllValue?: string;
+  capturingRegexp?: string;
   plugin: Definition<PluginSpec>;
 }
 

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -173,9 +173,9 @@ const DEFAULT_ALL_DASHBOARD: DashboardResource = {
             name: 'Instance',
             hidden: false,
           },
-          allow_all_value: true,
-          allow_multiple: true,
-          default_value: ['$__all'],
+          allowAllValue: true,
+          allowMultiple: true,
+          defaultValue: ['$__all'],
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
             spec: {
@@ -188,9 +188,9 @@ const DEFAULT_ALL_DASHBOARD: DashboardResource = {
         kind: 'ListVariable',
         spec: {
           name: 'interval',
-          default_value: '5m',
-          allow_all_value: false,
-          allow_multiple: false,
+          defaultValue: '5m',
+          allowAllValue: false,
+          allowMultiple: false,
           plugin: {
             kind: 'StaticListVariable',
             spec: { values: ['1m', '5m'] },

--- a/ui/dashboards/src/components/Variables/TemplateVariable.test.ts
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.test.ts
@@ -43,8 +43,8 @@ function allOption(): VariableOption {
 interface TestParams {
   description: string;
   input: {
-    allow_multiple: boolean;
-    allow_all_value: boolean;
+    allowMultiple: boolean;
+    allowAllValue: boolean;
     value: VariableValue;
     isFetchingOptions: boolean;
     fetchedOptions: VariableOption[];
@@ -63,8 +63,8 @@ describe('useListVariableState', () => {
     {
       description: '[!ALL][!MULTIPLE] is fetching',
       input: {
-        allow_multiple: false,
-        allow_all_value: false,
+        allowMultiple: false,
+        allowAllValue: false,
         value: 'hello',
         isFetchingOptions: true,
         fetchedOptions: [option('hello')],
@@ -80,8 +80,8 @@ describe('useListVariableState', () => {
     {
       description: '[!ALL][!MULTIPLE] state.value is in options',
       input: {
-        allow_multiple: false,
-        allow_all_value: false,
+        allowMultiple: false,
+        allowAllValue: false,
         value: 'hello',
         isFetchingOptions: false,
         fetchedOptions: [option('hello')],
@@ -97,8 +97,8 @@ describe('useListVariableState', () => {
     {
       description: '[ALL][MULTIPLE] state.value is in options',
       input: {
-        allow_multiple: true,
-        allow_all_value: true,
+        allowMultiple: true,
+        allowAllValue: true,
         value: 'hello',
         isFetchingOptions: false,
         fetchedOptions: [option('hello')],
@@ -114,8 +114,8 @@ describe('useListVariableState', () => {
     {
       description: '[!ALL][!MULTIPLE] state.value is null',
       input: {
-        allow_multiple: false,
-        allow_all_value: false,
+        allowMultiple: false,
+        allowAllValue: false,
         value: null,
         isFetchingOptions: false,
         fetchedOptions: [option('hello')],
@@ -131,8 +131,8 @@ describe('useListVariableState', () => {
     {
       description: '[ALL][MULTIPLE] state.value is null',
       input: {
-        allow_multiple: true,
-        allow_all_value: true,
+        allowMultiple: true,
+        allowAllValue: true,
         value: null,
         isFetchingOptions: false,
         fetchedOptions: [option('hello')],
@@ -148,8 +148,8 @@ describe('useListVariableState', () => {
     {
       description: '[!ALL][!MULTIPLE] state.value is not in options',
       input: {
-        allow_multiple: false,
-        allow_all_value: false,
+        allowMultiple: false,
+        allowAllValue: false,
         value: 'test',
         isFetchingOptions: false,
         fetchedOptions: [option('hello')],
@@ -165,8 +165,8 @@ describe('useListVariableState', () => {
     {
       description: '[ALL][MULTIPLE] state.value is not in options',
       input: {
-        allow_multiple: true,
-        allow_all_value: true,
+        allowMultiple: true,
+        allowAllValue: true,
         value: 'test',
         isFetchingOptions: false,
         fetchedOptions: [option('hello')],
@@ -185,8 +185,8 @@ describe('useListVariableState', () => {
         {
           name: 'myVar', // unused by the hook
           plugin: { spec: {}, kind: 'unknown-plugin' }, // unused by the hook
-          allow_multiple: params.input.allow_multiple,
-          allow_all_value: params.input.allow_all_value,
+          allowMultiple: params.input.allowMultiple,
+          allowAllValue: params.input.allowAllValue,
         },
         {
           value: params.input.value,

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -57,8 +57,8 @@ export function useListVariableState(
   // viewOptions are the options used in the view only (options + All if allowed)
   viewOptions: VariableOption[];
 } {
-  const allowMultiple = spec?.allow_multiple === true;
-  const allowAllValue = spec?.allow_all_value === true;
+  const allowMultiple = spec?.allowMultiple === true;
+  const allowAllValue = spec?.allowAllvalue === true;
   const loading = useMemo(() => variablesOptionsQuery.isFetching || false, [variablesOptionsQuery]);
   const options = variablesOptionsQuery.data;
 

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -58,7 +58,7 @@ export function useListVariableState(
   viewOptions: VariableOption[];
 } {
   const allowMultiple = spec?.allowMultiple === true;
-  const allowAllValue = spec?.allowAllvalue === true;
+  const allowAllValue = spec?.allowAllValue === true;
   const loading = useMemo(() => variablesOptionsQuery.isFetching || false, [variablesOptionsQuery]);
   const options = variablesOptionsQuery.data;
 
@@ -123,8 +123,8 @@ function ListVariable({ name, source }: TemplateVariableProps) {
   );
 
   const title = definition?.spec.display?.name ?? name;
-  const allowMultiple = definition?.spec.allow_multiple === true;
-  const allowAllValue = definition?.spec.allow_all_value === true;
+  const allowMultiple = definition?.spec.allowMultiple === true;
+  const allowAllValue = definition?.spec.allowAllValue === true;
 
   // Update value when changed
   useEffect(() => {

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -169,8 +169,8 @@ function PluginProvider({ children, builtinVariables }: PluginProviderProps) {
       if (v.value === ALL_VALUE) {
         const definition = findVariableDefinitionByName(name, definitions, externalDefinitions);
         // If the variable is a list variable and has a custom all value, then use that value instead
-        if (definition?.kind === 'ListVariable' && definition.spec.custom_all_value) {
-          v.value = definition.spec.custom_all_value;
+        if (definition?.kind === 'ListVariable' && definition.spec.customAllValue) {
+          v.value = definition.spec.customAllValue;
         } else {
           v.value = v.options?.map((o: { value: string }) => o.value) ?? null;
         }
@@ -349,7 +349,7 @@ function createTemplateVariableSrvStore({
                   draft[index] = {
                     kind: 'ListVariable',
                     spec: produce(variable.spec, (specDraft) => {
-                      specDraft.default_value = currentVariable.value;
+                      specDraft.defaultValue = currentVariable.value;
                     }),
                   };
                 }

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.test.ts
@@ -26,9 +26,9 @@ describe('hydrateTemplateVariableStates', () => {
             name: 'Instance',
             hidden: false,
           },
-          allow_all_value: true,
-          allow_multiple: true,
-          default_value: ['$__all'],
+          allowAllValue: true,
+          allowMultiple: true,
+          defaultValue: ['$__all'],
           plugin: {
             kind: 'PrometheusLabelValuesVariable',
             spec: {

--- a/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/hydrationUtils.ts
@@ -29,12 +29,12 @@ function hydrateTemplateVariableState(variable: VariableDefinition, initialValue
       break;
     case 'ListVariable':
       varState.options = [];
-      varState.value = initialValue ?? variable.spec.default_value ?? null;
-      // TODO: smarter fallbacks for default_value when allow_all_value is true
+      varState.value = initialValue ?? variable.spec.defaultValue ?? null;
+      // TODO: smarter fallbacks for defaultValue when allowAllValue is true
       if (varState.options.length > 0 && !varState.value) {
         const firstOptionValue = varState.options[0]?.value ?? null;
         if (firstOptionValue !== null) {
-          varState.value = variable.spec.allow_multiple ? [firstOptionValue] : firstOptionValue;
+          varState.value = variable.spec.allowMultiple ? [firstOptionValue] : firstOptionValue;
         }
       }
 

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
@@ -23,9 +23,9 @@ describe('checkSavedDefaultVariableStatus', () => {
         kind: 'ListVariable',
         spec: {
           name: 'interval',
-          default_value: '1m',
-          allow_all_value: false,
-          allow_multiple: false,
+          defaultValue: '1m',
+          allowAllValue: false,
+          allowMultiple: false,
           plugin: {
             kind: 'StaticListVariable',
             spec: {
@@ -42,9 +42,9 @@ describe('checkSavedDefaultVariableStatus', () => {
             name: 'Test display label',
             hidden: false,
           },
-          default_value: 'second list value',
-          allow_all_value: true,
-          allow_multiple: false,
+          defaultValue: 'second list value',
+          allowAllValue: true,
+          allowMultiple: false,
           plugin: {
             kind: 'StaticListVariable',
             spec: {
@@ -115,7 +115,7 @@ describe('checkSavedDefaultVariableStatus', () => {
             value: 'last list value',
           },
         ],
-        default_value: 'test list value',
+        defaultValue: 'test list value',
       }
     );
     variableState.set(
@@ -135,9 +135,9 @@ describe('checkSavedDefaultVariableStatus', () => {
         kind: 'ListVariable',
         spec: {
           name: 'interval',
-          default_value: '5m',
-          allow_all_value: false,
-          allow_multiple: false,
+          defaultValue: '5m',
+          allowAllValue: false,
+          allowMultiple: false,
           plugin: {
             kind: 'StaticListVariable',
             spec: {
@@ -152,7 +152,7 @@ describe('checkSavedDefaultVariableStatus', () => {
       { name: 'interval' },
       {
         value: '5m',
-        default_value: '5m',
+        defaultValue: '5m',
         loading: false,
         options: [
           {
@@ -175,8 +175,8 @@ describe('checkSavedDefaultVariableStatus', () => {
       {
         kind: 'ListVariable',
         spec: {
-          allow_all_value: false,
-          allow_multiple: false,
+          allowAllValue: false,
+          allowMultiple: false,
           plugin: {
             kind: 'StaticListVariable',
             spec: {

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.ts
@@ -25,7 +25,7 @@ export function checkSavedDefaultVariableStatus(definitions: VariableDefinition[
     const name = savedVariable.spec.name;
     if (savedVariable.kind === 'ListVariable') {
       const currentVariable = varState.get({ name });
-      if (currentVariable?.value !== null && currentVariable?.value !== savedVariable.spec.default_value) {
+      if (currentVariable?.value !== null && currentVariable?.value !== savedVariable.spec.defaultValue) {
         modifiedVariableNames.push(name);
         isSavedVariableModified = true;
       }

--- a/ui/e2e/src/data/updatedDefaultsDashboard.json
+++ b/ui/e2e/src/data/updatedDefaultsDashboard.json
@@ -54,9 +54,9 @@
         "kind": "ListVariable",
         "spec": {
           "name": "interval",
-          "default_value": "5m",
-          "allow_all_value": false,
-          "allow_multiple": false,
+          "defaultValue": "5m",
+          "allowAllValue": false,
+          "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
@@ -82,9 +82,9 @@
             "name": "Test display name",
             "hidden": false
           },
-          "default_value": "second value",
-          "allow_all_value": true,
-          "allow_multiple": false,
+          "defaultValue": "second value",
+          "allowAllValue": true,
+          "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -302,7 +302,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
               <Stack>
                 <TextField
                   label="Capturing Regexp Filter"
-                  value={state.listVariableFields.capturing_regexp || ''}
+                  value={state.listVariableFields.capturingRegexp || ''}
                   InputProps={{
                     readOnly: action === 'read',
                   }}
@@ -310,9 +310,9 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                     setState((draft) => {
                       if (e.target.value) {
                         // TODO: do a better fix, if empty string => it should skip the filter
-                        draft.listVariableFields.capturing_regexp = e.target.value;
+                        draft.listVariableFields.capturingRegexp = e.target.value;
                       } else {
-                        draft.listVariableFields.capturing_regexp = undefined;
+                        draft.listVariableFields.capturingRegexp = undefined;
                       }
                     });
                   }}

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -21,7 +21,7 @@ export function getInitialState(initialVariableDefinition: VariableDefinition) {
   const listVariableFields = {
     allowMultiple: false,
     allowAll: false,
-    capturing_regexp: undefined as string | undefined,
+    capturingRegexp: undefined as string | undefined,
     plugin: {
       kind: '',
       spec: {},
@@ -29,11 +29,11 @@ export function getInitialState(initialVariableDefinition: VariableDefinition) {
     customAllValue: undefined as string | undefined,
   };
   if (initialVariableDefinition.kind === 'ListVariable') {
-    listVariableFields.allowMultiple = initialVariableDefinition.spec.allow_all_value ?? false;
-    listVariableFields.allowAll = initialVariableDefinition.spec.allow_all_value ?? false;
-    listVariableFields.capturing_regexp = initialVariableDefinition.spec.capturing_regexp;
+    listVariableFields.allowMultiple = initialVariableDefinition.spec.allowAllValue ?? false;
+    listVariableFields.allowAll = initialVariableDefinition.spec.allowAllValue ?? false;
+    listVariableFields.capturingRegexp = initialVariableDefinition.spec.capturingRegexp;
     listVariableFields.plugin = initialVariableDefinition.spec.plugin;
-    listVariableFields.customAllValue = initialVariableDefinition.spec.custom_all_value;
+    listVariableFields.customAllValue = initialVariableDefinition.spec.customAllValue;
   }
 
   return {
@@ -78,11 +78,11 @@ export function getVariableDefinitionFromState(state: VariableEditorState): Vari
       spec: {
         name,
         display,
-        allow_multiple: state.listVariableFields.allowMultiple,
-        allow_all_value: state.listVariableFields.allowAll,
-        capturing_regexp: state.listVariableFields.capturing_regexp,
+        allowMultiple: state.listVariableFields.allowMultiple,
+        allowAllValue: state.listVariableFields.allowAll,
+        capturingRegexp: state.listVariableFields.capturingRegexp,
         plugin: state.listVariableFields.plugin,
-        custom_all_value: state.listVariableFields.customAllValue,
+        customAllValue: state.listVariableFields.customAllValue,
       },
     };
   }

--- a/ui/plugin-system/src/components/Variables/variable-model.test.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.test.ts
@@ -18,7 +18,7 @@ describe('filterVariableList', () => {
   const testSuite = [
     {
       title: 'basic case',
-      capturing_regexp: /([^-]*)-host-([^-]*)/g,
+      capturingRegexp: /([^-]*)-host-([^-]*)/g,
       originalValues: [
         { label: 'l1', value: 'us1-host-ahdix' },
         { label: 'l2', value: 'us1-host-diua' },
@@ -33,7 +33,7 @@ describe('filterVariableList', () => {
     },
     {
       title: 'duplicate captured value',
-      capturing_regexp: /prometheus-(.+):\d+/g,
+      capturingRegexp: /prometheus-(.+):\d+/g,
       originalValues: [
         { label: 'l1', value: 'prometheus-app:9090' },
         { label: 'l2', value: 'prometheus-app:9091' },
@@ -49,9 +49,9 @@ describe('filterVariableList', () => {
       ],
     },
   ];
-  testSuite.forEach(({ title, capturing_regexp, originalValues, result }) => {
+  testSuite.forEach(({ title, capturingRegexp, originalValues, result }) => {
     it(title, () => {
-      expect(filterVariableList(originalValues, capturing_regexp)).toEqual(result);
+      expect(filterVariableList(originalValues, capturingRegexp)).toEqual(result);
     });
   });
 });

--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -55,7 +55,7 @@ export function useListVariablePluginValues(definition: ListVariableDefinition) 
 
   const spec = definition.spec.plugin.spec;
   const capturingRegexp =
-    definition.spec.capturing_regexp !== undefined ? new RegExp(definition.spec.capturing_regexp, 'g') : undefined;
+    definition.spec.capturingRegexp !== undefined ? new RegExp(definition.spec.capturingRegexp, 'g') : undefined;
 
   let dependsOnVariables: string[] | undefined;
   if (variablePlugin?.dependsOn) {

--- a/ui/plugin-system/src/runtime/template-variables.ts
+++ b/ui/plugin-system/src/runtime/template-variables.ts
@@ -31,7 +31,7 @@ export type VariableState = {
    * If a local variable is overriding an external variable, external var will have the flag ``overridden=true``.
    */
   overridden?: boolean;
-  default_value?: VariableValue;
+  defaultValue?: VariableValue;
 };
 
 export type VariableStateMap = Record<string, VariableState>;


### PR DESCRIPTION
# Description

[BREAKINGCHANGE] snake_case -> camelCase in variable spec
- `allow_multiple` -> `allowMultiple`
- `allow_all_value` -> `allowAllValue`
- `capturing_regexp` -> `capturingRegexp`
- `default_value` -> `defaultValue`

For the context see discussion #1243 - [Antoine comment](https://github.com/perses/perses/discussions/1243#discussioncomment-6316495). To be consistent with Kubernetes naming conventions, proposed change is convert snake_case JSON properties to camelCase, see: 
  - https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#naming-conventions 
    - _"Go field names must be PascalCase. JSON field names must be camelCase. Other than capitalization of the initial letter, the two should almost always match. No underscores or dashes in either."_

Essentially undoes Shan's old PR here #593

~~TODO: panel spec migration PRs~~
TODO: write up release notes with details about migration and which properties were changed



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).