### PR TITLE
[FEATURE] Add global datasources CRUD

### DIFF
--- a/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
@@ -20,6 +20,7 @@ import {
   GridToolbarFilterButton,
   GridToolbarQuickFilter,
   GridRow,
+  GridRowParams,
   GridColumnHeaders,
 } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
@@ -42,7 +43,7 @@ const MemoizedRow = memo(GridRow);
 const MemoizedColumnHeaders = memo(GridColumnHeaders);
 
 export interface Row {
-  project: string;
+  project?: string;
   name: string;
   displayName: string;
   version: number;
@@ -81,7 +82,7 @@ export interface DatasourceDataGridProperties {
   initialState?: GridInitialStateCommunity;
   hideToolbar?: boolean;
   isLoading?: boolean;
-  onRowClick: (project: string, name: string) => void;
+  onRowClick: (params: GridRowParams) => void;
 }
 
 export function DatasourceDataGrid(props: DatasourceDataGridProperties) {
@@ -99,9 +100,7 @@ export function DatasourceDataGrid(props: DatasourceDataGridProperties) {
     <DataGrid
       disableRowSelectionOnClick
       autoHeight={true}
-      onRowClick={(params) => {
-        onRowClick(params.row.project, params.row.name);
-      }}
+      onRowClick={onRowClick}
       rows={rows}
       columns={columns}
       getRowId={(row) => row.name}

--- a/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
@@ -11,17 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource } from '@perses-dev/core';
+import { Datasource, GlobalDatasource } from '@perses-dev/core';
 import { DispatchWithoutAction, useCallback, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
-import { DeleteDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
-import { DatasourceEditorForm } from './DatasourceEditorForm';
+import { DeleteGlobalDatasourceDialog, DeleteProjectDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
+import { GlobalDatasourceEditorForm, ProjectDatasourceEditorForm } from './DatasourceEditorForm';
 
 export type ActionStr = 'Create' | 'Update';
 
-interface DatasourceDrawerProps {
+interface ProjectDatasourceDrawerProps {
   datasource: Datasource;
   isOpen: boolean;
   saveActionStr: ActionStr;
@@ -29,7 +29,7 @@ interface DatasourceDrawerProps {
   onClose: DispatchWithoutAction;
 }
 
-export function DatasourceDrawer(props: DatasourceDrawerProps) {
+export function ProjectDatasourceDrawer(props: ProjectDatasourceDrawerProps) {
   const { datasource, isOpen, saveActionStr, onSave, onClose } = props;
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
 
@@ -52,7 +52,7 @@ export function DatasourceDrawer(props: DatasourceDrawerProps) {
           }}
         >
           {isOpen && (
-            <DatasourceEditorForm
+            <ProjectDatasourceEditorForm
               initialDatasource={datasource}
               saveActionStr={saveActionStr}
               onSave={onSave}
@@ -61,7 +61,57 @@ export function DatasourceDrawer(props: DatasourceDrawerProps) {
             />
           )}
         </PluginRegistry>
-        <DeleteDatasourceDialog
+        <DeleteProjectDatasourceDialog
+          open={isDeleteDatasourceDialogStateOpened}
+          onClose={() => setDeleteDatasourceDialogStateOpened(false)}
+          onDelete={onClose}
+          datasource={datasource}
+        />
+      </ErrorBoundary>
+    </Drawer>
+  );
+}
+interface GlobalDatasourceDrawerProps {
+  datasource: GlobalDatasource;
+  isOpen: boolean;
+  saveActionStr: ActionStr;
+  onSave: (datasource: GlobalDatasource) => void;
+  onClose: DispatchWithoutAction;
+}
+
+export function GlobalDatasourceDrawer(props: GlobalDatasourceDrawerProps) {
+  const { datasource, isOpen, saveActionStr, onSave, onClose } = props;
+  const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
+
+  // When user clicks out of the drawer, do not close it, just do nothing
+  // This is a quick-win solution to avoid losing draft changes
+  // -> TODO allow closing by clicking-out without being too sensitive to missclicks
+  const handleClickOut = useCallback(() => {
+    return;
+  }, []);
+
+  return (
+    <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">
+      <ErrorBoundary FallbackComponent={ErrorAlert}>
+        <PluginRegistry
+          pluginLoader={bundledPluginLoader}
+          // TODO this required field is useless here
+          defaultPluginKinds={{
+            Panel: 'TimeSeriesChart',
+            TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+          }}
+        >
+          {isOpen && (
+            <GlobalDatasourceEditorForm
+              initialDatasource={datasource}
+              saveActionStr={saveActionStr}
+              onSave={onSave}
+              onClose={onClose}
+              onDelete={saveActionStr == 'Update' ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
+            />
+          )}
+        </PluginRegistry>
+        <DeleteGlobalDatasourceDialog
           open={isDeleteDatasourceDialogStateOpened}
           onClose={() => setDeleteDatasourceDialogStateOpened(false)}
           onDelete={onClose}

--- a/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useImmer } from 'use-immer';
-import { Datasource, Display } from '@perses-dev/core';
+import { Datasource, Display, GlobalDatasource } from '@perses-dev/core';
 import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
 import { DispatchWithoutAction, useCallback, useMemo, useState } from 'react';
 import { PluginEditor } from '@perses-dev/plugin-system';
@@ -20,7 +20,7 @@ import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import { useIsReadonly } from '../../model/config-client';
 
 // TODO: Replace with proper validation library
-function getValidation(state: Datasource) {
+function getValidation(state: Datasource | GlobalDatasource) {
   /** Name validation */
   let name = null;
   if (!state.metadata.name) {
@@ -38,7 +38,8 @@ function getValidation(state: Datasource) {
 }
 
 // this preprocessing ensure that we always have a defined object for the `display` property:
-function getInitialState(datasource: Datasource): Datasource {
+// TODO code duplication
+function getPatchedInitialProjectDs(datasource: Datasource): Datasource {
   const patchedDisplay: Display = {
     name: '',
     description: '',
@@ -60,7 +61,7 @@ function getInitialState(datasource: Datasource): Datasource {
   };
 }
 
-interface DatasourceEditorFormProps {
+interface ProjectDatasourceEditorFormProps {
   initialDatasource: Datasource;
   saveActionStr: string;
   onSave: (datasource: Datasource) => void;
@@ -68,12 +69,14 @@ interface DatasourceEditorFormProps {
   onDelete: DispatchWithoutAction | undefined;
 }
 
-export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
+// TODO code duplication
+export function ProjectDatasourceEditorForm(props: ProjectDatasourceEditorFormProps) {
   const { initialDatasource, saveActionStr, onSave, onClose, onDelete } = props;
+
+  const patchedInitialDatasource = getPatchedInitialProjectDs(initialDatasource);
+  const [state, setState] = useImmer(patchedInitialDatasource);
   const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
   const isReadonly = useIsReadonly();
-  const initialState = getInitialState(initialDatasource);
-  const [state, setState] = useImmer(initialState);
   const validation = useMemo(() => getValidation(state), [state]);
 
   // When saving, remove the display property if ever display.name is empty, then pass the value upstream
@@ -89,12 +92,204 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
 
   // When the user clicks on cancel, ask for discard approval if anything was changed
   const handleCancel = useCallback(() => {
-    if (JSON.stringify(initialState) !== JSON.stringify(state)) {
+    if (JSON.stringify(initialDatasource) !== JSON.stringify(state)) {
       setDiscardDialogStateOpened(true);
     } else {
       onClose();
     }
-  }, [state, initialState, setDiscardDialogStateOpened, onClose]);
+  }, [state, initialDatasource, setDiscardDialogStateOpened, onClose]);
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: (theme) => theme.spacing(1, 2),
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Typography variant="h2">{saveActionStr} Datasource</Typography>
+        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
+          <Button disabled={isReadonly || !validation.isValid} variant="contained" onClick={handleSave}>
+            {saveActionStr}
+          </Button>
+          <Button color="secondary" variant="outlined" onClick={handleCancel}>
+            Cancel
+          </Button>
+          {onDelete && (
+            <Button disabled={isReadonly} color="error" variant="outlined" onClick={onDelete}>
+              Delete
+            </Button>
+          )}
+        </Stack>
+      </Box>
+      <Box padding={2} sx={{ overflowY: 'scroll' }}>
+        <Grid container spacing={2} mb={2}>
+          <Grid item xs={4}>
+            <TextField
+              required
+              error={!!validation.name}
+              fullWidth
+              label="Name"
+              value={state.metadata.name}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              helperText={validation.name}
+              onChange={(v) => {
+                setState((draft) => {
+                  draft.metadata.name = v.target.value;
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={8}>
+            <TextField
+              fullWidth
+              label="Display Label"
+              value={state.spec.display?.name}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              onChange={(v) => {
+                setState((draft) => {
+                  if (draft.spec.display) {
+                    draft.spec.display.name = v.target.value;
+                  }
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              label="Description"
+              value={state.spec.display?.description}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              onChange={(v) => {
+                setState((draft) => {
+                  if (draft.spec.display) {
+                    draft.spec.display.description = v.target.value;
+                  }
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={6} sx={{ paddingTop: '5px !important' }}>
+            <Stack>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={state.spec.default}
+                    readOnly={isReadonly}
+                    onChange={(v) => {
+                      setState((draft) => {
+                        draft.spec.default = v.target.checked;
+                      });
+                    }}
+                  />
+                }
+                label="Set as default"
+              />
+              <Typography variant="caption">
+                Whether this datasource should be the default {state.spec.plugin.kind} to be used
+              </Typography>
+            </Stack>
+          </Grid>
+        </Grid>
+        <Divider />
+        <Typography py={1} variant="subtitle1">
+          Plugin Options
+        </Typography>
+        <PluginEditor
+          width="100%"
+          pluginType="Datasource"
+          pluginKindLabel="Source"
+          value={state.spec.plugin}
+          isReadonly={isReadonly}
+          onChange={(v) => {
+            setState((draft) => {
+              draft.spec.plugin = v;
+            });
+          }}
+        />
+      </Box>
+      <DiscardChangesConfirmationDialog
+        description="Are you sure you want to discard your changes? Changes cannot be recovered."
+        isOpen={isDiscardDialogStateOpened}
+        onCancel={() => setDiscardDialogStateOpened(false)}
+        onDiscardChanges={() => {
+          setDiscardDialogStateOpened(false);
+          onClose();
+        }}
+      />
+    </>
+  );
+}
+
+// this preprocessing ensure that we always have a defined object for the `display` property:
+// TODO code duplication
+function getPatchedInitialGlobalDs(datasource: GlobalDatasource): GlobalDatasource {
+  const patchedDisplay: Display = {
+    name: '',
+    description: '',
+  };
+
+  if (datasource.spec.display) {
+    patchedDisplay.name = datasource.spec.display.name;
+    if (datasource.spec.display.description) {
+      patchedDisplay.description = datasource.spec.display.description;
+    }
+  }
+
+  return {
+    ...datasource,
+    spec: {
+      ...datasource.spec,
+      display: patchedDisplay,
+    },
+  };
+}
+
+interface GlobalDatasourceEditorFormProps {
+  initialDatasource: GlobalDatasource;
+  saveActionStr: string;
+  onSave: (datasource: GlobalDatasource) => void;
+  onClose: DispatchWithoutAction;
+  onDelete: DispatchWithoutAction | undefined;
+}
+
+// TODO code duplication
+export function GlobalDatasourceEditorForm(props: GlobalDatasourceEditorFormProps) {
+  const { initialDatasource, saveActionStr, onSave, onClose, onDelete } = props;
+
+  const patchedInitialDatasource = getPatchedInitialGlobalDs(initialDatasource);
+  const [state, setState] = useImmer(patchedInitialDatasource);
+  const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
+  const isReadonly = useIsReadonly();
+  const validation = useMemo(() => getValidation(state), [state]);
+
+  // When saving, remove the display property if ever display.name is empty, then pass the value upstream
+  const handleSave = () => {
+    onSave({
+      ...state,
+      spec: {
+        ...state.spec,
+        display: state.spec.display?.name !== '' ? state.spec.display : undefined,
+      },
+    });
+  };
+
+  // When the user clicks on cancel, ask for discard approval if anything was changed
+  const handleCancel = useCallback(() => {
+    if (JSON.stringify(initialDatasource) !== JSON.stringify(state)) {
+      setDiscardDialogStateOpened(true);
+    } else {
+      onClose();
+    }
+  }, [state, initialDatasource, setDiscardDialogStateOpened, onClose]);
 
   return (
     <>

--- a/ui/app/src/model/admin-client.ts
+++ b/ui/app/src/model/admin-client.ts
@@ -1,0 +1,137 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { GlobalDatasource, fetch, fetchJson } from '@perses-dev/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import buildURL from './url-builder';
+import { HTTPHeader, HTTPMethodDELETE, HTTPMethodGET, HTTPMethodPOST, HTTPMethodPUT } from './http';
+
+const globalDatasourceResource = 'globaldatasources';
+
+/**
+ * Used to create a new global datasource in the API.
+ * Will automatically invalidate datasources and force the get query to be executed again.
+ */
+export function useCreateGlobalDatasourceMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GlobalDatasource, Error, GlobalDatasource>({
+    mutationKey: [globalDatasourceResource],
+    mutationFn: (datasource: GlobalDatasource) => {
+      return createGlobalDatasource(datasource);
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries([globalDatasourceResource]);
+    },
+  });
+}
+
+/**
+ * Used to update a global datasource in the API.
+ * Will automatically invalidate datasources and force the get query to be executed again.
+ */
+export function useUpdateGlobalDatasourceMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GlobalDatasource, Error, GlobalDatasource>({
+    mutationKey: [globalDatasourceResource],
+    mutationFn: (datasource: GlobalDatasource) => {
+      return updateGlobalDatasource(datasource);
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries([globalDatasourceResource]);
+    },
+  });
+}
+
+/**
+ * Used to delete a global datasource in the API.
+ * Will automatically invalidate datasources and force the get query to be executed again.
+ */
+export function useDeleteGlobalDatasourceMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<GlobalDatasource, Error, GlobalDatasource>({
+    mutationKey: [globalDatasourceResource],
+    mutationFn: (entity: GlobalDatasource) => {
+      return deleteGlobalDatasource(entity).then(() => {
+        return entity;
+      });
+    },
+    onSuccess: (datasource) => {
+      queryClient.removeQueries([globalDatasourceResource, datasource.metadata.name]);
+      return queryClient.invalidateQueries([globalDatasourceResource]);
+    },
+  });
+}
+
+/**
+ * Used to get a global datasource from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalDatasource(name: string) {
+  return useQuery<GlobalDatasource, Error>([globalDatasourceResource, name], () => {
+    return getGlobalDatasource(name);
+  });
+}
+
+/**
+ * Used to get global datasources from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalDatasourceList() {
+  return useQuery<GlobalDatasource[], Error>([globalDatasourceResource], () => {
+    return getGlobalDatasources();
+  });
+}
+
+export function createGlobalDatasource(entity: GlobalDatasource) {
+  const url = buildURL({ resource: globalDatasourceResource });
+  return fetchJson<GlobalDatasource>(url, {
+    method: HTTPMethodPOST,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+export function getGlobalDatasource(name: string) {
+  const url = buildURL({ resource: globalDatasourceResource, name: name });
+  return fetchJson<GlobalDatasource>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+export function getGlobalDatasources() {
+  const url = buildURL({ resource: globalDatasourceResource });
+  return fetchJson<GlobalDatasource[]>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+export function updateGlobalDatasource(entity: GlobalDatasource) {
+  const url = buildURL({ resource: globalDatasourceResource, name: entity.metadata.name });
+  return fetchJson<GlobalDatasource>(url, {
+    method: HTTPMethodPUT,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+export function deleteGlobalDatasource(entity: GlobalDatasource) {
+  const url = buildURL({ resource: globalDatasourceResource, name: entity.metadata.name });
+  return fetch(url, {
+    method: HTTPMethodDELETE,
+    headers: HTTPHeader,
+  });
+}

--- a/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
@@ -12,23 +12,21 @@
 // limitations under the License.
 
 import { Card } from '@mui/material';
-import { useDatasourceList } from '../../../model/project-client';
-import { ProjectDatasourceList } from '../../../components/DatasourceList/DatasourceList';
+import { useGlobalDatasourceList } from '../../../model/admin-client';
+import { GlobalDatasourceList } from '../../../components/DatasourceList/DatasourceList';
 
-interface ProjectDatasourcesProps {
-  projectName: string;
+interface GlobalDatasourcesProps {
   hideToolbar?: boolean;
   id?: string;
 }
 
-export function ProjectDatasources(props: ProjectDatasourcesProps) {
-  const { projectName, hideToolbar, id } = props;
-  const { data, isLoading } = useDatasourceList(projectName);
+export function GlobalDatasources(props: GlobalDatasourcesProps) {
+  const { hideToolbar, id } = props;
+  const { data, isLoading } = useGlobalDatasourceList();
 
   return (
     <Card id={id}>
-      <ProjectDatasourceList
-        projectName={projectName}
+      <GlobalDatasourceList
         datasourceList={data || []}
         hideToolbar={hideToolbar}
         isLoading={isLoading}

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -29,7 +29,7 @@ import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
 import { CreateDashboardDialog } from '../../components/dialogs';
 import { VariableFormDrawer } from '../../components/VariableList/VariableFormDrawer';
 import { useCreateVariableMutation, useCreateDatasourceMutation } from '../../model/project-client';
-import { DatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
+import { ProjectDatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
 import { ProjectDashboards } from './tabs/ProjectDashboards';
 import { ProjectVariables } from './tabs/ProjectVariables';
 import { ProjectDatasources } from './tabs/ProjectDatasources';
@@ -51,7 +51,7 @@ function TabButton(props: TabButtonProps) {
 
   const [openCreateDashboardDialogState, setOpenCreateDashboardDialogState] = useState(false);
   const [openCreateVariableDrawerState, setOpenCreateVariableDrawerState] = useState(false);
-  const [isCreateDatasourceDrawerStateOpened, setCreateDatasourceFormStateOpened] = useState(false);
+  const [isCreateDatasourceDrawerStateOpened, setCreateDatasourceDrawerStateOpened] = useState(false);
 
   const handleDashboardCreation = (dashboardSelector: DashboardSelector) => {
     navigate(`/projects/${dashboardSelector.project}/dashboards/${dashboardSelector.dashboard}/create`);
@@ -78,7 +78,7 @@ function TabButton(props: TabButtonProps) {
       createDatasourceMutation.mutate(datasource, {
         onSuccess: (createdDatasource: Datasource) => {
           successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
-          setCreateDatasourceFormStateOpened(false);
+          setCreateDatasourceDrawerStateOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);
@@ -138,9 +138,9 @@ function TabButton(props: TabButtonProps) {
           <CRUDButton
             text="Add Datasource"
             variant="contained"
-            onClick={() => setCreateDatasourceFormStateOpened(true)}
+            onClick={() => setCreateDatasourceDrawerStateOpened(true)}
           />
-          <DatasourceDrawer
+          <ProjectDatasourceDrawer
             datasource={{
               kind: 'Datasource',
               metadata: {
@@ -159,7 +159,7 @@ function TabButton(props: TabButtonProps) {
             isOpen={isCreateDatasourceDrawerStateOpened}
             saveActionStr="Create"
             onSave={handleDatasourceCreation}
-            onClose={() => setCreateDatasourceFormStateOpened(false)}
+            onClose={() => setCreateDatasourceDrawerStateOpened(false)}
           />
         </>
       );
@@ -222,7 +222,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
         justifyContent="space-between"
         sx={{ marginLeft: 2.5, marginRight: 2.5, borderBottom: 1, borderColor: 'divider' }}
       >
-        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+        <Tabs value={value} onChange={handleChange} aria-label="project tabs">
           <Tab
             label="Dashboards"
             icon={<ViewDashboardIcon />}
@@ -247,13 +247,13 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
         </Tabs>
         <TabButton index={value} projectName={projectName} />
       </Stack>
-      <TabPanel value={value} index="dashboards">
+      <TabPanel value={value} index={dashboardTabIndex}>
         <ProjectDashboards projectName={projectName} id="main-dashboard-list" />
       </TabPanel>
-      <TabPanel value={value} index="variables">
+      <TabPanel value={value} index={variablesTabIndex}>
         <ProjectVariables projectName={projectName} id="project-variable-list" />
       </TabPanel>
-      <TabPanel value={value} index="datasources">
+      <TabPanel value={value} index={datasourcesTabIndex}>
         <ProjectDatasources projectName={projectName} id="project-datasource-list" />
       </TabPanel>
     </Box>

--- a/ui/core/src/utils/text.ts
+++ b/ui/core/src/utils/text.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource, DashboardResource, VariableResource } from '../model';
+import { Datasource, DashboardResource, GlobalDatasource, VariableResource } from '../model';
 
 /**
  * If the dashboard has a display name, return the dashboard display name
@@ -36,7 +36,7 @@ export function getVariableDisplayName(variable: VariableResource) {
  * Else, only return the datasource name
  * @param variable Project or Global datasource
  */
-export function getDatasourceDisplayName(datasource: Datasource) {
+export function getDatasourceDisplayName(datasource: Datasource | GlobalDatasource) {
   return datasource.spec.display?.name || datasource.metadata.name;
 }
 
@@ -69,7 +69,7 @@ export function getVariableExtendedDisplayName(variable: VariableResource) {
  * Else, only return the datasource name
  * @param variable Project or Global datasource
  */
-export function getDatasourceExtendedDisplayName(datasource: Datasource) {
+export function getDatasourceExtendedDisplayName(datasource: Datasource | GlobalDatasource) {
   if (datasource.spec.display?.name) {
     return `${datasource.spec.display.name} (ID: ${datasource.metadata.name})`;
   }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

Issue ref: https://github.com/perses/perses/issues/1033

This PR adds global datasources CRUD, located in the Admin section.

![2023-07-21_22h34_06](https://github.com/perses/perses/assets/7058693/3c560413-5b4b-4645-b996-d353222a26d6)

⚠️There are lots of code duplicated from the project datasources #1282. I spent quite some time trying to factorize as much as possible but in the end I got stucked, especially by the fact union types combined with useState/useImmer seem like a bottleneck here (e.g it doesnt seem possible to infer the concrete type of the object being spread/destructured in order to reuse it for the updated state?). Maybe using an intermediary type to gather Datasource and GlobalDatasource (with e.g project info as optional) would be the way to go? Anyway I'm pretty new to React so I may have missed something here. To whoever will review this, please let me know if you know a way to refactor this and I'll be happy to do it. ⚠️

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
