### PR TITLE
[ENHANCEMENT] Choose largest time unit that produces natural numbers

### DIFF
--- a/ui/core/src/model/units/time.test.ts
+++ b/ui/core/src/model/units/time.test.ts
@@ -16,44 +16,164 @@ import { UnitTestCase } from './types';
 
 const TIME_TESTS: UnitTestCase[] = [
   {
-    value: 8000,
+    value: 0,
     unit: { kind: 'Milliseconds' },
-    expected: '8,000ms',
+    expected: '0s',
   },
   {
-    value: 8000,
+    value: 0,
     unit: { kind: 'Seconds' },
-    expected: '8,000s',
+    expected: '0s',
   },
   {
-    value: 300,
+    value: 0,
     unit: { kind: 'Minutes' },
-    expected: '300m',
+    expected: '0s',
   },
   {
-    value: 300,
+    value: 0,
     unit: { kind: 'Hours' },
-    expected: '300h',
+    expected: '0s',
   },
   {
-    value: 300,
+    value: 0,
     unit: { kind: 'Days' },
-    expected: '300d',
+    expected: '0s',
   },
   {
-    value: 300,
+    value: 0,
     unit: { kind: 'Weeks' },
-    expected: '300w',
+    expected: '0s',
   },
   {
-    value: 300,
+    value: 0,
     unit: { kind: 'Months' },
-    expected: '300 months',
+    expected: '0s',
   },
   {
-    value: 300,
+    value: 0,
     unit: { kind: 'Years' },
-    expected: '300 years',
+    expected: '0s',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Milliseconds' },
+    expected: '0.001ms',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Seconds' },
+    expected: '1ms',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Minutes' },
+    expected: '60ms',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Hours' },
+    expected: '3.6s',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Days' },
+    expected: '1.44m',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Weeks' },
+    expected: '10.1m',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Months' },
+    expected: '43.2m',
+  },
+  {
+    value: 0.001,
+    unit: { kind: 'Years' },
+    expected: '8.76h',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Milliseconds' },
+    expected: '1ms',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Seconds' },
+    expected: '1s',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Minutes' },
+    expected: '1m',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Hours' },
+    expected: '1h',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Days' },
+    expected: '1d',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Weeks' },
+    expected: '1w',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Months' },
+    expected: '1 month',
+  },
+  {
+    value: 1,
+    unit: { kind: 'Years' },
+    expected: '1 year',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Milliseconds' },
+    expected: '100ms',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Seconds' },
+    expected: '1.67m',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Minutes' },
+    expected: '1.67h',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Hours' },
+    expected: '4.17d',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Days' },
+    expected: '3.33 months',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Weeks' },
+    expected: '1.92 years',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Months' },
+    expected: '8.22 years',
+  },
+  {
+    value: 100,
+    unit: { kind: 'Years' },
+    expected: '100 years',
   },
 ];
 

--- a/ui/core/src/model/units/time.ts
+++ b/ui/core/src/model/units/time.ts
@@ -74,10 +74,12 @@ export enum PersesTimeToIntlTime {
   Years = 'year',
 }
 
