### PR TITLE
move pkg integration test outside

### DIFF
--- a/internal/api/e2e/api/dashboard_test.go
+++ b/internal/api/e2e/api/dashboard_test.go
@@ -13,7 +13,7 @@
 
 //go:build integration
 
-package e2e
+package api
 
 import (
 	"fmt"

--- a/internal/api/e2e/api/doc.go
+++ b/internal/api/e2e/api/doc.go
@@ -13,18 +13,7 @@
 
 //go:build integration
 
-package e2e
+package api
 
-import (
-	"testing"
-
-	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
-	"github.com/perses/perses/internal/api/shared"
-	"github.com/perses/perses/pkg/model/api"
-)
-
-func TestMainScenarioVariable(t *testing.T) {
-	e2eframework.MainTestScenarioWithProject(t, shared.PathVariable, func(projectName string, name string) (api.Entity, api.Entity) {
-		return e2eframework.NewProject(projectName), e2eframework.NewVariable(projectName, name)
-	})
-}
+// this file is only present to trigger the e2e test. The e2e test of the api are in a dedicated package to avoid
+// a cycle in the import: core -> utils -> core.

--- a/internal/api/e2e/api/globaldatasource_test.go
+++ b/internal/api/e2e/api/globaldatasource_test.go
@@ -13,7 +13,7 @@
 
 //go:build integration
 
-package e2e
+package api
 
 import (
 	"testing"

--- a/internal/api/e2e/api/globalvariable_test.go
+++ b/internal/api/e2e/api/globalvariable_test.go
@@ -13,7 +13,7 @@
 
 //go:build integration
 
-package e2e
+package api
 
 import (
 	"testing"

--- a/internal/api/e2e/api/migrate_test.go
+++ b/internal/api/e2e/api/migrate_test.go
@@ -13,7 +13,7 @@
 
 //go:build integration
 
-package e2e
+package api
 
 import (
 	"encoding/json"

--- a/internal/api/e2e/api/project_test.go
+++ b/internal/api/e2e/api/project_test.go
@@ -13,7 +13,7 @@
 
 //go:build integration
 
-package e2e
+package api
 
 import (
 	"fmt"
@@ -23,34 +23,33 @@ import (
 	"github.com/gavv/httpexpect/v2"
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
 	"github.com/perses/perses/internal/api/shared/dependency"
 	"github.com/perses/perses/pkg/model/api"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestMainScenarioDatasource(t *testing.T) {
-	e2eframework.MainTestScenarioWithProject(t, shared.PathDatasource, func(projectName string, name string) (api.Entity, api.Entity) {
-		return e2eframework.NewProject(projectName), e2eframework.NewDatasource(t, projectName, name)
+func TestMainScenarioProject(t *testing.T) {
+	e2eframework.MainTestScenario(t, shared.PathProject, func(name string) api.Entity {
+		return e2eframework.NewProject(name)
 	})
 }
 
-func TestCreateDatasourceWithEmptyProjectName(t *testing.T) {
+func TestDeleteProjectWithSubResources(t *testing.T) {
 	e2eframework.WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		entity := e2eframework.NewDatasource(t, "", "myDTS")
-		expect.POST(fmt.Sprintf("%s/%s", shared.APIV1Prefix, shared.PathDatasource)).
-			WithJSON(entity).
+		projectName := "perses"
+		dash := e2eframework.NewDashboard(t, "perses", "Demo")
+		project := e2eframework.NewProject(projectName)
+		datasource := e2eframework.NewDatasource(t, "perses", "Demo")
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, project, dash, datasource)
+		expect.DELETE(fmt.Sprintf("%s/%s/%s", shared.APIV1Prefix, shared.PathProject, projectName)).
 			Expect().
-			Status(http.StatusBadRequest)
-		return []api.Entity{}
-	})
-}
+			Status(http.StatusNoContent)
 
-func TestCreateDatasourceWithNonExistingProject(t *testing.T) {
-	e2eframework.WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		entity := e2eframework.NewDatasource(t, "awesomeProjectThatDoesntExist", "myDTS")
-		expect.POST(fmt.Sprintf("%s/%s", shared.APIV1Prefix, shared.PathDatasource)).
-			WithJSON(entity).
-			Expect().
-			Status(http.StatusBadRequest)
+		_, err := manager.GetDashboard().Get(projectName, dash.Metadata.Name)
+		assert.True(t, databaseModel.IsKeyNotFound(err))
+		_, err = manager.GetDatasource().Get(projectName, datasource.Metadata.Name)
+		assert.True(t, databaseModel.IsKeyNotFound(err))
 		return []api.Entity{}
 	})
 }

--- a/internal/api/e2e/api/variable_test.go
+++ b/internal/api/e2e/api/variable_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2023 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,9 +12,19 @@
 // limitations under the License.
 
 //go:build integration
-// +build integration
 
-package e2e
+package api
 
-// this file is only present to trigger the e2e test. The e2e test of the api are in a dedicated package to avoid
-// a cycle in the import: core -> utils -> core.
+import (
+	"testing"
+
+	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
+	"github.com/perses/perses/internal/api/shared"
+	"github.com/perses/perses/pkg/model/api"
+)
+
+func TestMainScenarioVariable(t *testing.T) {
+	e2eframework.MainTestScenarioWithProject(t, shared.PathVariable, func(projectName string, name string) (api.Entity, api.Entity) {
+		return e2eframework.NewProject(projectName), e2eframework.NewVariable(projectName, name)
+	})
+}

--- a/internal/api/e2e/client/datasource_test.go
+++ b/internal/api/e2e/client/datasource_test.go
@@ -13,19 +13,20 @@
 
 //go:build integration
 
-package v1
+package client
 
 import (
 	"testing"
 
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared/dependency"
+	"github.com/perses/perses/pkg/client/api/v1"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateDatasource(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		projectEntity := e2eframework.NewProject("perses")
 		entity := e2eframework.NewDatasource(t, "perses", "myDTS")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, projectEntity)
@@ -39,7 +40,7 @@ func TestCreateDatasource(t *testing.T) {
 }
 
 func TestUpdateDatasource(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		projectEntity := e2eframework.NewProject("perses")
 		entity := e2eframework.NewDatasource(t, "perses", "myDTS")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, projectEntity)
@@ -56,7 +57,7 @@ func TestUpdateDatasource(t *testing.T) {
 }
 
 func TestGetDatasource(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		projectEntity := e2eframework.NewProject("perses")
 		entity := e2eframework.NewDatasource(t, "perses", "myDTS")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, projectEntity)
@@ -71,7 +72,7 @@ func TestGetDatasource(t *testing.T) {
 }
 
 func TestDeleteDatasource(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		projectEntity := e2eframework.NewProject("perses")
 		entity := e2eframework.NewDatasource(t, "perses", "myDTS")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, projectEntity)
@@ -84,7 +85,7 @@ func TestDeleteDatasource(t *testing.T) {
 }
 
 func TestListDatasource(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		projectEntity := e2eframework.NewProject("perses")
 		entity := e2eframework.NewDatasource(t, "perses", "myDTS")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, projectEntity)

--- a/internal/api/e2e/client/doc.go
+++ b/internal/api/e2e/client/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package client
+
+// this file is only present to trigger the e2e test. The e2e test of the api are in a dedicated package to avoid
+// a cycle in the import: core -> utils -> core.

--- a/internal/api/e2e/client/project_test.go
+++ b/internal/api/e2e/client/project_test.go
@@ -13,19 +13,20 @@
 
 //go:build integration
 
-package v1
+package client
 
 import (
 	"testing"
 
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared/dependency"
+	"github.com/perses/perses/pkg/client/api/v1"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateProject(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		entity := e2eframework.NewProject("perses")
 		object, err := clientInterface.Project().Create(entity)
 		assert.NoError(t, err)
@@ -36,7 +37,7 @@ func TestCreateProject(t *testing.T) {
 }
 
 func TestUpdateProject(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		entity := e2eframework.NewProject("perses")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
 		object, err := clientInterface.Project().Update(entity)
@@ -49,7 +50,7 @@ func TestUpdateProject(t *testing.T) {
 }
 
 func TestGetProject(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		entity := e2eframework.NewProject("perses")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
 		object, err := clientInterface.Project().Get(entity.Metadata.Name)
@@ -60,7 +61,7 @@ func TestGetProject(t *testing.T) {
 }
 
 func TestDeleteProject(t *testing.T) {
-	withClient(t, func(clientInterface ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	withClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
 		entity := e2eframework.NewProject("perses")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
 		err := clientInterface.Project().Delete(entity.Metadata.Name)

--- a/internal/api/e2e/client/test_utils.go
+++ b/internal/api/e2e/client/test_utils.go
@@ -13,7 +13,7 @@
 
 //go:build integration
 
-package v1
+package client
 
 import (
 	"net/http/httptest"
@@ -21,11 +21,12 @@ import (
 
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/shared/dependency"
+	"github.com/perses/perses/pkg/client/api/v1"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	"github.com/perses/perses/pkg/model/api"
 )
 
-func withClient(t *testing.T, testFunc func(ClientInterface, dependency.PersistenceManager) []api.Entity) {
+func withClient(t *testing.T, testFunc func(v1.ClientInterface, dependency.PersistenceManager) []api.Entity) {
 	server, _, persistenceManager := e2eframework.CreateServer(t)
 	defer server.Close()
 	persesClient := createClient(t, server)
@@ -34,12 +35,12 @@ func withClient(t *testing.T, testFunc func(ClientInterface, dependency.Persiste
 
 }
 
-func createClient(t *testing.T, server *httptest.Server) ClientInterface {
+func createClient(t *testing.T, server *httptest.Server) v1.ClientInterface {
 	restClient, err := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
 		URL: server.URL,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewWithClient(restClient)
+	return v1.NewWithClient(restClient)
 }


### PR DESCRIPTION
This PR is moving the integration in the internal package.
This is following the conversation from #1190. Moving them outside of `pkg` will reduce the number of indirect dependencies you have in the go.mod when you are importing perses.