### PR TITLE
[BUGFIX] Time series stacked bar correct palette color and tooltip

### DIFF
--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -66,7 +66,13 @@ export function BarChart(props: BarChartProps) {
       series: {
         type: 'bar',
         label: {
+          show: true,
+          position: 'right',
           formatter: (params: { data: number[] }) => params.data[1] && formatValue(params.data[1], unit),
+        },
+        itemStyle: {
+          borderRadius: 4,
+          color: chartsTheme.echartsTheme[0],
         },
       },
       tooltip: {

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -77,6 +77,7 @@ export interface TimeChartProps {
   tooltipConfig?: TooltipConfig;
   noDataVariant?: 'chart' | 'message';
   syncGroup?: string;
+  isStackedBar?: boolean;
   onDataZoom?: (e: ZoomEventData) => void;
   onDoubleClick?: (e: MouseEvent) => void;
   __experimentalEChartsOptionsOverride?: (options: EChartsCoreOption) => EChartsCoreOption;
@@ -91,6 +92,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
     yAxis,
     unit,
     grid,
+    isStackedBar = false,
     tooltipConfig = { wrapLabels: true },
     noDataVariant = 'message',
     syncGroup,
@@ -213,8 +215,10 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
       animation: false,
       tooltip: {
         show: true,
-        trigger: 'axis',
-        showContent: false, // echarts tooltip content hidden since we use custom tooltip instead
+        trigger: isStackedBar ? 'item' : 'axis',
+        // ECharts tooltip content hidden since we use custom tooltip instead
+        showContent: isStackedBar,
+        appendToBody: true,
       },
       // https://echarts.apache.org/en/option.html#axisPointer
       axisPointer: {
@@ -250,6 +254,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
     __experimentalEChartsOptionsOverride,
     noDataVariant,
     timeZone,
+    isStackedBar,
   ]);
 
   return (

--- a/ui/components/src/utils/theme-gen.test.ts
+++ b/ui/components/src/utils/theme-gen.test.ts
@@ -43,14 +43,12 @@ describe('generateChartsTheme', () => {
             "barMaxWidth": 150,
             "itemStyle": Object {
               "borderColor": "#e0e0e0",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "borderWidth": 0,
-              "color": "#1976d2",
             },
             "label": Object {
               "color": "rgba(0, 0, 0, 0.87)",
-              "position": "right",
-              "show": true,
+              "show": false,
             },
           },
           "categoryAxis": Object {

--- a/ui/components/src/utils/theme-gen.ts
+++ b/ui/components/src/utils/theme-gen.ts
@@ -190,14 +190,12 @@ export function generateChartsTheme(
       barMaxWidth: 150,
       itemStyle: {
         borderWidth: 0,
+        borderRadius: 0,
         borderColor: muiTheme.palette.grey[300],
-        borderRadius: 4,
-        color: muiTheme.palette.primary.main,
       },
       label: {
-        position: 'right',
-        show: true,
-        color: muiTheme.palette.text.primary,
+        show: false,
+        color: primaryTextColor,
       },
     },
     gauge: {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -208,8 +208,13 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         const showTimeSeries = isSelected || isSelectAll;
 
         if (showTimeSeries) {
+          // Use timeChartData.length to ensure the data that is passed into the tooltip accounts for
+          // which legend items are selected.
+          const datasetIndex = timeChartData.length;
+          // Each series is stored as a separate dataset source.
+          // https://apache.github.io/echarts-handbook/en/concepts/dataset/#how-to-reference-several-datasets
           timeSeriesMapping.push(
-            getTimeSeries(seriesId, timeChartData.length, formattedSeriesName, visual, timeScale, seriesColor)
+            getTimeSeries(seriesId, datasetIndex, formattedSeriesName, visual, timeScale, seriesColor)
           );
 
           timeChartData.push({

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -48,6 +48,7 @@ import {
   useId,
   TimeChart,
   TimeChartSeriesMapping,
+  TooltipConfig,
 } from '@perses-dev/components';
 import { TimeSeriesChartOptions, DEFAULT_UNIT, DEFAULT_VISUAL } from './time-series-chart-model';
 import {
@@ -362,6 +363,10 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     setTimeRange({ start: new Date(event.start), end: new Date(event.end) });
   };
 
+  const isStackedBar = visual.display === 'bar' && visual.stack === 'All';
+
+  const tooltipConfig: TooltipConfig = { wrapLabels: true };
+
   return (
     <Box sx={{ padding: `${contentPadding}px` }}>
       <ContentWithLegend
@@ -404,7 +409,8 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
                 yAxis={echartsYAxis}
                 unit={unit}
                 grid={gridOverrides}
-                tooltipConfig={{ wrapLabels: true }}
+                isStackedBar={isStackedBar}
+                tooltipConfig={tooltipConfig}
                 syncGroup="default-panel-group" // TODO: make configurable from dashboard settings and per panel-group overrides
                 onDataZoom={handleDataZoom}
                 //  Show an empty chart when there is no data because the user unselected all items in

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -214,8 +214,10 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
         if (showTimeSeries) {
           // Use timeChartData.length to ensure the data that is passed into the tooltip accounts for
-          // which legend items are selected.
+          // which legend items are selected. This must happen before timeChartData.push to avoid an
+          // off-by-one error, seriesIndex cannot be used since it's needed to cycle through palette
           const datasetIndex = timeChartData.length;
+
           // Each series is stored as a separate dataset source.
           // https://apache.github.io/echarts-handbook/en/concepts/dataset/#how-to-reference-several-datasets
           timeSeriesMapping.push(

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -184,13 +184,6 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         // Format is determined by series_name_format in query spec
         const formattedSeriesName = timeSeries.formattedName ?? timeSeries.name;
 
-        if (Array.isArray(timeChartData)) {
-          timeChartData.push({
-            name: formattedSeriesName,
-            values: getTimeSeriesValues(timeSeries, timeScale),
-          });
-        }
-
         // Color is used for line, tooltip, and legend
         const seriesColor = getSeriesColor({
           // ECharts type for color is not always an array but it is always an array in ChartsThemeProvider
@@ -216,9 +209,15 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
         if (showTimeSeries) {
           timeSeriesMapping.push(
-            getTimeSeries(seriesId, seriesIndex, formattedSeriesName, visual, timeScale, seriesColor)
+            getTimeSeries(seriesId, timeChartData.length, formattedSeriesName, visual, timeScale, seriesColor)
           );
+
+          timeChartData.push({
+            name: formattedSeriesName,
+            values: getTimeSeriesValues(timeSeries, timeScale),
+          });
         }
+
         if (legend && legendItems) {
           legendItems.push({
             id: seriesId, // Avoids duplicate key console errors when there are duplicate series names

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -48,9 +48,13 @@ import {
   useId,
   TimeChart,
   TimeChartSeriesMapping,
-  TooltipConfig,
 } from '@perses-dev/components';
-import { TimeSeriesChartOptions, DEFAULT_UNIT, DEFAULT_VISUAL } from './time-series-chart-model';
+import {
+  TimeSeriesChartOptions,
+  DEFAULT_UNIT,
+  DEFAULT_VISUAL,
+  DEFAULT_TOOLTIP_CONFIG,
+} from './time-series-chart-model';
 import {
   getTimeSeries,
   getCommonTimeScaleForQueries,
@@ -365,8 +369,6 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
 
   const isStackedBar = visual.display === 'bar' && visual.stack === 'All';
 
-  const tooltipConfig: TooltipConfig = { wrapLabels: true };
-
   return (
     <Box sx={{ padding: `${contentPadding}px` }}>
       <ContentWithLegend
@@ -410,7 +412,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
                 unit={unit}
                 grid={gridOverrides}
                 isStackedBar={isStackedBar}
-                tooltipConfig={tooltipConfig}
+                tooltipConfig={DEFAULT_TOOLTIP_CONFIG}
                 syncGroup="default-panel-group" // TODO: make configurable from dashboard settings and per panel-group overrides
                 onDataZoom={handleDataZoom}
                 //  Show an empty chart when there is no data because the user unselected all items in

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { Definition, ThresholdOptions, UnitOptions } from '@perses-dev/core';
+import { TooltipConfig } from '@perses-dev/components';
 import { OptionsEditorProps, LegendSpecOptions } from '@perses-dev/plugin-system';
 
 /**
@@ -78,6 +79,8 @@ export const Y_AXIS_CONFIG = {
   min: { label: 'Min' },
   max: { label: 'Max' },
 };
+
+export const DEFAULT_TOOLTIP_CONFIG: TooltipConfig = { wrapLabels: true };
 
 export const DEFAULT_LINE_WIDTH = 1.5;
 export const DEFAULT_AREA_OPACITY = 0;

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -119,7 +119,7 @@ export function getLineSeries(
  */
 export function getTimeSeries(
   id: string,
-  seriesIndex: number,
+  datasetIndex: number,
   formattedName: string,
   visual: TimeSeriesChartVisualOptions,
   timeScale: TimeScale,
@@ -140,7 +140,7 @@ export function getTimeSeries(
     const series: BarSeriesOption = {
       type: 'bar',
       id: id,
-      datasetIndex: seriesIndex,
+      datasetIndex,
       name: formattedName,
       color: paletteColor,
       stack: visual.stack === 'All' ? visual.stack : undefined,
@@ -150,7 +150,7 @@ export function getTimeSeries(
   const series: LineSeriesOption = {
     type: 'line',
     id: id,
-    datasetIndex: seriesIndex,
+    datasetIndex,
     name: formattedName,
     connectNulls: visual.connect_nulls ?? DEFAULT_CONNECT_NULLS,
     color: paletteColor,

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -144,6 +144,9 @@ export function getTimeSeries(
       name: formattedName,
       color: paletteColor,
       stack: visual.stack === 'All' ? visual.stack : undefined,
+      label: {
+        show: false,
+      },
     };
     return series;
   }


### PR DESCRIPTION
## Summary

- Fix palette colors for TimeSeriesChart `visual.display: 'bar'`
- Adjust charts theme to account for vertical bar charts
- Fix stacked bar tooltip by using ECharts tooltip when visual.stack is set

## Examples

### Before palette and charts theme fixes
<img width="1264" alt="image" src="https://github.com/perses/perses/assets/9369625/1c8331ac-bfa6-47a6-856f-15648a25f46c">

### After change to ECharts `trigger: 'item'` tooltip

https://github.com/perses/perses/assets/9369625/b6490658-eb57-43d3-a467-faecd26f9db6

### After palette fix by removing itemStyle.color from charts theme-gen
<img width="1264" alt="image" src="https://github.com/perses/perses/assets/9369625/e3d531f7-4a54-474b-b475-66b4263deebe">
