### PR TITLE
[IGNORE] Add stacked bar story to debug Happo errors

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.stories.tsx
+++ b/ui/components/src/TimeChart/TimeChart.stories.tsx
@@ -12,8 +12,10 @@
 // limitations under the License.
 
 import { StoryObj, Meta } from '@storybook/react';
+import { waitForStableCanvas } from '@perses-dev/storybook';
+import { TimeSeries } from '@perses-dev/core';
 import { ChartInstance, DEFAULT_TOOLTIP_CONFIG, TimeChart } from '@perses-dev/components';
-import { Button, Stack, Typography } from '@mui/material';
+import { Button, Stack } from '@mui/material';
 import { useRef } from 'react';
 import { action } from '@storybook/addon-actions';
 
@@ -213,5 +215,75 @@ export const NoData: Story = {
         </div>
       </Stack>
     );
+  },
+};
+
+// Time series bar using visual.display and visual.stack
+const STACKED_BAR_DATA: TimeSeries[] = [
+  {
+    name: 'up{instance="demo.do.prometheus.io:3000",job="grafana"}',
+    values: [
+      [1673784000000, 1],
+      [1673784060000, 2],
+      [1673784120000, null],
+      [1673784180000, null],
+      [1673784240000, 4],
+      [1673784300000, 1],
+      [1673784360000, 2],
+      [1673784420000, 3],
+    ],
+  },
+  {
+    name: 'up{instance="demo.do.prometheus.io:3000",job="caddy"}',
+    values: [
+      [1673784000000, 8],
+      [1673784060000, 6],
+      [1673784120000, 10],
+      [1673784180000, 9],
+      [1673784240000, 7],
+      [1673784300000, 8],
+      [1673784360000, 12],
+      [1673784420000, 10],
+    ],
+  },
+];
+
+export const StackedBar: Story = {
+  parameters: {
+    happo: {
+      beforeScreenshot: async () => {
+        await waitForStableCanvas('canvas');
+      },
+    },
+  },
+  args: {
+    height: 200,
+    data: STACKED_BAR_DATA,
+    seriesMapping: [
+      {
+        type: 'bar',
+        id: 'up{instance="demo.do.prometheus.io:3000",job="grafana"}',
+        datasetIndex: 0,
+        name: 'up{instance="demo.do.prometheus.io:3000",job="grafana"}',
+        color: 'hsla(158782136,50%,50%,0.8)',
+      },
+    ],
+    yAxis: {
+      show: true,
+    },
+    unit: {
+      kind: 'Decimal' as const,
+      decimal_places: 2,
+      abbreviate: true,
+    },
+    tooltipConfig: DEFAULT_TOOLTIP_CONFIG,
+    grid: {
+      left: 20,
+      right: 20,
+      bottom: 0,
+    },
+  },
+  render: (args) => {
+    return <TimeChart {...args} isStackedBar={true} />;
   },
 };

--- a/ui/components/src/TimeChart/TimeChart.stories.tsx
+++ b/ui/components/src/TimeChart/TimeChart.stories.tsx
@@ -218,8 +218,7 @@ export const NoData: Story = {
   },
 };
 
