### PR TITLE
[IGNORE] Disable TimeChart happo test to debug timeout

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.stories.tsx
+++ b/ui/components/src/TimeChart/TimeChart.stories.tsx
@@ -111,11 +111,7 @@ const meta: Meta<typeof TimeChart> = {
     },
   },
   parameters: {
-    happo: {
-      beforeScreenshot: async () => {
-        await waitForStableCanvas('canvas');
-      },
-    },
+    happo: false,
   },
 };
 

--- a/ui/components/src/TimeChart/TimeChart.stories.tsx
+++ b/ui/components/src/TimeChart/TimeChart.stories.tsx
@@ -13,7 +13,6 @@
 
 import { StoryObj, Meta } from '@storybook/react';
 import { ChartInstance, TimeChart } from '@perses-dev/components';
-import { waitForStableCanvas } from '@perses-dev/storybook';
 import { Button, Stack, Typography } from '@mui/material';
 import { useRef } from 'react';
 import { action } from '@storybook/addon-actions';


### PR DESCRIPTION
Looking into failing jobs like this one: https://happo.io/a/1009/jobs/719894

Errors:
```
Canvas was not stable after 1 check(s). Trying again in 250.
Canvas was not stable after 2 check(s). Trying again in 250.
Canvas was not stable after 3 check(s). Trying again in 250.
Canvas was not stable after 4 check(s). Trying again in 250.
Canvas was not stable after 5 check(s). Trying again in 250.
Canvas was not stable after 6 check(s). Trying again in 250.
Canvas was not stable after 7 check(s). Trying again in 250.
Canvas was not stable after 8 check(s). Trying again in 250.
Canvas was not stable after 9 check(s). Trying again in 250.
Canvas was not stable after 10 check(s). Trying again in 250.
Canvas was not stable after 11 check(s). Trying again in 250.
Canvas was not stable after 12 check(s). Trying again in 250.
Canvas was not stable after 13 check(s). Trying again in 250.
Canvas was not stable after 14 check(s). Trying again in 250.
Canvas was not stable after 15 check(s). Trying again in 250.
Canvas was not stable after 16 check(s). Trying again in 250.
Canvas was not stable after 17 check(s). Trying again in 250.
Canvas was not stable after 18 check(s). Trying again in 250.
Canvas was not stable after 19 check(s). Trying again in 250.
Canvas element failed to stabilize.
```