### PR TITLE
[BUGFIX] Consider external vars in dashboard validation

### DIFF
--- a/pkg/model/api/v1/utils/variable_build_order.go
+++ b/pkg/model/api/v1/utils/variable_build_order.go
@@ -51,9 +51,21 @@ func buildGraph(variables []dashboard.Variable, projectVariables []*v1.Variable,
 	if err != nil {
 		return nil, err
 	}
-	variableNameList := make([]string, 0, len(variables))
+	var variableNameList []string
 	for _, v := range variables {
 		variableNameList = append(variableNameList, v.Spec.GetName())
+	}
+	for _, v := range projectVariables {
+		name := v.GetMetadata().GetName()
+		if !slices.Contains(variableNameList, name) {
+			variableNameList = append(variableNameList, name)
+		}
+	}
+	for _, v := range globalVariables {
+		name := v.GetMetadata().GetName()
+		if !slices.Contains(variableNameList, name) {
+			variableNameList = append(variableNameList, name)
+		}
 	}
 	return newGraph(variableNameList, deps), nil
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

I missed something in the previous PR https://github.com/perses/perses/pull/1306

The variables names list is computed again right after to build the graph of dependencies.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

> No UI Changes
