### PR TITLE
[BUGFIX] Time chart fix for incorrect connected values 

### DIFF
--- a/ui/core/src/utils/time-series-data.ts
+++ b/ui/core/src/utils/time-series-data.ts
@@ -32,37 +32,34 @@ export function getXValues(timeScale: TimeScale): number[] {
 
 /**
  * Given a TimeSeries from a query and a common time scale (see `getCommonTimeScale`),
- * process values and checks for 'NaN', while filling in any timestamps that are
- * missing from the time series data with `null` values.
+ * processes the time series values, filling in any timestamps that are missing
+ * from the time series data with `null` values.
  */
 export function getTimeSeriesValues(series: TimeSeries, timeScale: TimeScale) {
   let timestamp = timeScale.startMs;
 
   const values = series.values;
-  const completeResponse: TimeSeriesValueTuple[] = [];
-
-  const stepSize = timeScale.stepMs;
-  const endTimeStamp = timeScale.endMs;
+  const processedValues: TimeSeriesValueTuple[] = [];
 
   for (const valueTuple of values) {
-    // Adding the timestamps before start range
-    for (let t = timestamp; t < valueTuple[0]; t += stepSize) {
-      completeResponse.push([t, null]);
+    // Fill in values up to the current series value timestamp with nulls
+    while (timestamp < valueTuple[0]) {
+      processedValues.push([timestamp, null]);
+      timestamp += timeScale.stepMs;
     }
-    timestamp = valueTuple[0] + stepSize;
 
-    // Adding all the available data points, string check is to catch any 'NaN' values
-    const valueField = typeof valueTuple[1] === 'string' ? null : valueTuple[1];
-
-    completeResponse.push([valueTuple[0], valueField]);
+    // Now add the current value since timestamp should match
+    processedValues.push([timestamp, valueTuple[1]]);
+    timestamp += timeScale.stepMs;
   }
 
-  // Adding null if there is missing data till endTimeStamp
-  for (let t = timestamp; t <= endTimeStamp; t += stepSize) {
-    completeResponse.push([t, null]);
+  // Add null values at the end of the series if necessary
+  while (timestamp <= timeScale.endMs) {
+    processedValues.push([timestamp, null]);
+    timestamp += timeScale.stepMs;
   }
 
-  return completeResponse;
+  return processedValues;
 }
 
 /**

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -190,10 +190,9 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         const formattedSeriesName = timeSeries.formattedName ?? timeSeries.name;
 
         if (Array.isArray(timeChartData)) {
-          const processedValues = getTimeSeriesValues(timeSeries.values, timeScale);
           timeChartData.push({
             name: formattedSeriesName,
-            values: processedValues,
+            values: getTimeSeriesValues(timeSeries, timeScale),
           });
         }
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -19,6 +19,7 @@ import {
   useDeepMemo,
   getXValues,
   getYValues,
+  getTimeSeriesValues,
   DEFAULT_LEGEND,
   getCalculations,
   formatValue,
@@ -189,9 +190,10 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         const formattedSeriesName = timeSeries.formattedName ?? timeSeries.name;
 
         if (Array.isArray(timeChartData)) {
+          const processedValues = getTimeSeriesValues(timeSeries.values, timeScale);
           timeChartData.push({
             name: formattedSeriesName,
-            values: [...timeSeries.values],
+            values: processedValues,
           });
         }
 


### PR DESCRIPTION
## Before issue where data was connected
http://localhost:3000/projects/perses/dashboards/TimeChart_vs_LineChart?start=1689236880000&refresh=0s&end=1689240690000
<img width="739" alt="image" src="https://github.com/perses/perses/assets/9369625/d55b1e3d-f3d8-4599-b271-4b638d01e9bd">

## After fix with nulls filled in so empty space is shown correctly
http://localhost:3000/projects/perses/dashboards/TimeChart_vs_LineChart?start=1689236880000&refresh=0s&end=1689240690000
<img width="736" alt="image" src="https://github.com/perses/perses/assets/9369625/ff4a475f-577b-4c46-8a14-0ec8932e8831">

