### PR TITLE
[BUGFIX] Hanging preview state when adding a new list variable before Source selected

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -38,9 +38,9 @@ export function getInitialState(initialVariableDefinition: VariableDefinition) {
 
   return {
     name: initialVariableDefinition.spec.name,
-    title: initialVariableDefinition.spec.display?.name,
+    title: initialVariableDefinition.spec.display?.name ?? '',
     kind: initialVariableDefinition.kind,
-    description: initialVariableDefinition.spec.display?.description,
+    description: initialVariableDefinition.spec.display?.description ?? '',
     listVariableFields,
     textVariableFields,
   };


### PR DESCRIPTION
- closes #1291 ?
- This PR resolve also another bug not filed. When we use a prometheus label value source for the variable list, if we don´t set the label name, it makes a query giving a 404 and a strange json message. Now it is just not querying if the label name is empty.  

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

![image](https://github.com/perses/perses/assets/10258608/2de9a40e-cd57-4935-9903-a7837bf2ca94)


- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
