### PR TITLE
[BREAKINGCHANGE] Datasource selection by group

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -10,6 +10,22 @@
     },
     "spec": {
       "duration": "5m",
+      "datasources": {
+        "PrometheusLocal": {
+          "default": false,
+          "plugin": {
+            "kind": "PrometheusDatasource",
+            "spec": {
+              "proxy": {
+                "kind": "HTTPProxy",
+                "spec": {
+                  "url": "http://localhost:9090"
+                }
+              }
+            }
+          }
+        }
+      },
       "variables": [
         {
           "kind": "ListVariable",

--- a/dev/data/projectdatasource.json
+++ b/dev/data/projectdatasource.json
@@ -45,5 +45,21 @@
         }
       }
     }
+  },
+  {
+    "kind": "Datasource",
+    "metadata": {
+      "name": "PrometheusDemoBrowser",
+      "project": "perses"
+    },
+    "spec": {
+      "default": false,
+      "plugin": {
+        "kind": "PrometheusDatasource",
+        "spec": {
+          "direct_url": "https://prometheus.demo.do.prometheus.io"
+        }
+      }
+    }
   }
 ]

--- a/dev/populate.sh
+++ b/dev/populate.sh
@@ -60,7 +60,7 @@ function insertResourceData() {
 }
 
 function injectAllData() {
-  insertResourceData ./data/localdatasource.json true
+  insertResourceData ./data/projectdatasource.json true
   insertResourceData ./data/dashboard.json true
   insertResourceData ./data/project.json
   insertResourceData ./data/globaldatasource.json

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -44,6 +44,7 @@ func New(conf config.Config, banner string) (*app.Runner, dependency.Persistence
 	persesAPI := NewPersesAPI(serviceManager, conf)
 	persesFrontend := ui.NewPersesFrontend()
 	proxyMiddleware := &middleware.Proxy{
+		Dashboard:    persistenceManager.GetDashboard(),
 		Secret:       persistenceManager.GetSecret(),
 		GlobalSecret: persistenceManager.GetGlobalSecret(),
 		DTS:          persistenceManager.GetDatasource(),

--- a/internal/api/shared/schemas/base_def_query.cue
+++ b/internal/api/shared/schemas/base_def_query.cue
@@ -15,9 +15,9 @@ package base
 
 kind: string
 spec: {
-	datasource?: close({
+	datasource?: {
 		kind:  string
 		name?: string
-	})
+	}
 	// additional fields allowed
 }

--- a/scripts/cue-test/cue-test.go
+++ b/scripts/cue-test/cue-test.go
@@ -85,7 +85,7 @@ func validateAllDashboards(sch schemas.Schemas) {
 
 func validateAllDatasources(sch schemas.Schemas) {
 	logrus.Info("validate all datasources in dev/data")
-	data, err := os.ReadFile(path.Join("dev", "data", "localdatasource.json"))
+	data, err := os.ReadFile(path.Join("dev", "data", "projectdatasource.json"))
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/ui/app/src/model/datasource-api.test.ts
+++ b/ui/app/src/model/datasource-api.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { HTTPDatasourceAPI } from './datasource-api';
+
+interface TestData {
+  input: {
+    project?: string;
+    dashboard?: string;
+    name: string;
+  };
+  expected: string;
+}
+
+describe('buildProxyUrl', () => {
+  test.each([
+    {
+      title: 'should build global datasource proxy url',
+      input: { name: 'datasourceA' },
+      expected: '/proxy/globaldatasources/datasourceA',
+    },
+    {
+      title: 'should build project datasource proxy url',
+      input: { project: 'projectA', name: 'datasourceA' },
+      expected: '/proxy/projects/projectA/datasources/datasourceA',
+    },
+    {
+      title: 'should build dashboard datasource proxy url',
+      input: { project: 'projectA', dashboard: 'dashboardA', name: 'datasourceA' },
+      expected: '/proxy/projects/projectA/dashboards/dashboardA/datasources/datasourceA',
+    },
+  ])('$title', (data: TestData) => {
+    expect(new HTTPDatasourceAPI().buildProxyUrl(data.input)).toEqual(data.expected);
+  });
+});

--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -11,40 +11,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ProjectDatasource, DatasourceSelector, GlobalDatasource, Datasource } from '@perses-dev/core';
-import { DatasourceApi } from '@perses-dev/dashboards';
+import { ProjectDatasource, DatasourceSelector, GlobalDatasource } from '@perses-dev/core';
+import { BuildDatasourceProxyUrlFunc, DatasourceApi } from '@perses-dev/dashboards';
 import LRUCache from 'lru-cache';
 import { fetchDatasourceList } from './datasource-client';
 import { fetchGlobalDatasourceList } from './global-datasource-client';
 
-//TODO: Move to tanstack query for caching
 export class HTTPDatasourceAPI implements DatasourceApi {
-  getDatasource(
-    project: string,
-    selector: DatasourceSelector
-  ): Promise<{ resource: ProjectDatasource; proxyUrl: string } | undefined> {
+  /**
+   * Helper function for getting a proxy URL from separate input parameters.
+   * Give the following output according to the definition or not of the input.
+   * - /proxy/globaldatasources/{name}
+   * - /proxy/projects/{project}/datasources/{name}
+   * - /proxy/projects/{project}/dashboards/{dashboard}/{name}
+   *
+   * NB: despite the fact it's possible, it is useless to give a dashboard without a project as the url will for sure
+   * correspond to nothing.
+   * @param name
+   * @param dashboard
+   * @param project
+   */
+  buildProxyUrl({ project, dashboard, name }: { project?: string; dashboard?: string; name: string }): string {
+    let url = `${!project && !dashboard ? 'globaldatasources' : 'datasources'}/${encodeURIComponent(name)}`;
+    if (dashboard) {
+      url = `dashboards/${encodeURIComponent(dashboard)}/${url}`;
+    }
+    if (project) {
+      url = `projects/${encodeURIComponent(project)}/${url}`;
+    }
+    return `/proxy/${url}`;
+  }
+
+  getDatasource(project: string, selector: DatasourceSelector): Promise<ProjectDatasource | undefined> {
     return fetchDatasourceList(project, selector.kind, selector.name ? undefined : true, selector.name).then((list) => {
       // hopefully it should return at most one element
-      if (list[0] !== undefined) {
-        return {
-          resource: list[0],
-          proxyUrl: getProxyUrl(list[0]),
-        };
-      }
+      return list[0];
     });
   }
 
-  getGlobalDatasource(
-    selector: DatasourceSelector
-  ): Promise<{ resource: GlobalDatasource; proxyUrl: string } | undefined> {
+  getGlobalDatasource(selector: DatasourceSelector): Promise<GlobalDatasource | undefined> {
     return fetchGlobalDatasourceList(selector.kind, selector.name ? undefined : true, selector.name).then((list) => {
       // hopefully it should return at most one element
-      if (list[0] !== undefined) {
-        return {
-          resource: list[0],
-          proxyUrl: getProxyUrl(list[0]),
-        };
-      }
+      return list[0];
     });
   }
 
@@ -145,28 +153,28 @@ class Cache {
   }
 }
 
+//TODO: Move to tanstack query for caching
 export class CachedDatasourceAPI implements DatasourceApi {
   private readonly client: DatasourceApi;
   private readonly cache: Cache;
+  public buildProxyUrl?: BuildDatasourceProxyUrlFunc;
 
   constructor(client: DatasourceApi) {
     this.client = client;
     this.cache = new Cache();
+    this.buildProxyUrl = this.client.buildProxyUrl;
   }
 
-  getDatasource(
-    project: string,
-    selector: DatasourceSelector
-  ): Promise<{ resource: ProjectDatasource; proxyUrl: string } | undefined> {
+  getDatasource(project: string, selector: DatasourceSelector): Promise<ProjectDatasource | undefined> {
     const { resource, keyExist } = this.cache.getDatasource(project, selector);
     if (resource) {
-      return Promise.resolve({ resource: resource, proxyUrl: getProxyUrl(resource) });
+      return Promise.resolve(resource);
     }
     if (keyExist) {
-      // in case the keyExist, than mean we already did the query, but the datasource doesn't exist. So we can safely return an undefined Promise.
+      // in case the keyExist, then it means we already did the query, but the datasource doesn't exist. So we can safely return an undefined Promise.
       return Promise.resolve(undefined);
     }
-    return this.client.getDatasource(project, selector).then((result) => {
+    return this.client.getDatasource(project, selector).then((result?: ProjectDatasource) => {
       if (result === undefined) {
         // in case the result is undefined, we should then notify that the datasource doesn't exist for the given selector.
         // Like that, next time another panel ask for the exact same datasource (with the same selector), then we won't query the server to try it again.
@@ -174,53 +182,41 @@ export class CachedDatasourceAPI implements DatasourceApi {
         // We have the same logic for the globalDatasources.
         this.cache.setUndefinedDatasource(project, selector);
       } else {
-        this.cache.setDatasource(result.resource);
+        this.cache.setDatasource(result);
       }
       return result;
     });
   }
 
-  getGlobalDatasource(
-    selector: DatasourceSelector
-  ): Promise<{ resource: GlobalDatasource; proxyUrl: string } | undefined> {
+  getGlobalDatasource(selector: DatasourceSelector): Promise<GlobalDatasource | undefined> {
     const { resource, keyExist } = this.cache.getGlobalDatasource(selector);
     if (resource) {
-      return Promise.resolve({ resource: resource, proxyUrl: getProxyUrl(resource) });
+      return Promise.resolve(resource);
     }
     if (keyExist) {
       return Promise.resolve(undefined);
     }
-    return this.client.getGlobalDatasource(selector).then((result) => {
+    return this.client.getGlobalDatasource(selector).then((result?: GlobalDatasource) => {
       if (result === undefined) {
         this.cache.setUndefinedGlobalDatasource(selector);
       } else {
-        this.cache.setGlobalDatasource(result.resource);
+        this.cache.setGlobalDatasource(result);
       }
       return result;
     });
   }
 
   listDatasources(project: string, pluginKind?: string): Promise<ProjectDatasource[]> {
-    return this.client.listDatasources(project, pluginKind).then((list) => {
+    return this.client.listDatasources(project, pluginKind).then((list: ProjectDatasource[]) => {
       this.cache.setDatasources(list);
       return list;
     });
   }
 
   listGlobalDatasources(pluginKind?: string): Promise<GlobalDatasource[]> {
-    return this.client.listGlobalDatasources(pluginKind).then((list) => {
+    return this.client.listGlobalDatasources(pluginKind).then((list: GlobalDatasource[]) => {
       this.cache.setGlobalDatasources(list);
       return list;
     });
   }
-}
-
-// Helper function for getting a proxy URL from a datasource or global datasource
-function getProxyUrl(datasource: Datasource) {
-  let url = `/proxy`;
-  if (datasource.kind === 'Datasource') {
-    url += `/projects/${encodeURIComponent(datasource.metadata.project)}`;
-  }
-  url += `/${datasource.kind.toLowerCase()}s/${encodeURIComponent(datasource.metadata.name)}`;
-  return url;
 }

--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -42,10 +42,25 @@ export interface DatasourceSpec<PluginSpec = UnknownSpec> {
 }
 
 /**
- * A selector for pointing at a specific Datasource. If name is omitted, it's assumed that you want the default
- * Datasource for the specified kind.
+ * A selector for pointing at a specific Datasource.
  */
 export interface DatasourceSelector {
+  /**
+   * Kind of the datasource.
+   */
   kind: string;
+  /**
+   * Group of the datasource.
+   * Omit it if you don't store datasource by group.
+   * TODO: This group field is fairly ignored by the backend data model.
+   *   We need to decouple properly the backend and frontend data models.
+   *   A Zustand store would certainly help here to decouple definition from the backend and state from the UI.
+   *   => See Variable Store
+   */
+  group?: string;
+  /**
+   * Name of the datasource.
+   * If omitted, it's assumed that you target the default datasource for the specified kind (and group, if set)
+   */
   name?: string;
 }

--- a/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
@@ -1,0 +1,477 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  DatasourcePlugin,
+  DatasourceSelectItemGroup,
+  MockPlugin,
+  mockPluginRegistry,
+  PluginRegistry,
+  useListDatasourceSelectItems,
+} from '@perses-dev/plugin-system';
+import { DatasourceStoreProvider } from '@perses-dev/dashboards';
+import { PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  DashboardResource,
+  DashboardSpec,
+  Datasource,
+  DatasourceSpec,
+  GlobalDatasource,
+  ProjectDatasource,
+} from '@perses-dev/core';
+
+const PROJECT = 'perses';
+const FAKE_PLUGIN_KIND = 'FakeDatasourcePluginKind';
+
+const FakeDataSourcePlugin: DatasourcePlugin = {
+  createClient: jest.fn().mockReturnValue(undefined),
+  OptionsEditorComponent: () => {
+    return <div>Edit options here</div>;
+  },
+  createInitialOptions: () => ({ direct_url: '' }),
+};
+
+const MOCK_DS_PLUGIN: MockPlugin = {
+  pluginType: 'Datasource',
+  kind: FAKE_PLUGIN_KIND,
+  plugin: FakeDataSourcePlugin,
+};
+
+interface TestData {
+  input: {
+    // datasources input. Considered empty if not defined
+    datasources: {
+      local: Record<string, DatasourceSpec | undefined>; // `| undefined` is to make jest accept the type as parametrizable
+      project: Datasource[];
+      global: Datasource[];
+    };
+  };
+  expected: {
+    result: DatasourceSelectItemGroup[];
+  };
+}
+
+function definedInDashboard(props: { default: boolean }): DatasourceSpec {
+  return { default: props.default, plugin: { kind: FAKE_PLUGIN_KIND, spec: {} } };
+}
+
+function definedInProject(props: { name: string; default: boolean }): ProjectDatasource {
+  return {
+    kind: 'Datasource',
+    metadata: { name: props.name, project: PROJECT },
+    spec: { default: props.default, plugin: { kind: FAKE_PLUGIN_KIND, spec: {} } },
+  };
+}
+
+function definedGlobally(props: { name: string; default: boolean }): GlobalDatasource {
+  return {
+    kind: 'GlobalDatasource',
+    metadata: { name: props.name },
+    spec: { default: props.default, plugin: { kind: FAKE_PLUGIN_KIND, spec: {} } },
+  };
+}
+
+describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
+  test.each([
+    {
+      title: 'should return [] if no datasources',
+      input: {
+        datasources: {
+          local: {},
+          project: [],
+          global: [],
+        },
+      },
+      expected: {
+        result: [],
+      },
+    },
+    {
+      title: 'datasources from different groups with different names',
+      input: {
+        datasources: {
+          local: {
+            localDatasourceA: definedInDashboard({ default: false }),
+          },
+          project: [definedInProject({ name: 'projectDatasourceA', default: false })],
+          global: [definedGlobally({ name: 'globalDatasourceA', default: false })],
+        },
+      },
+      expected: {
+        result: [
+          {
+            editLink: undefined,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            items: [
+              {
+                name: 'Default (localDatasourceA from dashboard)',
+                selector: {
+                  kind: FAKE_PLUGIN_KIND,
+                },
+              },
+            ],
+          },
+          {
+            editLink: undefined,
+            group: 'dashboard',
+            items: [
+              {
+                name: 'localDatasourceA',
+                overridden: false,
+                selector: {
+                  group: 'dashboard',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'localDatasourceA',
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/projects/perses/datasources',
+            group: 'project',
+            items: [
+              {
+                name: 'projectDatasourceA',
+                overridden: false,
+                selector: {
+                  group: 'project',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'projectDatasourceA',
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/admin/datasources',
+            group: 'global',
+            items: [
+              {
+                name: 'globalDatasourceA',
+                overridden: false,
+                selector: {
+                  group: 'global',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'globalDatasourceA',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      title: 'default datasource',
+      input: {
+        datasources: {
+          local: {},
+          project: [],
+          global: [definedGlobally({ name: 'datasourceA', default: true })],
+        },
+      },
+      expected: {
+        result: [
+          {
+            editLink: undefined,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            items: [
+              {
+                name: 'Default (datasourceA from global)',
+                selector: {
+                  kind: FAKE_PLUGIN_KIND,
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/admin/datasources',
+            group: 'global',
+            items: [
+              {
+                name: 'datasourceA',
+                overridden: false,
+                selector: {
+                  group: 'global',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'datasourceA',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      title: 'only one datasource can be default (local has precedence)',
+      input: {
+        datasources: {
+          local: {
+            ['localDatasourceA']: definedInDashboard({ default: true }),
+          },
+          project: [definedInProject({ name: 'projectDatasourceA', default: true })],
+          global: [definedGlobally({ name: 'globalDatasourceA', default: true })],
+        },
+      },
+      expected: {
+        result: [
+          {
+            editLink: undefined,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            items: [
+              {
+                name: 'Default (localDatasourceA from dashboard)',
+                selector: {
+                  kind: FAKE_PLUGIN_KIND,
+                },
+              },
+            ],
+          },
+          {
+            editLink: undefined,
+            group: 'dashboard',
+            items: [
+              {
+                name: 'localDatasourceA',
+                overridden: false,
+                selector: {
+                  group: 'dashboard',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'localDatasourceA',
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/projects/perses/datasources',
+            group: 'project',
+            items: [
+              {
+                name: 'projectDatasourceA',
+                overridden: false,
+                selector: {
+                  group: 'project',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'projectDatasourceA',
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/admin/datasources',
+            group: 'global',
+            items: [
+              {
+                name: 'globalDatasourceA',
+                overridden: false,
+                selector: {
+                  group: 'global',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'globalDatasourceA',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      title: 'overridden datasources cannot be set as default',
+      input: {
+        datasources: {
+          local: {},
+          project: [definedInProject({ name: 'datasourceA', default: false })],
+          global: [definedGlobally({ name: 'datasourceA', default: true })],
+        },
+      },
+      expected: {
+        result: [
+          {
+            editLink: undefined,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            items: [
+              {
+                // This is the default datasource because first of the list
+                name: 'Default (datasourceA from project)',
+                selector: {
+                  kind: FAKE_PLUGIN_KIND,
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/projects/perses/datasources',
+            group: 'project',
+            items: [
+              {
+                name: 'datasourceA',
+                overridden: false,
+                overriding: true,
+                selector: {
+                  group: 'project',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'datasourceA',
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/admin/datasources',
+            group: 'global',
+            items: [
+              {
+                name: 'datasourceA',
+                overridden: true,
+                overriding: true, // Oddity coming from the algorithm. Not harmful as overriding is not checked if overridden is true
+                selector: {
+                  group: 'global',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'datasourceA',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      title: 'complex case with several overrides and a default coming from global',
+      input: {
+        datasources: {
+          local: {
+            ['datasourceA']: definedInDashboard({ default: false }),
+          },
+          project: [definedInProject({ name: 'datasourceB', default: false })],
+          global: [
+            definedGlobally({ name: 'defaultDatasource', default: true }),
+            definedGlobally({ name: 'datasourceB', default: false }),
+            definedGlobally({ name: 'datasourceA', default: false }),
+          ],
+        },
+      },
+      expected: {
+        result: [
+          {
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            items: [
+              {
+                name: 'Default (defaultDatasource from global)',
+                selector: {
+                  kind: FAKE_PLUGIN_KIND,
+                },
+              },
+            ],
+          },
+          {
+            editLink: undefined,
+            group: 'dashboard',
+            items: [
+              {
+                name: 'datasourceA',
+                overridden: false,
+                overriding: true,
+                selector: {
+                  group: 'dashboard',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'datasourceA',
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/projects/perses/datasources',
+            group: 'project',
+            items: [
+              {
+                name: 'datasourceB',
+                overridden: false,
+                overriding: true,
+                selector: {
+                  group: 'project',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'datasourceB',
+                },
+              },
+            ],
+          },
+          {
+            editLink: '/admin/datasources',
+            group: 'global',
+            items: [
+              {
+                name: 'defaultDatasource',
+                overridden: false,
+                selector: {
+                  group: 'global',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'defaultDatasource',
+                },
+              },
+              {
+                name: 'datasourceB',
+                overridden: true,
+                overriding: true, // Oddity coming from the algorithm. Not harmful as overriding is not checked if overridden is true
+                selector: {
+                  group: 'global',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'datasourceB',
+                },
+              },
+              {
+                name: 'datasourceA',
+                overridden: true,
+                overriding: true, // Oddity coming from the algorithm. Not harmful as overriding is not checked if overridden is true
+                selector: {
+                  group: 'global',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'datasourceA',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ])('$title', async (data: TestData) => {
+    const datasourceApiMock = {
+      buildProxyUrl: jest.fn().mockReturnValue(''),
+      getDatasource: jest.fn().mockReturnValue(Promise.resolve([])),
+      getGlobalDatasource: jest.fn().mockReturnValue(Promise.resolve([])),
+      listDatasources: jest.fn().mockReturnValue(Promise.resolve(data.input.datasources.project)),
+      listGlobalDatasources: jest.fn().mockReturnValue(Promise.resolve(data.input.datasources.global)),
+    };
+    const queryClient = new QueryClient();
+    const dashboard = {
+      spec: { datasources: data.input.datasources.local } as Partial<DashboardSpec>,
+    } as DashboardResource;
+    const wrapper = ({ children }: PropsWithChildren) => {
+      return (
+        <PluginRegistry {...mockPluginRegistry(MOCK_DS_PLUGIN)}>
+          <QueryClientProvider client={queryClient}>
+            <DatasourceStoreProvider
+              dashboardResource={dashboard}
+              projectName={PROJECT}
+              datasourceApi={datasourceApiMock}
+            >
+              {children}
+            </DatasourceStoreProvider>
+          </QueryClientProvider>
+        </PluginRegistry>
+      );
+    };
+    const { result } = renderHook(() => useListDatasourceSelectItems(FAKE_PLUGIN_KIND), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual(data.expected.result);
+  });
+});

--- a/ui/dashboards/src/test/datasource-provider.tsx
+++ b/ui/dashboards/src/test/datasource-provider.tsx
@@ -39,12 +39,13 @@ export const prometheusDemo: GlobalDatasource = {
 export const defaultDatasourceProps: Pick<DatasourceStoreProviderProps, 'datasourceApi' | 'dashboardResource'> = {
   dashboardResource: getTestDashboard(),
   datasourceApi: {
+    buildProxyUrl: () => '',
     getDatasource: () => {
       return Promise.resolve(undefined);
     },
     getGlobalDatasource: (selector) => {
       if (selector.kind === 'PrometheusDatasource') {
-        return Promise.resolve({ resource: prometheusDemo, proxyUrl: prometheusDemoUrl });
+        return Promise.resolve(prometheusDemo);
       }
 
       return Promise.resolve(undefined);

--- a/ui/plugin-system/src/components/DatasourceSelect.tsx
+++ b/ui/plugin-system/src/components/DatasourceSelect.tsx
@@ -11,10 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Select, SelectProps, MenuItem } from '@mui/material';
+import OpenInNewIcon from 'mdi-material-ui/OpenInNew';
+import { Select, SelectProps, MenuItem, Stack, Divider, ListItemText, Chip, IconButton, Box } from '@mui/material';
 import { DatasourceSelector } from '@perses-dev/core';
 import { useMemo } from 'react';
-import { useListDatasources } from '../runtime';
+import { useListDatasourceSelectItems } from '../runtime';
 
 // Props on MUI Select that we don't want people to pass because we're either redefining them or providing them in
 // this component
@@ -32,16 +33,35 @@ export interface DatasourceSelectProps extends Omit<SelectProps<string>, Omitted
  */
 export function DatasourceSelect(props: DatasourceSelectProps) {
   const { datasourcePluginKind, value, onChange, ...others } = props;
-  const { data, isLoading } = useListDatasources(datasourcePluginKind);
+  const { data, isLoading } = useListDatasourceSelectItems(datasourcePluginKind);
 
-  // Convert the datasource list into menu items with name/value strings that the Select input can work with
+  // Rebuild the group of the value if not provided
+  const defaultValue = useMemo(() => {
+    const group = (data ?? [])
+      .flatMap((itemGroup) => itemGroup.items)
+      .find((item) => {
+        return value.kind === item.selector.kind && value.name === item.selector.name && !item.overridden;
+      })?.selector.group;
+    return { ...value, group };
+  }, [value, data]);
+
+  // Convert the datasource list into menu items with name/group?/value strings that the Select input can work with
   const menuItems = useMemo(() => {
-    if (data === undefined) return [];
-    return data.map((ds) => ({ name: ds.name, value: selectorToOptionValue(ds.selector) }));
+    return (data ?? []).map((itemGroup) => ({
+      group: itemGroup.group,
+      editLink: itemGroup.editLink,
+      items: itemGroup.items.map((item) => ({
+        name: item.name,
+        overriding: item.overriding,
+        overridden: item.overridden,
+        group: item.selector.group,
+        value: selectorToOptionValue(item.selector),
+      })),
+    }));
   }, [data]);
 
   // While loading available values, just use an empty string so MUI select doesn't warn about values out of range
-  const optionValue = isLoading ? '' : selectorToOptionValue(value);
+  const optionValue = isLoading ? '' : selectorToOptionValue(defaultValue);
 
   // When the user makes a selection, convert the string option value back to a DatasourceSelector
   const handleChange: SelectProps<string>['onChange'] = (e) => {
@@ -49,15 +69,68 @@ export function DatasourceSelect(props: DatasourceSelectProps) {
     onChange(next);
   };
 
-  // TODO: Does this need a loading indicator of some kind?
+  // We use a fake action event when we click on the action of the chip (hijack the "delete" feature).
+  // This is because the href link action is on the `deleteIcon` property already, but the `onDelete` property
+  // controls its visibility.
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const fakeActionEvent = () => {};
+
+  // TODO:
+  //  - Does this need a loading indicator of some kind?
+  //  - The group's edit link is not clickable once selected.
+  //  - The group's edit link is disabled if datasource is overridden.
+  //    Ref: https://github.com/mui/material-ui/issues/36572
   return (
     <Select {...others} value={optionValue} onChange={handleChange}>
-      {menuItems.map((menuItem) => (
-        <MenuItem key={menuItem.value} value={menuItem.value}>
-          {menuItem.name}
-        </MenuItem>
-      ))}
+      {menuItems.map((menuItemGroup) => [
+        <Divider key={`${menuItemGroup.group}-divider`} />,
+        ...menuItemGroup.items.map((menuItem) => (
+          <MenuItem key={menuItem.value} value={menuItem.value} disabled={menuItem.overridden}>
+            <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
+              <ListItemText>
+                <DatasourceName
+                  name={menuItem.name}
+                  overridden={menuItem.overridden}
+                  overriding={menuItem.overriding}
+                />
+              </ListItemText>
+              <ListItemText style={{ textAlign: 'right' }}>
+                {menuItemGroup.group && menuItemGroup.group.length > 0 && (
+                  <Chip
+                    disabled={false}
+                    label={menuItemGroup.group}
+                    size="small"
+                    onDelete={menuItemGroup.editLink ? fakeActionEvent : undefined}
+                    deleteIcon={
+                      menuItemGroup.editLink ? (
+                        <IconButton href={menuItemGroup.editLink} target="_blank">
+                          <OpenInNewIcon fontSize="small" />
+                        </IconButton>
+                      ) : undefined
+                    }
+                  />
+                )}
+              </ListItemText>
+            </Stack>
+          </MenuItem>
+        )),
+      ])}
     </Select>
+  );
+}
+
+export function DatasourceName(props: { name: string; overridden?: boolean; overriding?: boolean }) {
+  const { name, overridden, overriding } = props;
+  return (
+    <>
+      {`${name} `}
+      {!overridden && overriding && (
+        <Box display="inline" fontWeight="normal" color={(theme) => theme.palette.primary.main}>
+          (overriding)
+        </Box>
+      )}
+      {overridden && '(overridden)'}
+    </>
   );
 }
 
@@ -66,17 +139,18 @@ const OPTION_VALUE_DELIMITER = '_____';
 
 // Given a DatasourceSelector, returns a string value like `{kind}_____{name}` that can be used as a Select input value
 function selectorToOptionValue(selector: DatasourceSelector): string {
-  return [selector.kind, selector.name ?? ''].join(OPTION_VALUE_DELIMITER);
+  return [selector.kind, selector.group ?? '', selector.name ?? ''].join(OPTION_VALUE_DELIMITER);
 }
 
 // Given an option value name like `{kind}_____{name}`, returns a DatasourceSelector
 function optionValueToSelector(optionValue: string): DatasourceSelector {
-  const [kind, name] = optionValue.split(OPTION_VALUE_DELIMITER);
-  if (kind === undefined || name === undefined) {
+  const [kind, group, name] = optionValue.split(OPTION_VALUE_DELIMITER);
+  if (kind === undefined || group === undefined || name === undefined) {
     throw new Error('Invalid optionValue string');
   }
   return {
     kind,
+    group: group === '' ? undefined : group,
     name: name === '' ? undefined : name,
   };
 }

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -25,13 +25,21 @@ export interface DatasourceStore {
   getDatasourceClient<Client>(selector: DatasourceSelector): Promise<Client>;
 
   /**
-   * Gets a list of datasource metadata for a plugin kind.
+   * Gets a list of datasource selection items for a plugin kind.
    */
-  listDatasourceMetadata(datasourcePluginKind: string): Promise<DatasourceMetadata[]>;
+  listDatasourceSelectItems(datasourcePluginKind: string): Promise<DatasourceSelectItemGroup[]>;
 }
 
-export interface DatasourceMetadata {
+export interface DatasourceSelectItemGroup {
+  group?: string;
+  editLink?: string;
+  items: DatasourceSelectItem[];
+}
+
+export interface DatasourceSelectItem {
   name: string;
+  overridden?: boolean;
+  overriding?: boolean;
   selector: DatasourceSelector;
 }
 
@@ -46,12 +54,14 @@ export function useDatasourceStore() {
 }
 
 /**
- * Lists all available Datasource instances for a given datasource plugin kind. Returns a list with the name of that
- * instance, as well as its DatasourceSelector for referencing it.
+ * Lists all available Datasource selection items for a given datasource plugin kind.
+ * Returns a list, with all information that can be used in a datasource selection context (group, name, selector, kind, ...)
  */
-export function useListDatasources(datasourcePluginKind: string) {
-  const { listDatasourceMetadata } = useDatasourceStore();
-  return useQuery(['listDatasourceMetadata', datasourcePluginKind], () => listDatasourceMetadata(datasourcePluginKind));
+export function useListDatasourceSelectItems(datasourcePluginKind: string) {
+  const { listDatasourceSelectItems } = useDatasourceStore();
+  return useQuery(['listDatasourceSelectItems', datasourcePluginKind], () =>
+    listDatasourceSelectItems(datasourcePluginKind)
+  );
 }
 
 /**

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
@@ -12,7 +12,12 @@
 // limitations under the License.
 
 import { DatasourceSelector } from '@perses-dev/core';
-import { DatasourceStoreContext, DatasourceStore, usePluginRegistry } from '@perses-dev/plugin-system';
+import {
+  DatasourceStoreContext,
+  DatasourceStore,
+  usePluginRegistry,
+  DatasourceSelectItemGroup,
+} from '@perses-dev/plugin-system';
 import { StoryFn, StoryContext } from '@storybook/react';
 
 declare module '@storybook/react' {
@@ -45,7 +50,7 @@ export const WithPluginSystemDatasourceStore = (Story: StoryFn, context: StoryCo
   // basic stories. It likely will need expanding in the future.
   // In general, `plugin-system` would probably benefit from a provider wrapper
   // for `DatasourceStoreContext` that is more generic than the one available
-  // in in the `dashboard` package for non-dashboard use cases.
+  // in the `dashboard` package for non-dashboard use cases.
   const defaultValue: DatasourceStore = {
     getDatasource: (selector) => {
       if (selector.kind === 'PrometheusDatasource') {
@@ -70,12 +75,16 @@ export const WithPluginSystemDatasourceStore = (Story: StoryFn, context: StoryCo
       }
       throw new Error(`WithDatasourceStore is not configured to support kind: ${selector.kind}`);
     },
-    listDatasourceMetadata: async (datasourcePluginKind) => {
+    listDatasourceSelectItems: async (datasourcePluginKind): Promise<DatasourceSelectItemGroup[]> => {
       if (datasourcePluginKind === 'PrometheusDatasource') {
         return Promise.resolve([
           {
-            name: 'PrometheusDatasource',
-            selector: { kind: 'PrometheusDatasource' },
+            items: [
+              {
+                name: 'PrometheusDatasource',
+                selector: { kind: 'PrometheusDatasource' },
+              },
+            ],
           },
         ]);
       }

--- a/ui/prometheus-plugin/src/model/prometheus-selectors.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-selectors.ts
@@ -31,7 +31,7 @@ export const DEFAULT_PROM: PrometheusDatasourceSelector = { kind: PROM_DATASOURC
  * Returns true if the provided PrometheusDatasourceSelector is the default one.
  */
 export function isDefaultPromSelector(selector: PrometheusDatasourceSelector) {
-  return selector.name === undefined;
+  return selector.name === undefined && selector.group === undefined;
 }
 
 /**

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -54,7 +54,7 @@ const createStubContext = () => {
     datasourceStore: {
       getDatasource: jest.fn(),
       getDatasourceClient: getDatasourceClient,
-      listDatasourceMetadata: jest.fn(),
+      listDatasourceSelectItems: jest.fn(),
     },
     refreshKey: 'test',
     refreshIntervalInMs: 0,


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
<!-- Context useful to a reviewer -->
Currently the datasource selection when we use it in a panel or variable is quite limited. It is not displaying the eventually overridden datasource (e.g a global datasource when a project datasource exist with the same name)

I'm proposing to keep this well split by group (default VS local VS project VS global datasource ) so the user understand better from where the datasource selected comes from. 

As a bonus, it continues on the implementation of the local datasources. Specially the part that computes the proxy url on the fly + related proxy middleware in the backend.

# Breaking changes
- ``DatasourceApi``: Moved build of proxy url to dedidated optional method
- ``DatasourceStore``: Modified the datasource "metadata" to a list of selection items, grouped by group

# Screenshots
<!-- If there are UI changes -->
![image](https://github.com/perses/perses/assets/10258608/d705f898-1566-43e9-a624-75c6de08dacf)

# References
- internal
  - relates #1033 
- react
  - impossible to make the chip clickable if the item is disabled. I guess this is ok to keep it like this for now.
https://github.com/mui/material-ui/issues/36572

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
