### PR TITLE
[BREAKINGCHANGE] Update DataQueriesProvider to support other data types

### DIFF
--- a/ui/core/src/model/query.ts
+++ b/ui/core/src/model/query.ts
@@ -20,6 +20,7 @@ interface QuerySpec<PluginSpec> {
 /**
  * A generic query definition interface that can be extended to support more than just TimeSeriesQuery
  */
+// Kind needs to be `any` because otherwise typescript will complain 'unknown' is not assignable to type '"TimeSeriesQuery"' in a few places
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface QueryDefinition<Kind = any, PluginSpec = UnknownSpec> {
   kind: Kind;
@@ -32,12 +33,8 @@ export interface QueryDefinition<Kind = any, PluginSpec = UnknownSpec> {
 export interface QueryType {
   TimeSeriesQuery: TimeSeriesData;
   // in the future we can add other query plugin and data types
-  // LogsQuery: LogsData;
+  // for example: we can add something like `LogsQuery: LogsData;`
 }
-
-// export interface LogsData {
-//   message: string;
-// }
 
 /**
  * Values of QueryType

--- a/ui/core/src/model/query.ts
+++ b/ui/core/src/model/query.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { Definition, UnknownSpec } from './definitions';
+import { TimeSeriesData } from './time-series-data';
 
 interface QuerySpec<PluginSpec> {
   plugin: Definition<PluginSpec>;
@@ -19,9 +20,27 @@ interface QuerySpec<PluginSpec> {
 /**
  * A generic query definition interface that can be extended to support more than just TimeSeriesQuery
  */
-export interface QueryDefinition<Kind = QueryType, PluginSpec = UnknownSpec> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface QueryDefinition<Kind = any, PluginSpec = UnknownSpec> {
   kind: Kind;
   spec: QuerySpec<PluginSpec>;
 }
 
-export type QueryType = 'TimeSeriesQuery';
+/**
+ * Mapping the query plugin to the data type it returns
+ */
+export interface QueryType {
+  TimeSeriesQuery: TimeSeriesData;
+  // in the future we can add other query plugin and data types
+  // LogsQuery: LogsData;
+}
+
+// export interface LogsData {
+//   message: string;
+// }
+
+/**
+ * Values of QueryType
+ * ex: 'TimeSeriesData'
+ */
+export type QueryDataType = QueryType[keyof QueryType];

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DataQueriesDefinition, DataQueriesProvider } from '@perses-dev/plugin-system';
+import { DataQueriesProvider } from '@perses-dev/plugin-system';
 import { PanelGroupItemId, useEditMode, usePanel, usePanelActions } from '../../context';
 import { useSuggestedStepMs } from '../../utils';
 import { Panel, PanelProps } from '../Panel/Panel';
@@ -45,12 +45,11 @@ export function GridItemContent(props: GridItemContentProps) {
     };
   }
 
-  // map TimeSeriesQueryDefinition to DataQueriesDefinition
+  // map TimeSeriesQueryDefinition to Definition<UnknownSpec>
   const suggestedStepMs = useSuggestedStepMs(width);
   const queryDefinitions = queries ?? [];
-  const definitions: DataQueriesDefinition[] = queryDefinitions.map((query) => {
+  const definitions = queryDefinitions.map((query) => {
     return {
-      type: query.kind,
       kind: query.spec.plugin.kind,
       spec: query.spec.plugin.spec,
     };

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { QueryDefinition } from '@perses-dev/core';
-import { DataQueriesProvider } from '@perses-dev/plugin-system';
+import { DataQueriesDefinition, DataQueriesProvider } from '@perses-dev/plugin-system';
 import { PanelGroupItemId, useEditMode, usePanel, usePanelActions } from '../../context';
 import { useSuggestedStepMs } from '../../utils';
 import { Panel, PanelProps } from '../Panel/Panel';
@@ -46,11 +45,12 @@ export function GridItemContent(props: GridItemContentProps) {
     };
   }
 
-  // map TimeSeriesQueryDefinition to Definition<UnknownSpec>
+  // map TimeSeriesQueryDefinition to DataQueriesDefinition
   const suggestedStepMs = useSuggestedStepMs(width);
   const queryDefinitions = queries ?? [];
-  const definitions = queryDefinitions.map((query: QueryDefinition) => {
+  const definitions: DataQueriesDefinition[] = queryDefinitions.map((query) => {
     return {
+      type: query.kind,
       kind: query.spec.plugin.kind,
       spec: query.spec.plugin.spec,
     };

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -13,7 +13,7 @@
 
 import { useRef } from 'react';
 import { Box } from '@mui/material';
-import { DataQueriesDefinition, DataQueriesProvider } from '@perses-dev/plugin-system';
+import { DataQueriesProvider } from '@perses-dev/plugin-system';
 import { PanelEditorValues } from '../../context';
 import { Panel } from '../Panel';
 import { useSuggestedStepMs } from '../../utils';
@@ -35,11 +35,10 @@ export function PanelPreview({ panelDefinition }: Pick<PanelEditorValues, 'panel
 
   const queries = panelDefinition.spec.queries ?? [];
 
-  // map TimeSeriesQueryDefinition to DataQueriesDefinition
-  const definitions: DataQueriesDefinition[] = queries.length
+  // map TimeSeriesQueryDefinition to Definition<UnknownSpec>
+  const definitions = queries.length
     ? queries.map((query) => {
         return {
-          type: query.kind,
           kind: query.spec.plugin.kind,
           spec: query.spec.plugin.spec,
         };

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -13,8 +13,7 @@
 
 import { useRef } from 'react';
 import { Box } from '@mui/material';
-import { QueryDefinition } from '@perses-dev/core';
-import { DataQueriesProvider } from '@perses-dev/plugin-system';
+import { DataQueriesDefinition, DataQueriesProvider } from '@perses-dev/plugin-system';
 import { PanelEditorValues } from '../../context';
 import { Panel } from '../Panel';
 import { useSuggestedStepMs } from '../../utils';
@@ -36,10 +35,11 @@ export function PanelPreview({ panelDefinition }: Pick<PanelEditorValues, 'panel
 
   const queries = panelDefinition.spec.queries ?? [];
 
-  // map TimeSeriesQueryDefinition to Definition<UnknownSpec>
-  const definitions = queries.length
-    ? queries.map((query: QueryDefinition) => {
+  // map TimeSeriesQueryDefinition to DataQueriesDefinition
+  const definitions: DataQueriesDefinition[] = queries.length
+    ? queries.map((query) => {
         return {
+          type: query.kind,
           kind: query.spec.plugin.kind,
           spec: query.spec.plugin.spec,
         };

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartPanel.tsx
@@ -30,7 +30,7 @@ export function BarChartPanel(props: BarChartPanelProps) {
   const chartsTheme = useChartsTheme();
   const PADDING = chartsTheme.container.padding.default;
 
-  const { queryResults, isLoading, isFetching } = useDataQueries(); // gets data queries from a context provider, see DataQueriesProvider
+  const { queryResults, isLoading, isFetching } = useDataQueries('TimeSeriesQuery'); // gets data queries from a context provider, see DataQueriesProvider
 
   const barChartData: BarChartData[] = useMemo(() => {
     const calculate = CalculationsMap[calculation as CalculationType];

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartPanel.tsx
@@ -33,7 +33,7 @@ export function GaugeChartPanel(props: GaugeChartPanelProps) {
 
   const { thresholds: thresholdsColors } = useChartsTheme();
 
-  const { queryResults, isLoading } = useDataQueries();
+  const { queryResults, isLoading } = useDataQueries('TimeSeriesQuery');
 
   // ensures all default unit properties set if undef
   const unit = merge({}, DEFAULT_UNIT, pluginSpec.unit);

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -15,7 +15,7 @@ import { TitleComponentOption } from 'echarts';
 import { StatChart, StatChartData, useChartsTheme, GraphSeries } from '@perses-dev/components';
 import { Box, Stack, Skeleton, Typography, SxProps } from '@mui/material';
 import { useMemo } from 'react';
-import { CalculationsMap, CalculationType } from '@perses-dev/core';
+import { CalculationsMap, CalculationType, TimeSeriesData } from '@perses-dev/core';
 import { useDataQueries, UseDataQueryResults, PanelProps } from '@perses-dev/plugin-system';
 import { StatChartOptions } from './stat-chart-model';
 import { convertSparkline, getColorFromThresholds } from './utils/data-transform';
@@ -31,7 +31,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
     contentDimensions,
   } = props;
 
-  const { queryResults, isLoading, isFetching } = useDataQueries();
+  const { queryResults, isLoading, isFetching } = useDataQueries('TimeSeriesQuery');
   const statChartData = useStatChartData(queryResults, calculation);
   const isMultiSeries = statChartData.length > 1;
 
@@ -96,7 +96,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
 }
 
 const useStatChartData = (
-  queryResults: UseDataQueryResults['queryResults'],
+  queryResults: UseDataQueryResults<TimeSeriesData>['queryResults'],
   calculation: CalculationType
 ): StatChartData[] => {
   return useMemo(() => {

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -93,7 +93,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   // Colors are manually applied since our legend and tooltip are built custom with React.
   const categoricalPalette = chartsTheme.echartsTheme.color;
 
-  const { isFetching, isLoading, queryResults } = useDataQueries();
+  const { isFetching, isLoading, queryResults } = useDataQueries('TimeSeriesQuery');
 
   const hasData = queryResults.some((result) => result.data && result.data.series.length > 0);
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -13,7 +13,14 @@
 
 import type { YAXisComponentOption } from 'echarts';
 import { LineSeriesOption, BarSeriesOption } from 'echarts/charts';
-import { StepOptions, TimeScale, TimeSeries, TimeSeriesValueTuple, getCommonTimeScale } from '@perses-dev/core';
+import {
+  StepOptions,
+  TimeScale,
+  TimeSeries,
+  TimeSeriesValueTuple,
+  getCommonTimeScale,
+  TimeSeriesData,
+} from '@perses-dev/core';
 import {
   OPTIMIZED_MODE_SERIES_LIMIT,
   LegacyTimeSeries,
@@ -51,7 +58,9 @@ export const BLUR_FADEOUT_OPACITY = 0.5;
  * the x axis (i.e. start/end dates and a step that is divisible into all of
  * the queries' steps).
  */
-export function getCommonTimeScaleForQueries(queries: UseDataQueryResults['queryResults']): TimeScale | undefined {
+export function getCommonTimeScaleForQueries(
+  queries: UseDataQueryResults<TimeSeriesData>['queryResults']
+): TimeScale | undefined {
   const seriesData = queries.map((query) => (query.isLoading ? undefined : query.data));
   return getCommonTimeScale(seriesData);
 }

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { render, renderHook } from '@testing-library/react';
 import { MOCK_TIME_SERIES_DATA } from '../../test';
 import { DataQueriesProvider, useDataQueries } from './DataQueriesProvider';
+import { DataQueriesDefinition } from './model';
 
 jest.mock('../time-series-queries', () => ({
   useTimeSeriesQueries: jest.fn().mockImplementation(() => [{ data: MOCK_TIME_SERIES_DATA }]),
@@ -22,9 +23,8 @@ jest.mock('../time-series-queries', () => ({
 
 describe('useDataQueries', () => {
   it('should return the correct data for TimeSeriesQuery', () => {
-    const definitions = [
+    const definitions: DataQueriesDefinition[] = [
       {
-        type: 'TimeSeriesQuery',
         kind: 'PrometheusTimeSeriesQuery',
         spec: {
           query: 'up',
@@ -45,7 +45,8 @@ describe('useDataQueries', () => {
 
 describe('DataQueriesProvider', () => {
   it('should throw an errory for unsupported query type', () => {
-    const definitions = [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const definitions: any = [
       {
         type: 'CustomQuery',
         kind: 'CustomQueryPlugin',

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
@@ -1,0 +1,61 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { render, renderHook } from '@testing-library/react';
+import { MOCK_TIME_SERIES_DATA } from '../../test';
+import { DataQueriesProvider, useDataQueries } from './DataQueriesProvider';
+
+jest.mock('../time-series-queries', () => ({
+  useTimeSeriesQueries: jest.fn().mockImplementation(() => [{ data: MOCK_TIME_SERIES_DATA }]),
+}));
+
+describe('useDataQueries', () => {
+  it('should return the correct data for TimeSeriesQuery', () => {
+    const definitions = [
+      {
+        type: 'TimeSeriesQuery',
+        kind: 'PrometheusTimeSeriesQuery',
+        spec: {
+          query: 'up',
+        },
+      },
+    ];
+
+    const wrapper = ({ children }: React.PropsWithChildren) => {
+      return <DataQueriesProvider definitions={definitions}>{children}</DataQueriesProvider>;
+    };
+
+    const { result } = renderHook(() => useDataQueries('TimeSeriesQuery'), {
+      wrapper,
+    });
+    expect(result.current.queryResults[0]?.data).toEqual(MOCK_TIME_SERIES_DATA);
+  });
+});
+
+describe('DataQueriesProvider', () => {
+  it('should throw an errory for unsupported query type', () => {
+    const definitions = [
+      {
+        type: 'CustomQuery',
+        kind: 'CustomQueryPlugin',
+        spec: {
+          query: 'hi',
+        },
+      },
+    ];
+    expect(() => {
+      render(<DataQueriesProvider definitions={definitions} />);
+    }).toThrow('Query type is not supported: CustomQuery');
+  });
+});

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -12,16 +12,17 @@
 // limitations under the License.
 
 import { createContext, useCallback, useContext, useMemo } from 'react';
-import { Definition, TimeSeriesQueryDefinition, UnknownSpec } from '@perses-dev/core';
+import { QueryType, TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { useTimeSeriesQueries } from '../time-series-queries';
-import { DataQueriesProviderProps, QueryData, UseDataQueryResults } from './model';
+import {
+  DataQueriesProviderProps,
+  UseDataQueryResults,
+  transformQueryResults,
+  DataQueriesContextType,
+  QueryData,
+} from './model';
 
-export function useDataQueries(): UseDataQueryResults {
-  const ctx = useDataQueriesContext();
-  return ctx;
-}
-
-export const DataQueriesContext = createContext<UseDataQueryResults | undefined>(undefined);
+export const DataQueriesContext = createContext<DataQueriesContextType | undefined>(undefined);
 
 export function useDataQueriesContext() {
   const ctx = useContext(DataQueriesContext);
@@ -31,47 +32,66 @@ export function useDataQueriesContext() {
   return ctx;
 }
 
+export function useDataQueries<T extends keyof QueryType>(queryType: T): UseDataQueryResults<QueryType[T]> {
+  const ctx = useDataQueriesContext();
+
+  // Filter the query results based on the specified query type
+  const filteredQueryResults = ctx.queryResults.filter(
+    (queryResult) => queryResult.definition.kind === queryType
+  ) as Array<QueryData<QueryType[T]>>;
+
+  // Filter the errors based on the specified query type
+  const filteredErrors = ctx.errors.filter((errors, index) => ctx.queryResults[index]?.definition.kind === queryType);
+
+  // Create a new context object with the filtered results and errors
+  const filteredCtx = {
+    queryResults: filteredQueryResults,
+    isFetching: filteredQueryResults.some((result) => result.isFetching),
+    isLoading: filteredQueryResults.some((result) => result.isLoading),
+    refetchAll: ctx.refetchAll,
+    errors: filteredErrors,
+  };
+
+  return filteredCtx;
+}
+
 export function DataQueriesProvider(props: DataQueriesProviderProps) {
   const { definitions, options, children } = props;
 
-  // For now we will map each query plugin definition to TimeSeriesQueryDefinition
-  // Later on when we add support for other query types,
-  // we will have to map each query maps to the correct QueryDefinition
-  const timeSeriesQueries = definitions.map(
-    (definition) =>
-      ({
+  const queryDefinitions = definitions.map((definition) => {
+    if (definition.type === undefined || definition.type === 'TimeSeriesQuery') {
+      return {
         kind: 'TimeSeriesQuery',
         spec: {
           plugin: definition,
         },
-      } as TimeSeriesQueryDefinition)
-  );
-  const results = useTimeSeriesQueries(timeSeriesQueries, options);
+      } as TimeSeriesQueryDefinition;
+    }
 
-  const data = results.map(({ data, isFetching, isLoading, refetch, error }, i) => {
-    return {
-      definition: definitions[i],
-      data,
-      isFetching,
-      isLoading,
-      refetch,
-      error,
-    } as QueryData<Definition<UnknownSpec>>;
+    throw new Error(`Query type is not supported: ${definition.type}`);
   });
 
+  // Filter definitions for time series query and other future query plugins
+  const timeSeriesQueries = queryDefinitions.filter(
+    (definition) => definition.kind === 'TimeSeriesQuery'
+  ) as TimeSeriesQueryDefinition[];
+  const timeSeriesResults = useTimeSeriesQueries(timeSeriesQueries, options);
+
   const refetchAll = useCallback(() => {
-    results.forEach((result) => result.refetch());
-  }, [results]);
+    timeSeriesResults.forEach((result) => result.refetch());
+  }, [timeSeriesResults]);
 
   const ctx = useMemo(() => {
+    const mergedQueryResults = [...transformQueryResults(timeSeriesResults, timeSeriesQueries)];
+
     return {
-      queryResults: data,
-      isFetching: results.some((result) => result.isFetching),
-      isLoading: results.some((result) => result.isLoading),
+      queryResults: mergedQueryResults,
+      isFetching: mergedQueryResults.some((result) => result.isFetching),
+      isLoading: mergedQueryResults.some((result) => result.isLoading),
       refetchAll,
-      errors: results.map((result) => result.error),
+      errors: mergedQueryResults.map((result) => result.error),
     };
-  }, [data, results, refetchAll]);
+  }, [timeSeriesQueries, timeSeriesResults, refetchAll]);
 
   return <DataQueriesContext.Provider value={ctx}>{children}</DataQueriesContext.Provider>;
 }

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -20,6 +20,7 @@ import {
   transformQueryResults,
   DataQueriesContextType,
   QueryData,
+  useQueryType,
 } from './model';
 
 export const DataQueriesContext = createContext<DataQueriesContextType | undefined>(undefined);
@@ -58,17 +59,16 @@ export function useDataQueries<T extends keyof QueryType>(queryType: T): UseData
 export function DataQueriesProvider(props: DataQueriesProviderProps) {
   const { definitions, options, children } = props;
 
-  const queryDefinitions = definitions.map((definition) => {
-    if (definition.type === undefined || definition.type === 'TimeSeriesQuery') {
-      return {
-        kind: 'TimeSeriesQuery',
-        spec: {
-          plugin: definition,
-        },
-      } as TimeSeriesQueryDefinition;
-    }
+  const getQueryType = useQueryType();
 
-    throw new Error(`Query type is not supported: ${definition.type}`);
+  const queryDefinitions = definitions.map((definition) => {
+    const type = getQueryType(definition.kind);
+    return {
+      kind: type,
+      spec: {
+        plugin: definition,
+      },
+    };
   });
 
   // Filter definitions for time series query and other future query plugins

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -17,8 +17,8 @@ import { useCallback, useMemo } from 'react';
 import { useListPluginMetadata } from '../plugin-registry';
 
 type QueryOptions = Record<string, unknown>;
-export interface DataQueriesProviderProps {
-  definitions: Array<Definition<UnknownSpec>>;
+export interface DataQueriesProviderProps<QueryPluginSpec = UnknownSpec> {
+  definitions: Array<Definition<QueryPluginSpec>>;
   options?: QueryOptions;
   children?: React.ReactNode;
 }

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Definition, QueryDefinition, QueryType, UnknownSpec } from '@perses-dev/core';
-import { QueryDataType } from '@perses-dev/core';
+import { Definition, QueryDefinition, QueryType, UnknownSpec, QueryDataType } from '@perses-dev/core';
 import { UseQueryResult } from '@tanstack/react-query';
 
 type QueryOptions = Record<string, unknown>;

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -11,32 +11,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Definition, TimeSeriesData, UnknownSpec } from '@perses-dev/core';
+import { Definition, QueryDefinition, QueryType, UnknownSpec } from '@perses-dev/core';
+import { QueryDataType } from '@perses-dev/core';
+import { UseQueryResult } from '@tanstack/react-query';
 
 type QueryOptions = Record<string, unknown>;
 
-interface DataQueriesDefinitions<QueryPluginDefinition> {
-  definitions: QueryPluginDefinition[];
+export interface DataQueriesDefinition extends Definition<UnknownSpec> {
+  /**
+   * @default 'TimeSeriesQuery'
+   */
+  type?: keyof QueryType;
 }
-export interface DataQueriesProviderProps<QueryPluginDefinition = Definition<UnknownSpec>>
-  extends DataQueriesDefinitions<QueryPluginDefinition> {
+
+export interface DataQueriesProviderProps {
+  definitions: DataQueriesDefinition[];
   options?: QueryOptions;
   children?: React.ReactNode;
 }
 
-export interface UseDataQueryResults<QueryPluginDefinition = Definition<UnknownSpec>> {
-  queryResults: Array<QueryData<QueryPluginDefinition>>;
+export interface DataQueriesContextType {
+  queryResults: QueryData[];
   refetchAll: () => void;
   isFetching: boolean;
   isLoading: boolean;
   errors: unknown[];
 }
 
-export interface QueryData<QueryPluginDefinition> {
-  data?: TimeSeriesData;
-  definition: QueryPluginDefinition;
+export interface UseDataQueryResults<T> extends Omit<DataQueriesContextType, 'queryResults'> {
+  queryResults: Array<QueryData<T>>;
+}
+
+export type QueryData<T = QueryDataType> = {
+  data?: T;
+  definition: QueryDefinition;
   error: unknown;
   isFetching: boolean;
   isLoading: boolean;
   refetch?: () => void;
+};
+
+export function transformQueryResults(results: UseQueryResult[], definitions: QueryDefinition[]) {
+  return results.map(({ data, isFetching, isLoading, refetch, error }, i) => {
+    return {
+      definition: definitions[i],
+      data,
+      isFetching,
+      isLoading,
+      refetch,
+      error,
+    } as QueryData;
+  });
 }

--- a/ui/plugin-system/src/test/index.ts
+++ b/ui/plugin-system/src/test/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './render';
+export * from './mock-data';

--- a/ui/plugin-system/src/test/mock-data.ts
+++ b/ui/plugin-system/src/test/mock-data.ts
@@ -1,0 +1,38 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TimeSeriesData } from '@perses-dev/core';
+
+export const MOCK_TIME_SERIES_DATA: TimeSeriesData = {
+  timeRange: {
+    start: new Date(1666625490000),
+    end: new Date(1666625535000),
+  },
+  stepMs: 24379,
+  series: [
+    {
+      name: 'device="/dev/vda1", env="demo", fstype="ext4", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/"',
+      values: [
+        [1666479357903, 0.27700745551584494],
+        [1666479382282, 0.27701284657366565],
+      ],
+    },
+    {
+      name: 'device="/dev/vda15", env="demo", fstype="vfat", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/boot/efi"',
+      values: [
+        [1666479357903, 0.08486496097624885],
+        [1666479382282, 0.08486496097624885],
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Currently our DataQueriesProvider serves as the core component for data querying. It decouples the visualization layer from the data source layer. This separation allows users to update queries easily without affecting the visualization. 

However, our current implementation is limited to supporting time series queries only. We want to expand the capabilities of the DataQueriesProvider to support other data types, such as traces and logs. This improvement will  provide developers more versatility and flexibility when running queries.

**Changes**
- Modify the `DataQueriesProvider` to filter the definitions into different query types, returning a mix of data types
- Update `useDataQueries` hook to accept a `queryType` prop and return results specifically related to that query type.

**Usage**
Here’s an example of usage of the modified interface:
```
export function MyCustomPanel() {
  const definitions = [
    // TimeSeriesQueryPluginDefinition
    { kind: 'PrometheusTimeSeriesQuery', spec: prometheusTimeSeriesSpec },
    // LogsQueryPluginDefinition
    { kind: 'ElasticLogsQuery', spec: elasticLogsSpec },
  ];

  return (
    <DataQueriesProvider definitions={definitions}>
      <InstantQueryComponent />
      <LogsComponent />
      <TableComponent />
    </DataQueriesProvider>
  );
}

export function TableComponent() {
  // table can render any data type
  const { queryResults: { data: timeSeriesData } = useDataQueries('TimeSeresQuery');
  const { queryResults: { data: logs } = useDataQueries('LogsQuery');

  if (timeSeriesData) {
    return <TimeSeriesTable />
  }

  if (logs) {
    return <LogsTable />
  }
}
```