### PR TITLE
[FEATURE] Global Datasource CRUD + DRY refactoring

### DIFF
--- a/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
@@ -20,6 +20,7 @@ import {
   GridToolbarFilterButton,
   GridToolbarQuickFilter,
   GridRow,
+  GridRowParams,
   GridColumnHeaders,
 } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
@@ -42,7 +43,7 @@ const MemoizedRow = memo(GridRow);
 const MemoizedColumnHeaders = memo(GridColumnHeaders);
 
 export interface Row {
-  project: string;
+  project?: string;
   name: string;
   displayName: string;
   version: number;
@@ -81,7 +82,7 @@ export interface DatasourceDataGridProperties {
   initialState?: GridInitialStateCommunity;
   hideToolbar?: boolean;
   isLoading?: boolean;
-  onRowClick: (project: string, name: string) => void;
+  onRowClick: (params: GridRowParams) => void;
 }
 
 export function DatasourceDataGrid(props: DatasourceDataGridProperties) {
@@ -99,9 +100,7 @@ export function DatasourceDataGrid(props: DatasourceDataGridProperties) {
     <DataGrid
       disableRowSelectionOnClick
       autoHeight={true}
-      onRowClick={(params) => {
-        onRowClick(params.row.project, params.row.name);
-      }}
+      onRowClick={onRowClick}
       rows={rows}
       columns={columns}
       getRowId={(row) => row.name}

--- a/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDataGrid.tsx
@@ -20,7 +20,6 @@ import {
   GridToolbarFilterButton,
   GridToolbarQuickFilter,
   GridRow,
-  GridRowParams,
   GridColumnHeaders,
 } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
@@ -82,7 +81,7 @@ export interface DatasourceDataGridProperties {
   initialState?: GridInitialStateCommunity;
   hideToolbar?: boolean;
   isLoading?: boolean;
-  onRowClick: (params: GridRowParams) => void;
+  onRowClick: (name: string, project?: string) => void;
 }
 
 export function DatasourceDataGrid(props: DatasourceDataGridProperties) {
@@ -100,7 +99,9 @@ export function DatasourceDataGrid(props: DatasourceDataGridProperties) {
     <DataGrid
       disableRowSelectionOnClick
       autoHeight={true}
-      onRowClick={onRowClick}
+      onRowClick={(params) => {
+        onRowClick(params.row.name, params.row.project);
+      }}
       rows={rows}
       columns={columns}
       getRowId={(row) => row.name}

--- a/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
@@ -11,17 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource } from '@perses-dev/core';
+import { Datasource, GlobalDatasource } from '@perses-dev/core';
 import { DispatchWithoutAction, useCallback, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
-import { DeleteDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
-import { DatasourceEditorForm } from './DatasourceEditorForm';
+import { DeleteGlobalDatasourceDialog, DeleteProjectDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
+import { GlobalDatasourceEditorForm, ProjectDatasourceEditorForm } from './DatasourceEditorForm';
 
 export type ActionStr = 'Create' | 'Update';
 
-interface DatasourceDrawerProps {
+interface ProjectDatasourceDrawerProps {
   datasource: Datasource;
   isOpen: boolean;
   saveActionStr: ActionStr;
@@ -29,7 +29,7 @@ interface DatasourceDrawerProps {
   onClose: DispatchWithoutAction;
 }
 
-export function DatasourceDrawer(props: DatasourceDrawerProps) {
+export function ProjectDatasourceDrawer(props: ProjectDatasourceDrawerProps) {
   const { datasource, isOpen, saveActionStr, onSave, onClose } = props;
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
 
@@ -52,7 +52,7 @@ export function DatasourceDrawer(props: DatasourceDrawerProps) {
           }}
         >
           {isOpen && (
-            <DatasourceEditorForm
+            <ProjectDatasourceEditorForm
               initialDatasource={datasource}
               saveActionStr={saveActionStr}
               onSave={onSave}
@@ -61,7 +61,57 @@ export function DatasourceDrawer(props: DatasourceDrawerProps) {
             />
           )}
         </PluginRegistry>
-        <DeleteDatasourceDialog
+        <DeleteProjectDatasourceDialog
+          open={isDeleteDatasourceDialogStateOpened}
+          onClose={() => setDeleteDatasourceDialogStateOpened(false)}
+          onDelete={onClose}
+          datasource={datasource}
+        />
+      </ErrorBoundary>
+    </Drawer>
+  );
+}
+interface GlobalDatasourceDrawerProps {
+  datasource: GlobalDatasource;
+  isOpen: boolean;
+  saveActionStr: ActionStr;
+  onSave: (datasource: GlobalDatasource) => void;
+  onClose: DispatchWithoutAction;
+}
+
+export function GlobalDatasourceDrawer(props: GlobalDatasourceDrawerProps) {
+  const { datasource, isOpen, saveActionStr, onSave, onClose } = props;
+  const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
+
+  // When user clicks out of the drawer, do not close it, just do nothing
+  // This is a quick-win solution to avoid losing draft changes
+  // -> TODO allow closing by clicking-out without being too sensitive to missclicks
+  const handleClickOut = useCallback(() => {
+    return;
+  }, []);
+
+  return (
+    <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">
+      <ErrorBoundary FallbackComponent={ErrorAlert}>
+        <PluginRegistry
+          pluginLoader={bundledPluginLoader}
+          // TODO this required field is useless here
+          defaultPluginKinds={{
+            Panel: 'TimeSeriesChart',
+            TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+          }}
+        >
+          {isOpen && (
+            <GlobalDatasourceEditorForm
+              initialDatasource={datasource}
+              saveActionStr={saveActionStr}
+              onSave={onSave}
+              onClose={onClose}
+              onDelete={saveActionStr == 'Update' ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
+            />
+          )}
+        </PluginRegistry>
+        <DeleteGlobalDatasourceDialog
           open={isDeleteDatasourceDialogStateOpened}
           onClose={() => setDeleteDatasourceDialogStateOpened(false)}
           onDelete={onClose}

--- a/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useImmer } from 'use-immer';
-import { Datasource, Display } from '@perses-dev/core';
+import { Datasource, Display, GlobalDatasource } from '@perses-dev/core';
 import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
 import { DispatchWithoutAction, useCallback, useMemo, useState } from 'react';
 import { PluginEditor } from '@perses-dev/plugin-system';
@@ -20,7 +20,7 @@ import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import { useIsReadonly } from '../../model/config-client';
 
 // TODO: Replace with proper validation library
-function getValidation(state: Datasource) {
+function getValidation(state: Datasource | GlobalDatasource) {
   /** Name validation */
   let name = null;
   if (!state.metadata.name) {
@@ -38,7 +38,8 @@ function getValidation(state: Datasource) {
 }
 
 // this preprocessing ensure that we always have a defined object for the `display` property:
-function getInitialState(datasource: Datasource): Datasource {
+// TODO code duplication
+function getPatchedInitialProjectDs(datasource: Datasource): Datasource {
   const patchedDisplay: Display = {
     name: '',
     description: '',
@@ -60,7 +61,7 @@ function getInitialState(datasource: Datasource): Datasource {
   };
 }
 
-interface DatasourceEditorFormProps {
+interface ProjectDatasourceEditorFormProps {
   initialDatasource: Datasource;
   saveActionStr: string;
   onSave: (datasource: Datasource) => void;
@@ -68,12 +69,14 @@ interface DatasourceEditorFormProps {
   onDelete: DispatchWithoutAction | undefined;
 }
 
-export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
+// TODO code duplication
+export function ProjectDatasourceEditorForm(props: ProjectDatasourceEditorFormProps) {
   const { initialDatasource, saveActionStr, onSave, onClose, onDelete } = props;
+
+  const patchedInitialDatasource = getPatchedInitialProjectDs(initialDatasource);
+  const [state, setState] = useImmer(patchedInitialDatasource);
   const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
   const isReadonly = useIsReadonly();
-  const initialState = getInitialState(initialDatasource);
-  const [state, setState] = useImmer(initialState);
   const validation = useMemo(() => getValidation(state), [state]);
 
   // When saving, remove the display property if ever display.name is empty, then pass the value upstream
@@ -89,12 +92,204 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
 
   // When the user clicks on cancel, ask for discard approval if anything was changed
   const handleCancel = useCallback(() => {
-    if (JSON.stringify(initialState) !== JSON.stringify(state)) {
+    if (JSON.stringify(initialDatasource) !== JSON.stringify(state)) {
       setDiscardDialogStateOpened(true);
     } else {
       onClose();
     }
-  }, [state, initialState, setDiscardDialogStateOpened, onClose]);
+  }, [state, initialDatasource, setDiscardDialogStateOpened, onClose]);
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: (theme) => theme.spacing(1, 2),
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Typography variant="h2">{saveActionStr} Datasource</Typography>
+        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
+          <Button disabled={isReadonly || !validation.isValid} variant="contained" onClick={handleSave}>
+            {saveActionStr}
+          </Button>
+          <Button color="secondary" variant="outlined" onClick={handleCancel}>
+            Cancel
+          </Button>
+          {onDelete && (
+            <Button disabled={isReadonly} color="error" variant="outlined" onClick={onDelete}>
+              Delete
+            </Button>
+          )}
+        </Stack>
+      </Box>
+      <Box padding={2} sx={{ overflowY: 'scroll' }}>
+        <Grid container spacing={2} mb={2}>
+          <Grid item xs={4}>
+            <TextField
+              required
+              error={!!validation.name}
+              fullWidth
+              label="Name"
+              value={state.metadata.name}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              helperText={validation.name}
+              onChange={(v) => {
+                setState((draft) => {
+                  draft.metadata.name = v.target.value;
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={8}>
+            <TextField
+              fullWidth
+              label="Display Label"
+              value={state.spec.display?.name}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              onChange={(v) => {
+                setState((draft) => {
+                  if (draft.spec.display) {
+                    draft.spec.display.name = v.target.value;
+                  }
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              label="Description"
+              value={state.spec.display?.description}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              onChange={(v) => {
+                setState((draft) => {
+                  if (draft.spec.display) {
+                    draft.spec.display.description = v.target.value;
+                  }
+                });
+              }}
+            />
+          </Grid>
+          <Grid item xs={6} sx={{ paddingTop: '5px !important' }}>
+            <Stack>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={state.spec.default}
+                    readOnly={isReadonly}
+                    onChange={(v) => {
+                      setState((draft) => {
+                        draft.spec.default = v.target.checked;
+                      });
+                    }}
+                  />
+                }
+                label="Set as default"
+              />
+              <Typography variant="caption">
+                Whether this datasource should be the default {state.spec.plugin.kind} to be used
+              </Typography>
+            </Stack>
+          </Grid>
+        </Grid>
+        <Divider />
+        <Typography py={1} variant="subtitle1">
+          Plugin Options
+        </Typography>
+        <PluginEditor
+          width="100%"
+          pluginType="Datasource"
+          pluginKindLabel="Source"
+          value={state.spec.plugin}
+          isReadonly={isReadonly}
+          onChange={(v) => {
+            setState((draft) => {
+              draft.spec.plugin = v;
+            });
+          }}
+        />
+      </Box>
+      <DiscardChangesConfirmationDialog
+        description="Are you sure you want to discard your changes? Changes cannot be recovered."
+        isOpen={isDiscardDialogStateOpened}
+        onCancel={() => setDiscardDialogStateOpened(false)}
+        onDiscardChanges={() => {
+          setDiscardDialogStateOpened(false);
+          onClose();
+        }}
+      />
+    </>
+  );
+}
+
+// this preprocessing ensure that we always have a defined object for the `display` property:
+// TODO code duplication
+function getPatchedInitialGlobalDs(datasource: GlobalDatasource): GlobalDatasource {
+  const patchedDisplay: Display = {
+    name: '',
+    description: '',
+  };
+
+  if (datasource.spec.display) {
+    patchedDisplay.name = datasource.spec.display.name;
+    if (datasource.spec.display.description) {
+      patchedDisplay.description = datasource.spec.display.description;
+    }
+  }
+
+  return {
+    ...datasource,
+    spec: {
+      ...datasource.spec,
+      display: patchedDisplay,
+    },
+  };
+}
+
+interface GlobalDatasourceEditorFormProps {
+  initialDatasource: GlobalDatasource;
+  saveActionStr: string;
+  onSave: (datasource: GlobalDatasource) => void;
+  onClose: DispatchWithoutAction;
+  onDelete: DispatchWithoutAction | undefined;
+}
+
+// TODO code duplication
+export function GlobalDatasourceEditorForm(props: GlobalDatasourceEditorFormProps) {
+  const { initialDatasource, saveActionStr, onSave, onClose, onDelete } = props;
+
+  const patchedInitialDatasource = getPatchedInitialGlobalDs(initialDatasource);
+  const [state, setState] = useImmer(patchedInitialDatasource);
+  const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
+  const isReadonly = useIsReadonly();
+  const validation = useMemo(() => getValidation(state), [state]);
+
+  // When saving, remove the display property if ever display.name is empty, then pass the value upstream
+  const handleSave = () => {
+    onSave({
+      ...state,
+      spec: {
+        ...state.spec,
+        display: state.spec.display?.name !== '' ? state.spec.display : undefined,
+      },
+    });
+  };
+
+  // When the user clicks on cancel, ask for discard approval if anything was changed
+  const handleCancel = useCallback(() => {
+    if (JSON.stringify(initialDatasource) !== JSON.stringify(state)) {
+      setDiscardDialogStateOpened(true);
+    } else {
+      onClose();
+    }
+  }, [state, initialDatasource, setDiscardDialogStateOpened, onClose]);
 
   return (
     <>

--- a/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
@@ -12,15 +12,15 @@
 // limitations under the License.
 
 import { useImmer } from 'use-immer';
-import { Datasource, Display, GlobalDatasource } from '@perses-dev/core';
+import { Display, Datasource } from '@perses-dev/core';
 import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
-import { DispatchWithoutAction, useCallback, useMemo, useState } from 'react';
+import { Dispatch, DispatchWithoutAction, useCallback, useMemo, useState } from 'react';
 import { PluginEditor } from '@perses-dev/plugin-system';
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import { useIsReadonly } from '../../model/config-client';
 
 // TODO: Replace with proper validation library
-function getValidation(state: Datasource | GlobalDatasource) {
+function getValidation(state: Datasource) {
   /** Name validation */
   let name = null;
   if (!state.metadata.name) {
@@ -37,9 +37,11 @@ function getValidation(state: Datasource | GlobalDatasource) {
   };
 }
 
-// this preprocessing ensure that we always have a defined object for the `display` property:
-// TODO code duplication
-function getPatchedInitialProjectDs(datasource: Datasource): Datasource {
+/**
+ * This preprocessing ensures that we always have a defined object for the `display` property
+ * @param datasource
+ */
+function getInitialState<T extends Datasource>(datasource: T): T {
   const patchedDisplay: Display = {
     name: '',
     description: '',
@@ -61,19 +63,18 @@ function getPatchedInitialProjectDs(datasource: Datasource): Datasource {
   };
 }
 
-interface ProjectDatasourceEditorFormProps {
-  initialDatasource: Datasource;
+interface DatasourceEditorFormProps<T extends Datasource> {
+  initialDatasource: T;
   saveActionStr: string;
-  onSave: (datasource: Datasource) => void;
+  onSave: Dispatch<T>;
   onClose: DispatchWithoutAction;
-  onDelete: DispatchWithoutAction | undefined;
+  onDelete?: DispatchWithoutAction;
 }
 
-// TODO code duplication
-export function ProjectDatasourceEditorForm(props: ProjectDatasourceEditorFormProps) {
+export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEditorFormProps<T>) {
   const { initialDatasource, saveActionStr, onSave, onClose, onDelete } = props;
 
-  const patchedInitialDatasource = getPatchedInitialProjectDs(initialDatasource);
+  const patchedInitialDatasource = getInitialState(initialDatasource);
   const [state, setState] = useImmer(patchedInitialDatasource);
   const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
   const isReadonly = useIsReadonly();
@@ -92,205 +93,12 @@ export function ProjectDatasourceEditorForm(props: ProjectDatasourceEditorFormPr
 
   // When the user clicks on cancel, ask for discard approval if anything was changed
   const handleCancel = useCallback(() => {
-    if (JSON.stringify(initialDatasource) !== JSON.stringify(state)) {
+    if (JSON.stringify(patchedInitialDatasource) !== JSON.stringify(state)) {
       setDiscardDialogStateOpened(true);
     } else {
       onClose();
     }
-  }, [state, initialDatasource, setDiscardDialogStateOpened, onClose]);
-  return (
-    <>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          padding: (theme) => theme.spacing(1, 2),
-          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-        }}
-      >
-        <Typography variant="h2">{saveActionStr} Datasource</Typography>
-        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          <Button disabled={isReadonly || !validation.isValid} variant="contained" onClick={handleSave}>
-            {saveActionStr}
-          </Button>
-          <Button color="secondary" variant="outlined" onClick={handleCancel}>
-            Cancel
-          </Button>
-          {onDelete && (
-            <Button disabled={isReadonly} color="error" variant="outlined" onClick={onDelete}>
-              Delete
-            </Button>
-          )}
-        </Stack>
-      </Box>
-      <Box padding={2} sx={{ overflowY: 'scroll' }}>
-        <Grid container spacing={2} mb={2}>
-          <Grid item xs={4}>
-            <TextField
-              required
-              error={!!validation.name}
-              fullWidth
-              label="Name"
-              value={state.metadata.name}
-              InputProps={{
-                readOnly: isReadonly,
-              }}
-              helperText={validation.name}
-              onChange={(v) => {
-                setState((draft) => {
-                  draft.metadata.name = v.target.value;
-                });
-              }}
-            />
-          </Grid>
-          <Grid item xs={8}>
-            <TextField
-              fullWidth
-              label="Display Label"
-              value={state.spec.display?.name}
-              InputProps={{
-                readOnly: isReadonly,
-              }}
-              onChange={(v) => {
-                setState((draft) => {
-                  if (draft.spec.display) {
-                    draft.spec.display.name = v.target.value;
-                  }
-                });
-              }}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <TextField
-              fullWidth
-              label="Description"
-              value={state.spec.display?.description}
-              InputProps={{
-                readOnly: isReadonly,
-              }}
-              onChange={(v) => {
-                setState((draft) => {
-                  if (draft.spec.display) {
-                    draft.spec.display.description = v.target.value;
-                  }
-                });
-              }}
-            />
-          </Grid>
-          <Grid item xs={6} sx={{ paddingTop: '5px !important' }}>
-            <Stack>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={state.spec.default}
-                    readOnly={isReadonly}
-                    onChange={(v) => {
-                      setState((draft) => {
-                        draft.spec.default = v.target.checked;
-                      });
-                    }}
-                  />
-                }
-                label="Set as default"
-              />
-              <Typography variant="caption">
-                Whether this datasource should be the default {state.spec.plugin.kind} to be used
-              </Typography>
-            </Stack>
-          </Grid>
-        </Grid>
-        <Divider />
-        <Typography py={1} variant="subtitle1">
-          Plugin Options
-        </Typography>
-        <PluginEditor
-          width="100%"
-          pluginType="Datasource"
-          pluginKindLabel="Source"
-          value={state.spec.plugin}
-          isReadonly={isReadonly}
-          onChange={(v) => {
-            setState((draft) => {
-              draft.spec.plugin = v;
-            });
-          }}
-        />
-      </Box>
-      <DiscardChangesConfirmationDialog
-        description="Are you sure you want to discard your changes? Changes cannot be recovered."
-        isOpen={isDiscardDialogStateOpened}
-        onCancel={() => setDiscardDialogStateOpened(false)}
-        onDiscardChanges={() => {
-          setDiscardDialogStateOpened(false);
-          onClose();
-        }}
-      />
-    </>
-  );
-}
-
-// this preprocessing ensure that we always have a defined object for the `display` property:
-// TODO code duplication
-function getPatchedInitialGlobalDs(datasource: GlobalDatasource): GlobalDatasource {
-  const patchedDisplay: Display = {
-    name: '',
-    description: '',
-  };
-
-  if (datasource.spec.display) {
-    patchedDisplay.name = datasource.spec.display.name;
-    if (datasource.spec.display.description) {
-      patchedDisplay.description = datasource.spec.display.description;
-    }
-  }
-
-  return {
-    ...datasource,
-    spec: {
-      ...datasource.spec,
-      display: patchedDisplay,
-    },
-  };
-}
-
-interface GlobalDatasourceEditorFormProps {
-  initialDatasource: GlobalDatasource;
-  saveActionStr: string;
-  onSave: (datasource: GlobalDatasource) => void;
-  onClose: DispatchWithoutAction;
-  onDelete: DispatchWithoutAction | undefined;
-}
-
-// TODO code duplication
-export function GlobalDatasourceEditorForm(props: GlobalDatasourceEditorFormProps) {
-  const { initialDatasource, saveActionStr, onSave, onClose, onDelete } = props;
-
-  const patchedInitialDatasource = getPatchedInitialGlobalDs(initialDatasource);
-  const [state, setState] = useImmer(patchedInitialDatasource);
-  const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
-  const isReadonly = useIsReadonly();
-  const validation = useMemo(() => getValidation(state), [state]);
-
-  // When saving, remove the display property if ever display.name is empty, then pass the value upstream
-  const handleSave = () => {
-    onSave({
-      ...state,
-      spec: {
-        ...state.spec,
-        display: state.spec.display?.name !== '' ? state.spec.display : undefined,
-      },
-    });
-  };
-
-  // When the user clicks on cancel, ask for discard approval if anything was changed
-  const handleCancel = useCallback(() => {
-    if (JSON.stringify(initialDatasource) !== JSON.stringify(state)) {
-      setDiscardDialogStateOpened(true);
-    } else {
-      onClose();
-    }
-  }, [state, initialDatasource, setDiscardDialogStateOpened, onClose]);
-
+  }, [state, patchedInitialDatasource, setDiscardDialogStateOpened, onClose]);
   return (
     <>
       <Box

--- a/ui/app/src/components/DatasourceList/DatasourceList.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceList.tsx
@@ -11,22 +11,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource, getDatasourceDisplayName, getDatasourceExtendedDisplayName } from '@perses-dev/core';
+import {
+  Datasource,
+  GlobalDatasource,
+  getDatasourceDisplayName,
+  getDatasourceExtendedDisplayName,
+} from '@perses-dev/core';
 import { Stack, Tooltip } from '@mui/material';
-import { GridColDef, GridValueGetterParams } from '@mui/x-data-grid';
+import { GridColDef, GridRowParams, GridValueGetterParams } from '@mui/x-data-grid';
 import { useCallback, useMemo, useState } from 'react';
 import { intlFormatDistance } from 'date-fns';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
 import { useSnackbar } from '@perses-dev/components';
+import {
+  useCreateGlobalDatasourceMutation,
+  useDeleteGlobalDatasourceMutation,
+  useUpdateGlobalDatasourceMutation,
+} from '../../model/admin-client';
 import {
   useCreateDatasourceMutation,
   useDeleteDatasourceMutation,
   useUpdateDatasourceMutation,
 } from '../../model/datasource-client';
 import { DatasourceDataGrid, Row } from './DatasourceDataGrid';
-import { DatasourceDrawer } from './DatasourceDrawer';
+import { GlobalDatasourceDrawer, ProjectDatasourceDrawer } from './DatasourceDrawer';
 
-export interface DatasourceListProperties {
+export interface ProjectDatasourceListProperties {
   projectName: string;
   datasourceList: Datasource[];
   hideToolbar?: boolean;
@@ -41,7 +51,7 @@ export interface DatasourceListProperties {
  * @param props.initialState Provide a way to override default initialState
  * @param props.isLoading Display a loading circle if enableds
  */
-export function DatasourceList(props: DatasourceListProperties) {
+export function ProjectDatasourceList(props: ProjectDatasourceListProperties) {
   const { projectName, datasourceList, hideToolbar, initialState, isLoading } = props;
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
@@ -97,7 +107,7 @@ export function DatasourceList(props: DatasourceListProperties) {
         deleteDatasourceMutation.mutate(targetedDatasource, {
           onSuccess: (deletedDatasource: Datasource) => {
             successSnackbar(
-              `Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} was successfully deleted`
+              `Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} has been successfully deleted`
             );
             setEditDatasourceFormStateOpened(false);
           },
@@ -130,8 +140,8 @@ export function DatasourceList(props: DatasourceListProperties) {
   );
 
   const onRowClick = useCallback(
-    (project: string, name: string) => {
-      setTargetedDatasource(getDatasource(project, name));
+    (params: GridRowParams) => {
+      setTargetedDatasource(getDatasource(params.row.project, params.row.name));
       setEditDatasourceFormStateOpened(true);
     },
     [getDatasource]
@@ -199,7 +209,189 @@ export function DatasourceList(props: DatasourceListProperties) {
         onRowClick={onRowClick}
       />
       {targetedDatasource && (
-        <DatasourceDrawer
+        <ProjectDatasourceDrawer
+          datasource={targetedDatasource}
+          isOpen={isEditDatasourceFormStateOpened}
+          saveActionStr="Update"
+          onSave={handleDatasourceUpdate}
+          onClose={() => setEditDatasourceFormStateOpened(false)}
+        />
+      )}
+    </Stack>
+  );
+}
+
+export interface GlobalDatasourceListProperties {
+  datasourceList: GlobalDatasource[];
+  hideToolbar?: boolean;
+  initialState?: GridInitialStateCommunity;
+  isLoading?: boolean;
+}
+
+/**
+ * Display datasources in a table style.
+ * @param props.datasourceList Contains all datasources to display
+ * @param props.hideToolbar Hide toolbar if enabled
+ * @param props.initialState Provide a way to override default initialState
+ * @param props.isLoading Display a loading circle if enableds
+ */
+export function GlobalDatasourceList(props: GlobalDatasourceListProperties) {
+  const { datasourceList, hideToolbar, initialState, isLoading } = props;
+
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createDatasourceMutation = useCreateGlobalDatasourceMutation();
+  const deleteDatasourceMutation = useDeleteGlobalDatasourceMutation();
+  const updateDatasourceMutation = useUpdateGlobalDatasourceMutation();
+
+  const getDatasource = useCallback(
+    (name: string) => {
+      return datasourceList.find((datasource) => datasource.metadata.name === name);
+    },
+    [datasourceList]
+  );
+
+  const rows = useMemo(() => {
+    return datasourceList.map(
+      (datasource) =>
+        ({
+          name: datasource.metadata.name,
+          displayName: getDatasourceDisplayName(datasource),
+          version: datasource.metadata.version,
+          createdAt: datasource.metadata.created_at,
+          updatedAt: datasource.metadata.updated_at,
+          type: datasource.spec.plugin.kind,
+        } as Row)
+    );
+  }, [datasourceList]);
+
+  const [targetedDatasource, setTargetedDatasource] = useState<GlobalDatasource>();
+  const [isEditDatasourceFormStateOpened, setEditDatasourceFormStateOpened] = useState<boolean>(false);
+
+  const handleDatasourceUpdate = useCallback(
+    (datasource: GlobalDatasource) => {
+      if (targetedDatasource != undefined && datasource.metadata.name != targetedDatasource.metadata.name) {
+        // In this case "move" the datasource, aka create it with the new name & remove the former one
+        // We do this because we can't just do a PUT call in that case (results in "document not found" error)
+        // TODO: create + delete calls should be bundled together so that we avoid the case where only one would succeed
+        createDatasourceMutation.mutate(datasource, {
+          onSuccess: (createdDatasource: GlobalDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceExtendedDisplayName(createdDatasource)} has been successfully created`
+            );
+            setEditDatasourceFormStateOpened(false);
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            throw err;
+          },
+        });
+        deleteDatasourceMutation.mutate(targetedDatasource, {
+          onSuccess: (deletedDatasource: GlobalDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} has been successfully deleted`
+            );
+            setEditDatasourceFormStateOpened(false);
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            throw err;
+          },
+        });
+      } else {
+        updateDatasourceMutation.mutate(datasource, {
+          onSuccess: (updatedDatasource: GlobalDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`
+            );
+            setEditDatasourceFormStateOpened(false);
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            throw err;
+          },
+        });
+      }
+    },
+    [
+      exceptionSnackbar,
+      successSnackbar,
+      createDatasourceMutation,
+      deleteDatasourceMutation,
+      updateDatasourceMutation,
+      targetedDatasource,
+    ]
+  );
+
+  const onRowClick = useCallback(
+    (params: GridRowParams) => {
+      setTargetedDatasource(getDatasource(params.row.name));
+      setEditDatasourceFormStateOpened(true);
+    },
+    [getDatasource]
+  );
+
+  const columns = useMemo<Array<GridColDef<Row>>>(
+    () => [
+      { field: 'type', headerName: 'Type', type: 'string', flex: 2 },
+      {
+        field: 'name',
+        headerName: 'Name',
+        type: 'string',
+        flex: 2,
+        renderCell: (params) => <pre>{params.value}</pre>,
+      },
+      { field: 'displayName', headerName: 'Display Name', type: 'string', flex: 3, minWidth: 150 },
+      {
+        field: 'version',
+        headerName: 'Version',
+        type: 'number',
+        align: 'right',
+        headerAlign: 'right',
+        flex: 1,
+        minWidth: 80,
+      },
+      {
+        field: 'createdAt',
+        headerName: 'Creation Date',
+        type: 'dateTime',
+        flex: 1,
+        minWidth: 125,
+        valueGetter: (params: GridValueGetterParams) => new Date(params.row.createdAt),
+        renderCell: (params) => (
+          <Tooltip title={params.value.toUTCString()} placement="top">
+            <span>{intlFormatDistance(params.value, new Date())}</span>
+          </Tooltip>
+        ),
+      },
+      {
+        field: 'updatedAt',
+        headerName: 'Last Update',
+        type: 'dateTime',
+        flex: 1,
+        minWidth: 125,
+        valueGetter: (params: GridValueGetterParams) => new Date(params.row.updatedAt),
+        renderCell: (params) => (
+          <Tooltip title={params.value.toUTCString()} placement="top">
+            <span>{intlFormatDistance(params.value, new Date())}</span>
+          </Tooltip>
+        ),
+      },
+    ],
+    []
+  );
+
+  return (
+    <Stack width="100%">
+      <DatasourceDataGrid
+        rows={rows}
+        columns={columns}
+        initialState={initialState}
+        hideToolbar={hideToolbar}
+        isLoading={isLoading}
+        onRowClick={onRowClick}
+      />
+      {targetedDatasource && (
+        <GlobalDatasourceDrawer
           datasource={targetedDatasource}
           isOpen={isEditDatasourceFormStateOpened}
           saveActionStr="Update"

--- a/ui/app/src/components/VariableList/VariablesList.tsx
+++ b/ui/app/src/components/VariableList/VariablesList.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getVariableDisplayName, getVariableProject, Variable } from '@perses-dev/core';
+import { DispatchWithPromise, getVariableDisplayName, getVariableProject, Variable } from '@perses-dev/core';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
 import React, { useCallback, useMemo, useState } from 'react';
 import { GridActionsCellItem, GridColDef, GridRowParams, GridValueGetterParams } from '@mui/x-data-grid';
@@ -25,8 +25,6 @@ import { useIsReadonly } from '../../model/config-client';
 import { DeleteVariableDialog } from '../dialogs';
 import { VariableDataGrid, Row } from './VariableDataGrid';
 import { VariableFormDrawer } from './VariableFormDrawer';
-
-type DispatchWithPromise<A> = (value: A) => Promise<void>;
 
 export interface VariableListProperties<T extends Variable> {
   data: T[];

--- a/ui/app/src/components/dialogs/DeleteDatasourceDialog.tsx
+++ b/ui/app/src/components/dialogs/DeleteDatasourceDialog.tsx
@@ -11,110 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Dispatch, DispatchWithoutAction, useCallback } from 'react';
+import { Dispatch, DispatchWithoutAction } from 'react';
 import { Button } from '@mui/material';
-import { Dialog, useSnackbar } from '@perses-dev/components';
-import { Datasource, GlobalDatasource } from '@perses-dev/core';
+import { Dialog } from '@perses-dev/components';
+import { Datasource } from '@perses-dev/core';
 import { getDatasourceExtendedDisplayName } from '@perses-dev/core/dist/utils/text';
-import { useDeleteGlobalDatasourceMutation } from '../../model/admin-client';
-import { useDeleteDatasourceMutation } from '../../model/datasource-client';
 
-export interface DeleteProjectDatasourceDialogProps {
-  datasource: Datasource;
+export interface DeleteDatasourceDialogProps<T extends Datasource> {
+  datasource: T;
   open: boolean;
+  onSubmit: Dispatch<T>;
   onClose: DispatchWithoutAction;
-  onDelete: DispatchWithoutAction;
-  onSuccess?: Dispatch<Datasource>;
 }
 
 /**
  * Dialog used to delete a datasource.
- * @param props.open Define if the dialog should be opened or not.
- * @param props.closeDialog Provides the function to close itself.
- * @param props.onConfirm Action to perform when user confirmed.
+ * TODO: All delete dialogs are starting to be duplicates and can be probably merged into a single one.
+ *  We´d just need to improve our tooling around dynamic text generation.
  * @param props.datasource The datasource resource to delete.
+ * @param props.open Define if the dialog should be opened or not.
+ * @param props.onSubmit Action to perform when user confirmed.
+ * @param props.onClose Provides the function to close itself.
  * @constructor
  */
-export const DeleteProjectDatasourceDialog = (props: DeleteProjectDatasourceDialogProps) => {
-  const { datasource, open, onClose, onDelete, onSuccess } = props;
-  const { successSnackbar, exceptionSnackbar } = useSnackbar();
-
-  const deleteDatasourceMutation = useDeleteDatasourceMutation(datasource.metadata.project);
-
-  const handleSubmit = useCallback(() => {
-    return deleteDatasourceMutation.mutate(datasource, {
-      onSuccess: (deletedDatasource: Datasource) => {
-        successSnackbar(`Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} was successfully deleted`);
-        onClose();
-        onDelete();
-        if (onSuccess) {
-          onSuccess(datasource);
-        }
-      },
-      onError: (err) => {
-        exceptionSnackbar(err);
-        throw err;
-      },
-    });
-  }, [deleteDatasourceMutation, datasource, onClose, onDelete, onSuccess, successSnackbar, exceptionSnackbar]);
-
-  return <DeleteDatasourceDialog datasource={datasource} open={open} onDelete={handleSubmit} onClose={onClose} />;
-};
-
-export interface DeleteGlobalDatasourceDialogProps {
-  datasource: GlobalDatasource;
-  open: boolean;
-  onClose: DispatchWithoutAction;
-  onDelete: DispatchWithoutAction;
-  onSuccess?: Dispatch<GlobalDatasource>;
-}
-
-/**
- * Dialog used to delete a global datasource.
- * @param props.open Define if the dialog should be opened or not.
- * @param props.closeDialog Provides the function to close itself.
- * @param props.onConfirm Action to perform when user confirmed.
- * @param props.datasource The datasource resource to delete.
- * @constructor
- */
-export const DeleteGlobalDatasourceDialog = (props: DeleteGlobalDatasourceDialogProps) => {
-  const { datasource, open, onClose, onDelete, onSuccess } = props;
-  const { successSnackbar, exceptionSnackbar } = useSnackbar();
-
-  const deleteDatasourceMutation = useDeleteGlobalDatasourceMutation();
-
-  const handleSubmit = useCallback(() => {
-    return deleteDatasourceMutation.mutate(datasource, {
-      onSuccess: (deletedDatasource: GlobalDatasource) => {
-        successSnackbar(`Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} was successfully deleted`);
-        onClose();
-        onDelete();
-        if (onSuccess) {
-          onSuccess(datasource);
-        }
-      },
-      onError: (err) => {
-        exceptionSnackbar(err);
-        throw err;
-      },
-    });
-  }, [deleteDatasourceMutation, datasource, onClose, onDelete, onSuccess, successSnackbar, exceptionSnackbar]);
-
-  return <DeleteDatasourceDialog datasource={datasource} open={open} onDelete={handleSubmit} onClose={onClose} />;
-};
-
-interface DeleteDatasourceDialogProps {
-  datasource: Datasource | GlobalDatasource;
-  open: boolean;
-  onDelete: DispatchWithoutAction;
-  onClose: DispatchWithoutAction;
-}
-
-/**
- * Generic component to build a Dialog for datasource deletion
- */
-function DeleteDatasourceDialog(props: DeleteDatasourceDialogProps) {
-  const { datasource, open, onDelete, onClose } = props;
+export function DeleteDatasourceDialog<T extends Datasource>(props: DeleteDatasourceDialogProps<T>) {
+  const { datasource, open, onSubmit, onClose } = props;
 
   return (
     <Dialog open={open} onClose={onClose}>
@@ -124,7 +45,7 @@ function DeleteDatasourceDialog(props: DeleteDatasourceDialogProps) {
         cannot be undone.
       </Dialog.Content>
       <Dialog.Actions>
-        <Button variant="contained" type="submit" onClick={onDelete}>
+        <Button variant="contained" type="submit" onClick={() => onSubmit(datasource)}>
           Delete
         </Button>
         <Button variant="outlined" color="secondary" onClick={onClose}>

--- a/ui/app/src/components/dialogs/DeleteDatasourceDialog.tsx
+++ b/ui/app/src/components/dialogs/DeleteDatasourceDialog.tsx
@@ -14,11 +14,12 @@
 import { Dispatch, DispatchWithoutAction, useCallback } from 'react';
 import { Button } from '@mui/material';
 import { Dialog, useSnackbar } from '@perses-dev/components';
-import { Datasource } from '@perses-dev/core';
+import { Datasource, GlobalDatasource } from '@perses-dev/core';
 import { getDatasourceExtendedDisplayName } from '@perses-dev/core/dist/utils/text';
+import { useDeleteGlobalDatasourceMutation } from '../../model/admin-client';
 import { useDeleteDatasourceMutation } from '../../model/datasource-client';
 
-export interface DeleteDatasourceDialogProps {
+export interface DeleteProjectDatasourceDialogProps {
   datasource: Datasource;
   open: boolean;
   onClose: DispatchWithoutAction;
@@ -34,9 +35,10 @@ export interface DeleteDatasourceDialogProps {
  * @param props.datasource The datasource resource to delete.
  * @constructor
  */
-export const DeleteDatasourceDialog = (props: DeleteDatasourceDialogProps) => {
+export const DeleteProjectDatasourceDialog = (props: DeleteProjectDatasourceDialogProps) => {
   const { datasource, open, onClose, onDelete, onSuccess } = props;
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
+
   const deleteDatasourceMutation = useDeleteDatasourceMutation(datasource.metadata.project);
 
   const handleSubmit = useCallback(() => {
@@ -56,6 +58,64 @@ export const DeleteDatasourceDialog = (props: DeleteDatasourceDialogProps) => {
     });
   }, [deleteDatasourceMutation, datasource, onClose, onDelete, onSuccess, successSnackbar, exceptionSnackbar]);
 
+  return <DeleteDatasourceDialog datasource={datasource} open={open} onDelete={handleSubmit} onClose={onClose} />;
+};
+
+export interface DeleteGlobalDatasourceDialogProps {
+  datasource: GlobalDatasource;
+  open: boolean;
+  onClose: DispatchWithoutAction;
+  onDelete: DispatchWithoutAction;
+  onSuccess?: Dispatch<GlobalDatasource>;
+}
+
+/**
+ * Dialog used to delete a global datasource.
+ * @param props.open Define if the dialog should be opened or not.
+ * @param props.closeDialog Provides the function to close itself.
+ * @param props.onConfirm Action to perform when user confirmed.
+ * @param props.datasource The datasource resource to delete.
+ * @constructor
+ */
+export const DeleteGlobalDatasourceDialog = (props: DeleteGlobalDatasourceDialogProps) => {
+  const { datasource, open, onClose, onDelete, onSuccess } = props;
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+
+  const deleteDatasourceMutation = useDeleteGlobalDatasourceMutation();
+
+  const handleSubmit = useCallback(() => {
+    return deleteDatasourceMutation.mutate(datasource, {
+      onSuccess: (deletedDatasource: GlobalDatasource) => {
+        successSnackbar(`Datasource ${getDatasourceExtendedDisplayName(deletedDatasource)} was successfully deleted`);
+        onClose();
+        onDelete();
+        if (onSuccess) {
+          onSuccess(datasource);
+        }
+      },
+      onError: (err) => {
+        exceptionSnackbar(err);
+        throw err;
+      },
+    });
+  }, [deleteDatasourceMutation, datasource, onClose, onDelete, onSuccess, successSnackbar, exceptionSnackbar]);
+
+  return <DeleteDatasourceDialog datasource={datasource} open={open} onDelete={handleSubmit} onClose={onClose} />;
+};
+
+interface DeleteDatasourceDialogProps {
+  datasource: Datasource | GlobalDatasource;
+  open: boolean;
+  onDelete: DispatchWithoutAction;
+  onClose: DispatchWithoutAction;
+}
+
+/**
+ * Generic component to build a Dialog for datasource deletion
+ */
+function DeleteDatasourceDialog(props: DeleteDatasourceDialogProps) {
+  const { datasource, open, onDelete, onClose } = props;
+
   return (
     <Dialog open={open} onClose={onClose}>
       <Dialog.Header>Delete Datasource</Dialog.Header>
@@ -64,7 +124,7 @@ export const DeleteDatasourceDialog = (props: DeleteDatasourceDialogProps) => {
         cannot be undone.
       </Dialog.Content>
       <Dialog.Actions>
-        <Button variant="contained" type="submit" onClick={handleSubmit}>
+        <Button variant="contained" type="submit" onClick={onDelete}>
           Delete
         </Button>
         <Button variant="outlined" color="secondary" onClick={onClose}>
@@ -73,4 +133,4 @@ export const DeleteDatasourceDialog = (props: DeleteDatasourceDialogProps) => {
       </Dialog.Actions>
     </Dialog>
   );
-};
+}

--- a/ui/app/src/model/admin-client.ts
+++ b/ui/app/src/model/admin-client.ts
@@ -1,0 +1,137 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { GlobalDatasource, fetch, fetchJson } from '@perses-dev/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import buildURL from './url-builder';
+import { HTTPHeader, HTTPMethodDELETE, HTTPMethodGET, HTTPMethodPOST, HTTPMethodPUT } from './http';
+
+const globalDatasourceResource = 'globaldatasources';
+
+/**
+ * Used to create a new global datasource in the API.
+ * Will automatically invalidate datasources and force the get query to be executed again.
+ */
+export function useCreateGlobalDatasourceMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GlobalDatasource, Error, GlobalDatasource>({
+    mutationKey: [globalDatasourceResource],
+    mutationFn: (datasource: GlobalDatasource) => {
+      return createGlobalDatasource(datasource);
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries([globalDatasourceResource]);
+    },
+  });
+}
+
+/**
+ * Used to update a global datasource in the API.
+ * Will automatically invalidate datasources and force the get query to be executed again.
+ */
+export function useUpdateGlobalDatasourceMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GlobalDatasource, Error, GlobalDatasource>({
+    mutationKey: [globalDatasourceResource],
+    mutationFn: (datasource: GlobalDatasource) => {
+      return updateGlobalDatasource(datasource);
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries([globalDatasourceResource]);
+    },
+  });
+}
+
+/**
+ * Used to delete a global datasource in the API.
+ * Will automatically invalidate datasources and force the get query to be executed again.
+ */
+export function useDeleteGlobalDatasourceMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<GlobalDatasource, Error, GlobalDatasource>({
+    mutationKey: [globalDatasourceResource],
+    mutationFn: (entity: GlobalDatasource) => {
+      return deleteGlobalDatasource(entity).then(() => {
+        return entity;
+      });
+    },
+    onSuccess: (datasource) => {
+      queryClient.removeQueries([globalDatasourceResource, datasource.metadata.name]);
+      return queryClient.invalidateQueries([globalDatasourceResource]);
+    },
+  });
+}
+
+/**
+ * Used to get a global datasource from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalDatasource(name: string) {
+  return useQuery<GlobalDatasource, Error>([globalDatasourceResource, name], () => {
+    return getGlobalDatasource(name);
+  });
+}
+
+/**
+ * Used to get global datasources from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalDatasourceList() {
+  return useQuery<GlobalDatasource[], Error>([globalDatasourceResource], () => {
+    return getGlobalDatasources();
+  });
+}
+
+export function createGlobalDatasource(entity: GlobalDatasource) {
+  const url = buildURL({ resource: globalDatasourceResource });
+  return fetchJson<GlobalDatasource>(url, {
+    method: HTTPMethodPOST,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+export function getGlobalDatasource(name: string) {
+  const url = buildURL({ resource: globalDatasourceResource, name: name });
+  return fetchJson<GlobalDatasource>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+export function getGlobalDatasources() {
+  const url = buildURL({ resource: globalDatasourceResource });
+  return fetchJson<GlobalDatasource[]>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+export function updateGlobalDatasource(entity: GlobalDatasource) {
+  const url = buildURL({ resource: globalDatasourceResource, name: entity.metadata.name });
+  return fetchJson<GlobalDatasource>(url, {
+    method: HTTPMethodPUT,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+export function deleteGlobalDatasource(entity: GlobalDatasource) {
+  const url = buildURL({ resource: globalDatasourceResource, name: entity.metadata.name });
+  return fetch(url, {
+    method: HTTPMethodDELETE,
+    headers: HTTPHeader,
+  });
+}

--- a/ui/app/src/model/datasource-client.ts
+++ b/ui/app/src/model/datasource-client.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource, fetchJson } from '@perses-dev/core';
+import { ProjectDatasource, fetchJson } from '@perses-dev/core';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { HTTPMethodGET, HTTPMethodPOST, HTTPMethodPUT, HTTPMethodDELETE, HTTPHeader } from './http';
 import buildQueryKey from './querykey-builder';
@@ -39,7 +39,7 @@ export function fetchDatasourceList(project: string, kind?: string, defaultDatas
     project: project,
     queryParams: buildDatasourceQueryParameters(kind, defaultDatasource, name),
   });
-  return fetchJson<Datasource[]>(url);
+  return fetchJson<ProjectDatasource[]>(url);
 }
 
 /**
@@ -50,9 +50,9 @@ export function useCreateDatasourceMutation(projectName: string) {
   const queryClient = useQueryClient();
   const key = buildQueryKey({ resource, parent: projectName });
 
-  return useMutation<Datasource, Error, Datasource>({
+  return useMutation<ProjectDatasource, Error, ProjectDatasource>({
     mutationKey: key,
-    mutationFn: (datasource: Datasource) => {
+    mutationFn: (datasource: ProjectDatasource) => {
       return createDatasource(datasource);
     },
     onSuccess: () => {
@@ -69,9 +69,9 @@ export function useUpdateDatasourceMutation(projectName: string) {
   const queryClient = useQueryClient();
   const key = buildQueryKey({ resource, parent: projectName });
 
-  return useMutation<Datasource, Error, Datasource>({
+  return useMutation<ProjectDatasource, Error, ProjectDatasource>({
     mutationKey: key,
-    mutationFn: (datasource: Datasource) => {
+    mutationFn: (datasource: ProjectDatasource) => {
       return updateDatasource(datasource);
     },
     onSuccess: () => {
@@ -88,9 +88,9 @@ export function useDeleteDatasourceMutation(projectName: string) {
   const queryClient = useQueryClient();
   const key = buildQueryKey({ resource, parent: projectName });
 
-  return useMutation<Datasource, Error, Datasource>({
+  return useMutation<ProjectDatasource, Error, ProjectDatasource>({
     mutationKey: key,
-    mutationFn: (entity: Datasource) => {
+    mutationFn: (entity: ProjectDatasource) => {
       return deleteDatasource(entity).then(() => {
         return entity;
       });
@@ -107,7 +107,7 @@ export function useDeleteDatasourceMutation(projectName: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDatasource(project: string, name: string) {
-  return useQuery<Datasource, Error>(buildQueryKey({ resource, parent: project, name }), () => {
+  return useQuery<ProjectDatasource, Error>(buildQueryKey({ resource, parent: project, name }), () => {
     return getDatasource(project, name);
   });
 }
@@ -117,14 +117,14 @@ export function useDatasource(project: string, name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDatasourceList(project: string) {
-  return useQuery<Datasource[], Error>(buildQueryKey({ resource, parent: project }), () => {
+  return useQuery<ProjectDatasource[], Error>(buildQueryKey({ resource, parent: project }), () => {
     return getDatasources(project);
   });
 }
 
-export function createDatasource(entity: Datasource) {
+export function createDatasource(entity: ProjectDatasource) {
   const url = buildURL({ resource, project: entity.metadata.project });
-  return fetchJson<Datasource>(url, {
+  return fetchJson<ProjectDatasource>(url, {
     method: HTTPMethodPOST,
     headers: HTTPHeader,
     body: JSON.stringify(entity),
@@ -133,7 +133,7 @@ export function createDatasource(entity: Datasource) {
 
 export function getDatasource(project: string, name: string) {
   const url = buildURL({ resource, project: project, name: name });
-  return fetchJson<Datasource>(url, {
+  return fetchJson<ProjectDatasource>(url, {
     method: HTTPMethodGET,
     headers: HTTPHeader,
   });
@@ -141,22 +141,22 @@ export function getDatasource(project: string, name: string) {
 
 export function getDatasources(project?: string) {
   const url = buildURL({ resource, project: project });
-  return fetchJson<Datasource[]>(url, {
+  return fetchJson<ProjectDatasource[]>(url, {
     method: HTTPMethodGET,
     headers: HTTPHeader,
   });
 }
 
-export function updateDatasource(entity: Datasource) {
+export function updateDatasource(entity: ProjectDatasource) {
   const url = buildURL({ resource, project: entity.metadata.project, name: entity.metadata.name });
-  return fetchJson<Datasource>(url, {
+  return fetchJson<ProjectDatasource>(url, {
     method: HTTPMethodPUT,
     headers: HTTPHeader,
     body: JSON.stringify(entity),
   });
 }
 
-export function deleteDatasource(entity: Datasource) {
+export function deleteDatasource(entity: ProjectDatasource) {
   const url = buildURL({ resource, project: entity.metadata.project, name: entity.metadata.name });
   return fetch(url, {
     method: HTTPMethodDELETE,

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -27,7 +27,7 @@ import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
 import { VariableFormDrawer } from '../../components/VariableList/VariableFormDrawer';
 import { useCreateGlobalVariableMutation } from '../../model/global-variable-client';
 import { useCreateGlobalDatasourceMutation } from '../../model/admin-client';
-import { GlobalDatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
+import { DatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
 import { GlobalVariables } from './tabs/GlobalVariables';
 import { GlobalDatasources } from './tabs/GlobalDatasources';
 
@@ -47,21 +47,6 @@ function TabButton(props: TabButtonProps) {
   const [isCreateGlobalDatasourceDrawerStateOpened, setCreateGlobalDatasourceFormStateOpened] = useState(false);
   const [openCreateVariableDrawerState, setOpenCreateVariableDrawerState] = useState(false);
 
-  const handleGlobalDatasourceCreation = useCallback(
-    (datasource: GlobalDatasource) => {
-      createDatasourceMutation.mutate(datasource, {
-        onSuccess: (createdDatasource: GlobalDatasource) => {
-          successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
-          setCreateGlobalDatasourceFormStateOpened(false);
-        },
-        onError: (err) => {
-          exceptionSnackbar(err);
-          throw err;
-        },
-      });
-    },
-    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
-  );
   const handleVariableCreation = useCallback(
     (variable: GlobalVariableResource) => {
       createGlobalVariableMutation.mutate(variable, {
@@ -78,6 +63,22 @@ function TabButton(props: TabButtonProps) {
       });
     },
     [exceptionSnackbar, successSnackbar, createGlobalVariableMutation]
+  );
+
+  const handleGlobalDatasourceCreation = useCallback(
+    (datasource: GlobalDatasource) => {
+      createDatasourceMutation.mutate(datasource, {
+        onSuccess: (createdDatasource: GlobalDatasource) => {
+          successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
+          setCreateGlobalDatasourceFormStateOpened(false);
+        },
+        onError: (err) => {
+          exceptionSnackbar(err);
+          throw err;
+        },
+      });
+    },
+    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
   );
 
   switch (props.index) {
@@ -118,7 +119,7 @@ function TabButton(props: TabButtonProps) {
             variant="contained"
             onClick={() => setCreateGlobalDatasourceFormStateOpened(true)}
           />
-          <GlobalDatasourceDrawer
+          <DatasourceDrawer
             datasource={{
               kind: 'GlobalDatasource',
               metadata: {

--- a/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
@@ -12,23 +12,21 @@
 // limitations under the License.
 
 import { Card } from '@mui/material';
-import { useDatasourceList } from '../../../model/datasource-client';
-import { ProjectDatasourceList } from '../../../components/DatasourceList/DatasourceList';
+import { useGlobalDatasourceList } from '../../../model/admin-client';
+import { GlobalDatasourceList } from '../../../components/DatasourceList/DatasourceList';
 
-interface ProjectDatasourcesProps {
-  projectName: string;
+interface GlobalDatasourcesProps {
   hideToolbar?: boolean;
   id?: string;
 }
 
-export function ProjectDatasources(props: ProjectDatasourcesProps) {
-  const { projectName, hideToolbar, id } = props;
-  const { data, isLoading } = useDatasourceList(projectName);
+export function GlobalDatasources(props: GlobalDatasourcesProps) {
+  const { hideToolbar, id } = props;
+  const { data, isLoading } = useGlobalDatasourceList();
 
   return (
     <Card id={id}>
-      <ProjectDatasourceList
-        projectName={projectName}
+      <GlobalDatasourceList
         datasourceList={data || []}
         hideToolbar={hideToolbar}
         isLoading={isLoading}

--- a/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
@@ -12,8 +12,16 @@
 // limitations under the License.
 
 import { Card } from '@mui/material';
-import { useGlobalDatasourceList } from '../../../model/admin-client';
-import { GlobalDatasourceList } from '../../../components/DatasourceList/DatasourceList';
+import { getDatasourceDisplayName, GlobalDatasource } from '@perses-dev/core';
+import { useSnackbar } from '@perses-dev/components';
+import { useCallback } from 'react';
+import { DatasourceList } from '../../../components/DatasourceList/DatasourceList';
+import {
+  useCreateGlobalDatasourceMutation,
+  useDeleteGlobalDatasourceMutation,
+  useGlobalDatasourceList,
+  useUpdateGlobalDatasourceMutation,
+} from '../../../model/admin-client';
 
 interface GlobalDatasourcesProps {
   hideToolbar?: boolean;
@@ -23,12 +31,83 @@ interface GlobalDatasourcesProps {
 export function GlobalDatasources(props: GlobalDatasourcesProps) {
   const { hideToolbar, id } = props;
   const { data, isLoading } = useGlobalDatasourceList();
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+
+  const createDatasourceMutation = useCreateGlobalDatasourceMutation();
+  const deleteDatasourceMutation = useDeleteGlobalDatasourceMutation();
+  const updateDatasourceMutation = useUpdateGlobalDatasourceMutation();
+
+  const handleDatasourceCreate = useCallback(
+    (datasource: GlobalDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        createDatasourceMutation.mutate(datasource, {
+          onSuccess: (createdDatasource: GlobalDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
+  );
+
+  const handleDatasourceUpdate = useCallback(
+    (datasource: GlobalDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        updateDatasourceMutation.mutate(datasource, {
+          onSuccess: (updatedDatasource: GlobalDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, updateDatasourceMutation]
+  );
+
+  const handleDatasourceDelete = useCallback(
+    (datasource: GlobalDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        deleteDatasourceMutation.mutate(datasource, {
+          onSuccess: (deletedDatasource: GlobalDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(deletedDatasource)} has been successfully deleted`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, deleteDatasourceMutation]
+  );
 
   return (
     <Card id={id}>
-      <GlobalDatasourceList
-        datasourceList={data || []}
+      <DatasourceList
+        data={data || []}
         hideToolbar={hideToolbar}
+        onCreate={handleDatasourceCreate}
+        onUpdate={handleDatasourceUpdate}
+        onDelete={handleDatasourceDelete}
         isLoading={isLoading}
         initialState={{
           columns: {

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -28,8 +28,8 @@ import { useSnackbar } from '@perses-dev/components';
 import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
 import { CreateDashboardDialog } from '../../components/dialogs';
 import { VariableFormDrawer } from '../../components/VariableList/VariableFormDrawer';
+import { ProjectDatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
 import { useCreateDatasourceMutation } from '../../model/datasource-client';
-import { DatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
 import { useCreateVariableMutation } from '../../model/variable-client';
 import { ProjectDashboards } from './tabs/ProjectDashboards';
 import { ProjectVariables } from './tabs/ProjectVariables';
@@ -52,7 +52,7 @@ function TabButton(props: TabButtonProps) {
 
   const [openCreateDashboardDialogState, setOpenCreateDashboardDialogState] = useState(false);
   const [openCreateVariableDrawerState, setOpenCreateVariableDrawerState] = useState(false);
-  const [isCreateDatasourceDrawerStateOpened, setCreateDatasourceFormStateOpened] = useState(false);
+  const [isCreateDatasourceDrawerStateOpened, setCreateDatasourceDrawerStateOpened] = useState(false);
 
   const handleDashboardCreation = (dashboardSelector: DashboardSelector) => {
     navigate(`/projects/${dashboardSelector.project}/dashboards/${dashboardSelector.dashboard}/create`);
@@ -79,7 +79,7 @@ function TabButton(props: TabButtonProps) {
       createDatasourceMutation.mutate(datasource, {
         onSuccess: (createdDatasource: Datasource) => {
           successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
-          setCreateDatasourceFormStateOpened(false);
+          setCreateDatasourceDrawerStateOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);
@@ -139,9 +139,9 @@ function TabButton(props: TabButtonProps) {
           <CRUDButton
             text="Add Datasource"
             variant="contained"
-            onClick={() => setCreateDatasourceFormStateOpened(true)}
+            onClick={() => setCreateDatasourceDrawerStateOpened(true)}
           />
-          <DatasourceDrawer
+          <ProjectDatasourceDrawer
             datasource={{
               kind: 'Datasource',
               metadata: {
@@ -160,7 +160,7 @@ function TabButton(props: TabButtonProps) {
             isOpen={isCreateDatasourceDrawerStateOpened}
             saveActionStr="Create"
             onSave={handleDatasourceCreation}
-            onClose={() => setCreateDatasourceFormStateOpened(false)}
+            onClose={() => setCreateDatasourceDrawerStateOpened(false)}
           />
         </>
       );
@@ -223,7 +223,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
         justifyContent="space-between"
         sx={{ marginLeft: 2.5, marginRight: 2.5, borderBottom: 1, borderColor: 'divider' }}
       >
-        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+        <Tabs value={value} onChange={handleChange} aria-label="project tabs">
           <Tab
             label="Dashboards"
             icon={<ViewDashboardIcon />}
@@ -248,13 +248,13 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
         </Tabs>
         <TabButton index={value} projectName={projectName} />
       </Stack>
-      <TabPanel value={value} index="dashboards">
+      <TabPanel value={value} index={dashboardTabIndex}>
         <ProjectDashboards projectName={projectName} id="main-dashboard-list" />
       </TabPanel>
-      <TabPanel value={value} index="variables">
+      <TabPanel value={value} index={variablesTabIndex}>
         <ProjectVariables projectName={projectName} id="project-variable-list" />
       </TabPanel>
-      <TabPanel value={value} index="datasources">
+      <TabPanel value={value} index={datasourcesTabIndex}>
         <ProjectDatasources projectName={projectName} id="project-datasource-list" />
       </TabPanel>
     </Box>

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -20,7 +20,7 @@ import {
   getDatasourceDisplayName,
   getVariableExtendedDisplayName,
   DashboardSelector,
-  Datasource,
+  ProjectDatasource,
   VariableResource,
 } from '@perses-dev/core';
 import { useNavigate } from 'react-router-dom';
@@ -28,14 +28,14 @@ import { useSnackbar } from '@perses-dev/components';
 import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
 import { CreateDashboardDialog } from '../../components/dialogs';
 import { VariableFormDrawer } from '../../components/VariableList/VariableFormDrawer';
-import { ProjectDatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
+import { DatasourceDrawer } from '../../components/DatasourceList/DatasourceDrawer';
 import { useCreateDatasourceMutation } from '../../model/datasource-client';
 import { useCreateVariableMutation } from '../../model/variable-client';
 import { ProjectDashboards } from './tabs/ProjectDashboards';
 import { ProjectVariables } from './tabs/ProjectVariables';
 import { ProjectDatasources } from './tabs/ProjectDatasources';
 
-const dashboardTabIndex = 'dashboards';
+const dashboardsTabIndex = 'dashboards';
 const variablesTabIndex = 'variables';
 const datasourcesTabIndex = 'datasources';
 
@@ -75,9 +75,9 @@ function TabButton(props: TabButtonProps) {
   );
 
   const handleDatasourceCreation = useCallback(
-    (datasource: Datasource) => {
+    (datasource: ProjectDatasource) => {
       createDatasourceMutation.mutate(datasource, {
-        onSuccess: (createdDatasource: Datasource) => {
+        onSuccess: (createdDatasource: ProjectDatasource) => {
           successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
           setCreateDatasourceDrawerStateOpened(false);
         },
@@ -91,7 +91,7 @@ function TabButton(props: TabButtonProps) {
   );
 
   switch (props.index) {
-    case dashboardTabIndex:
+    case dashboardsTabIndex:
       return (
         <>
           <CRUDButton
@@ -141,7 +141,7 @@ function TabButton(props: TabButtonProps) {
             variant="contained"
             onClick={() => setCreateDatasourceDrawerStateOpened(true)}
           />
-          <ProjectDatasourceDrawer
+          <DatasourceDrawer
             datasource={{
               kind: 'Datasource',
               metadata: {
@@ -208,7 +208,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
 
   const navigate = useNavigate();
 
-  const [value, setValue] = useState((initialTab ?? dashboardTabIndex).toLowerCase());
+  const [value, setValue] = useState((initialTab ?? dashboardsTabIndex).toLowerCase());
 
   const handleChange = (event: SyntheticEvent, newTabIndex: string) => {
     setValue(newTabIndex);
@@ -228,8 +228,8 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
             label="Dashboards"
             icon={<ViewDashboardIcon />}
             iconPosition="start"
-            {...a11yProps(dashboardTabIndex)}
-            value={dashboardTabIndex}
+            {...a11yProps(dashboardsTabIndex)}
+            value={dashboardsTabIndex}
           />
           <Tab
             label="Variables"
@@ -248,7 +248,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
         </Tabs>
         <TabButton index={value} projectName={projectName} />
       </Stack>
-      <TabPanel value={value} index={dashboardTabIndex}>
+      <TabPanel value={value} index={dashboardsTabIndex}>
         <ProjectDashboards projectName={projectName} id="main-dashboard-list" />
       </TabPanel>
       <TabPanel value={value} index={variablesTabIndex}>

--- a/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
@@ -12,8 +12,16 @@
 // limitations under the License.
 
 import { Card } from '@mui/material';
-import { useDatasourceList } from '../../../model/datasource-client';
-import { ProjectDatasourceList } from '../../../components/DatasourceList/DatasourceList';
+import { useSnackbar } from '@perses-dev/components';
+import { useCallback } from 'react';
+import { getDatasourceDisplayName, ProjectDatasource } from '@perses-dev/core';
+import {
+  useDatasourceList,
+  useCreateDatasourceMutation,
+  useDeleteDatasourceMutation,
+  useUpdateDatasourceMutation,
+} from '../../../model/datasource-client';
+import { DatasourceList } from '../../../components/DatasourceList/DatasourceList';
 
 interface ProjectDatasourcesProps {
   projectName: string;
@@ -25,12 +33,83 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
   const { projectName, hideToolbar, id } = props;
   const { data, isLoading } = useDatasourceList(projectName);
 
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+
+  const createDatasourceMutation = useCreateDatasourceMutation(projectName);
+  const deleteDatasourceMutation = useDeleteDatasourceMutation(projectName);
+  const updateDatasourceMutation = useUpdateDatasourceMutation(projectName);
+
+  const handleDatasourceCreate = useCallback(
+    (datasource: ProjectDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        createDatasourceMutation.mutate(datasource, {
+          onSuccess: (createdDatasource: ProjectDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
+  );
+
+  const handleDatasourceUpdate = useCallback(
+    (datasource: ProjectDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        updateDatasourceMutation.mutate(datasource, {
+          onSuccess: (updatedDatasource: ProjectDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, updateDatasourceMutation]
+  );
+
+  const handleDatasourceDelete = useCallback(
+    (datasource: ProjectDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        deleteDatasourceMutation.mutate(datasource, {
+          onSuccess: (deletedDatasource: ProjectDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(deletedDatasource)} has been successfully deleted`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, deleteDatasourceMutation]
+  );
+
   return (
     <Card id={id}>
-      <ProjectDatasourceList
-        projectName={projectName}
-        datasourceList={data || []}
+      <DatasourceList
+        data={data || []}
         hideToolbar={hideToolbar}
+        onCreate={handleDatasourceCreate}
+        onUpdate={handleDatasourceUpdate}
+        onDelete={handleDatasourceDelete}
         isLoading={isLoading}
         initialState={{
           columns: {

--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -27,11 +27,13 @@ export interface GlobalDatasource {
 /**
  * A Datasource resource, that belongs to a project.
  */
-export interface Datasource {
+export interface ProjectDatasource {
   kind: 'Datasource';
   metadata: ProjectMetadata;
   spec: DatasourceSpec;
 }
+
+export type Datasource = ProjectDatasource | GlobalDatasource;
 
 export interface DatasourceSpec<PluginSpec = UnknownSpec> {
   display?: Display;

--- a/ui/core/src/model/resource.ts
+++ b/ui/core/src/model/resource.ts
@@ -21,3 +21,7 @@ export interface Metadata {
 export interface ProjectMetadata extends Metadata {
   project: string;
 }
+
+export function getMetadataProject(metadata: ProjectMetadata | Metadata): string | undefined {
+  return 'project' in metadata ? metadata.project : undefined;
+}

--- a/ui/core/src/utils/text.ts
+++ b/ui/core/src/utils/text.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource, DashboardResource, GlobalDatasource, Variable } from '../model';
+import { DashboardResource, Variable, Datasource } from '../model';
 
 /**
  * If the dashboard has a display name, return the dashboard display name
@@ -34,9 +34,9 @@ export function getVariableDisplayName(variable: Variable) {
 /**
  * If the variable has a display name, return the datasource display name
  * Else, only return the datasource name
- * @param variable Project or Global datasource
+ * @param datasource Project or Global datasource
  */
-export function getDatasourceDisplayName(datasource: Datasource | GlobalDatasource) {
+export function getDatasourceDisplayName(datasource: Datasource) {
   return datasource.spec.display?.name || datasource.metadata.name;
 }
 
@@ -67,11 +67,11 @@ export function getVariableExtendedDisplayName(variable: Variable) {
 /**
  * If the datasource has a display name, return the datasource display name and the datasource name
  * Else, only return the datasource name
- * @param variable Project or Global datasource
+ * @param datasource Project or Global datasource
  */
-export function getDatasourceExtendedDisplayName(datasource: Datasource | GlobalDatasource) {
+export function getDatasourceExtendedDisplayName(datasource: Datasource) {
   if (datasource.spec.display?.name) {
-    return `${datasource.spec.display.name} (ID: ${datasource.metadata.name})`;
+    return `${datasource.spec.display.name} (Name: ${datasource.metadata.name})`;
   }
   return datasource.metadata.name;
 }

--- a/ui/core/src/utils/text.ts
+++ b/ui/core/src/utils/text.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource, DashboardResource, Variable } from '../model';
+import { Datasource, DashboardResource, GlobalDatasource, Variable } from '../model';
 
 /**
  * If the dashboard has a display name, return the dashboard display name
@@ -36,7 +36,7 @@ export function getVariableDisplayName(variable: Variable) {
  * Else, only return the datasource name
  * @param variable Project or Global datasource
  */
-export function getDatasourceDisplayName(datasource: Datasource) {
+export function getDatasourceDisplayName(datasource: Datasource | GlobalDatasource) {
   return datasource.spec.display?.name || datasource.metadata.name;
 }
 
@@ -69,7 +69,7 @@ export function getVariableExtendedDisplayName(variable: Variable) {
  * Else, only return the datasource name
  * @param variable Project or Global datasource
  */
-export function getDatasourceExtendedDisplayName(datasource: Datasource) {
+export function getDatasourceExtendedDisplayName(datasource: Datasource | GlobalDatasource) {
   if (datasource.spec.display?.name) {
     return `${datasource.spec.display.name} (ID: ${datasource.metadata.name})`;
   }

--- a/ui/core/src/utils/types.ts
+++ b/ui/core/src/utils/types.ts
@@ -11,11 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './event';
-export * from './fetch';
-export * from './is-empty-object';
-export * from './memo';
-export * from './panel-refs';
-export * from './text';
-export * from './time-series-data';
-export * from './types';
+export type DispatchWithPromise<A> = (value: A) => Promise<void>;

--- a/ui/dashboards/src/context/DatasourceStoreProvider.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.tsx
@@ -15,7 +15,7 @@ import { ReactNode, useCallback, useMemo } from 'react';
 import {
   DashboardResource,
   DashboardSpec,
-  Datasource,
+  ProjectDatasource,
   DatasourceSelector,
   DatasourceSpec,
   GlobalDatasource,
@@ -42,13 +42,13 @@ export interface DatasourceApi {
   getDatasource: (
     project: string,
     selector: DatasourceSelector
-  ) => Promise<{ resource: Datasource; proxyUrl: string } | undefined>;
+  ) => Promise<{ resource: ProjectDatasource; proxyUrl: string } | undefined>;
 
   getGlobalDatasource: (
     selector: DatasourceSelector
   ) => Promise<{ resource: GlobalDatasource; proxyUrl: string } | undefined>;
 
-  listDatasources: (project: string, pluginKind?: string) => Promise<Datasource[]>;
+  listDatasources: (project: string, pluginKind?: string) => Promise<ProjectDatasource[]>;
 
   listGlobalDatasources: (pluginKind?: string) => Promise<GlobalDatasource[]>;
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
Refactoring on top of the global datasource CRUD PR #1319  to use generics like we do for the global/project variables.

![image](https://github.com/perses/perses/assets/10258608/14e963ae-2963-4f8c-881e-a0fcd4afa99c)
Ref #1033 
Closes #1319 (Let's see if we can automatically close a PR but I'm not sure)
# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
