### PR TITLE
[BUGFIX] datasource form: make name readonly after creation + fix wrong titles/names in readonly mode

### DIFF
--- a/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
@@ -17,21 +17,19 @@ import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
 import { DeleteDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
-import { DatasourceEditorForm } from './DatasourceEditorForm';
-
-export type ActionStr = 'Create' | 'Update';
+import { Action, DatasourceEditorForm } from './DatasourceEditorForm';
 
 interface DatasourceDrawerProps<T extends Datasource> {
   datasource: T;
   isOpen: boolean;
-  saveActionStr: ActionStr;
+  action: Action;
   onSave: Dispatch<T>;
   onDelete?: DispatchWithPromise<T>;
   onClose: DispatchWithoutAction;
 }
 
 export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerProps<T>) {
-  const { datasource, isOpen, saveActionStr, onSave, onClose, onDelete } = props;
+  const { datasource, isOpen, action, onSave, onClose, onDelete } = props;
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
 
   // When user clicks out of the drawer, do not close it, just do nothing
@@ -55,12 +53,10 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
           {isOpen && (
             <DatasourceEditorForm
               initialDatasource={datasource}
-              saveActionStr={saveActionStr}
+              action={action}
               onSave={onSave}
               onClose={onClose}
-              onDelete={
-                saveActionStr == 'Update' && onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined
-              }
+              onDelete={action == 'update' && onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
             />
           )}
         </PluginRegistry>

--- a/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceDrawer.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Datasource, DispatchWithPromise } from '@perses-dev/core';
-import { Dispatch, DispatchWithoutAction, useCallback, useState } from 'react';
+import { Dispatch, DispatchWithoutAction, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
@@ -34,10 +34,10 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
 
   // When user clicks out of the drawer, do not close it, just do nothing
   // This is a quick-win solution to avoid losing draft changes
-  // -> TODO allow closing by clicking-out without being too sensitive to missclicks
-  const handleClickOut = useCallback(() => {
-    return;
-  }, []);
+  // -> TODO find a way to enable closing by clicking-out, with a discard confirmation modal popping up
+  const handleClickOut = () => {
+    /* do nothing */
+  };
 
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">

--- a/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
@@ -156,8 +156,8 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
               label="Name"
               value={state.metadata.name}
               InputProps={{
-                disabled: !isReadonly && action !== 'create',
-                readOnly: isReadonly,
+                disabled: action === 'update',
+                readOnly: action === 'read',
               }}
               helperText={validation.name}
               onChange={(v) => {

--- a/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
+++ b/ui/app/src/components/DatasourceList/DatasourceEditorForm.tsx
@@ -13,7 +13,18 @@
 
 import { useImmer } from 'use-immer';
 import { Display, Datasource } from '@perses-dev/core';
-import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Divider,
+  FormControlLabel,
+  Grid,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+  capitalize,
+} from '@mui/material';
 import { Dispatch, DispatchWithoutAction, useCallback, useMemo, useState } from 'react';
 import { PluginEditor } from '@perses-dev/plugin-system';
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
@@ -63,22 +74,31 @@ function getInitialState<T extends Datasource>(datasource: T): T {
   };
 }
 
+export type Action = 'read' | 'create' | 'update';
+
 interface DatasourceEditorFormProps<T extends Datasource> {
   initialDatasource: T;
-  saveActionStr: string;
+  action: Action;
   onSave: Dispatch<T>;
   onClose: DispatchWithoutAction;
   onDelete?: DispatchWithoutAction;
 }
 
 export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEditorFormProps<T>) {
-  const { initialDatasource, saveActionStr, onSave, onClose, onDelete } = props;
+  const { initialDatasource, action, onSave, onClose, onDelete } = props;
 
   const patchedInitialDatasource = getInitialState(initialDatasource);
   const [state, setState] = useImmer(patchedInitialDatasource);
   const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
   const isReadonly = useIsReadonly();
   const validation = useMemo(() => getValidation(state), [state]);
+
+  const title = useMemo(() => {
+    if (action === 'read') return 'View Datasource';
+    if (action === 'create') return 'Create Datasource';
+    if (action === 'update') return 'Edit Datasource';
+    return '';
+  }, [action]);
 
   // When saving, remove the display property if ever display.name is empty, then pass the value upstream
   const handleSave = () => {
@@ -109,13 +129,15 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
           borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
         }}
       >
-        <Typography variant="h2">{saveActionStr} Datasource</Typography>
+        <Typography variant="h2">{title}</Typography>
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          <Button disabled={isReadonly || !validation.isValid} variant="contained" onClick={handleSave}>
-            {saveActionStr}
-          </Button>
+          {!isReadonly && (
+            <Button disabled={!validation.isValid} variant="contained" onClick={handleSave}>
+              {capitalize(action)}
+            </Button>
+          )}
           <Button color="secondary" variant="outlined" onClick={handleCancel}>
-            Cancel
+            {isReadonly ? 'Close' : 'Cancel'}
           </Button>
           {onDelete && (
             <Button disabled={isReadonly} color="error" variant="outlined" onClick={onDelete}>
@@ -134,6 +156,7 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
               label="Name"
               value={state.metadata.name}
               InputProps={{
+                disabled: !isReadonly && action !== 'create',
                 readOnly: isReadonly,
               }}
               helperText={validation.name}

--- a/ui/app/src/components/VariableList/VariableFormDrawer.tsx
+++ b/ui/app/src/components/VariableList/VariableFormDrawer.tsx
@@ -60,8 +60,15 @@ export function VariableFormDrawer<T extends Variable>(props: VariableFormDrawer
 
   const initialTimeRange = useInitialTimeRange('1h');
 
+  // When user clicks out of the drawer, do not close it, just do nothing
+  // This is a quick-win solution to avoid losing draft changes
+  // -> TODO find a way to enable closing by clicking-out, with a discard confirmation modal popping up
+  const handleClickOut = () => {
+    /* do nothing */
+  };
+
   return (
-    <Drawer isOpen={isOpen} onClose={onClose} data-testid="variable-editor">
+    <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="variable-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry
           pluginLoader={bundledPluginLoader}

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -135,7 +135,7 @@ function TabButton(props: TabButtonProps) {
               },
             }}
             isOpen={isCreateGlobalDatasourceDrawerStateOpened}
-            saveActionStr="Create"
+            action="create"
             onSave={handleGlobalDatasourceCreation}
             onClose={() => setCreateGlobalDatasourceFormStateOpened(false)}
           />

--- a/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
@@ -17,7 +17,6 @@ import { useSnackbar } from '@perses-dev/components';
 import { useCallback } from 'react';
 import { DatasourceList } from '../../../components/DatasourceList/DatasourceList';
 import {
-  useCreateGlobalDatasourceMutation,
   useDeleteGlobalDatasourceMutation,
   useGlobalDatasourceList,
   useUpdateGlobalDatasourceMutation,
@@ -33,30 +32,8 @@ export function GlobalDatasources(props: GlobalDatasourcesProps) {
   const { data, isLoading } = useGlobalDatasourceList();
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
 
-  const createDatasourceMutation = useCreateGlobalDatasourceMutation();
   const deleteDatasourceMutation = useDeleteGlobalDatasourceMutation();
   const updateDatasourceMutation = useUpdateGlobalDatasourceMutation();
-
-  const handleDatasourceCreate = useCallback(
-    (datasource: GlobalDatasource): Promise<void> => {
-      return new Promise((resolve, reject) => {
-        createDatasourceMutation.mutate(datasource, {
-          onSuccess: (createdDatasource: GlobalDatasource) => {
-            successSnackbar(
-              `Global Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`
-            );
-            resolve();
-          },
-          onError: (err) => {
-            exceptionSnackbar(err);
-            reject();
-            throw err;
-          },
-        });
-      });
-    },
-    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
-  );
 
   const handleDatasourceUpdate = useCallback(
     (datasource: GlobalDatasource): Promise<void> => {
@@ -105,7 +82,6 @@ export function GlobalDatasources(props: GlobalDatasourcesProps) {
       <DatasourceList
         data={data || []}
         hideToolbar={hideToolbar}
-        onCreate={handleDatasourceCreate}
         onUpdate={handleDatasourceUpdate}
         onDelete={handleDatasourceDelete}
         isLoading={isLoading}

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -158,7 +158,7 @@ function TabButton(props: TabButtonProps) {
               },
             }}
             isOpen={isCreateDatasourceDrawerStateOpened}
-            saveActionStr="Create"
+            action="create"
             onSave={handleDatasourceCreation}
             onClose={() => setCreateDatasourceDrawerStateOpened(false)}
           />

--- a/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
@@ -17,7 +17,6 @@ import { useCallback } from 'react';
 import { getDatasourceDisplayName, ProjectDatasource } from '@perses-dev/core';
 import {
   useDatasourceList,
-  useCreateDatasourceMutation,
   useDeleteDatasourceMutation,
   useUpdateDatasourceMutation,
 } from '../../../model/datasource-client';
@@ -35,30 +34,8 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
 
-  const createDatasourceMutation = useCreateDatasourceMutation(projectName);
   const deleteDatasourceMutation = useDeleteDatasourceMutation(projectName);
   const updateDatasourceMutation = useUpdateDatasourceMutation(projectName);
-
-  const handleDatasourceCreate = useCallback(
-    (datasource: ProjectDatasource): Promise<void> => {
-      return new Promise((resolve, reject) => {
-        createDatasourceMutation.mutate(datasource, {
-          onSuccess: (createdDatasource: ProjectDatasource) => {
-            successSnackbar(
-              `Global Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`
-            );
-            resolve();
-          },
-          onError: (err) => {
-            exceptionSnackbar(err);
-            reject();
-            throw err;
-          },
-        });
-      });
-    },
-    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
-  );
 
   const handleDatasourceUpdate = useCallback(
     (datasource: ProjectDatasource): Promise<void> => {
@@ -107,7 +84,6 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
       <DatasourceList
         data={data || []}
         hideToolbar={hideToolbar}
-        onCreate={handleDatasourceCreate}
         onUpdate={handleDatasourceUpdate}
         onDelete={handleDatasourceDelete}
         isLoading={isLoading}

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -147,7 +147,8 @@ export function VariableEditForm(props: VariableEditFormProps) {
               value={state.name}
               helperText={validation.name}
               InputProps={{
-                readOnly: action === 'update' || action === 'read',
+                disabled: action === 'update',
+                readOnly: action === 'read',
               }}
               onChange={(v) => {
                 setState((draft) => {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

fixes https://github.com/perses/perses/issues/1356.

This PR brings small changes to the datasource creation/edit form:
- it makes the datasource name attribute readonly after creation. This fixes the bug raised with #1356. The decision to remove this feature comes from other reasons than just this fix, see the comments in this issue to have more context.
![image](https://github.com/perses/perses/assets/7058693/0e9183c6-1322-4028-b499-43fec9b3c492)
- it fixes some wrong titles/names in readonly mode.
![image](https://github.com/perses/perses/assets/7058693/2e6b917b-7d17-4762-af21-98f83bb0eea6)
- it also aligns variable & datasource forms behaviors when clicking out of the drawer: it's now doing nothing for both - until we find a proper solution to have closure with discard confirmation modal showing up in this situation.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.