### PR TITLE
[FEATURE] Consider external vars in dashboard validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/sirupsen/logrus v1.9.2
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.3
+	golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
+golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874 h1:kWC3b7j6Fu09SnEBr7P4PuQyM0R6sqyH9R+EjIvT1nQ=
+golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -57,7 +57,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, cfg config.Config) e
 	apiEndpoints := []endpoint{
 		configendpoint.New(cfg),
 		migrateendpoint.New(serviceManager.GetMigration()),
-		validateendpoint.New(serviceManager.GetSchemas()),
+		validateendpoint.New(serviceManager.GetSchemas(), serviceManager.GetDashboard()),
 	}
 	return &api{
 		apiV1Endpoints: apiV1Endpoints,

--- a/internal/api/impl/validate/validate.go
+++ b/internal/api/impl/validate/validate.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/shared"
 	"github.com/perses/perses/internal/api/shared/schemas"
 	"github.com/perses/perses/internal/api/shared/validate"
@@ -25,11 +26,15 @@ import (
 )
 
 type Endpoint struct {
-	sch schemas.Schemas
+	sch       schemas.Schemas
+	dashboard dashboard.Service
 }
 
-func New(sch schemas.Schemas) *Endpoint {
-	return &Endpoint{sch: sch}
+func New(sch schemas.Schemas, dashboard dashboard.Service) *Endpoint {
+	return &Endpoint{
+		sch:       sch,
+		dashboard: dashboard,
+	}
 }
 
 func (e *Endpoint) RegisterRoutes(g *echo.Group) {
@@ -46,9 +51,11 @@ func (e *Endpoint) ValidateDashboard(ctx echo.Context) error {
 	if err := ctx.Bind(entity); err != nil {
 		return shared.HandleBadRequestError(err.Error())
 	}
-	if err := validate.Dashboard(entity, e.sch); err != nil {
+
+	if err := e.dashboard.Validate(entity); err != nil {
 		return shared.HandleBadRequestError(err.Error())
 	}
+
 	return ctx.NoContent(http.StatusOK)
 }
 

--- a/internal/api/interface/v1/dashboard/interface.go
+++ b/internal/api/interface/v1/dashboard/interface.go
@@ -40,4 +40,5 @@ type DAO interface {
 
 type Service interface {
 	shared.ToolboxService
+	Validate(entity *v1.Dashboard) error
 }

--- a/internal/api/shared/dependency/service_manager.go
+++ b/internal/api/shared/dependency/service_manager.go
@@ -73,7 +73,7 @@ func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 	if err != nil {
 		return nil, err
 	}
-	dashboardService := dashboardImpl.NewService(dao.GetDashboard(), schemasService)
+	dashboardService := dashboardImpl.NewService(dao.GetDashboard(), schemasService, dao.GetGlobalVariable(), dao.GetVariable())
 	datasourceService := datasourceImpl.NewService(dao.GetDatasource(), schemasService)
 	folderService := folderImpl.NewService(dao.GetFolder())
 	variableService := variableImpl.NewService(dao.GetVariable(), schemasService)


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

Backend should take in account the external variables (project/global variables) when it is verifying that the variables used by a dashboard are defined.

This is the case for all validation by endpoints (on dashboard create/update + on each call of the /validate endpoint).

The static validation done by percli lint (without --online) doesn't assume on any external variable. It may fail if somebody try to use it to validate a dashboard which uses external variables.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes
> No UI Changes
