### PR TITLE
[FEATURE] Time series bar support using `visual.display` in TimeSeriesChart spec

### DIFF
--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -31,9 +31,10 @@ import (
 }
 
 #visual: {
+	display?:       "line" | "bar"
 	line_width?:    number & >=0.25 & <=3
 	area_opacity?:  number & >=0 & <=1
-	show_points?:   "Auto" | "Always"
+	show_points?:   "Auto" | "Always" // TODO: change to lowercase as part of kebab-case migration in PR #1262
 	palette?:       #palette
 	point_radius?:  number & >=0 & <=6
 	stack?:         "All" | "Percent" // TODO: Percent option is disabled until support is added

--- a/schemas/panels/time-series/time-series.json
+++ b/schemas/panels/time-series/time-series.json
@@ -27,6 +27,7 @@
       ]
     },
     "visual": {
+      "display": "line",
       "line_width": 2,
       "point_radius": 3
     }

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -24,7 +24,7 @@ import type {
   TooltipComponentOption,
 } from 'echarts';
 import { ECharts as EChartsInstance, use } from 'echarts/core';
-import { LineChart as EChartsLineChart } from 'echarts/charts';
+import { LineChart as EChartsLineChart, BarChart as EChartsBarChart } from 'echarts/charts';
 import {
   GridComponent,
   DatasetComponent,
@@ -53,6 +53,7 @@ import { useTimeZone } from '../context/TimeZoneProvider';
 
 use([
   EChartsLineChart,
+  EChartsBarChart,
   GridComponent,
   DatasetComponent,
   DataZoomComponent,

--- a/ui/components/src/model/graph.ts
+++ b/ui/components/src/model/graph.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { TimeSeriesValueTuple } from '@perses-dev/core';
-import { LineSeriesOption } from 'echarts/charts';
+import { LineSeriesOption, BarSeriesOption } from 'echarts/charts';
 import { LegendItem } from '../Legend';
 
 // adjust display when there are many time series to help with performance
@@ -33,8 +33,10 @@ export interface LegacyTimeSeries extends Omit<LineSeriesOption, 'data'> {
 }
 
 // TODO: Continue to simplify TimeChart types, fix legend and thresholds
-export type TimeChartSeriesMapping = LineSeriesOption[];
+export type TimeChartSeriesMapping = TimeSeriesOption[];
 export type TimeChartLegendItems = LegendItem[];
+
+export type TimeSeriesOption = LineSeriesOption | BarSeriesOption;
 
 // TODO: Rename to LegacyEChartsDataFormat
 export type EChartsDataFormat = {

--- a/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/VisualOptionsEditor.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Slider, Switch } from '@mui/material';
+import { Slider, Switch, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { OptionsEditorControl, OptionsEditorGroup, SettingsAutocomplete } from '@perses-dev/components';
 import {
   DEFAULT_AREA_OPACITY,
@@ -56,6 +56,33 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
   return (
     <OptionsEditorGroup title="Visual">
       <OptionsEditorControl
+        label={'Display'}
+        control={
+          <ToggleButtonGroup
+            color="primary"
+            exclusive
+            value={value.display}
+            onChange={(__, newValue) => {
+              onChange({
+                ...value,
+                display: newValue,
+              });
+            }}
+          >
+            <ToggleButton
+              value="line"
+              selected={value.display === undefined || value.display === 'line'}
+              aria-label="display line series"
+            >
+              Line
+            </ToggleButton>
+            <ToggleButton value="bar" aria-label="display bar series">
+              Bar
+            </ToggleButton>
+          </ToggleButtonGroup>
+        }
+      />
+      <OptionsEditorControl
         label={VISUAL_CONFIG.line_width.label}
         control={
           <Slider
@@ -66,6 +93,7 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             marks
             min={VISUAL_CONFIG.line_width.min}
             max={VISUAL_CONFIG.line_width.max}
+            disabled={value.display === 'bar'}
             onChange={handleLineWidthChange}
           />
         }
@@ -81,6 +109,7 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
             marks
             min={VISUAL_CONFIG.area_opacity.min}
             max={VISUAL_CONFIG.area_opacity.max}
+            disabled={value.display === 'bar'}
             onChange={handleAreaOpacityChange}
           />
         }
@@ -115,6 +144,7 @@ export function VisualOptionsEditor({ value, onChange }: VisualOptionsEditorProp
         control={
           <Switch
             checked={value.connect_nulls ?? DEFAULT_CONNECT_NULLS}
+            disabled={value.display === 'bar'}
             onChange={(e) => {
               onChange({
                 ...value,

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -48,9 +48,10 @@ export interface TimeSeriesChartPaletteOptions {
 }
 
 export type TimeSeriesChartVisualOptions = {
+  display?: 'line' | 'bar';
   line_width?: number;
   area_opacity?: number;
-  show_points?: 'Auto' | 'Always';
+  show_points?: 'Auto' | 'Always'; // TODO: lowercase as part of kebab-case migration
   palette?: TimeSeriesChartPaletteOptions;
   point_radius?: number;
   stack?: StackOptions;

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -51,7 +51,8 @@ export type TimeSeriesChartVisualOptions = {
   display?: 'line' | 'bar';
   line_width?: number;
   area_opacity?: number;
-  show_points?: 'Auto' | 'Always'; // TODO: lowercase as part of kebab-case migration
+  // TODO: change to lowercase as part of kebab-case migration in PR #1262
+  show_points?: 'Auto' | 'Always';
   palette?: TimeSeriesChartPaletteOptions;
   point_radius?: number;
   stack?: StackOptions;

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -12,13 +12,14 @@
 // limitations under the License.
 
 import type { YAXisComponentOption } from 'echarts';
-import { LineSeriesOption } from 'echarts/charts';
+import { LineSeriesOption, BarSeriesOption } from 'echarts/charts';
 import { StepOptions, TimeScale, TimeSeries, TimeSeriesValueTuple, getCommonTimeScale } from '@perses-dev/core';
 import {
   OPTIMIZED_MODE_SERIES_LIMIT,
   LegacyTimeSeries,
   EChartsDataFormat,
   EChartsValues,
+  TimeSeriesOption,
 } from '@perses-dev/components';
 import { useTimeSeriesQueries, UseDataQueryResults } from '@perses-dev/plugin-system';
 import {
@@ -123,7 +124,7 @@ export function getTimeSeries(
   visual: TimeSeriesChartVisualOptions,
   timeScale: TimeScale,
   paletteColor?: string
-): LineSeriesOption {
+): TimeSeriesOption {
   const lineWidth = visual.line_width ?? DEFAULT_LINE_WIDTH;
   const pointRadius = visual.point_radius ?? DEFAULT_POINT_RADIUS;
 
@@ -135,6 +136,17 @@ export function getTimeSeries(
     showPoints = true;
   }
 
+  if (visual.display === 'bar') {
+    const series: BarSeriesOption = {
+      type: 'bar',
+      id: id,
+      datasetIndex: seriesIndex,
+      name: formattedName,
+      color: paletteColor,
+      stack: visual.stack === 'All' ? visual.stack : undefined,
+    };
+    return series;
+  }
   const series: LineSeriesOption = {
     type: 'line',
     id: id,


### PR DESCRIPTION
## Overview
Adds ability to have a time series bar chart type using existing TimeSeriesChart panel.
The new optional property added to the spec is `visual.display: 'line' | 'bar'` (with the default being 'line' if undefined)

## Screenshot
<img width="1708" alt="Screenshot 2023-07-08 at 10 11 53 PM" src="https://github.com/perses/perses/assets/9369625/91da09dd-8068-4a01-adc0-d16b461ff574">