-// Note: This conversion will not be exactly accurate for months and years,
-// due variations in the lengths of months (i.e. 28 - 31 days) and years (i.e. leap years).
-// For precision with months and years, we would need more complex algorithms and/or external libraries.
-// However, we expect that measurements in months and years will be rare.
+/**
+ * Note: This conversion will not be exactly accurate for months and years,
+ * due variations in the lengths of months (i.e. 28 - 31 days) and years (i.e. leap years).
+ * For precision with months and years, we would need more complex algorithms and/or external libraries.
+ * However, we expect that measurements in months and years will be rare.
+ */
 const TIME_UNITS_IN_SECONDS: Record<TimeUnitKind, number> = {
   Years: 31536000, // 365 days
   Months: 2592000, // 30 days
@@ -100,7 +102,9 @@ const LARGEST_TO_SMALLEST_TIME_UNITS: TimeUnitKind[] = [
   'Milliseconds',
 ];
 
-// Choose the first time unit that produces a number greater than 1, starting from the biggest time unit.
+/**
+ * Choose the first time unit that produces a number greater than 1, starting from the biggest time unit.
+ */
 function getValueAndKindForNaturalNumbers(value: number, kind: TimeUnitKind): { value: number; kind: TimeUnitKind } {
   const valueInSeconds = value * TIME_UNITS_IN_SECONDS[kind];
 
@@ -125,11 +129,13 @@ function isMonthOrYear(kind: TimeUnitKind): boolean {
 }
 
 export function formatTime(value: number, { kind, decimal_places }: TimeUnitOptions): string {
-  if (value === 0) return '0s';
+  const { value: valueForNaturalNumbers, kind: kindForNaturalNumbers } = getValueAndKindForNaturalNumbers(value, kind);
 
-  const valueAndKindForNaturalNumbers = getValueAndKindForNaturalNumbers(value, kind);
-  value = valueAndKindForNaturalNumbers.value;
-  kind = valueAndKindForNaturalNumbers.kind;
+  return _formatTime(valueForNaturalNumbers, { kind: kindForNaturalNumbers, decimal_places });
+}
+
+function _formatTime(value: number, { kind, decimal_places }: TimeUnitOptions): string {
+  if (value === 0) return '0s';
 
   const formatterOptions: Intl.NumberFormatOptions = {
     style: 'unit',

--- a/ui/core/src/model/units/time.ts
+++ b/ui/core/src/model/units/time.ts
@@ -74,13 +74,67 @@ export enum PersesTimeToIntlTime {
   Years = 'year',
 }
 
+// Note: This conversion will not be exactly accurate for months and years,
+// due variations in the lengths of months (i.e. 28 - 31 days) and years (i.e. leap years).
+// For precision with months and years, we would need more complex algorithms and/or external libraries.
+// However, we expect that measurements in months and years will be rare.
+const TIME_UNITS_IN_SECONDS: Record<TimeUnitKind, number> = {
+  Years: 31536000, // 365 days
+  Months: 2592000, // 30 days
+  Weeks: 604800,
+  Days: 86400,
+  Hours: 3600,
+  Minutes: 60,
+  Seconds: 1,
+  Milliseconds: 0.001,
+};
+
+const LARGEST_TO_SMALLEST_TIME_UNITS: TimeUnitKind[] = [
+  'Years',
+  'Months',
+  'Weeks',
+  'Days',
+  'Hours',
+  'Minutes',
+  'Seconds',
+  'Milliseconds',
+];
+
+// Choose the first time unit that produces a number greater than 1, starting from the biggest time unit.
+function getValueAndKindForNaturalNumbers(value: number, kind: TimeUnitKind): { value: number; kind: TimeUnitKind } {
+  const valueInSeconds = value * TIME_UNITS_IN_SECONDS[kind];
+
+  // Initialize for TS
+  const largestTimeUnit = LARGEST_TO_SMALLEST_TIME_UNITS[0] || 'Years';
+  let timeUnit: TimeUnitKind = largestTimeUnit;
+  let valueInTimeUnit: number = valueInSeconds / TIME_UNITS_IN_SECONDS[largestTimeUnit];
+
+  for (timeUnit of LARGEST_TO_SMALLEST_TIME_UNITS) {
+    valueInTimeUnit = valueInSeconds / TIME_UNITS_IN_SECONDS[timeUnit];
+    if (valueInTimeUnit >= 1) {
+      return { value: valueInTimeUnit, kind: timeUnit };
+    }
+  }
+
+  // If we didn't find a time unit, we have to settle for the smallest time unit (which is the last time unit).
+  return { value: valueInTimeUnit, kind: timeUnit };
+}
+
+function isMonthOrYear(kind: TimeUnitKind): boolean {
+  return kind === 'Months' || kind === 'Years';
+}
+
 export function formatTime(value: number, { kind, decimal_places }: TimeUnitOptions): string {
-  const isMonthOrYear = kind === 'Months' || kind === 'Years';
+  if (value === 0) return '0s';
+
+  const valueAndKindForNaturalNumbers = getValueAndKindForNaturalNumbers(value, kind);
+  value = valueAndKindForNaturalNumbers.value;
+  kind = valueAndKindForNaturalNumbers.kind;
 
   const formatterOptions: Intl.NumberFormatOptions = {
     style: 'unit',
     unit: PersesTimeToIntlTime[kind],
-    unitDisplay: isMonthOrYear ? 'long' : 'narrow',
+    unitDisplay: isMonthOrYear(kind) ? 'long' : 'narrow',
   };
 
   if (hasDecimalPlaces(decimal_places)) {

--- a/ui/core/src/model/units/time.ts
+++ b/ui/core/src/model/units/time.ts
@@ -129,18 +129,14 @@ function isMonthOrYear(kind: TimeUnitKind): boolean {
 }
 
 export function formatTime(value: number, { kind, decimal_places }: TimeUnitOptions): string {
-  const { value: valueForNaturalNumbers, kind: kindForNaturalNumbers } = getValueAndKindForNaturalNumbers(value, kind);
-
-  return _formatTime(valueForNaturalNumbers, { kind: kindForNaturalNumbers, decimal_places });
-}
-
-function _formatTime(value: number, { kind, decimal_places }: TimeUnitOptions): string {
   if (value === 0) return '0s';
+
+  const results = getValueAndKindForNaturalNumbers(value, kind);
 
   const formatterOptions: Intl.NumberFormatOptions = {
     style: 'unit',
-    unit: PersesTimeToIntlTime[kind],
-    unitDisplay: isMonthOrYear(kind) ? 'long' : 'narrow',
+    unit: PersesTimeToIntlTime[results.kind],
+    unitDisplay: isMonthOrYear(results.kind) ? 'long' : 'narrow',
   };
 
   if (hasDecimalPlaces(decimal_places)) {
@@ -151,5 +147,5 @@ function _formatTime(value: number, { kind, decimal_places }: TimeUnitOptions): 
   }
 
   const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(value);
+  return formatter.format(results.value);
 }

--- a/ui/core/src/model/units/units.ts
+++ b/ui/core/src/model/units/units.ts
@@ -19,7 +19,7 @@ import { UnitGroup, UnitGroupConfig, UnitConfig } from './types';
 
 /**
  * Most of the number formatting is based on Intl.NumberFormat, which is built into JavaScript.
- * Prefer Intl.NumbeFormat because it covers most use cases and will continue to be well-supported with time.
+ * Prefer Intl.NumbeFormat because it covers most use cases and will continue to be supported with time.
  *
  * To format bytes, we also make use of the `numbro` package,
  * because it can handle adding units like KB, MB, GB, etc. correctly.


### PR DESCRIPTION
The goal of this work is to produce y-axis values that are easier to understand. In the code, we pick the largest time unit that still produces natural numbers (numbers > 1). 

## Goal 
| We currently say 3000ms | We want to say 3s |
| -- | -- |
| <img width="292" alt="Screenshot 2023-07-25 at 11 51 12 AM" src="https://github.com/perses/perses/assets/2584129/a2e7076b-7a1f-4f09-b502-a564ccbf0ccb"> | <img width="243" alt="Screenshot 2023-07-25 at 11 51 22 AM" src="https://github.com/perses/perses/assets/2584129/83144002-67bf-48e8-a25f-bc2e0d0cde7e"> |


## Perses Examples
| Before | After |
| -- | -- |
| <img width="602" alt="Screenshot 2023-07-25 at 11 58 18 AM" src="https://github.com/perses/perses/assets/2584129/20e1a929-7dab-4347-b8fb-a6069bba18e5"> | <img width="658" alt="Screenshot 2023-07-25 at 12 02 09 PM" src="https://github.com/perses/perses/assets/2584129/40739922-cdd8-48b1-88e7-bd3b2520fccf"> |
| <img width="572" alt="Screenshot 2023-07-25 at 11 56 55 AM" src="https://github.com/perses/perses/assets/2584129/973d91f5-6e9d-4c78-807d-3b7026ff32c6"> | <img width="681" alt="Screenshot 2023-07-25 at 11 56 02 AM" src="https://github.com/perses/perses/assets/2584129/9a5fcdd6-32bb-4344-8707-31cf207b9062"> |