### PR TITLE
[BUGFIX] Fix no lazy loading after adding DataQueriesProvider 

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Box } from '@mui/material';
+import { useInView } from 'react-intersection-observer';
 import { DataQueriesProvider } from '@perses-dev/plugin-system';
 import { PanelGroupItemId, useEditMode, usePanel, usePanelActions } from '../../context';
 import { useSuggestedStepMs } from '../../utils';
@@ -35,6 +37,12 @@ export function GridItemContent(props: GridItemContentProps) {
   const { isEditMode } = useEditMode();
   const { openEditPanel, openDeletePanelDialog, duplicatePanel } = usePanelActions(panelGroupItemId);
 
+  const { ref, inView } = useInView({
+    threshold: 0.3,
+    initialInView: false,
+    triggerOnce: true,
+  });
+
   // Provide actions to the panel when in edit mode
   let editHandlers: PanelProps['editHandlers'] = undefined;
   if (isEditMode) {
@@ -56,13 +64,23 @@ export function GridItemContent(props: GridItemContentProps) {
   });
 
   return (
-    <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs }}>
-      <Panel
-        definition={panelDefinition}
-        editHandlers={editHandlers}
-        panelOptions={props.panelOptions}
-        panelGroupItemId={panelGroupItemId}
-      />
-    </DataQueriesProvider>
+    <Box
+      ref={ref}
+      sx={{
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs }} enabled={inView}>
+        {inView && (
+          <Panel
+            definition={panelDefinition}
+            editHandlers={editHandlers}
+            panelOptions={props.panelOptions}
+            panelGroupItemId={panelGroupItemId}
+          />
+        )}
+      </DataQueriesProvider>
+    </Box>
   );
 }

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -38,7 +38,7 @@ export function GridItemContent(props: GridItemContentProps) {
   const { openEditPanel, openDeletePanelDialog, duplicatePanel } = usePanelActions(panelGroupItemId);
 
   const { ref, inView } = useInView({
-    threshold: 0.3,
+    threshold: 0.2, // we have the flexibility to adjust this threshold to trigger queries slightly earlier or later based on performance
     initialInView: false,
     triggerOnce: true,
   });
@@ -71,7 +71,7 @@ export function GridItemContent(props: GridItemContentProps) {
         height: '100%',
       }}
     >
