### PR TITLE
[IGNORE] Cleanup jest warnings in dashboards package

### DIFF
--- a/ui/dashboards/src/test/render.tsx
+++ b/ui/dashboards/src/test/render.tsx
@@ -20,6 +20,8 @@ import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ChartsProvider, SnackbarProvider, testChartsTheme } from '@perses-dev/components';
 import { mockPluginRegistry, PluginRegistry } from '@perses-dev/plugin-system';
+import { DatasourceStoreProvider } from '../context';
+import { defaultDatasourceProps } from '../test';
 import { MOCK_PLUGINS } from './plugin-registry';
 
 interface CustomRouterProps {
@@ -65,7 +67,9 @@ export function renderWithContext(
         <QueryParamProvider adapter={ReactRouter6Adapter}>
           <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
             <ChartsProvider chartsTheme={testChartsTheme}>
-              <PluginRegistry {...mockPluginRegistry(...MOCK_PLUGINS)}>{ui}</PluginRegistry>
+              <PluginRegistry {...mockPluginRegistry(...MOCK_PLUGINS)}>
+                <DatasourceStoreProvider {...defaultDatasourceProps}>{ui}</DatasourceStoreProvider>
+              </PluginRegistry>
             </ChartsProvider>
           </SnackbarProvider>
         </QueryParamProvider>


### PR DESCRIPTION
Add DatasourceStoreProvider in dashboards package test context helper to fix all the warnings in console when running unit tests

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
