### PR TITLE
[BUGFIX] Tooltip hidden when many series and legend item selected

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -208,8 +208,13 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         const showTimeSeries = isSelected || isSelectAll;
 
         if (showTimeSeries) {
+          // Use timeChartData.length to ensure the data that is passed into the tooltip accounts for
+          // which legend items are selected.
+          const datasetIndex = timeChartData.length;
+          // Each series is stored as a separate dataset source.
+          // https://apache.github.io/echarts-handbook/en/concepts/dataset/#how-to-reference-several-datasets
           timeSeriesMapping.push(
-            getTimeSeries(seriesId, timeChartData.length, formattedSeriesName, visual, timeScale, seriesColor)
+            getTimeSeries(seriesId, datasetIndex, formattedSeriesName, visual, timeScale, seriesColor)
           );
 
           timeChartData.push({

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -184,13 +184,6 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         // Format is determined by series_name_format in query spec
         const formattedSeriesName = timeSeries.formattedName ?? timeSeries.name;
 
-        if (Array.isArray(timeChartData)) {
-          timeChartData.push({
-            name: formattedSeriesName,
-            values: getTimeSeriesValues(timeSeries, timeScale),
-          });
-        }
-
         // Color is used for line, tooltip, and legend
         const seriesColor = getSeriesColor({
           // ECharts type for color is not always an array but it is always an array in ChartsThemeProvider
@@ -216,9 +209,15 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
         if (showTimeSeries) {
           timeSeriesMapping.push(
-            getTimeSeries(seriesId, seriesIndex, formattedSeriesName, visual, timeScale, seriesColor)
+            getTimeSeries(seriesId, timeChartData.length, formattedSeriesName, visual, timeScale, seriesColor)
           );
+
+          timeChartData.push({
+            name: formattedSeriesName,
+            values: getTimeSeriesValues(timeSeries, timeScale),
+          });
         }
+
         if (legend && legendItems) {
           legendItems.push({
             id: seriesId, // Avoids duplicate key console errors when there are duplicate series names

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -119,7 +119,7 @@ export function getLineSeries(
  */
 export function getTimeSeries(
   id: string,
-  seriesIndex: number,
+  datasetIndex: number,
   formattedName: string,
   visual: TimeSeriesChartVisualOptions,
   timeScale: TimeScale,
@@ -140,7 +140,7 @@ export function getTimeSeries(
     const series: BarSeriesOption = {
       type: 'bar',
       id: id,
-      datasetIndex: seriesIndex,
+      datasetIndex,
       name: formattedName,
       color: paletteColor,
       stack: visual.stack === 'All' ? visual.stack : undefined,
@@ -150,7 +150,7 @@ export function getTimeSeries(
   const series: LineSeriesOption = {
     type: 'line',
     id: id,
-    datasetIndex: seriesIndex,
+    datasetIndex,
     name: formattedName,
     connectNulls: visual.connect_nulls ?? DEFAULT_CONNECT_NULLS,
     color: paletteColor,


### PR DESCRIPTION
Adjust TimeSeriesChart panel mapping to account for selected series, before it was looping through all dataset sources regardless of which legend items were selected

## Before
No tooltip on hover when second series selected
![image](https://github.com/perses/perses/assets/9369625/209316f3-1cbb-4c62-b27c-6c3caf82e1e2)

## After
Tooltip showing when second series selected
![image](https://github.com/perses/perses/assets/9369625/4f6a3550-ed7f-496d-8738-8f9c81d8fdda)
 