-// Time series bar using visual.display and visual.stack
-// http://localhost:3000/projects/perses/dashboards/DemoDashboard?start=1690076587000&refresh=0s&var-JobPromVariableProj=alertmanager&var-InstancePromVariableProj=demo.do.prometheus.io%3A9093&end=1690076694000
+// Time series bar test data to demonstrate visual.display and visual.stack
 const STACKED_BAR_DATA: TimeSeries[] = [
   {
     name: '{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',

--- a/ui/components/src/TimeChart/TimeChart.stories.tsx
+++ b/ui/components/src/TimeChart/TimeChart.stories.tsx
@@ -15,7 +15,7 @@ import { StoryObj, Meta } from '@storybook/react';
 import { waitForStableCanvas } from '@perses-dev/storybook';
 import { TimeSeries } from '@perses-dev/core';
 import { ChartInstance, DEFAULT_TOOLTIP_CONFIG, TimeChart } from '@perses-dev/components';
-import { Button, Stack } from '@mui/material';
+import { Button, Stack, Typography } from '@mui/material';
 import { useRef } from 'react';
 import { action } from '@storybook/addon-actions';
 
@@ -219,31 +219,45 @@ export const NoData: Story = {
 };
 
 // Time series bar using visual.display and visual.stack
+// http://localhost:3000/projects/perses/dashboards/DemoDashboard?start=1690076587000&refresh=0s&var-JobPromVariableProj=alertmanager&var-InstancePromVariableProj=demo.do.prometheus.io%3A9093&end=1690076694000
 const STACKED_BAR_DATA: TimeSeries[] = [
   {
-    name: 'up{instance="demo.do.prometheus.io:3000",job="grafana"}',
+    name: '{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
     values: [
-      [1673784000000, 1],
-      [1673784060000, 2],
-      [1673784120000, null],
-      [1673784180000, null],
-      [1673784240000, 4],
-      [1673784300000, 1],
-      [1673784360000, 2],
-      [1673784420000, 3],
+      [1690076580000, 585465856],
+      [1690076595000, 597020672],
+      [1690076610000, 595795968],
+      [1690076625000, 595472384],
+      [1690076640000, 604037120],
+      [1690076655000, 587571200],
+      [1690076670000, 584241152],
+      [1690076685000, 584945664],
     ],
   },
   {
-    name: 'up{instance="demo.do.prometheus.io:3000",job="caddy"}',
+    name: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
     values: [
-      [1673784000000, 8],
-      [1673784060000, 6],
-      [1673784120000, 10],
-      [1673784180000, 9],
-      [1673784240000, 7],
-      [1673784300000, 8],
-      [1673784360000, 12],
-      [1673784420000, 10],
+      [1690076580000, 41164800],
+      [1690076595000, 41177088],
+      [1690076610000, 41193472],
+      [1690076625000, 41209856],
+      [1690076640000, 41234432],
+      [1690076655000, 41246720],
+      [1690076670000, 41267200],
+      [1690076685000, 41279488],
+    ],
+  },
+  {
+    name: 'node_memory_MemFree_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+    values: [
+      [1690076580000, 106176512],
+      [1690076595000, 94519296],
+      [1690076610000, 95629312],
+      [1690076625000, 95854592],
+      [1690076640000, 87154688],
+      [1690076655000, 103501824],
+      [1690076670000, 106725376],
+      [1690076685000, 105930752],
     ],
   },
 ];
@@ -258,25 +272,52 @@ export const StackedBar: Story = {
   },
   args: {
     height: 200,
+    timeScale: { startMs: 1690076580000, endMs: 1690076685000, stepMs: 15000, rangeMs: 105000 },
     data: STACKED_BAR_DATA,
     seriesMapping: [
       {
         type: 'bar',
-        id: 'up{instance="demo.do.prometheus.io:3000",job="grafana"}',
+        id: 'time-series-panel-19{env="demo",instance="demo.do.prometheus.io:9100",job="node"}0',
         datasetIndex: 0,
-        name: 'up{instance="demo.do.prometheus.io:3000",job="grafana"}',
-        color: 'hsla(158782136,50%,50%,0.8)',
+        name: '{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+        color: '#56B4E9',
+        stack: 'all',
+        label: {
+          show: false,
+        },
+      },
+      {
+        type: 'bar',
+        id: 'time-series-panel-19node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}1',
+        datasetIndex: 1,
+        name: 'node_memory_Buffers_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+        color: '#009E73',
+        stack: 'all',
+        label: {
+          show: false,
+        },
+      },
+      {
+        type: 'bar',
+        id: 'time-series-panel-19node_memory_MemFree_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}2',
+        datasetIndex: 2,
+        name: 'node_memory_MemFree_bytes{env="demo",instance="demo.do.prometheus.io:9100",job="node"}',
+        color: '#0072B2',
+        stack: 'all',
+        label: {
+          show: false,
+        },
       },
     ],
     yAxis: {
       show: true,
+      min: 400000000,
     },
     unit: {
-      kind: 'Decimal' as const,
-      decimal_places: 2,
+      kind: 'Decimal',
       abbreviate: true,
     },
-    tooltipConfig: DEFAULT_TOOLTIP_CONFIG,
+    tooltipConfig: { wrapLabels: true, enablePinning: false },
     grid: {
       left: 20,
       right: 20,

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -119,6 +119,11 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
   const { timeZone } = useTimeZone();
   const totalSeries = data?.length ?? 0;
 
+  console.log(seriesMapping);
+  console.log(data);
+  console.log(timeScaleProp);
+  console.log(yAxis);
+
   let timeScale: TimeScale;
   if (timeScaleProp === undefined) {
     const commonTimeScale = getCommonTimeScale(data);

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -119,11 +119,6 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
   const { timeZone } = useTimeZone();
   const totalSeries = data?.length ?? 0;
 
-  console.log(seriesMapping);
-  console.log(data);
-  console.log(timeScaleProp);
-  console.log(yAxis);
-
   let timeScale: TimeScale;
   if (timeScaleProp === undefined) {
     const commonTimeScale = getCommonTimeScale(data);

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -271,6 +271,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
     noDataVariant,
     timeZone,
     tooltipPinnedCoords,
+    isStackedBar,
   ]);
 
   return (

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -375,9 +375,16 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   // Used to opt in to ECharts trigger item which show subgroup data accurately
   const isStackedBar = visual.display === 'bar' && visual.stack === 'All';
 
+  // Turn on tooltip pinning by default but opt out for stacked bar or if explicitly set in tooltip panel spec
+  let enablePinning = true;
+  if (isStackedBar) {
+    enablePinning = false;
+  } else if (tooltip?.enable_pinning !== undefined) {
+    enablePinning = tooltip.enable_pinning;
+  }
   const tooltipConfig: TooltipConfig = {
     ...DEFAULT_TOOLTIP_CONFIG,
-    enablePinning: tooltip?.enable_pinning ?? true,
+    enablePinning,
   };
 
   return (


### PR DESCRIPTION
## Summary
- Add stacked bar story
- Fix dep array after #1313 
- adjust panel conditions to ensure tooltip pinning is off when isStackedBar

## Screenshots
<img width="1686" alt="image" src="https://github.com/perses/perses/assets/9369625/fe54f0f3-0837-4c07-a4a1-17418f120bf7">

<img width="1269" alt="image" src="https://github.com/perses/perses/assets/9369625/841c8343-93b8-4f3d-9236-fbf7eaa80d0e">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
