### PR TITLE
[WIP] Closest datapoint styles and pinned crosshair remains after cursor leaves chart 

### DIFF
--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -149,6 +149,7 @@ export const EChart = React.memo(function EChart<T>({
 
   // Update chart data when option changes
   useEffect(() => {
+    console.log('EChart -> prevOption updated... ', option);
     if (!chartElement.current) return;
     chartElement.current.setOption(option, true);
   }, [option]);

--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -14,7 +14,6 @@
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { ECharts, EChartsCoreOption, init, connect } from 'echarts/core';
 import { Box, SxProps, Theme } from '@mui/material';
-import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
 import { EChartsTheme } from '../model';
 
@@ -121,7 +120,6 @@ export const EChart = React.memo(function EChart<T>({
   onChartInitialized,
 }: EChartsProps<T>) {
   const initialOption = useRef<EChartsCoreOption>(option);
-  const prevOption = useRef<EChartsCoreOption>(option);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartElement = useRef<ECharts | null>(null);
 
@@ -151,10 +149,8 @@ export const EChart = React.memo(function EChart<T>({
 
   // Update chart data when option changes
   useEffect(() => {
-    if (prevOption.current === undefined || isEqual(prevOption.current, option)) return;
     if (!chartElement.current) return;
     chartElement.current.setOption(option, true);
-    prevOption.current = option;
   }, [option]);
 
   // Resize chart, cleanup listener on unmount

--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -149,7 +149,6 @@ export const EChart = React.memo(function EChart<T>({
 
   // Update chart data when option changes
   useEffect(() => {
-    console.log('EChart -> prevOption updated... ', option);
     if (!chartElement.current) return;
     chartElement.current.setOption(option, true);
   }, [option]);

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -239,6 +239,8 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
       return __experimentalEChartsOptionsOverride(option);
     }
 
+    console.log('OPTION -> updated... ', option);
+    console.log('tooltipPinnedCoords -> updated... ', tooltipPinnedCoords);
     return option;
   }, [
     data,
@@ -251,6 +253,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
     __experimentalEChartsOptionsOverride,
     noDataVariant,
     timeZone,
+    tooltipPinnedCoords,
   ]);
 
   return (
@@ -262,16 +265,11 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
         if (chartRef.current !== undefined && chartRef.current.containPixel('grid', pointInPixel)) {
           const pointInGrid: number[] = chartRef.current.convertFromPixel('grid', pointInPixel);
           console.log('pointInGrid -> ', pointInGrid);
-        }
 
-        // Pin and unpin when clicking on chart canvas but not tooltip text.
-        if (e.target instanceof HTMLCanvasElement) {
           // https://github.com/perses/perses/compare/main...sjcobb/tooltip-pin-attach-mark-line-init
           const pinnedCrosshair: LineSeriesOption = {
             name: 'Pinned Crosshair',
             type: 'line',
-            // data: [[startTime, null] as unknown],
-            // data: [1689444705000, 0.02],
             // data: [timeScale.startMs, 0.02],
             markLine: {
               symbol: 'none',
@@ -281,9 +279,8 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
               },
               data: [
                 {
-                  // xAxis: 1689444705000,
-                  // yAxis: 0.02,
-                  xAxis: timeScale.startMs,
+                  // xAxis: timeScale.startMs,
+                  xAxis: pointInGrid[0],
                 },
               ],
               // data: [timeScale.startMs, 0.02],
@@ -297,6 +294,10 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
             },
           };
           seriesMapping.push(pinnedCrosshair as TimeSeriesOption);
+        }
+
+        // Pin and unpin when clicking on chart canvas but not tooltip text.
+        if (e.target instanceof HTMLCanvasElement) {
           setTooltipPinnedCoords((current) => {
             if (current === null) {
               return {

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -15,6 +15,7 @@ import { ECharts as EChartsInstance } from 'echarts/core';
 import { LineSeriesOption } from 'echarts/charts';
 import { formatValue, TimeSeriesValueTuple, UnitOptions, TimeSeries } from '@perses-dev/core';
 import { EChartsDataFormat, OPTIMIZED_MODE_SERIES_LIMIT, TimeChartSeriesMapping } from '../model';
+import { getPointInGrid } from '../utils';
 import { CursorCoordinates, CursorData } from './tooltip-model';
 
 // increase multipliers to show more series in tooltip
@@ -328,18 +329,14 @@ export function getNearbySeriesData({
   if (cursorTargetMatchesChart === false) return [];
 
   if (chart['_model'] === undefined || data === null) return [];
-  const chartModel = chart['_model'];
-  const yInterval = chartModel.getComponent('yAxis').axis.scale._interval;
-  const totalSeries = data.length;
 
-  const yBuffer = getYBuffer({ yInterval, totalSeries, showAllSeries });
-
-  const pointInPixel = [mousePos.plotCanvas.x ?? 0, mousePos.plotCanvas.y ?? 0];
-  if (chart.containPixel('grid', pointInPixel)) {
-    const pointInGrid: number[] = chart.convertFromPixel('grid', pointInPixel);
-    if (pointInGrid[0] !== undefined && pointInGrid[1] !== undefined) {
-      return checkforNearbyTimeSeries(data, seriesMapping, pointInGrid, yBuffer, chart, unit);
-    }
+  const pointInGrid = getPointInGrid(mousePos.plotCanvas.x, mousePos.plotCanvas.y, chart);
+  if (pointInGrid !== null) {
+    const chartModel = chart['_model'];
+    const yInterval = chartModel.getComponent('yAxis').axis.scale._interval;
+    const totalSeries = data.length;
+    const yBuffer = getYBuffer({ yInterval, totalSeries, showAllSeries });
+    return checkforNearbyTimeSeries(data, seriesMapping, pointInGrid, yBuffer, chart, unit);
   }
 
   return [];

--- a/ui/components/src/utils/chart-actions.ts
+++ b/ui/components/src/utils/chart-actions.ts
@@ -64,3 +64,22 @@ export function clearHighlightedSeries(chart: EChartsInstance, totalSeries: numb
     }
   }
 }
+
+/*
+ * Convert a point from pixel coordinate to logical coordinate.
+ * Used to determine if cursor is over chart canvas and closest datapoint.
+ * https://echarts.apache.org/en/api.html#echartsInstance.convertFromPixel
+ */
+export function getPointInGrid(cursorCoordX: number, cursorCoordY: number, chart?: EChartsInstance) {
+  if (chart === undefined) {
+    return null;
+  }
+
+  const pointInPixel = [cursorCoordX, cursorCoordY];
+  if (!chart.containPixel('grid', pointInPixel)) {
+    return null;
+  }
+
+  const pointInGrid: number[] = chart.convertFromPixel('grid', pointInPixel);
+  return pointInGrid;
+}

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -13,7 +13,7 @@
 
 import { useMemo, useRef, useState } from 'react';
 import { Box, Skeleton, useTheme } from '@mui/material';
-import type { GridComponentOption } from 'echarts';
+import type { GridComponentOption, LineSeriesOption } from 'echarts';
 import merge from 'lodash/merge';
 import {
   useDeepMemo,
@@ -48,6 +48,7 @@ import {
   useId,
   TimeChart,
   TimeChartSeriesMapping,
+  TimeSeriesOption,
 } from '@perses-dev/components';
 import { TimeSeriesChartOptions, DEFAULT_UNIT, DEFAULT_VISUAL } from './time-series-chart-model';
 import {
@@ -269,6 +270,37 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         seriesIndex++;
       });
     }
+
+    // const pinnedCrosshair: LineSeriesOption = {
+    //   name: 'Pinned Crosshair',
+    //   type: 'line',
+    //   // data: [[startTime, null] as unknown],
+    //   // data: [1689444705000, 0.02],
+    //   // data: [timeScale.startMs, 0.02],
+    //   markLine: {
+    //     symbol: 'none',
+    //     symbolSize: 0,
+    //     itemStyle: {
+    //       color: '#eee',
+    //     },
+    //     data: [
+    //       {
+    //         // xAxis: 1689444705000,
+    //         // yAxis: 0.02,
+    //         xAxis: timeScale.startMs,
+    //       },
+    //     ],
+    //     // data: [timeScale.startMs, 0.02],
+    //     lineStyle: {
+    //       width: 1,
+    //       type: 'dashed',
+    //     },
+    //     label: {
+    //       // distance: [20, 8],
+    //     },
+    //   },
+    // };
+    // timeSeriesMapping.push(pinnedCrosshair as TimeSeriesOption);
 
     return {
       graphData,

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -48,7 +48,6 @@ import {
   useId,
   TimeChart,
   TimeChartSeriesMapping,
-  TimeSeriesOption,
 } from '@perses-dev/components';
 import { TimeSeriesChartOptions, DEFAULT_UNIT, DEFAULT_VISUAL } from './time-series-chart-model';
 import {
@@ -192,6 +191,8 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
           });
         }
 
+        console.log(muiTheme.palette);
+
         // Color is used for line, tooltip, and legend
         const seriesColor = getSeriesColor({
           // ECharts type for color is not always an array but it is always an array in ChartsThemeProvider
@@ -217,7 +218,15 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
         if (showTimeSeries) {
           timeSeriesMapping.push(
-            getTimeSeries(seriesId, seriesIndex, formattedSeriesName, visual, timeScale, seriesColor)
+            getTimeSeries(
+              seriesId,
+              seriesIndex,
+              formattedSeriesName,
+              visual,
+              timeScale,
+              seriesColor,
+              muiTheme.palette.mode
+            )
           );
         }
         if (legend && legendItems) {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -271,37 +271,6 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
       });
     }
 
-    // const pinnedCrosshair: LineSeriesOption = {
-    //   name: 'Pinned Crosshair',
-    //   type: 'line',
-    //   // data: [[startTime, null] as unknown],
-    //   // data: [1689444705000, 0.02],
-    //   // data: [timeScale.startMs, 0.02],
-    //   markLine: {
-    //     symbol: 'none',
-    //     symbolSize: 0,
-    //     itemStyle: {
-    //       color: '#eee',
-    //     },
-    //     data: [
-    //       {
-    //         // xAxis: 1689444705000,
-    //         // yAxis: 0.02,
-    //         xAxis: timeScale.startMs,
-    //       },
-    //     ],
-    //     // data: [timeScale.startMs, 0.02],
-    //     lineStyle: {
-    //       width: 1,
-    //       type: 'dashed',
-    //     },
-    //     label: {
-    //       // distance: [20, 8],
-    //     },
-    //   },
-    // };
-    // timeSeriesMapping.push(pinnedCrosshair as TimeSeriesOption);
-
     return {
       graphData,
       timeScale,

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -123,7 +123,8 @@ export function getTimeSeries(
   formattedName: string,
   visual: TimeSeriesChartVisualOptions,
   timeScale: TimeScale,
-  paletteColor?: string
+  paletteColor: string,
+  themeMode: 'dark' | 'light'
 ): TimeSeriesOption {
   const lineWidth = visual.line_width ?? DEFAULT_LINE_WIDTH;
   const pointRadius = visual.point_radius ?? DEFAULT_POINT_RADIUS;
@@ -157,6 +158,7 @@ export function getTimeSeries(
     stack: visual.stack === 'All' ? visual.stack : undefined,
     sampling: 'lttb',
     progressiveThreshold: OPTIMIZED_MODE_SERIES_LIMIT, // https://echarts.apache.org/en/option.html#series-lines.progressiveThreshold
+    // symbol: 'emptyCircle',
     showSymbol: showPoints,
     showAllSymbol: true,
     symbolSize: pointRadius,
@@ -174,6 +176,18 @@ export function getTimeSeries(
       lineStyle: {
         width: lineWidth + 1.5,
         opacity: 1,
+      },
+    },
+    selectedMode: 'single',
+    select: {
+      itemStyle: {
+        // color: paletteColor,
+        // color: themeMode === 'light' ? '#000' : '#fff',
+        color: themeMode === 'light' ? '#fff' : '#000',
+        // borderColor: themeMode === 'light' ? '#000' : '#fff',
+        borderColor: paletteColor,
+        borderType: 'solid',
+        borderWidth: 3,
       },
     },
     blur: {


### PR DESCRIPTION
## Summary
- Crosshair remains in place when tooltip is pinned instead of disappearing
- Closest datapoint to cursor 'select' styles
- Do not snap to nearest datapoint in xAxis.axisPointer options

<img width="807" alt="image" src="https://github.com/perses/perses/assets/9369625/4f85dc44-383a-42e8-9d60-9378f33c2727">
