### PR TITLE
[IGNORE] Mac specific error fix for cmd: make cue-test

### DIFF
--- a/scripts/cue-test/cue-test.go
+++ b/scripts/cue-test/cue-test.go
@@ -37,6 +37,9 @@ func validateSchemas(folder string, vf validateFunc) {
 		logrus.Fatal(err)
 	}
 	for _, dir := range dirEntries {
+		if dir.Name() == ".DS_Store" {
+			continue
+		}
 		data, readErr := os.ReadFile(filepath.Join(folder, dir.Name(), fmt.Sprintf("%s.json", dir.Name())))
 		if readErr != nil {
 			logrus.Fatal(readErr)


### PR DESCRIPTION
There is probably a better way to fix this, but this PR is my quick attempt to fix an error I see when using `make cue-test`

## Error example
```bash
sjcobb@Stevens-MacBook-Pro perses % make cue-test
>> test cue schemas with json data
go run ./scripts/cue-test/cue-test.go
WARN[0000] Plugin .DS_Store will not be loaded: it is not a folder 
INFO[0001] validate schemas under "schemas/panels"      
FATA[0001] open schemas/panels/.DS_Store/.DS_Store.json: not a directory 
exit status 1
make: *** [cue-test] Error 1
```