### PR TITLE
[BUGFIX] Disable tooltip pinning in panel preview

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -343,7 +343,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
             if (current === null) {
               const cursorX = pointInGrid[0];
               const closestTimestamp = getClosestTimestampInFullDataset(data, cursorX);
-              const pinnedCrosshair = merge(DEFAULT_PINNED_CROSSHAIR, {
+              const pinnedCrosshair = merge({}, DEFAULT_PINNED_CROSSHAIR, {
                 markLine: {
                   data: [
                     {

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -13,7 +13,7 @@
 
 import { useState } from 'react';
 import { Box } from '@mui/material';
-import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { ChartsProvider, ErrorAlert, ErrorBoundary, useChartsTheme } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
 import {
   PanelDrawer,
@@ -49,6 +49,9 @@ export const DashboardApp = (props: DashboardAppProps) => {
     initialVariableIsSticky,
     isReadonly,
   } = props;
+
+  const chartsTheme = useChartsTheme();
+
   const { setEditMode } = useEditMode();
   const { dashboard, setDashboard } = useDashboard();
   const [originalDashboard, setOriginalDashboard] = useState<DashboardResource | undefined>(undefined);
@@ -117,7 +120,9 @@ export const DashboardApp = (props: DashboardAppProps) => {
             }}
           />
         </ErrorBoundary>
-        <PanelDrawer />
+        <ChartsProvider chartsTheme={chartsTheme} enablePinning={false}>
+          <PanelDrawer />
+        </ChartsProvider>
         <PanelGroupDialog />
         <DeletePanelGroupDialog />
         <DeletePanelDialog />


### PR DESCRIPTION
## Overview
In order to fix zIndex issues when clicking to pin on a dashboard, changes were made in #1258 that break tooltip pinning once inside a Drawer. Since pinning isn't as useful in PanelPreview.tsx, this PR disables tooltip pinning by adding a nested `<ChartsProvider chartsTheme={chartsTheme} enablePinning={false}>`

This is follow up to #1317, that branch will be merged first

## Screenshot
<img width="954" alt="image" src="https://github.com/perses/perses/assets/9369625/d1aebb3f-a12d-4683-a17c-e1111bb22433">