-      <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs }} enabled={inView}>
+      <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs }} queryOptions={{ enabled: inView }}>
         {inView && (
           <Panel
             definition={panelDefinition}

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -13,7 +13,6 @@
 
 import { useState, useMemo, memo } from 'react';
 import useResizeObserver from 'use-resize-observer';
-import { useInView } from 'react-intersection-observer';
 import { ErrorBoundary, ErrorAlert, combineSx, useId, useChartsTheme } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
 import { Card, CardProps, CardContent } from '@mui/material';
@@ -66,12 +65,6 @@ export const Panel = memo(function Panel(props: PanelProps) {
     return { width, height };
   }, [width, height]);
 
-  const { ref, inView } = useInView({
-    threshold: 0.3,
-    initialInView: false,
-    triggerOnce: true,
-  });
-
   const chartsTheme = useChartsTheme();
 
   const handleMouseEnter: CardProps['onMouseEnter'] = (e) => {
@@ -84,7 +77,6 @@ export const Panel = memo(function Panel(props: PanelProps) {
 
   return (
     <Card
-      ref={ref}
       component="section"
       sx={combineSx(
         {
@@ -127,13 +119,11 @@ export const Panel = memo(function Panel(props: PanelProps) {
         ref={setContentElement}
       >
         <ErrorBoundary FallbackComponent={ErrorAlert} resetKeys={[definition.spec.plugin.spec]}>
-          {inView === true && (
-            <PanelContent
-              panelPluginKind={definition.spec.plugin.kind}
-              spec={definition.spec.plugin.spec}
-              contentDimensions={contentDimensions}
-            />
-          )}
+          <PanelContent
+            panelPluginKind={definition.spec.plugin.kind}
+            spec={definition.spec.plugin.spec}
+            contentDimensions={contentDimensions}
+          />
         </ErrorBoundary>
       </CardContent>
     </Card>

--- a/ui/e2e/.happo.js
+++ b/ui/e2e/.happo.js
@@ -19,16 +19,14 @@ module.exports = {
   apiSecret: process.env.HAPPO_API_SECRET,
   project: 'perses-ui',
 
-  plugins: [
-    happoPluginTypescript(),
-  ],
+  plugins: [happoPluginTypescript()],
 
   targets: {
     'chrome-desktop': new RemoteBrowserTarget('chrome', {
-      // Keep this in sync with the viewport setting in `base.playwright.config.ts` 
-      // for consistency for canvas elements, which are converted into images when 
+      // Keep this in sync with the viewport setting in `base.playwright.config.ts`
+      // for consistency for canvas elements, which are converted into images when
       // run in playwright and sent to happo.
-      viewport: '1200x800',
+      viewport: '1200x1000',
     }),
   },
 };

--- a/ui/e2e/src/config/base.playwright.config.ts
+++ b/ui/e2e/src/config/base.playwright.config.ts
@@ -66,7 +66,7 @@ const config: PlaywrightTestConfig = {
         // Keep this in sync with the setting in `.happo.js` for consistency for
         // canvas elements, which are converted into images when run in playwright
         // and sent to happo.
-        viewport: { width: 1200, height: 800 },
+        viewport: { width: 1200, height: 1000 },
       },
     },
   ],

--- a/ui/e2e/src/pages/Panel.ts
+++ b/ui/e2e/src/pages/Panel.ts
@@ -55,7 +55,7 @@ export class Panel {
     // Need to look up to panel draggable parent first to get the resize handle.
     // The classname selector here is not ideal, but it's all that is available
     // because this lives deeper in another library.
-    this.resizeHandle = this.container.locator('..').locator('.react-resizable-handle');
+    this.resizeHandle = this.container.locator('..').locator('..').locator('.react-resizable-handle');
 
     this.figure = this.container.getByRole('figure');
     this.canvas = this.container.locator('canvas');

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -57,7 +57,7 @@ export function useDataQueries<T extends keyof QueryType>(queryType: T): UseData
 }
 
 export function DataQueriesProvider(props: DataQueriesProviderProps) {
-  const { definitions, options, children, enabled = true } = props;
+  const { definitions, options, children, queryOptions } = props;
 
   const getQueryType = useQueryType();
 
@@ -75,7 +75,7 @@ export function DataQueriesProvider(props: DataQueriesProviderProps) {
   const timeSeriesQueries = queryDefinitions.filter(
     (definition) => definition.kind === 'TimeSeriesQuery'
   ) as TimeSeriesQueryDefinition[];
-  const timeSeriesResults = useTimeSeriesQueries(timeSeriesQueries, options, enabled);
+  const timeSeriesResults = useTimeSeriesQueries(timeSeriesQueries, options, queryOptions);
 
   const refetchAll = useCallback(() => {
     timeSeriesResults.forEach((result) => result.refetch());

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -57,7 +57,7 @@ export function useDataQueries<T extends keyof QueryType>(queryType: T): UseData
 }
 
 export function DataQueriesProvider(props: DataQueriesProviderProps) {
-  const { definitions, options, children } = props;
+  const { definitions, options, children, enabled = true } = props;
 
   const getQueryType = useQueryType();
 
@@ -75,7 +75,7 @@ export function DataQueriesProvider(props: DataQueriesProviderProps) {
   const timeSeriesQueries = queryDefinitions.filter(
     (definition) => definition.kind === 'TimeSeriesQuery'
   ) as TimeSeriesQueryDefinition[];
-  const timeSeriesResults = useTimeSeriesQueries(timeSeriesQueries, options);
+  const timeSeriesResults = useTimeSeriesQueries(timeSeriesQueries, options, enabled);
 
   const refetchAll = useCallback(() => {
     timeSeriesResults.forEach((result) => result.refetch());

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Definition, QueryDefinition, UnknownSpec, QueryDataType } from '@perses-dev/core';
-import { UseQueryResult } from '@tanstack/react-query';
+import { QueryObserverOptions, UseQueryResult } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { useListPluginMetadata } from '../plugin-registry';
 
@@ -21,10 +21,7 @@ export interface DataQueriesProviderProps<QueryPluginSpec = UnknownSpec> {
   definitions: Array<Definition<QueryPluginSpec>>;
   children?: React.ReactNode;
   options?: QueryOptions;
-  /**
-   * @default true
-   */
-  enabled?: boolean;
+  queryOptions?: QueryObserverOptions;
 }
 
 export interface DataQueriesContextType {

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -19,8 +19,12 @@ import { useListPluginMetadata } from '../plugin-registry';
 type QueryOptions = Record<string, unknown>;
 export interface DataQueriesProviderProps<QueryPluginSpec = UnknownSpec> {
   definitions: Array<Definition<QueryPluginSpec>>;
-  options?: QueryOptions;
   children?: React.ReactNode;
+  options?: QueryOptions;
+  /**
+   * @default true
+   */
+  enabled?: boolean;
 }
 
 export interface DataQueriesContextType {

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -77,13 +77,17 @@ function getQueryOptions({
 /**
  * Runs a time series query using a plugin and returns the results.
  */
-export const useTimeSeriesQuery = (definition: TimeSeriesQueryDefinition, options?: UseTimeSeriesQueryOptions) => {
+export const useTimeSeriesQuery = (
+  definition: TimeSeriesQueryDefinition,
+  options?: UseTimeSeriesQueryOptions,
+  enabled?: boolean
+) => {
   const { data: plugin } = usePlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
   const context = useTimeSeriesQueryContext();
 
   const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
   return useQuery({
-    enabled: queryEnabled,
+    enabled: enabled || queryEnabled,
     queryKey: queryKey,
     refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : false,
     queryFn: () => {
@@ -101,7 +105,11 @@ export const useTimeSeriesQuery = (definition: TimeSeriesQueryDefinition, option
 /**
  * Runs multiple time series queries using plugins and returns the results.
  */
-export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], options?: UseTimeSeriesQueryOptions) {
+export function useTimeSeriesQueries(
+  definitions: TimeSeriesQueryDefinition[],
+  options?: UseTimeSeriesQueryOptions,
+  enabled = true
+) {
   const { getPlugin } = usePluginRegistry();
   const context = useTimeSeriesQueryContext();
 
@@ -115,7 +123,7 @@ export function useTimeSeriesQueries(definitions: TimeSeriesQueryDefinition[], o
       const plugin = pluginLoaderResponse[idx]?.data;
       const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
       return {
-        enabled: queryEnabled,
+        enabled: enabled && queryEnabled,
         queryKey: queryKey,
         refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : undefined,
         queryFn: async () => {

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -11,7 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useQuery, useQueries, useQueryClient, Query, QueryCache, QueryKey } from '@tanstack/react-query';
+import {
+  useQuery,
+  useQueries,
+  useQueryClient,
+  Query,
+  QueryCache,
+  QueryKey,
+  QueryObserverOptions,
+} from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec, TimeSeriesData } from '@perses-dev/core';
 import { TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryPlugin } from '../model';
 import { VariableStateMap, useTemplateVariableValues } from './template-variables';
@@ -80,14 +88,14 @@ function getQueryOptions({
 export const useTimeSeriesQuery = (
   definition: TimeSeriesQueryDefinition,
   options?: UseTimeSeriesQueryOptions,
-  enabled?: boolean
+  queryOptions?: QueryObserverOptions
 ) => {
   const { data: plugin } = usePlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
   const context = useTimeSeriesQueryContext();
 
   const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
   return useQuery({
-    enabled: enabled || queryEnabled,
+    enabled: (queryOptions?.enabled ?? true) || queryEnabled,
     queryKey: queryKey,
     refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : false,
     queryFn: () => {
@@ -108,7 +116,7 @@ export const useTimeSeriesQuery = (
 export function useTimeSeriesQueries(
   definitions: TimeSeriesQueryDefinition[],
   options?: UseTimeSeriesQueryOptions,
-  enabled = true
+  queryOptions?: QueryObserverOptions
 ) {
   const { getPlugin } = usePluginRegistry();
   const context = useTimeSeriesQueryContext();
@@ -123,7 +131,7 @@ export function useTimeSeriesQueries(
       const plugin = pluginLoaderResponse[idx]?.data;
       const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
       return {
-        enabled: enabled && queryEnabled,
+        enabled: (queryOptions?.enabled ?? true) && queryEnabled,
         queryKey: queryKey,
         refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : undefined,
         queryFn: async () => {


### PR DESCRIPTION
There is a regression where lazy loading isn't working after introducing `DataQueriesProvider`.

This is because `DataQueryProvider` wraps the component only renders if it is in view port, resulting in all queries running when the page loads. 

This PR adds a new prop called enabled in DataQueriesProvider to provide the capability to disable running the query automatically