### PR TITLE
[BUGFIX] Fix unpin tooltip icon click, adjust help text

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -344,6 +344,9 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
             wrapLabels={tooltipConfig.wrapLabels}
             pinnedPos={tooltipPinnedCoords}
             unit={unit}
+            onUnpinClick={() => {
+              setTooltipPinnedCoords(null);
+            }}
           />
         )}
       <EChart

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
@@ -46,7 +46,7 @@ describe('TooltipHeader', () => {
     renderComponent(tooltipContent);
     expect(screen.getByText('Dec 23, 2022 -')).toBeInTheDocument();
     expect(screen.getByText('13:53:00')).toBeInTheDocument();
-    expect(screen.getByText('Click to Pin')).toBeInTheDocument();
+    expect(screen.getByText('Click chart to Pin')).toBeInTheDocument();
   });
 
   it('should display with unpin text', () => {

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
@@ -46,7 +46,7 @@ describe('TooltipHeader', () => {
     renderComponent(tooltipContent);
     expect(screen.getByText('Dec 23, 2022 -')).toBeInTheDocument();
     expect(screen.getByText('13:53:00')).toBeInTheDocument();
-    expect(screen.getByText('Click chart to Pin')).toBeInTheDocument();
+    expect(screen.getByText('Click chart to pin')).toBeInTheDocument();
   });
 
   it('should display with unpin text', () => {

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
@@ -57,7 +57,7 @@ describe('TooltipHeader', () => {
       showAllSeries: false,
     };
     renderComponent(tooltipContent);
-    expect(screen.getByText('Click to Unpin')).toBeInTheDocument();
+    expect(screen.getByText('Click to unpin')).toBeInTheDocument();
   });
 
   it('should not display show all toggle when only 1 total series', () => {

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
@@ -65,6 +65,8 @@ export const TooltipHeader = memo(function TooltipHeader({
   // TODO: accurately calc whether more series are outside scrollable region using yBuffer, avg series name length, TOOLTIP_MAX_HEIGHT
   const showAllSeriesToggle = totalSeries > 5;
 
+  const pinTooltipHelpText = isTooltipPinned ? 'Click to Unpin' : 'Click chart to pin';
+
   return (
     <Box
       sx={(theme) => ({
@@ -118,7 +120,7 @@ export const TooltipHeader = memo(function TooltipHeader({
                 verticalAlign: 'middle',
               }}
             >
-              Click to {isTooltipPinned ? 'Unpin' : 'Pin'}
+              {pinTooltipHelpText}
             </Typography>
             {isTooltipPinned ? (
               <Pin

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
@@ -65,7 +65,7 @@ export const TooltipHeader = memo(function TooltipHeader({
   // TODO: accurately calc whether more series are outside scrollable region using yBuffer, avg series name length, TOOLTIP_MAX_HEIGHT
   const showAllSeriesToggle = totalSeries > 5;
 
-  const pinTooltipHelpText = isTooltipPinned ? 'Click to Unpin' : 'Click chart to Pin';
+  const pinTooltipHelpText = isTooltipPinned ? 'Click to unpin' : 'Click chart to pin';
 
   return (
     <Box

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
@@ -65,7 +65,7 @@ export const TooltipHeader = memo(function TooltipHeader({
   // TODO: accurately calc whether more series are outside scrollable region using yBuffer, avg series name length, TOOLTIP_MAX_HEIGHT
   const showAllSeriesToggle = totalSeries > 5;
 
-  const pinTooltipHelpText = isTooltipPinned ? 'Click to Unpin' : 'Click chart to pin';
+  const pinTooltipHelpText = isTooltipPinned ? 'Click to Unpin' : 'Click chart to Pin';
 
   return (
     <Box


### PR DESCRIPTION
## Overview

- TimeChart rewrite follow up to fix clicking on 'Unpin' icon 
  - prev PR #1268
- Adjust help text based on user feedback

### Fixed unpin icon click:

https://github.com/perses/perses/assets/9369625/0a897baf-1772-4afa-84cb-71ea1cccc301

### New help text ex:
<img width="405" alt="image" src="https://github.com/perses/perses/assets/9369625/f6c7c541-ea54-4bc2-971e-b362850da511">

