### PR TITLE
[IGNORE] Disable flaky noData TimeChart visual regression test

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.stories.tsx
+++ b/ui/components/src/TimeChart/TimeChart.stories.tsx
@@ -196,6 +196,10 @@ export const NoData: Story = {
       },
     },
   },
+  parameters: {
+    // TODO: look into why test is flaky
+    happo: false,
+  },
   render: (args) => {
     return (
       <Stack>


### PR DESCRIPTION
Test is flaky so disabling for now

Examples:
- https://happo.io/a/1009/p/1516/compare/1796e508aa670adfe27250c06ea6da821e72c8ae/bd0fd009daa7a6bbffc1890a4ecd93d0f648164e
- https://happo.io/a/1009/p/1516/compare/fe88431e44589e17f3443325523d912064a6fd29/1796e508aa670adfe27250c06ea6da821e72c8ae

<img width="702" alt="image" src="https://github.com/perses/perses/assets/9369625/d1529836-2b5c-4ff9-b328-5a7881708283">

