### PR TITLE
[IGNORE] ECharts version upgrade to 5.4.3

### DIFF
--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -41,7 +41,7 @@
     "@uiw/react-codemirror": "^4.19.1",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.7",
-    "echarts": "npm:echarts-nightly@5.5.0-dev.20230517",
+    "echarts": "^5.4.3",
     "lodash": "^4.17.21",
     "mathjs": "^10.6.4",
     "mdi-material-ui": "^7.4.0",

--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -128,7 +128,14 @@ export const EChart = React.memo(function EChart<T>({
   // Initialize chart, dispose on unmount
   useLayoutEffect(() => {
     if (containerRef.current === null || chartElement.current !== null) return;
-    chartElement.current = init(containerRef.current, theme, { renderer: renderer ?? 'canvas' });
+
+    try {
+      chartElement.current = init(containerRef.current, theme, { renderer: renderer ?? 'canvas' });
+    } catch (error) {
+      console.error('Error initializing ECharts: ', error);
+      return;
+    }
+
     if (chartElement.current === undefined) return;
     chartElement.current.setOption(initialOption.current, true);
     onChartInitialized?.(chartElement.current);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -130,7 +130,7 @@
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.7",
-        "echarts": "npm:echarts-nightly@5.5.0-dev.20230517",
+        "echarts": "^5.4.3",
         "lodash": "^4.17.21",
         "mathjs": "^10.6.4",
         "mdi-material-ui": "^7.4.0",
@@ -145,6 +145,28 @@
         "@mui/material": "^5.10.0",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "components/node_modules/echarts": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.4.4"
+      }
+    },
+    "components/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "components/node_modules/zrender": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     },
     "core": {
@@ -13447,21 +13469,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/echarts": {
-      "name": "echarts-nightly",
-      "version": "5.5.0-dev.20230517",
-      "resolved": "https://registry.npmjs.org/echarts-nightly/-/echarts-nightly-5.5.0-dev.20230517.tgz",
-      "integrity": "sha512-TrwaACfwxeD6lRkj/Pz7w4YutlJ16oialy7iz9Wff/ri4hXDqvROOtP2WiDoG53N/c/iKPk4HA4eqLm0Tj6pqQ==",
-      "dependencies": {
-        "tslib": "2.3.0",
-        "zrender": "npm:zrender-nightly@^5.5.0-dev.20230517"
-      }
-    },
-    "node_modules/echarts/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -26624,20 +26631,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/zrender": {
-      "name": "zrender-nightly",
-      "version": "5.5.0-dev.20230517",
-      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.5.0-dev.20230517.tgz",
-      "integrity": "sha512-8/cPfChxHqgS1kqWcaGauQYH8+EEtjmMYLWko4EYyuh0OOGZqEzTBOibnh+A73eh+JSQDfD5G0jSxN6Ynz17HQ==",
-      "dependencies": {
-        "tslib": "2.3.0"
-      }
-    },
-    "node_modules/zrender/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-    },
     "node_modules/zustand": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.3.tgz",
@@ -26682,7 +26675,7 @@
         "color-hash": "^2.0.2",
         "date-fns": "^2.28.0",
         "dompurify": "^2.4.0",
-        "echarts": "npm:echarts-nightly@5.5.0-dev.20230517",
+        "echarts": "^5.4.3",
         "immer": "^9.0.15",
         "lodash": "^4.17.21",
         "marked": "^4.2.12"
@@ -26697,6 +26690,28 @@
         "@mui/material": "^5.10.0",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "panels-plugin/node_modules/echarts": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.4.4"
+      }
+    },
+    "panels-plugin/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "panels-plugin/node_modules/zrender": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     },
     "plugin-system": {
@@ -29800,13 +29815,37 @@
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.7",
-        "echarts": "npm:echarts-nightly@5.5.0-dev.20230517",
+        "echarts": "^5.4.3",
         "lodash": "^4.17.21",
         "mathjs": "^10.6.4",
         "mdi-material-ui": "^7.4.0",
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
         "react-virtuoso": "^4.3.6"
+      },
+      "dependencies": {
+        "echarts": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+          "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+          "requires": {
+            "tslib": "2.3.0",
+            "zrender": "5.4.4"
+          }
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        },
+        "zrender": {
+          "version": "5.4.4",
+          "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+          "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+          "requires": {
+            "tslib": "2.3.0"
+          }
+        }
       }
     },
     "@perses-dev/core": {
@@ -29873,10 +29912,34 @@
         "color-hash": "^2.0.2",
         "date-fns": "^2.28.0",
         "dompurify": "^2.4.0",
-        "echarts": "npm:echarts-nightly@5.5.0-dev.20230517",
+        "echarts": "^5.4.3",
         "immer": "^9.0.15",
         "lodash": "^4.17.21",
         "marked": "^4.2.12"
+      },
+      "dependencies": {
+        "echarts": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+          "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+          "requires": {
+            "tslib": "2.3.0",
+            "zrender": "5.4.4"
+          }
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        },
+        "zrender": {
+          "version": "5.4.4",
+          "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+          "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+          "requires": {
+            "tslib": "2.3.0"
+          }
+        }
       }
     },
     "@perses-dev/plugin-system": {
@@ -36665,22 +36728,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "echarts": {
-      "version": "npm:echarts-nightly@5.5.0-dev.20230517",
-      "resolved": "https://registry.npmjs.org/echarts-nightly/-/echarts-nightly-5.5.0-dev.20230517.tgz",
-      "integrity": "sha512-TrwaACfwxeD6lRkj/Pz7w4YutlJ16oialy7iz9Wff/ri4hXDqvROOtP2WiDoG53N/c/iKPk4HA4eqLm0Tj6pqQ==",
-      "requires": {
-        "tslib": "2.3.0",
-        "zrender": "npm:zrender-nightly@^5.5.0-dev.20230517"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-        }
       }
     },
     "ee-first": {
@@ -46464,21 +46511,6 @@
         "archiver-utils": "^2.1.0",
         "compress-commons": "^4.1.0",
         "readable-stream": "^3.6.0"
-      }
-    },
-    "zrender": {
-      "version": "npm:zrender-nightly@5.5.0-dev.20230517",
-      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.5.0-dev.20230517.tgz",
-      "integrity": "sha512-8/cPfChxHqgS1kqWcaGauQYH8+EEtjmMYLWko4EYyuh0OOGZqEzTBOibnh+A73eh+JSQDfD5G0jSxN6Ynz17HQ==",
-      "requires": {
-        "tslib": "2.3.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-        }
       }
     },
     "zustand": {

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -35,7 +35,7 @@
     "color-hash": "^2.0.2",
     "date-fns": "^2.28.0",
     "dompurify": "^2.4.0",
-    "echarts": "npm:echarts-nightly@5.5.0-dev.20230517",
+    "echarts": "^5.4.3",
     "immer": "^9.0.15",
     "lodash": "^4.17.21",
     "marked": "^4.2.12"


### PR DESCRIPTION
ECharts 5.4.3 is released now! https://github.com/apache/echarts/releases/tag/5.4.3

This includes Julie's PR here: https://github.com/apache/echarts/pull/18524
Allows us to continue iterating on our custom highlighting in TimeSeriesChart panel using their official release instead of echarts-nightly