### PR TITLE
[FEATURE] Add project datasources CRUD

### DIFF
--- a/internal/api/shared/validate/testdata/datasource_custom.json
+++ b/internal/api/shared/validate/testdata/datasource_custom.json
@@ -1,0 +1,23 @@
+{
+  "kind": "Datasource",
+  "metadata": {
+    "name": "PrometheusDemoPersonal",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "Prometheus PERSONAL Demo instance",
+      "description": "This is my personal Prometheus demo instance."
+    },
+    "default": false,
+    "plugin": {
+      "kind": "PrometheusDatasource",
+      "spec": {
+        "direct_url": "https://localhost:9090"
+      }
+    }
+  }
+}

--- a/internal/api/shared/validate/testdata/datasource_default.json
+++ b/internal/api/shared/validate/testdata/datasource_default.json
@@ -1,0 +1,54 @@
+{
+  "kind": "Datasource",
+  "metadata": {
+    "name": "PrometheusDemoOfficial",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "Prometheus OFFICIAL Demo instance",
+      "description": "This is the Prometheus Official demo instance."
+    },
+    "default": true,
+    "plugin": {
+      "kind": "PrometheusDatasource",
+      "spec": {
+        "proxy": {
+          "kind": "HTTPProxy",
+          "spec": {
+            "allowed_endpoints": [
+              {
+                "endpoint_pattern": "/api/v1/labels",
+                "method": "POST"
+              },
+              {
+                "endpoint_pattern": "/api/v1/series",
+                "method": "POST"
+              },
+              {
+                "endpoint_pattern": "/api/v1/metadata",
+                "method": "GET"
+              },
+              {
+                "endpoint_pattern": "/api/v1/query",
+                "method": "POST"
+              },
+              {
+                "endpoint_pattern": "/api/v1/query_range",
+                "method": "POST"
+              },
+              {
+                "endpoint_pattern": "/api/v1/label/([a-zA-Z0-9_-]+)/values",
+                "method": "GET"
+              }
+            ],
+            "url": "https://prometheus.demo.do.prometheus.io"
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/api/shared/validate/validate.go
+++ b/internal/api/shared/validate/validate.go
@@ -52,6 +52,7 @@ func Datasource[T modelV1.DatasourceInterface](entity T, list []T, sch schemas.S
 }
 
 func validateUnicityOfDefaultDTS[T modelV1.DatasourceInterface](entity T, list []T) error {
+	name := entity.GetMetadata().GetName()
 	spec := entity.GetDTSSpec()
 	// Since the entity is not supposed to be a default datasource, no need to verify if there is another one already defined as default
 	if !spec.Default {
@@ -59,6 +60,10 @@ func validateUnicityOfDefaultDTS[T modelV1.DatasourceInterface](entity T, list [
 	}
 	entityPluginKind := spec.Plugin.Kind
 	for _, dts := range list {
+		if name == dts.GetMetadata().GetName() {
+			// nothing to check if comparing with same datasource
+			continue
+		}
 		dtsSpec := dts.GetDTSSpec()
 		if dtsSpec.Default && dtsSpec.Plugin.Kind == entityPluginKind {
 			return fmt.Errorf("datasource %q cannot be a default %q because there is already one defined named %q", entity.GetMetadata().GetName(), entityPluginKind, dts.GetMetadata().GetName())

--- a/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
@@ -1,0 +1,137 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Stack, Typography } from '@mui/material';
+import {
+  DataGrid,
+  GridColDef,
+  GridToolbarContainer,
+  GridToolbarColumnsButton,
+  GridToolbarFilterButton,
+  GridToolbarQuickFilter,
+  GridRow,
+  GridColumnHeaders,
+} from '@mui/x-data-grid';
+import { memo, useMemo } from 'react';
+import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+
+const DATA_GRID_INITIAL_STATE = {
+  columns: {
+    columnVisibilityModel: {},
+  },
+  sorting: {
+    sortModel: [{ field: 'displayName', sort: 'asc' }],
+  },
+  pagination: {
+    paginationModel: { pageSize: 10, page: 0 },
+  },
+};
+
+// https://mui.com/x/react-data-grid/performance/
+const MemoizedRow = memo(GridRow);
+const MemoizedColumnHeaders = memo(GridColumnHeaders);
+
+export interface Row {
+  project: string;
+  name: string;
+  displayName: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  viewedAt?: string;
+}
+
+function DatasourcesGridToolbar() {
+  return (
+    <GridToolbarContainer>
+      <Stack direction="row" width="100%" gap={4} m={2}>
+        <Stack sx={{ flexShrink: 1 }} width="100%">
+          <GridToolbarQuickFilter sx={{ width: '100%' }} />
+        </Stack>
+        <Stack direction="row" sx={{ flexShrink: 3 }} width="100%">
+          <GridToolbarColumnsButton sx={{ width: '100%' }} />
+          <GridToolbarFilterButton sx={{ width: '100%' }} />
+        </Stack>
+      </Stack>
+    </GridToolbarContainer>
+  );
+}
+
+function NoDatasourceRowOverlay() {
+  return (
+    <Stack sx={{ alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+      <Typography>No datasources</Typography>
+    </Stack>
+  );
+}
+
+export interface DatasourceDataGridProperties {
+  columns: Array<GridColDef<Row>>;
+  rows: Row[];
+  initialState?: GridInitialStateCommunity;
+  hideToolbar?: boolean;
+  isLoading?: boolean;
+  onRowClick: (project: string, name: string) => void;
+}
+
+export function DatasourceDataGrid(props: DatasourceDataGridProperties) {
+  const { columns, rows, initialState, hideToolbar, isLoading, onRowClick } = props;
+
+  // Merging default initial state with the props initial state (props initial state will overwrite properties)
+  const mergedInitialState = useMemo(() => {
+    return {
+      ...DATA_GRID_INITIAL_STATE,
+      ...(initialState || {}),
+    } as GridInitialStateCommunity;
+  }, [initialState]);
+
+  return (
+    <DataGrid
+      disableRowSelectionOnClick
+      autoHeight={true}
+      onRowClick={(params) => {
+        onRowClick(params.row.project, params.row.name);
+      }}
+      rows={rows}
+      columns={columns}
+      getRowId={(row) => row.name}
+      loading={isLoading}
+      slots={
+        hideToolbar
+          ? { noRowsOverlay: NoDatasourceRowOverlay }
+          : {
+              toolbar: DatasourcesGridToolbar,
+              row: MemoizedRow,
+              columnHeaders: MemoizedColumnHeaders,
+              noRowsOverlay: NoDatasourceRowOverlay,
+            }
+      }
+      pageSizeOptions={[10, 25, 50, 100]}
+      initialState={mergedInitialState}
+      sx={{
+        // disable cell selection style
+        '.MuiDataGrid-columnHeader:focus': {
+          outline: 'none',
+        },
+        // disable cell selection style
+        '.MuiDataGrid-cell:focus': {
+          outline: 'none',
+        },
+        // pointer cursor on ALL rows
+        '& .MuiDataGrid-row:hover': {
+          cursor: 'pointer',
+        },
+      }}
+    ></DataGrid>
+  );
+}

--- a/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
@@ -1,0 +1,97 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Datasource } from '@perses-dev/core';
+import { DispatchWithoutAction, useState } from 'react';
+import { DiscardChangesConfirmationDialog, Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { PluginRegistry } from '@perses-dev/plugin-system';
+import { bundledPluginLoader } from '../../model/bundled-plugins';
+import { DeleteDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
+import { DatasourceEditorForm } from './DatasourceEditorForm';
+
+interface DatasourceDrawerProps {
+  datasource: Datasource;
+  isOpen: boolean;
+  saveAction: string;
+  onSave: (datasource: Datasource) => void;
+  onClose: DispatchWithoutAction;
+}
+
+export function DatasourceDrawer(props: DatasourceDrawerProps) {
+  const { datasource, isOpen, saveAction, onSave, onClose } = props;
+  const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
+  const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
+  const [hasDraftChanges, setHasDraftChanges] = useState<boolean>(false);
+
+  const handleSave = (datasource: Datasource) => {
+    setHasDraftChanges(false);
+    onSave(datasource);
+  };
+
+  const handleClose = () => {
+    if (hasDraftChanges) {
+      setDiscardDialogStateOpened(true);
+    } else {
+      onClose();
+    }
+  };
+
+  const handleDelete = () => {
+    setHasDraftChanges(false);
+    onClose();
+  };
+
+  const handleDiscard = () => {
+    setHasDraftChanges(false);
+    setDiscardDialogStateOpened(false);
+    onClose();
+  };
+
+  return (
+    <Drawer isOpen={isOpen} onClose={handleClose} data-testid="datasource-editor">
+      <ErrorBoundary FallbackComponent={ErrorAlert}>
+        <PluginRegistry
+          pluginLoader={bundledPluginLoader}
+          // TODO this required field is useless here
+          defaultPluginKinds={{
+            Panel: 'TimeSeriesChart',
+            TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+          }}
+        >
+          {isOpen && (
+            <DatasourceEditorForm
+              initialDatasource={datasource}
+              saveAction={saveAction}
+              flagAsDraft={() => setHasDraftChanges(true)}
+              onSave={handleSave}
+              onCancel={handleClose}
+              onDelete={saveAction == 'Update' ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
+            />
+          )}
+        </PluginRegistry>
+        <DeleteDatasourceDialog
+          open={isDeleteDatasourceDialogStateOpened}
+          onClose={() => setDeleteDatasourceDialogStateOpened(false)}
+          onDelete={handleDelete}
+          datasource={datasource}
+        />
+        <DiscardChangesConfirmationDialog
+          description="Are you sure you want to discard your changes? Changes cannot be recovered."
+          isOpen={isDiscardDialogStateOpened}
+          onCancel={() => setDiscardDialogStateOpened(false)}
+          onDiscardChanges={handleDiscard}
+        />
+      </ErrorBoundary>
+    </Drawer>
+  );
+}

--- a/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
@@ -12,53 +12,36 @@
 // limitations under the License.
 
 import { Datasource } from '@perses-dev/core';
-import { DispatchWithoutAction, useState } from 'react';
-import { DiscardChangesConfirmationDialog, Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { DispatchWithoutAction, useCallback, useState } from 'react';
+import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
 import { DeleteDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
 import { DatasourceEditorForm } from './DatasourceEditorForm';
 
+export type ActionStr = 'Create' | 'Update';
+
 interface DatasourceDrawerProps {
   datasource: Datasource;
   isOpen: boolean;
-  saveAction: string;
+  saveActionStr: ActionStr;
   onSave: (datasource: Datasource) => void;
   onClose: DispatchWithoutAction;
 }
 
 export function DatasourceDrawer(props: DatasourceDrawerProps) {
-  const { datasource, isOpen, saveAction, onSave, onClose } = props;
+  const { datasource, isOpen, saveActionStr, onSave, onClose } = props;
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
-  const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
-  const [hasDraftChanges, setHasDraftChanges] = useState<boolean>(false);
 
-  const handleSave = (datasource: Datasource) => {
-    setHasDraftChanges(false);
-    onSave(datasource);
-  };
-
-  const handleClose = () => {
-    if (hasDraftChanges) {
-      setDiscardDialogStateOpened(true);
-    } else {
-      onClose();
-    }
-  };
-
-  const handleDelete = () => {
-    setHasDraftChanges(false);
-    onClose();
-  };
-
-  const handleDiscard = () => {
-    setHasDraftChanges(false);
-    setDiscardDialogStateOpened(false);
-    onClose();
-  };
+  // When user clicks out of the drawer, do not close it, just do nothing
+  // This is a quick-win solution to avoid losing draft changes
+  // -> TODO allow closing by clicking-out without being too sensitive to missclicks
+  const handleClickOut = useCallback(() => {
+    return;
+  }, []);
 
   return (
-    <Drawer isOpen={isOpen} onClose={handleClose} data-testid="datasource-editor">
+    <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry
           pluginLoader={bundledPluginLoader}
@@ -71,25 +54,18 @@ export function DatasourceDrawer(props: DatasourceDrawerProps) {
           {isOpen && (
             <DatasourceEditorForm
               initialDatasource={datasource}
-              saveAction={saveAction}
-              flagAsDraft={() => setHasDraftChanges(true)}
-              onSave={handleSave}
-              onCancel={handleClose}
-              onDelete={saveAction == 'Update' ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
+              saveActionStr={saveActionStr}
+              onSave={onSave}
+              onClose={onClose}
+              onDelete={saveActionStr == 'Update' ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
             />
           )}
         </PluginRegistry>
         <DeleteDatasourceDialog
           open={isDeleteDatasourceDialogStateOpened}
           onClose={() => setDeleteDatasourceDialogStateOpened(false)}
-          onDelete={handleDelete}
+          onDelete={onClose}
           datasource={datasource}
-        />
-        <DiscardChangesConfirmationDialog
-          description="Are you sure you want to discard your changes? Changes cannot be recovered."
-          isOpen={isDiscardDialogStateOpened}
-          onCancel={() => setDiscardDialogStateOpened(false)}
-          onDiscardChanges={handleDiscard}
         />
       </ErrorBoundary>
     </Drawer>

--- a/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
@@ -1,0 +1,231 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useImmer } from 'use-immer';
+import { Datasource, Display } from '@perses-dev/core';
+import {
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  FormHelperText,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { DispatchWithoutAction, useMemo } from 'react';
+import { PluginEditor } from '@perses-dev/plugin-system';
+import { useIsReadonly } from '../../model/config-client';
+
+// TODO: Replace with proper validation library
+function getValidation(state: Datasource) {
+  /** Name validation */
+  let name = null;
+  if (!state.metadata.name) {
+    name = 'Name is required';
+  }
+  // name can only contain alphanumeric characters and underscores and no spaces
+  if (state.metadata.name && !/^[a-zA-Z0-9_-]+$/.test(state.metadata.name)) {
+    name = 'Name can only contain alphanumeric characters, underscores, and dashes';
+  }
+
+  return {
+    name,
+    isValid: !name,
+  };
+}
+
+// this preprocessing ensure that we always have a defined object for the `display` property:
+function getInitialState(datasource: Datasource): Datasource {
+  const patchedDisplay: Display = {
+    name: '',
+    description: '',
+  };
+
+  if (datasource.spec.display) {
+    patchedDisplay.name = datasource.spec.display.name;
+    if (datasource.spec.display.description) {
+      patchedDisplay.description = datasource.spec.display.description;
+    }
+  }
+
+  return {
+    ...datasource,
+    spec: {
+      ...datasource.spec,
+      display: patchedDisplay,
+    },
+  };
+}
+
+interface DatasourceEditorFormProps {
+  initialDatasource: Datasource;
+  saveAction: string;
+  onSave: (datasource: Datasource) => void;
+  onCancel: DispatchWithoutAction;
+  onDelete: DispatchWithoutAction | undefined;
+  flagAsDraft: DispatchWithoutAction;
+}
+
+export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
+  const { initialDatasource, saveAction, flagAsDraft, onSave, onCancel, onDelete } = props;
+
+  const isReadonly = useIsReadonly();
+  const [state, setState] = useImmer(getInitialState(initialDatasource));
+  const validation = useMemo(() => getValidation(state), [state]);
+
+  // When saving, remove the display property if ever display.name is empty, then pass the value upstream
+  const handleSave = () => {
+    onSave({
+      ...state,
+      spec: {
+        ...state.spec,
+        display: state.spec.display?.name !== '' ? state.spec.display : undefined,
+      },
+    });
+  };
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: (theme) => theme.spacing(1, 2),
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Typography variant="h2">{saveAction} Datasource</Typography>
+        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
+          <Button disabled={isReadonly || !validation.isValid} variant="contained" onClick={handleSave}>
+            {saveAction}
+          </Button>
+          <Button color="secondary" variant="outlined" onClick={onCancel}>
+            Cancel
+          </Button>
+          {onDelete && (
+            <Button disabled={isReadonly} color="error" variant="outlined" onClick={onDelete}>
+              Delete
+            </Button>
+          )}
+        </Stack>
+      </Box>
+      <Box padding={2} sx={{ overflowY: 'scroll' }}>
+        <Grid container spacing={2} mb={2}>
+          <Grid item xs={4}>
+            <TextField
+              required
+              error={!!validation.name}
+              fullWidth
+              label="Name"
+              value={state.metadata.name}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              helperText={validation.name}
+              onChange={(v) => {
+                flagAsDraft();
+                setState((draft) => {
+                  draft.metadata.name = v.target.value;
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={8}>
+            <TextField
+              fullWidth
+              label="Display Label"
+              value={state.spec.display?.name}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              onChange={(v) => {
+                flagAsDraft();
+                setState((draft) => {
+                  if (draft.spec.display) {
+                    draft.spec.display.name = v.target.value;
+                  }
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              label="Description"
+              value={state.spec.display?.description}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              onChange={(v) => {
+                flagAsDraft();
+                setState((draft) => {
+                  if (draft.spec.display) {
+                    draft.spec.display.description = v.target.value;
+                  }
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <FormControl fullWidth>
+              {/* TODO: How to ensure ids are unique? */}
+              <InputLabel id="datasource-default-label">Default</InputLabel>
+              <Select
+                labelId="datasource-default-label"
+                id="datasource-default-select"
+                label="Default"
+                value={state.spec.default == true ? 'yes' : 'no'}
+                readOnly={isReadonly}
+                onChange={(v) => {
+                  flagAsDraft();
+                  setState((draft) => {
+                    draft.spec.default = v.target.value === 'yes';
+                  });
+                }}
+                sx={{ width: '100%' }}
+              >
+                <MenuItem value="yes">Yes</MenuItem>
+                <MenuItem value="no">No</MenuItem>
+              </Select>
+            </FormControl>
+            <FormHelperText>
+              Whether this datasource should be the default {state.spec.plugin.kind} to be used
+            </FormHelperText>
+          </Grid>
+        </Grid>
+        <Divider />
+        <Typography py={1} variant="subtitle1">
+          Plugin Options
+        </Typography>
+        <PluginEditor
+          width="100%"
+          pluginType="Datasource"
+          pluginKindLabel="Source"
+          value={state.spec.plugin}
+          isReadonly={isReadonly}
+          onChange={(v) => {
+            flagAsDraft();
+            setState((draft) => {
+              draft.spec.plugin = v;
+            });
+          }}
+        />
+      </Box>
+    </>
+  );
+}

--- a/ui/app/src/components/DatasourceList/DatasourceList.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceList.tsx
@@ -202,7 +202,7 @@ export function DatasourceList(props: DatasourceListProperties) {
         <DatasourceDrawer
           datasource={targetedDatasource}
           isOpen={isEditDatasourceFormStateOpened}
-          saveAction="Update"
+          saveActionStr="Update"
           onSave={handleDatasourceUpdate}
           onClose={() => setEditDatasourceFormStateOpened(false)}
         />

--- a/ui/app/src/components/DatasourceList/DatasourceList.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceList.tsx
@@ -1,0 +1,212 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Datasource, getDatasourceDisplayName, getDatasourceExtendedDisplayName } from '@perses-dev/core';
+import { Stack, Tooltip } from '@mui/material';
+import { GridColDef, GridValueGetterParams } from '@mui/x-data-grid';
+import { useCallback, useMemo, useState } from 'react';
+import { intlFormatDistance } from 'date-fns';
+import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { useSnackbar } from '@perses-dev/components';
+import {
+  useCreateDatasourceMutation,
+  useDeleteDatasourceMutation,
+  useUpdateDatasourceMutation,
+} from '../../model/project-client';
+import { DatasourceDataGrid, Row } from './DatasourceDataGrid';
+import { DatasourceDrawer } from './DatasourceDrawer';
+
+export interface DatasourceListProperties {
+  projectName: string;
+  datasourceList: Datasource[];
+  hideToolbar?: boolean;
+  initialState?: GridInitialStateCommunity;
+  isLoading?: boolean;
+}
+
+/**
+ * Display datasources in a table style.
+ * @param props.datasourceList Contains all datasources to display
+ * @param props.hideToolbar Hide toolbar if enabled
+ * @param props.initialState Provide a way to override default initialState
+ * @param props.isLoading Display a loading circle if enableds
+ */
+export function DatasourceList(props: DatasourceListProperties) {
+  const { projectName, datasourceList, hideToolbar, initialState, isLoading } = props;
+
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createDatasourceMutation = useCreateDatasourceMutation(projectName);
+  const deleteDatasourceMutation = useDeleteDatasourceMutation(projectName);
+  const updateDatasourceMutation = useUpdateDatasourceMutation(projectName);
+
+  const getDatasource = useCallback(
+    (project: string, name: string) => {
+      return datasourceList.find(
+        (datasource) => datasource.metadata.project === project && datasource.metadata.name === name
+      );
+    },
+    [datasourceList]
+  );
+
+  const rows = useMemo(() => {
+    return datasourceList.map(
+      (datasource) =>
+        ({
+          project: datasource.metadata.project,
+          name: datasource.metadata.name,
+          displayName: getDatasourceDisplayName(datasource),
+          version: datasource.metadata.version,
+          createdAt: datasource.metadata.created_at,
+          updatedAt: datasource.metadata.updated_at,
+          type: datasource.spec.plugin.kind,
+        } as Row)
+    );
+  }, [datasourceList]);
+
+  const [targetedDatasource, setTargetedDatasource] = useState<Datasource>();
+  const [isEditDatasourceFormStateOpened, setEditDatasourceFormStateOpened] = useState<boolean>(false);
+
+  const handleDatasourceUpdate = useCallback(
+    (datasource: Datasource) => {
+      if (targetedDatasource != undefined && datasource.metadata.name != targetedDatasource.metadata.name) {
+        // In this case "move" the datasource, aka create it with the new name & remove the former one
+        // We do this because we can't just do a PUT call in that case (results in "document not found" error)
+        // TODO: create + delete calls should be bundled together so that we avoid the case where only one would succeed
+        createDatasourceMutation.mutate(datasource, {
+          onSuccess: (createdDatasource: Datasource) => {
+            successSnackbar(
+              `Datasource ${getDatasourceExtendedDisplayName(createdDatasource)} has been successfully created`
+            );
+            setEditDatasourceFormStateOpened(false);
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            throw err;
+          },
+        });
+        deleteDatasourceMutation.mutate(targetedDatasource, {
+          onSuccess: (deletedDatasource: Datasource) => {
+            successSnackbar(
+              `Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} was successfully deleted`
+            );
+            setEditDatasourceFormStateOpened(false);
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            throw err;
+          },
+        });
+      } else {
+        updateDatasourceMutation.mutate(datasource, {
+          onSuccess: (updatedDatasource: Datasource) => {
+            successSnackbar(`Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`);
+            setEditDatasourceFormStateOpened(false);
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            throw err;
+          },
+        });
+      }
+    },
+    [
+      exceptionSnackbar,
+      successSnackbar,
+      createDatasourceMutation,
+      deleteDatasourceMutation,
+      updateDatasourceMutation,
+      targetedDatasource,
+    ]
+  );
+
+  const onRowClick = useCallback(
+    (project: string, name: string) => {
+      setTargetedDatasource(getDatasource(project, name));
+      setEditDatasourceFormStateOpened(true);
+    },
+    [getDatasource]
+  );
+
+  const columns = useMemo<Array<GridColDef<Row>>>(
+    () => [
+      { field: 'project', headerName: 'Project', type: 'string', flex: 2, minWidth: 150 },
+      { field: 'type', headerName: 'Type', type: 'string', flex: 2 },
+      {
+        field: 'name',
+        headerName: 'Name',
+        type: 'string',
+        flex: 2,
+        renderCell: (params) => <pre>{params.value}</pre>,
+      },
+      { field: 'displayName', headerName: 'Display Name', type: 'string', flex: 3, minWidth: 150 },
+      {
+        field: 'version',
+        headerName: 'Version',
+        type: 'number',
+        align: 'right',
+        headerAlign: 'right',
+        flex: 1,
+        minWidth: 80,
+      },
+      {
+        field: 'createdAt',
+        headerName: 'Creation Date',
+        type: 'dateTime',
+        flex: 1,
+        minWidth: 125,
+        valueGetter: (params: GridValueGetterParams) => new Date(params.row.createdAt),
+        renderCell: (params) => (
+          <Tooltip title={params.value.toUTCString()} placement="top">
+            <span>{intlFormatDistance(params.value, new Date())}</span>
+          </Tooltip>
+        ),
+      },
+      {
+        field: 'updatedAt',
+        headerName: 'Last Update',
+        type: 'dateTime',
+        flex: 1,
+        minWidth: 125,
+        valueGetter: (params: GridValueGetterParams) => new Date(params.row.updatedAt),
+        renderCell: (params) => (
+          <Tooltip title={params.value.toUTCString()} placement="top">
+            <span>{intlFormatDistance(params.value, new Date())}</span>
+          </Tooltip>
+        ),
+      },
+    ],
+    []
+  );
+
+  return (
+    <Stack width="100%">
+      <DatasourceDataGrid
+        rows={rows}
+        columns={columns}
+        initialState={initialState}
+        hideToolbar={hideToolbar}
+        isLoading={isLoading}
+        onRowClick={onRowClick}
+      />
+      {targetedDatasource && (
+        <DatasourceDrawer
+          datasource={targetedDatasource}
+          isOpen={isEditDatasourceFormStateOpened}
+          saveAction="Update"
+          onSave={handleDatasourceUpdate}
+          onClose={() => setEditDatasourceFormStateOpened(false)}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/ui/app/src/components/dialogs/DeleteDatasourceDialog.tsx
+++ b/ui/app/src/components/dialogs/DeleteDatasourceDialog.tsx
@@ -1,0 +1,76 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Dispatch, DispatchWithoutAction, useCallback } from 'react';
+import { Button } from '@mui/material';
+import { Dialog, useSnackbar } from '@perses-dev/components';
+import { Datasource } from '@perses-dev/core';
+import { getDatasourceExtendedDisplayName } from '@perses-dev/core/dist/utils/text';
+import { useDeleteDatasourceMutation } from '../../model/project-client';
+
+export interface DeleteDatasourceDialogProps {
+  datasource: Datasource;
+  open: boolean;
+  onClose: DispatchWithoutAction;
+  onDelete: DispatchWithoutAction;
+  onSuccess?: Dispatch<Datasource>;
+}
+
+/**
+ * Dialog used to delete a datasource.
+ * @param props.open Define if the dialog should be opened or not.
+ * @param props.closeDialog Provides the function to close itself.
+ * @param props.onConfirm Action to perform when user confirmed.
+ * @param props.datasource The datasource resource to delete.
+ * @constructor
+ */
+export const DeleteDatasourceDialog = (props: DeleteDatasourceDialogProps) => {
+  const { datasource, open, onClose, onDelete, onSuccess } = props;
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const deleteDatasourceMutation = useDeleteDatasourceMutation(datasource.metadata.project);
+
+  const handleSubmit = useCallback(() => {
+    return deleteDatasourceMutation.mutate(datasource, {
+      onSuccess: (deletedDatasource: Datasource) => {
+        successSnackbar(`Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} was successfully deleted`);
+        onClose();
+        onDelete();
+        if (onSuccess) {
+          onSuccess(datasource);
+        }
+      },
+      onError: (err) => {
+        exceptionSnackbar(err);
+        throw err;
+      },
+    });
+  }, [deleteDatasourceMutation, datasource, onClose, onDelete, onSuccess, successSnackbar, exceptionSnackbar]);
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <Dialog.Header>Delete Datasource</Dialog.Header>
+      <Dialog.Content>
+        Are you sure you want to delete the datasource {getDatasourceExtendedDisplayName(datasource)}? This action
+        cannot be undone.
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button variant="contained" type="submit" onClick={handleSubmit}>
+          Delete
+        </Button>
+        <Button variant="outlined" color="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  );
+};

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -157,7 +157,7 @@ function TabButton(props: TabButtonProps) {
               },
             }}
             isOpen={isCreateDatasourceDrawerStateOpened}
-            saveAction="Create"
+            saveActionStr="Create"
             onSave={handleDatasourceCreation}
             onClose={() => setCreateDatasourceFormStateOpened(false)}
           />

--- a/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
@@ -1,0 +1,46 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Card } from '@mui/material';
+import { useDatasourceList } from '../../../model/project-client';
+import { DatasourceList } from '../../../components/DatasourceList/DatasourceList';
+
+interface ProjectDatasourcesProps {
+  projectName: string;
+  hideToolbar?: boolean;
+  id?: string;
+}
+
+export function ProjectDatasources(props: ProjectDatasourcesProps) {
+  const { projectName, hideToolbar, id } = props;
+  const { data, isLoading } = useDatasourceList(projectName);
+
+  return (
+    <Card id={id}>
+      <DatasourceList
+        projectName={projectName}
+        datasourceList={data || []}
+        hideToolbar={hideToolbar}
+        isLoading={isLoading}
+        initialState={{
+          columns: {
+            columnVisibilityModel: {
+              project: false,
+              version: false,
+            },
+          },
+        }}
+      />
+    </Card>
+  );
+}

--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -25,7 +25,7 @@ export interface GlobalDatasource {
 }
 
 /**
- * A Datasource that belongs to a project.
+ * A Datasource resource, that belongs to a project.
  */
 export interface Datasource {
   kind: 'Datasource';

--- a/ui/core/src/utils/text.ts
+++ b/ui/core/src/utils/text.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DashboardResource, VariableResource } from '../model';
+import { Datasource, DashboardResource, VariableResource } from '../model';
 
 /**
  * If the dashboard has a display name, return the dashboard display name
@@ -29,6 +29,15 @@ export function getDashboardDisplayName(dashboard: DashboardResource) {
  */
 export function getVariableDisplayName(variable: VariableResource) {
   return variable.spec.spec.display?.name ?? variable.metadata.name;
+}
+
+/**
+ * If the variable has a display name, return the datasource display name
+ * Else, only return the datasource name
+ * @param variable Project or Global datasource
+ */
+export function getDatasourceDisplayName(datasource: Datasource) {
+  return datasource.spec.display?.name || datasource.metadata.name;
 }
 
 /**
@@ -53,4 +62,16 @@ export function getVariableExtendedDisplayName(variable: VariableResource) {
     return `${variable.spec.spec.display.name} (Name: ${variable.metadata.name})`;
   }
   return variable.metadata.name;
+}
+
+/**
+ * If the datasource has a display name, return the datasource display name and the datasource name
+ * Else, only return the datasource name
+ * @param variable Project or Global datasource
+ */
+export function getDatasourceExtendedDisplayName(datasource: Datasource) {
+  if (datasource.spec.display?.name) {
+    return `${datasource.spec.display.name} (ID: ${datasource.metadata.name})`;
+  }
+  return datasource.metadata.name;
 }

--- a/ui/e2e/src/pages/AppProjectPage.ts
+++ b/ui/e2e/src/pages/AppProjectPage.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { Locator, Page } from '@playwright/test';
+import { DatasourceEditor } from './DatasourceEditor';
 import { VariableEditor } from './VariableEditor';
 
 const mainDashboardListId = 'main-dashboard-list';
@@ -28,8 +29,11 @@ export class AppProjectPage {
 
   readonly variableEditor: Locator;
   readonly addVariableButton: Locator;
-
   readonly variableList: Locator;
+
+  readonly datasourceEditor: Locator;
+  readonly addDatasourceButton: Locator;
+  readonly datasourceList: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -41,8 +45,11 @@ export class AppProjectPage {
 
     this.addVariableButton = page.getByRole('button', { name: 'Add Variable' });
     this.variableEditor = page.getByTestId('variable-editor');
-
     this.variableList = page.locator('#project-variable-list');
+
+    this.addDatasourceButton = page.getByRole('button', { name: 'Add Datasource' });
+    this.datasourceEditor = page.getByTestId('datasource-editor');
+    this.datasourceList = page.locator('#project-datasource-list');
   }
 
   async goto(projectName: string) {
@@ -126,5 +133,15 @@ export class AppProjectPage {
 
   getVariableEditor() {
     return new VariableEditor(this.variableEditor);
+  }
+
+  async startCreatingDatasources() {
+    await this.addDatasourceButton.click();
+    const datasourceEditor = this.getDatasourceEditor();
+    await datasourceEditor.isVisible();
+  }
+
+  getDatasourceEditor() {
+    return new DatasourceEditor(this.datasourceEditor);
   }
 }

--- a/ui/e2e/src/pages/DatasourceEditor.ts
+++ b/ui/e2e/src/pages/DatasourceEditor.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { Locator } from '@playwright/test';
-import { selectMenuItem } from '../utils';
 
 export class DatasourceEditor {
   readonly container: Locator;
@@ -23,6 +22,8 @@ export class DatasourceEditor {
   readonly displayLabelInput: Locator;
   readonly descriptionInput: Locator;
 
+  readonly isDefaultSwitch: Locator;
+
   constructor(container: Locator) {
     this.container = container;
 
@@ -31,6 +32,8 @@ export class DatasourceEditor {
     this.nameInput = container.getByLabel('Name');
     this.displayLabelInput = container.getByLabel('Display Label');
     this.descriptionInput = container.getByLabel('Description');
+
+    this.isDefaultSwitch = container.getByLabel('Set as default');
   }
 
   async setName(name: string) {
@@ -48,7 +51,11 @@ export class DatasourceEditor {
     await this.descriptionInput.type(description);
   }
 
-  async selectDefault(isDefault: string) {
-    await selectMenuItem(this.container, 'Default', isDefault);
+  async setDefault(isDefault: boolean) {
+    if (isDefault) {
+      await this.isDefaultSwitch.check();
+    } else {
+      await this.isDefaultSwitch.uncheck();
+    }
   }
 }

--- a/ui/e2e/src/pages/DatasourceEditor.ts
+++ b/ui/e2e/src/pages/DatasourceEditor.ts
@@ -1,0 +1,54 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Locator } from '@playwright/test';
+import { selectMenuItem } from '../utils';
+
+export class DatasourceEditor {
+  readonly container: Locator;
+
+  readonly createButton: Locator;
+
+  readonly nameInput: Locator;
+  readonly displayLabelInput: Locator;
+  readonly descriptionInput: Locator;
+
+  constructor(container: Locator) {
+    this.container = container;
+
+    this.createButton = container.getByRole('button', { name: 'Create' });
+
+    this.nameInput = container.getByLabel('Name');
+    this.displayLabelInput = container.getByLabel('Display Label');
+    this.descriptionInput = container.getByLabel('Description');
+  }
+
+  async setName(name: string) {
+    await this.nameInput.clear();
+    await this.nameInput.type(name);
+  }
+
+  async setDisplayLabel(displayLabel: string) {
+    await this.displayLabelInput.clear();
+    await this.displayLabelInput.type(displayLabel);
+  }
+
+  async setDescription(description: string) {
+    await this.descriptionInput.clear();
+    await this.descriptionInput.type(description);
+  }
+
+  async selectDefault(isDefault: string) {
+    await selectMenuItem(this.container, 'Default', isDefault);
+  }
+}

--- a/ui/e2e/src/tests/projectView.spec.ts
+++ b/ui/e2e/src/tests/projectView.spec.ts
@@ -93,7 +93,7 @@ test.describe('ProjectView', () => {
     await datasourceEditor.setName('my_ds');
     await datasourceEditor.setDisplayLabel('My personal datasource');
     await datasourceEditor.setDescription('This is a datasource for personal use');
-    await datasourceEditor.selectDefault('no');
+    await datasourceEditor.setDefault(false);
     await datasourceEditor.createButton.click();
 
     await expect(projectPage.datasourceList).toContainText('my_ds');

--- a/ui/e2e/src/tests/projectView.spec.ts
+++ b/ui/e2e/src/tests/projectView.spec.ts
@@ -81,4 +81,21 @@ test.describe('ProjectView', () => {
 
     await expect(projectPage.variableList).toContainText('$list_var');
   });
+
+  test('can create a datasource', async ({ page }) => {
+    const projectPage = new AppProjectPage(page);
+    await projectPage.goto(project);
+
+    await projectPage.gotoDatasourcesTab();
+
+    await projectPage.addDatasourceButton.click();
+    const datasourceEditor = projectPage.getDatasourceEditor();
+    await datasourceEditor.setName('my_ds');
+    await datasourceEditor.setDisplayLabel('My personal datasource');
+    await datasourceEditor.setDescription('This is a datasource for personal use');
+    await datasourceEditor.selectDefault('no');
+    await datasourceEditor.createButton.click();
+
+    await expect(projectPage.datasourceList).toContainText('my_ds');
+  });
 });

--- a/ui/plugin-system/src/components/OptionsEditorRadios/OptionsEditorRadios.tsx
+++ b/ui/plugin-system/src/components/OptionsEditorRadios/OptionsEditorRadios.tsx
@@ -1,0 +1,72 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { FormControl, FormControlLabel, Radio, RadioGroup, RadioGroupProps, Box, Typography } from '@mui/material';
+import { useState } from 'react';
+import { OptionsEditorTabPanel } from '../OptionsEditorTabPanel';
+
+export type OptionsEditorRadio = {
+  label: string;
+  /**
+   * Content rendered when the tab is active.
+   */
+  content: React.ReactNode;
+};
+
+export type OptionsEditorRadiosProps = {
+  tabs: OptionsEditorRadio[];
+  defaultTab: number;
+  onModeChange: (value: number) => void;
+  isReadonly?: boolean;
+};
+
+export const OptionsEditorRadios = (props: OptionsEditorRadiosProps) => {
+  const { tabs, defaultTab, onModeChange, isReadonly } = props;
+  const [activeTab, setActiveTab] = useState(defaultTab);
+
+  const handleChange: RadioGroupProps['onChange'] = (_, value) => {
+    const v = parseInt(value);
+    setActiveTab(v);
+    onModeChange(v);
+  };
+
+  return (
+    <>
+      <Box sx={{ borderBottom: 1, borderColor: (theme) => theme.palette.divider }}>
+        <FormControl>
+          <Typography variant="overline" component="h4">
+            Mode:
+          </Typography>
+          <RadioGroup
+            row
+            defaultValue={defaultTab}
+            value={activeTab}
+            onChange={handleChange}
+            aria-labelledby="Configuration radio"
+          >
+            {tabs.map(({ label }, i) => {
+              return <FormControlLabel disabled={isReadonly} key={label} value={i} control={<Radio />} label={label} />;
+            })}
+          </RadioGroup>
+        </FormControl>
+      </Box>
+      {tabs.map(({ label, content }, i) => {
+        return (
+          <OptionsEditorTabPanel key={label} value={activeTab} index={i}>
+            {content}
+          </OptionsEditorTabPanel>
+        );
+      })}
+    </>
+  );
+};

--- a/ui/plugin-system/src/components/OptionsEditorRadios/index.ts
+++ b/ui/plugin-system/src/components/OptionsEditorRadios/index.ts
@@ -11,15 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './CalculationSelector';
-export * from './DatasourceSelect';
-export * from './LegendOptionsEditor';
 export * from './OptionsEditorRadios';
-export * from './OptionsEditorTabs';
-export * from './PanelSpecEditor';
-export * from './PluginEditor';
-export * from './PluginKindSelect';
-export * from './PluginRegistry';
-export * from './PluginSpecEditor';
-export * from './TimeSeriesQueryEditor';
-export * from './Variables';

--- a/ui/plugin-system/src/components/OptionsEditorTabPanel/OptionsEditorTabPanel.tsx
+++ b/ui/plugin-system/src/components/OptionsEditorTabPanel/OptionsEditorTabPanel.tsx
@@ -11,15 +11,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './CalculationSelector';
-export * from './DatasourceSelect';
-export * from './LegendOptionsEditor';
-export * from './OptionsEditorRadios';
-export * from './OptionsEditorTabs';
-export * from './PanelSpecEditor';
-export * from './PluginEditor';
-export * from './PluginKindSelect';
-export * from './PluginRegistry';
-export * from './PluginSpecEditor';
-export * from './TimeSeriesQueryEditor';
-export * from './Variables';
+import { Box } from '@mui/material';
+
+interface OptionsEditorTabPanelProps {
+  children: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+export function OptionsEditorTabPanel(props: OptionsEditorTabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  const isActive = value === index;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={!isActive}
+      id={`options-editor-tabpanel-${index}`}
+      aria-labelledby={`options-editor-tab-${index}`}
+      {...other}
+    >
+      {isActive && <Box mt={2}>{children}</Box>}
+    </div>
+  );
+}

--- a/ui/plugin-system/src/components/OptionsEditorTabPanel/index.ts
+++ b/ui/plugin-system/src/components/OptionsEditorTabPanel/index.ts
@@ -11,15 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './CalculationSelector';
-export * from './DatasourceSelect';
-export * from './LegendOptionsEditor';
-export * from './OptionsEditorRadios';
-export * from './OptionsEditorTabs';
-export * from './PanelSpecEditor';
-export * from './PluginEditor';
-export * from './PluginKindSelect';
-export * from './PluginRegistry';
-export * from './PluginSpecEditor';
-export * from './TimeSeriesQueryEditor';
-export * from './Variables';
+export * from './OptionsEditorTabPanel';

--- a/ui/plugin-system/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
+++ b/ui/plugin-system/src/components/OptionsEditorTabs/OptionsEditorTabs.tsx
@@ -13,7 +13,7 @@
 
 import { Tab, Tabs, TabsProps, Box } from '@mui/material';
 import { useState } from 'react';
-import { TabPanel } from './TabPanel';
+import { OptionsEditorTabPanel } from '../OptionsEditorTabPanel';
 
 export type OptionsEditorTab = {
   label: string;
@@ -52,9 +52,9 @@ export const OptionsEditorTabs = ({ tabs }: OptionsEditorTabsProps) => {
       </Box>
       {tabs.map(({ label, content }, i) => {
         return (
-          <TabPanel key={label} value={activeTab} index={i}>
+          <OptionsEditorTabPanel key={label} value={activeTab} index={i}>
             {content}
-          </TabPanel>
+          </OptionsEditorTabPanel>
         );
       })}
     </>

--- a/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/index.ts
+++ b/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/index.ts
@@ -11,28 +11,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from '@mui/material';
-
-interface TabPanelProps {
-  children: React.ReactNode;
-  index: number;
-  value: number;
-}
-
-export function TabPanel(props: TabPanelProps) {
-  const { children, value, index, ...other } = props;
-
-  const isActive = value === index;
-
-  return (
-    <div
-      role="tabpanel"
-      hidden={!isActive}
-      id={`options-editor-tabpanel-${index}`}
-      aria-labelledby={`options-editor-tab-${index}`}
-      {...other}
-    >
-      {isActive && <Box mt={2}>{children}</Box>}
-    </div>
-  );
-}
+export * from './PrometheusDatasourceEditor';
+export * from './types';

--- a/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/types.ts
+++ b/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/types.ts
@@ -1,0 +1,43 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { RequestHeaders } from '@perses-dev/core';
+
+// TODO unify this one with PrometheusDatasourceSpec from prometheus-datasource.tsx ? or rename one or the other for disambiguition?
+export interface PrometheusDatasourceSpec {
+  direct_url?: string;
+  proxy?: HTTPProxy;
+}
+
+export interface HTTPProxy {
+  kind: 'HTTPProxy';
+  spec: HTTPProxySpec;
+}
+export interface HTTPProxySpec {
+  // url is the url of the datasource. It is not the url of the proxy.
+  // The Perses server is the proxy, so it needs to know where to redirect the request.
+  url: string;
+  // allowed_endpoints is a list of tuples of http methods and http endpoints that will be accessible.
+  // Leave it empty if you don't want to restrict the access to the datasource.
+  allowed_endpoints?: HTTPAllowedEndpoint[];
+  // headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+  headers?: RequestHeaders;
+  // secret is the name of the secret that should be used for the proxy or discovery configuration
+  // It will contain any sensitive information such as password, token, certificate.
+  secret?: string;
+}
+
+export interface HTTPAllowedEndpoint {
+  endpoint_pattern: string;
+  method: string;
+}

--- a/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/types.ts
+++ b/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/types.ts
@@ -13,7 +13,7 @@
 
 import { RequestHeaders } from '@perses-dev/core';
 
-// TODO unify this one with PrometheusDatasourceSpec from prometheus-datasource.tsx ? or rename one or the other for disambiguition?
+// TODO unify this one with the other PrometheusDatasourceSpec used for datasource store manipulation
 export interface PrometheusDatasourceSpec {
   direct_url?: string;
   proxy?: HTTPProxy;

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
@@ -14,6 +14,10 @@
 import { RequestHeaders } from '@perses-dev/core';
 import { DatasourcePlugin } from '@perses-dev/plugin-system';
 import { instantQuery, rangeQuery, labelNames, labelValues, PrometheusClient } from '../model';
+import {
+  PrometheusDatasourceEditor,
+  PrometheusDatasourceSpec as PrometheusDatasourceSpecFull,
+} from './PrometheusDatasourceEditor';
 
 export interface PrometheusDatasourceSpec {
   direct_url?: string;
@@ -45,8 +49,8 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
   };
 };
 
-export const PrometheusDatasource: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient> = {
+export const PrometheusDatasource: DatasourcePlugin<PrometheusDatasourceSpecFull, PrometheusClient> = {
   createClient,
-  OptionsEditorComponent: () => null,
+  OptionsEditorComponent: PrometheusDatasourceEditor,
   createInitialOptions: () => ({ direct_url: '' }),
 };


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

Issue ref: https://github.com/perses/perses/issues/1033

This PR adds project datasources CRUD, leveraging on the tab layout from #1267. It also comes with:
- A bugfix on backend side: updating the already-defined-as-default datasource was causing unwanted request rejection (_"cannot set A as default since there's already a default datasource set (A)"_).
- New reusable component `OptionsEditorRadio` for RadioGroup-based options.

![2023-07-10_09h37_59](https://github.com/perses/perses/assets/7058693/fa68d2e6-440b-4420-8f98-29239b153ce3)

_NB: contrary to what was done for variables, here you have no action button in the list view: clicking on a row opens the drawer form for this datasource and it's there that you can act on it. We agreed with @Gladorme to have this divergence between variables & datasources UX temporarily: since we were not able to identify which one is better, the goal is to have people being able to play with the 2 designs for a while (should end before v1 release :D), then ultimately decide which one we prefer to keep & implement consistency between datasources & variables UX in a later PR._

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
