### PR TITLE
[ENHANCEMENT] Improve performance in `checkforNearbyTimeSeries`

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -68,8 +68,13 @@ export function checkforNearbyTimeSeries(
 
   const yValueCounts: Map<number, number> = new Map();
 
-  let closestTimestamp = null;
-  const closestDistance = Infinity;
+  // Only need to loop through first dataset source since getCommonTimeScale ensures xAxis timestamps are consistent
+  const firstDatasetValues = data[0]?.values;
+  const closestTimestamp = firstDatasetValues ? getClosestTimestamp(cursorX, firstDatasetValues) : null;
+
+  if (closestTimestamp === null) {
+    return [];
+  }
 
   // find the timestamp with data that is closest to cursorX
   for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
@@ -80,11 +85,6 @@ export function checkforNearbyTimeSeries(
     if (currentDataset == null) break;
 
     const currentDatasetValues: TimeSeriesValueTuple[] = currentDataset.values;
-
-    // Determine closestTimestamp before checking whether it is equal to xValue. Consolidating
-    // with second currentDatasetValues loop below would result in duplicate nearby series
-    closestTimestamp = getClosestTimestamp(cursorX, closestTimestamp, closestDistance, currentDatasetValues);
-
     if (currentDatasetValues === undefined || !Array.isArray(currentDatasetValues)) break;
     const lineSeries = currentSeries as LineSeriesOption;
     const currentSeriesName = lineSeries.name ? lineSeries.name.toString() : '';

--- a/ui/components/src/utils/chart-actions.test.ts
+++ b/ui/components/src/utils/chart-actions.test.ts
@@ -121,7 +121,7 @@ const TEST_TIME_SERIES_DATA: TimeSeries[] = [
 
 describe('getClosestTimestamp', () => {
   it('should determine closest timestamp to current cursor xValue in single dataset source', () => {
-    expect(getClosestTimestamp(1690381320276.3362, null, Infinity, TEST_TIME_SERIES_VALUES)).toEqual(1690381320000);
+    expect(getClosestTimestamp(1690381320276.3362, TEST_TIME_SERIES_VALUES)).toEqual(1690381320000);
   });
 });
 

--- a/ui/components/src/utils/chart-actions.ts
+++ b/ui/components/src/utils/chart-actions.ts
@@ -161,12 +161,10 @@ export function checkCrosshairPinnedStatus(seriesMapping: TimeChartSeriesMapping
  * Find closest timestamp to logical x coordinate returned from echartsInstance.convertFromPixel
  * Used to find nearby series in time series tooltip.
  */
-export function getClosestTimestamp(
-  cursorX: number,
-  currentClosestTimestamp: null | number,
-  currentClosestDistance: number,
-  timeSeriesValues: TimeSeriesValueTuple[]
-) {
+export function getClosestTimestamp(cursorX: number, timeSeriesValues: TimeSeriesValueTuple[]) {
+  let currentClosestTimestamp: number | null = null;
+  let currentClosestDistance = Infinity;
+
   for (const [timestamp] of timeSeriesValues) {
     const distance = Math.abs(timestamp - cursorX);
     if (distance < currentClosestDistance) {
@@ -186,12 +184,11 @@ export function getClosestTimestampInFullDataset(data: TimeSeries[], cursorX?: n
   }
   const totalSeries = data.length;
   let closestTimestamp = null;
-  const closestDistance = Infinity;
   for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
     const currentDataset = totalSeries > 0 ? data[seriesIdx] : null;
     if (currentDataset == null) break;
     const currentValues: TimeSeriesValueTuple[] = currentDataset.values;
-    closestTimestamp = getClosestTimestamp(cursorX, closestTimestamp, closestDistance, currentValues);
+    closestTimestamp = getClosestTimestamp(cursorX, currentValues);
   }
   return closestTimestamp;
 }

--- a/ui/core/src/utils/time-series-data.ts
+++ b/ui/core/src/utils/time-series-data.ts
@@ -31,7 +31,6 @@ export function getXValues(timeScale: TimeScale): number[] {
 }
 
 /**
- * [DEPRECATED] Used for legacy LineChart 'category' axis approach.
  * Given a TimeSeries from a query and a common time scale (see `getCommonTimeScale`),
  * processes the time series values, filling in any timestamps that are missing
  * from the time series data with `null` values.
@@ -64,6 +63,7 @@ export function getTimeSeriesValues(series: TimeSeries, timeScale: TimeScale) {
 }
 
 /**
+ * [DEPRECATED] Used for legacy LineChart 'category' axis approach.
  * Given a TimeSeries from a query and a common time scale (see `getCommonTimeScale`),
  * gets the values for the y axis of a graph, filling in any timestamps that are
  * missing from the time series data with `null` values.

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -245,7 +245,6 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
         seriesIndex++;
       }
     }
-    graphData.xAxis = xAxisData;
 
     if (thresholds && thresholds.steps) {
       // Convert how thresholds are defined in the panel spec to valid ECharts 'line' series.

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -17,7 +17,6 @@ import type { GridComponentOption } from 'echarts';
 import merge from 'lodash/merge';
 import {
   useDeepMemo,
-  getXValues,
   getTimeSeriesValues,
   DEFAULT_LEGEND,
   getCalculations,
@@ -35,7 +34,6 @@ import {
   legendValues,
 } from '@perses-dev/plugin-system';
 import {
-  EChartsDataFormat,
   ChartInstance,
   YAxisLabel,
   ZoomEventData,
@@ -60,7 +58,6 @@ import {
 import {
   getTimeSeries,
   getCommonTimeScaleForQueries,
-  EMPTY_GRAPH_DATA,
   convertPanelYAxis,
   getThresholdSeries,
   convertPercentThreshold,
@@ -136,7 +133,6 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     // We skip the expensive loops below until we are done loading or fetching.
     if (isLoading || isFetching) {
       return {
-        graphData: EMPTY_GRAPH_DATA,
         timeChartData: [],
         timeSeriesMapping: [],
       };
@@ -145,19 +141,10 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     const timeScale = getCommonTimeScaleForQueries(queryResults);
     if (timeScale === undefined) {
       return {
-        graphData: EMPTY_GRAPH_DATA,
         timeChartData: [],
         timeSeriesMapping: [],
       };
     }
-
-    const graphData: EChartsDataFormat = {
-      timeSeries: [],
-      xAxis: [],
-      legendItems: [],
-      rangeMs: timeScale.rangeMs,
-    };
-    const xAxisData = [...getXValues(timeScale)];
 
     const legendItems: LegendItem[] = [];
 
@@ -185,7 +172,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
       for (let i = 0; i < result.data.series.length; i++) {
         const timeSeries: TimeSeries | undefined = result.data.series[i];
         if (timeSeries === undefined) {
-          return { graphData, timeChartData: [], timeSeriesMapping: [], legendItems: [] };
+          return { timeChartData: [], timeSeriesMapping: [], legendItems: [] };
         }
 
         // Format is determined by series_name_format in query spec
@@ -284,7 +271,6 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
     }
 
     return {
-      graphData,
       timeScale,
       timeChartData,
       timeSeriesMapping,


### PR DESCRIPTION
Rely on `getCommonTimeScale` and `getTimeSeriesValues` to ensure consistent xAxis intervals. We don't need to manually check every series.