### PR TITLE
[ENHANCEMENT] Bar chart updates

### DIFF
--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -21,7 +21,7 @@ import { Box } from '@mui/material';
 import { useChartsTheme } from '../context/ChartsThemeProvider';
 import { EChart } from '../EChart';
 import { ModeOption } from '../ModeSelector';
-import { getYAxes } from '../utils';
+import { formatAxesValues } from '../utils';
 
 use([EChartsBarChart, GridComponent, DatasetComponent, TitleComponent, TooltipComponent, CanvasRenderer]);
 
@@ -63,7 +63,7 @@ export function BarChart(props: BarChartProps) {
           source: source,
         },
       ],
-      xAxis: getYAxes({}, unit),
+      xAxis: formatAxesValues({}, unit),
       yAxis: {
         type: 'category',
         splitLine: {

--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -21,7 +21,7 @@ import { Box } from '@mui/material';
 import { useChartsTheme } from '../context/ChartsThemeProvider';
 import { EChart } from '../EChart';
 import { ModeOption } from '../ModeSelector';
-import { formatAxesValues } from '../utils';
+import { getFormattedAxis } from '../utils';
 
 use([EChartsBarChart, GridComponent, DatasetComponent, TitleComponent, TooltipComponent, CanvasRenderer]);
 
@@ -63,7 +63,7 @@ export function BarChart(props: BarChartProps) {
           source: source,
         },
       ],
-      xAxis: formatAxesValues({}, unit),
+      xAxis: getFormattedAxis({}, unit),
       yAxis: {
         type: 'category',
         splitLine: {

--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -105,6 +105,7 @@ export function BarChart(props: BarChartProps) {
         formatter: (params: { name: string; data: number[] }) =>
           params.data[1] && `<b>${params.name}</b> &emsp; ${formatValue(params.data[1], unit)}`,
       },
+      // increase distance between grid and container to prevent y axis labels from getting cut off
       grid: {
         left: '5%',
         right: '5%',

--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -105,6 +105,10 @@ export function BarChart(props: BarChartProps) {
         formatter: (params: { name: string; data: number[] }) =>
           params.data[1] && `<b>${params.name}</b> &emsp; ${formatValue(params.data[1], unit)}`,
       },
+      grid: {
+        left: '5%',
+        right: '5%',
+      },
     };
   }, [data, chartsTheme, width, mode, unit]);
 

--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -21,6 +21,7 @@ import { Box } from '@mui/material';
 import { useChartsTheme } from '../context/ChartsThemeProvider';
 import { EChart } from '../EChart';
 import { ModeOption } from '../ModeSelector';
+import { getYAxes } from '../utils';
 
 use([EChartsBarChart, GridComponent, DatasetComponent, TitleComponent, TooltipComponent, CanvasRenderer]);
 
@@ -45,7 +46,7 @@ export function BarChart(props: BarChartProps) {
   const chartsTheme = useChartsTheme();
 
   const option: EChartsCoreOption = useMemo(() => {
-    if (data == null) return chartsTheme.noDataOption;
+    if (data == null || !data.length) return chartsTheme.noDataOption;
 
     const source: Array<Array<BarChartData['label'] | BarChartData['value']>> = [];
     data.map((d) => {
@@ -62,7 +63,7 @@ export function BarChart(props: BarChartProps) {
           source: source,
         },
       ],
-      xAxis: {},
+      xAxis: getYAxes({}, unit),
       yAxis: {
         type: 'category',
         splitLine: {

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -46,7 +46,7 @@ import {
   enableDataZoom,
   getDateRange,
   getFormattedDate,
-  getYAxes,
+  formatAxesValues,
   restoreChart,
   ZoomEventData,
 } from '../utils';
@@ -185,7 +185,7 @@ export const LineChart = forwardRef<ChartInstance, LineChartProps>(function Line
           },
         },
       },
-      yAxis: getYAxes(yAxis, unit),
+      yAxis: formatAxesValues(yAxis, unit),
       animation: false,
       tooltip: {
         show: true,

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -46,7 +46,7 @@ import {
   enableDataZoom,
   getDateRange,
   getFormattedDate,
-  formatAxesValues,
+  getFormattedAxis,
   restoreChart,
   ZoomEventData,
 } from '../utils';
@@ -185,7 +185,7 @@ export const LineChart = forwardRef<ChartInstance, LineChartProps>(function Line
           },
         },
       },
-      yAxis: formatAxesValues(yAxis, unit),
+      yAxis: getFormattedAxis(yAxis, unit),
       animation: false,
       tooltip: {
         show: true,

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -52,7 +52,7 @@ import {
   enableDataZoom,
   getFormattedAxisLabel,
   getPointInGrid,
-  formatAxesValues,
+  getFormattedAxis,
   restoreChart,
   ZoomEventData,
 } from '../utils';
@@ -223,7 +223,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
           snap: false, // important so shared crosshair does not lag
         },
       },
-      yAxis: formatAxesValues(yAxis, unit),
+      yAxis: getFormattedAxis(yAxis, unit),
       animation: false,
       tooltip: {
         show: true,

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -52,7 +52,7 @@ import {
   enableDataZoom,
   getFormattedAxisLabel,
   getPointInGrid,
-  getYAxes,
+  formatAxesValues,
   restoreChart,
   ZoomEventData,
 } from '../utils';
@@ -223,7 +223,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
           snap: false, // important so shared crosshair does not lag
         },
       },
-      yAxis: getYAxes(yAxis, unit),
+      yAxis: formatAxesValues(yAxis, unit),
       animation: false,
       tooltip: {
         show: true,

--- a/ui/components/src/utils/axis.ts
+++ b/ui/components/src/utils/axis.ts
@@ -12,15 +12,15 @@
 // limitations under the License.
 
 import merge from 'lodash/merge';
-import type { YAXisComponentOption } from 'echarts';
+import type { XAXisComponentOption, YAXisComponentOption } from 'echarts';
 import { formatValue, UnitOptions } from '@perses-dev/core';
 
 /*
- * Populate yAxis properties, returns an Array since multiple y axes will be supported in the future
+ * Populate yAxis or xAxis properties, returns an Array since multiple axes will be supported in the future
  */
-export function getYAxes(yAxis?: YAXisComponentOption, unit?: UnitOptions) {
+export function formatAxesValues(axis?: YAXisComponentOption | XAXisComponentOption, unit?: UnitOptions) {
   // TODO: support alternate yAxis that shows on right side
-  const Y_AXIS_DEFAULT = {
+  const AXIS_DEFAULT = {
     type: 'value',
     boundaryGap: [0, '10%'],
     axisLabel: {
@@ -29,7 +29,7 @@ export function getYAxes(yAxis?: YAXisComponentOption, unit?: UnitOptions) {
       },
     },
   };
-  return [merge(Y_AXIS_DEFAULT, yAxis)];
+  return [merge(AXIS_DEFAULT, axis)];
 }
 
 /**

--- a/ui/components/src/utils/axis.ts
+++ b/ui/components/src/utils/axis.ts
@@ -18,7 +18,7 @@ import { formatValue, UnitOptions } from '@perses-dev/core';
 /*
  * Populate yAxis or xAxis properties, returns an Array since multiple axes will be supported in the future
  */
-export function formatAxesValues(axis?: YAXisComponentOption | XAXisComponentOption, unit?: UnitOptions) {
+export function getFormattedAxis(axis?: YAXisComponentOption | XAXisComponentOption, unit?: UnitOptions) {
   // TODO: support alternate yAxis that shows on right side
   const AXIS_DEFAULT = {
     type: 'value',

--- a/ui/core/src/model/calculations.ts
+++ b/ui/core/src/model/calculations.ts
@@ -66,8 +66,6 @@ export const CALCULATIONS_CONFIG: Readonly<Record<CalculationType, CalculationCo
   },
 } as const;
 
-export const DEFAULT_CALCULATION: CalculationType = 'Sum';
-
 type CalculationValue = number | null | undefined;
 
 /**

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.test.tsx
@@ -153,6 +153,7 @@ describe('BarChartOptionsEditorSettings', () => {
       expect.objectContaining({
         unit: {
           kind: 'Decimal',
+          abbreviate: true,
         },
         calculation: 'LastNumber',
         sort: 'desc',

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.test.tsx
@@ -133,4 +133,31 @@ describe('BarChartOptionsEditorSettings', () => {
     const unitSelector = screen.getByRole('combobox', { name: 'Unit' });
     expect(unitSelector).toBeDisabled;
   });
+
+  it('should reset settings to defaults', () => {
+    const onChange = jest.fn();
+    renderBarChartOptionsEditorSettings(
+      {
+        unit: {
+          kind: 'Years',
+        },
+        calculation: 'First',
+        sort: 'asc',
+        mode: 'percentage',
+      },
+      onChange
+    );
+    const resetButton = screen.getByRole('button', { name: 'Reset To Defaults', exact: true });
+    userEvent.click(resetButton);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unit: {
+          kind: 'Decimal',
+        },
+        calculation: 'LastNumber',
+        sort: 'desc',
+        mode: 'value',
+      })
+    );
+  });
 });

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
@@ -28,6 +28,7 @@ import {
   SortOption,
 } from '@perses-dev/components';
 import { CalculationType, DEFAULT_CALCULATION, UnitOptions, isPercentUnit } from '@perses-dev/core';
+import { Button } from '@mui/material';
 import { BarChartOptions, DEFAULT_UNIT, BarChartOptionsEditorProps } from './bar-chart-model';
 
 export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps) {
@@ -65,6 +66,17 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
     );
   };
 
+  const handleResetSettings: React.MouseEventHandler<HTMLButtonElement> = () => {
+    onChange(
+      produce(value, (draft: BarChartOptions) => {
+        draft.calculation = 'LastNumber';
+        draft.unit = DEFAULT_UNIT;
+        draft.sort = 'desc';
+        draft.mode = 'value';
+      })
+    );
+  };
+
   // ensures decimal_places defaults to correct value
   const unit = merge({}, DEFAULT_UNIT, value.unit);
 
@@ -76,6 +88,13 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
           <CalculationSelector value={value.calculation ?? DEFAULT_CALCULATION} onChange={handleCalculationChange} />
           <SortSelector value={value.sort} onChange={handleSortChange} />
           <ModeSelector value={value.mode} onChange={handleModeChange} disablePercentageMode={isPercentUnit(unit)} />
+        </OptionsEditorGroup>
+      </OptionsEditorColumn>
+      <OptionsEditorColumn>
+        <OptionsEditorGroup title="Reset Settings">
+          <Button variant="outlined" color="secondary" onClick={handleResetSettings}>
+            Reset To Defaults
+          </Button>
         </OptionsEditorGroup>
       </OptionsEditorColumn>
     </OptionsEditorGrid>

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
@@ -31,8 +31,9 @@ import { CalculationType, UnitOptions, isPercentUnit } from '@perses-dev/core';
 import { Button } from '@mui/material';
 import {
   BarChartOptions,
-  DEFAULT_UNIT,
   BarChartOptionsEditorProps,
+  DEFAULT_CALCULATION,
+  DEFAULT_UNIT,
   DEFAULT_SORT,
   DEFAULT_MODE,
 } from './bar-chart-model';
@@ -75,7 +76,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   const handleResetSettings: React.MouseEventHandler<HTMLButtonElement> = () => {
     onChange(
       produce(value, (draft: BarChartOptions) => {
-        draft.calculation = 'LastNumber';
+        draft.calculation = DEFAULT_CALCULATION;
         draft.unit = DEFAULT_UNIT;
         draft.sort = DEFAULT_SORT;
         draft.mode = DEFAULT_MODE;

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
@@ -27,9 +27,15 @@ import {
   ModeOption,
   SortOption,
 } from '@perses-dev/components';
-import { CalculationType, DEFAULT_CALCULATION, UnitOptions, isPercentUnit } from '@perses-dev/core';
+import { CalculationType, UnitOptions, isPercentUnit } from '@perses-dev/core';
 import { Button } from '@mui/material';
-import { BarChartOptions, DEFAULT_UNIT, BarChartOptionsEditorProps } from './bar-chart-model';
+import {
+  BarChartOptions,
+  DEFAULT_UNIT,
+  BarChartOptionsEditorProps,
+  DEFAULT_SORT,
+  DEFAULT_MODE,
+} from './bar-chart-model';
 
 export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps) {
   const { onChange, value } = props;
@@ -71,8 +77,8 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
       produce(value, (draft: BarChartOptions) => {
         draft.calculation = 'LastNumber';
         draft.unit = DEFAULT_UNIT;
-        draft.sort = 'desc';
-        draft.mode = 'value';
+        draft.sort = DEFAULT_SORT;
+        draft.mode = DEFAULT_MODE;
       })
     );
   };
@@ -85,7 +91,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
       <OptionsEditorColumn>
         <OptionsEditorGroup title="Misc">
           <UnitSelector value={unit} onChange={handleUnitChange} disabled={value.mode === 'percentage'} />
-          <CalculationSelector value={value.calculation ?? DEFAULT_CALCULATION} onChange={handleCalculationChange} />
+          <CalculationSelector value={value.calculation} onChange={handleCalculationChange} />
           <SortSelector value={value.sort} onChange={handleSortChange} />
           <ModeSelector value={value.mode} onChange={handleModeChange} disablePercentageMode={isPercentUnit(unit)} />
         </OptionsEditorGroup>

--- a/ui/panels-plugin/src/plugins/bar-chart/bar-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/bar-chart/bar-chart-model.ts
@@ -16,6 +16,8 @@ import { CalculationType, Definition, UnitOptions } from '@perses-dev/core';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 
 export const DEFAULT_UNIT: UnitOptions = { kind: 'Decimal' };
+export const DEFAULT_SORT: SortOption = 'desc';
+export const DEFAULT_MODE: ModeOption = 'value';
 
 /**
  * The schema for a BarChart panel.
@@ -43,7 +45,7 @@ export function createInitialBarChartOptions(): BarChartOptions {
   return {
     calculation: 'LastNumber',
     unit: DEFAULT_UNIT,
-    sort: 'desc',
-    mode: 'value',
+    sort: DEFAULT_SORT,
+    mode: DEFAULT_MODE,
   };
 }

--- a/ui/panels-plugin/src/plugins/bar-chart/bar-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/bar-chart/bar-chart-model.ts
@@ -15,7 +15,8 @@ import { ModeOption, SortOption } from '@perses-dev/components';
 import { CalculationType, Definition, UnitOptions } from '@perses-dev/core';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 
-export const DEFAULT_UNIT: UnitOptions = { kind: 'Decimal' };
+export const DEFAULT_CALCULATION: CalculationType = 'LastNumber';
+export const DEFAULT_UNIT: UnitOptions = { kind: 'Decimal', abbreviate: true };
 export const DEFAULT_SORT: SortOption = 'desc';
 export const DEFAULT_MODE: ModeOption = 'value';
 
@@ -43,7 +44,7 @@ export type BarChartOptionsEditorProps = OptionsEditorProps<BarChartOptions>;
  */
 export function createInitialBarChartOptions(): BarChartOptions {
   return {
-    calculation: 'LastNumber',
+    calculation: DEFAULT_CALCULATION,
     unit: DEFAULT_UNIT,
     sort: DEFAULT_SORT,
     mode: DEFAULT_MODE,

--- a/ui/panels-plugin/src/plugins/bar-chart/utils.ts
+++ b/ui/panels-plugin/src/plugins/bar-chart/utils.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { BarChartData, SortOption } from '@perses-dev/components';
+import { DEFAULT_SORT } from './bar-chart-model';
 
 export function calculatePercentages(data: BarChartData[]) {
   const sum = data.reduce((accumulator, { value }) => accumulator + (value ?? 0), 0);
@@ -24,7 +25,7 @@ export function calculatePercentages(data: BarChartData[]) {
   });
 }
 
-export function sortSeriesData(data: BarChartData[], sortOrder: SortOption = 'desc') {
+export function sortSeriesData(data: BarChartData[], sortOrder: SortOption = DEFAULT_SORT) {
   if (sortOrder === 'asc') {
     // sort in ascending order by value
     return data.sort((a, b) => {

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChartOptionsEditorSettings.tsx
@@ -24,7 +24,7 @@ import {
   OptionsEditorControl,
   ThresholdsEditor,
 } from '@perses-dev/components';
-import { DEFAULT_CALCULATION, ThresholdOptions } from '@perses-dev/core';
+import { ThresholdOptions } from '@perses-dev/core';
 import {
   GaugeChartOptions,
   DEFAULT_UNIT,
@@ -76,7 +76,7 @@ export function GaugeChartOptionsEditorSettings(props: GaugeChartOptionsEditorPr
       <OptionsEditorColumn>
         <OptionsEditorGroup title="Misc">
           <UnitSelector value={unit} onChange={handleUnitChange} />
-          <CalculationSelector value={value.calculation ?? DEFAULT_CALCULATION} onChange={handleCalculationChange} />
+          <CalculationSelector value={value.calculation} onChange={handleCalculationChange} />
           <OptionsEditorControl
             label="Max"
             control={

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.tsx
@@ -27,7 +27,6 @@ import {
   FontSizeSelectorProps,
   FontSizeOption,
 } from '@perses-dev/components';
-import { DEFAULT_CALCULATION } from '@perses-dev/core';
 import { StatChartOptions, StatChartOptionsEditorProps } from './stat-chart-model';
 
 export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProps) {
@@ -85,7 +84,7 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
             control={<Switch checked={!!value.sparkline} onChange={handleSparklineChange} />}
           />
           <UnitSelector value={value.unit} onChange={handleUnitChange} />
-          <CalculationSelector value={value.calculation ?? DEFAULT_CALCULATION} onChange={handleCalculationChange} />
+          <CalculationSelector value={value.calculation} onChange={handleCalculationChange} />
           <FontSizeSelector value={value.value_font_size} onChange={handleFontSizeChange} />
         </OptionsEditorGroup>
       </OptionsEditorColumn>


### PR DESCRIPTION
- Updates formatting of x axis values
- Adds a "Reset to Defaults" button to the bar chart settings
- Fixes empty state so that "No data" message is shown when appropriate
- Prevents y axis labels from getting cut off

X axis before:
<img width="1064" alt="Screen Shot 2023-07-24 at 1 25 20 PM" src="https://github.com/perses/perses/assets/22085207/0fcfb65e-b35a-45bd-9c8c-4362a59e234e">
X axis after:
<img width="1072" alt="Screen Shot 2023-07-24 at 1 24 45 PM" src="https://github.com/perses/perses/assets/22085207/c0ad8537-ff01-448e-a586-d7491a0e1a59">

Reset to Defaults button:
<img width="737" alt="Screen Shot 2023-07-24 at 1 26 36 PM" src="https://github.com/perses/perses/assets/22085207/5b93284b-6d41-4934-ba5c-f0320f88bf97">

Empty state:
<img width="1082" alt="Screen Shot 2023-07-24 at 1 27 56 PM" src="https://github.com/perses/perses/assets/22085207/186acbc0-6968-4b4e-bdd6-7494d3b52026">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
