### PR TITLE
[ENHANCEMENT] Include panel definition in extra panel props

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -58,7 +58,12 @@ export function GridItemContent(props: GridItemContentProps) {
 
   return (
     <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs }}>
-      <Panel definition={panelDefinition} editHandlers={editHandlers} panelOptions={props.panelOptions} />
+      <Panel
+        definition={panelDefinition}
+        editHandlers={editHandlers}
+        panelOptions={props.panelOptions}
+        panelGroupItemId={panelGroupItemId}
+      />
     </DataQueriesProvider>
   );
 }

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -31,7 +31,11 @@ export type PanelOptions = {
    * Content to render in the top-right corner of the panel. It will only be
    * rendered when the panel is in edit mode.
    */
-  extra?: () => React.ReactNode;
+  extra?: (props: PanelExtraProps) => React.ReactNode;
+};
+
+type PanelExtraProps = {
+  panelDefinition?: PanelDefinition;
 };
 
 /**
@@ -91,7 +95,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
       {...others}
     >
       <PanelHeader
-        extra={panelOptions?.extra?.()}
+        extra={panelOptions?.extra?.({ panelDefinition: definition })}
         id={headerId}
         title={definition.spec.display.name}
         description={definition.spec.display.description}

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -17,6 +17,7 @@ import { useInView } from 'react-intersection-observer';
 import { ErrorBoundary, ErrorAlert, combineSx, useId, useChartsTheme } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
 import { Card, CardProps, CardContent } from '@mui/material';
+import { PanelGroupItemId } from '../../context';
 import { PanelHeader, PanelHeaderProps } from './PanelHeader';
 import { PanelContent } from './PanelContent';
 
@@ -24,6 +25,7 @@ export interface PanelProps extends CardProps<'section'> {
   definition: PanelDefinition;
   editHandlers?: PanelHeaderProps['editHandlers'];
   panelOptions?: PanelOptions;
+  panelGroupItemId?: PanelGroupItemId;
 }
 
 export type PanelOptions = {
@@ -34,15 +36,22 @@ export type PanelOptions = {
   extra?: (props: PanelExtraProps) => React.ReactNode;
 };
 
-type PanelExtraProps = {
+export type PanelExtraProps = {
+  /**
+   * The PanelDefinition for the panel.
+   */
   panelDefinition?: PanelDefinition;
+  /**
+   * The PanelGroupItemId for the panel.
+   */
+  panelGroupItemId?: PanelGroupItemId;
 };
 
 /**
  * Renders a PanelDefinition's content inside of a Card.
  */
 export const Panel = memo(function Panel(props: PanelProps) {
-  const { definition, editHandlers, onMouseEnter, onMouseLeave, sx, panelOptions, ...others } = props;
+  const { definition, editHandlers, onMouseEnter, onMouseLeave, sx, panelOptions, panelGroupItemId, ...others } = props;
 
   // Make sure we have an ID we can use for aria attributes
   const generatedPanelId = useId('Panel');
@@ -95,7 +104,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
       {...others}
     >
       <PanelHeader
-        extra={panelOptions?.extra?.({ panelDefinition: definition })}
+        extra={panelOptions?.extra?.({ panelDefinition: definition, panelGroupItemId })}
         id={headerId}
         title={definition.spec.display.name}
         description={definition.spec.display.description}


### PR DESCRIPTION
Include an optional `panelDefinition` and `panelGroupItemId` in the panel props: See https://github.com/perses/perses/pull/1315#discussion_r1270969119

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
