### PR TITLE
[FEATURE] Add $__range(_ms/_s) builtin variables + add support for curly bracket variables + fix prefixed variables by other variable name

### DIFF
--- a/ui/core/src/model/time.ts
+++ b/ui/core/src/model/time.ts
@@ -13,6 +13,13 @@
 
 import { Duration, sub } from 'date-fns';
 
+const ONE_SECOND_IN_MS = 1000;
+const ONE_MINUTE_IN_MS = 60000;
+const ONE_HOUR_IN_MS = 3600000;
+const ONE_DAY_IN_MS = 86400000; // assuming a day has always 24h
+const ONE_WEEK_IN_MS = 604800000; // assuming a week has always 7d
+const ONE_YEAR_IN_MS = 31536000000; // assuming a year has always 365d
+
 export type UnixTimeMs = number;
 
 export type DateTimeFormat = number | string;
@@ -102,6 +109,31 @@ export function isDurationString(maybeDuration: string): maybeDuration is Durati
   return DURATION_REGEX.test(maybeDuration);
 }
 
+export function intervalToPrometheusDuration(timeRange: AbsoluteTimeRange): Duration {
+  let durationInMs = timeRange.end.valueOf() - timeRange.start.valueOf();
+  const years = Math.trunc(durationInMs / ONE_YEAR_IN_MS);
+  if (years > 0) durationInMs -= years * ONE_YEAR_IN_MS;
+  const weeks = Math.trunc(durationInMs / ONE_WEEK_IN_MS);
+  if (weeks > 0) durationInMs -= weeks * ONE_WEEK_IN_MS;
+  const days = Math.trunc(durationInMs / ONE_DAY_IN_MS);
+  if (days > 0) durationInMs -= days * ONE_DAY_IN_MS;
+  const hours = Math.trunc(durationInMs / ONE_HOUR_IN_MS);
+  if (hours > 0) durationInMs -= hours * ONE_HOUR_IN_MS;
+  const minutes = Math.trunc(durationInMs / ONE_MINUTE_IN_MS);
+  if (minutes > 0) durationInMs -= minutes * ONE_MINUTE_IN_MS;
+  const seconds = Math.trunc(durationInMs / ONE_SECOND_IN_MS);
+
+  return {
+    years: years,
+    months: 0,
+    weeks: weeks,
+    days: days,
+    hours: hours,
+    minutes: minutes,
+    seconds: seconds,
+  };
+}
+
 export function formatDuration(duration: Duration): string {
   const result: string[] = [];
   if (duration.years) {
@@ -141,51 +173,51 @@ const ROUNDED_STEP_INTERVALS = [
   // max: 0.75s
   { maxMs: 750, roundedStepMs: 500, display: '0.5s' },
   // max: 1.5s
-  { maxMs: 1500, roundedStepMs: 1000, display: '1s' },
+  { maxMs: ONE_SECOND_IN_MS * 1.5, roundedStepMs: ONE_SECOND_IN_MS, display: '1s' },
   // max: 3.5s
-  { maxMs: 3500, roundedStepMs: 2000, display: '2s' },
+  { maxMs: ONE_SECOND_IN_MS * 3.5, roundedStepMs: ONE_SECOND_IN_MS * 2, display: '2s' },
   // max: 7.5s
-  { maxMs: 7500, roundedStepMs: 5000, display: '5s' },
+  { maxMs: ONE_SECOND_IN_MS * 7.5, roundedStepMs: ONE_SECOND_IN_MS * 5, display: '5s' },
   // max: 12.5s
-  { maxMs: 12500, roundedStepMs: 10000, display: '10s' },
+  { maxMs: ONE_SECOND_IN_MS * 12.5, roundedStepMs: ONE_SECOND_IN_MS * 10, display: '10s' },
   // max: 17.5s
-  { maxMs: 17500, roundedStepMs: 15000, display: '15s' },
+  { maxMs: ONE_SECOND_IN_MS * 17.5, roundedStepMs: ONE_SECOND_IN_MS * 15, display: '15s' },
   // max: 25s
-  { maxMs: 25000, roundedStepMs: 20000, display: '20s' },
+  { maxMs: ONE_SECOND_IN_MS * 25, roundedStepMs: ONE_SECOND_IN_MS * 20, display: '20s' },
   // max: 45s
-  { maxMs: 45000, roundedStepMs: 30000, display: '30s' },
+  { maxMs: ONE_SECOND_IN_MS * 45, roundedStepMs: ONE_SECOND_IN_MS * 30, display: '30s' },
   // max: 1.5m
-  { maxMs: 90000, roundedStepMs: 60000, display: '1m' },
+  { maxMs: ONE_MINUTE_IN_MS * 1.5, roundedStepMs: ONE_MINUTE_IN_MS, display: '1m' },
   // max: 3.5m
-  { maxMs: 210000, roundedStepMs: 120000, display: '2m' },
+  { maxMs: ONE_MINUTE_IN_MS * 3.5, roundedStepMs: ONE_MINUTE_IN_MS * 2, display: '2m' },
   // max: 7.5m
-  { maxMs: 450000, roundedStepMs: 300000, display: '5m' },
+  { maxMs: ONE_MINUTE_IN_MS * 7.5, roundedStepMs: ONE_MINUTE_IN_MS * 5, display: '5m' },
   // max: 12.5m
-  { maxMs: 750000, roundedStepMs: 600000, display: '10m' },
+  { maxMs: ONE_MINUTE_IN_MS * 12.5, roundedStepMs: ONE_MINUTE_IN_MS * 10, display: '10m' },
   // max: 12.5m
-  { maxMs: 1050000, roundedStepMs: 900000, display: '15m' },
+  { maxMs: ONE_MINUTE_IN_MS * 12.5, roundedStepMs: ONE_MINUTE_IN_MS * 15, display: '15m' },
   // max: 25m
-  { maxMs: 1500000, roundedStepMs: 1200000, display: '20m' },
+  { maxMs: ONE_MINUTE_IN_MS * 25, roundedStepMs: ONE_MINUTE_IN_MS * 20, display: '20m' },
   // max: 45m
-  { maxMs: 2700000, roundedStepMs: 1800000, display: '30m' },
+  { maxMs: ONE_MINUTE_IN_MS * 45, roundedStepMs: ONE_MINUTE_IN_MS * 30, display: '30m' },
   // max: 1.5h
-  { maxMs: 5400000, roundedStepMs: 3600000, display: '1h' },
+  { maxMs: ONE_HOUR_IN_MS * 1.5, roundedStepMs: ONE_HOUR_IN_MS, display: '1h' },
   // max: 2.5h
-  { maxMs: 9000000, roundedStepMs: 7200000, display: '2h' },
+  { maxMs: ONE_HOUR_IN_MS * 2.5, roundedStepMs: ONE_HOUR_IN_MS * 2, display: '2h' },
   // max: 4.5h
-  { maxMs: 16200000, roundedStepMs: 10800000, display: '3h' },
+  { maxMs: ONE_HOUR_IN_MS * 4.5, roundedStepMs: ONE_HOUR_IN_MS * 3, display: '3h' },
   // max: 9h
-  { maxMs: 32400000, roundedStepMs: 21600000, display: '6h' },
+  { maxMs: ONE_HOUR_IN_MS * 9, roundedStepMs: ONE_HOUR_IN_MS * 6, display: '6h' },
   // max: 1d
-  { maxMs: 86400000, roundedStepMs: 43200000, display: '12h' },
+  { maxMs: ONE_DAY_IN_MS, roundedStepMs: ONE_HOUR_IN_MS * 12, display: '12h' },
   // max: 1w
-  { maxMs: 604800000, roundedStepMs: 86400000, display: '1d' },
+  { maxMs: ONE_WEEK_IN_MS, roundedStepMs: ONE_DAY_IN_MS, display: '1d' },
   // max: 3w
-  { maxMs: 1814400000, roundedStepMs: 604800000, display: '1w' },
+  { maxMs: ONE_WEEK_IN_MS * 3, roundedStepMs: ONE_WEEK_IN_MS, display: '1w' },
   // max: 6w
-  { maxMs: 3628800000, roundedStepMs: 2592000000, display: '30d' },
+  { maxMs: ONE_WEEK_IN_MS * 6, roundedStepMs: ONE_DAY_IN_MS * 30, display: '30d' },
   // max: 2y
-  { maxMs: 63072000000, roundedStepMs: 31536000000, display: '1y' },
+  { maxMs: ONE_YEAR_IN_MS * 2, roundedStepMs: ONE_YEAR_IN_MS, display: '1y' },
 ];
 
 /**

--- a/ui/core/src/model/time.ts
+++ b/ui/core/src/model/time.ts
@@ -102,6 +102,29 @@ export function isDurationString(maybeDuration: string): maybeDuration is Durati
   return DURATION_REGEX.test(maybeDuration);
 }
 
+export function formatDuration(duration: Duration): string {
+  const result: string[] = [];
+  if (duration.years) {
+    result.push(`${duration.years}y`);
+  }
+  if (duration.weeks) {
+    result.push(`${duration.weeks}w`);
+  }
+  if (duration.days) {
+    result.push(`${duration.days}d`);
+  }
+  if (duration.hours) {
+    result.push(`${duration.hours}h`);
+  }
+  if (duration.minutes) {
+    result.push(`${duration.minutes}m`);
+  }
+  if (duration.seconds) {
+    result.push(`${duration.seconds}s`);
+  }
+  return result.join(' ');
+}
+
 const DEFAULT_STEP_MS = 15000;
 
 const ROUNDED_STEP_INTERVALS = [

--- a/ui/core/src/model/units/time.test.ts
+++ b/ui/core/src/model/units/time.test.ts
@@ -11,6 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {
+  AbsoluteTimeRange,
+  formatDuration,
+  FormatTestCase,
+  IntervalTestCase,
+  intervalToPrometheusDuration,
+} from '@perses-dev/core';
+import { Duration } from 'date-fns';
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
 
@@ -176,10 +184,144 @@ const TIME_TESTS: UnitTestCase[] = [
     expected: '100 years',
   },
 ];
-
 describe('formatValue', () => {
   it.each(TIME_TESTS)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
     const { value, unit, expected } = args;
     expect(formatValue(value, unit)).toEqual(expected);
   });
+});
+
+const INTERVAL_TO_PROMETHEUS_DURATION: IntervalTestCase[] = [
+  {
+    timeRange: {
+      start: new Date(1998, 0, 1),
+      end: new Date(1998, 0, 2),
+    } as AbsoluteTimeRange,
+    expected: {
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 1,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    } as Duration,
+  },
+  {
+    timeRange: {
+      start: new Date(1998, 0, 1),
+      end: new Date(1998, 0, 8),
+    } as AbsoluteTimeRange,
+    expected: {
+      years: 0,
+      months: 0,
+      weeks: 1,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    } as Duration,
+  },
+  {
+    timeRange: {
+      start: new Date(1998, 0, 1, 0, 0, 0),
+      end: new Date(1998, 0, 1, 2, 10, 30),
+    } as AbsoluteTimeRange,
+    expected: {
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 2,
+      minutes: 10,
+      seconds: 30,
+    } as Duration,
+  },
+  {
+    timeRange: {
+      start: new Date(1998, 0, 1, 0, 0, 0),
+      end: new Date(1998, 0, 366, 0, 0, 0),
+    } as AbsoluteTimeRange,
+    expected: {
+      years: 1,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    } as Duration,
+  },
+  {
+    timeRange: {
+      start: new Date(1998, 0, 1, 0, 0, 0),
+      end: new Date(1998, 0, 31, 0, 0, 0),
+    } as AbsoluteTimeRange,
+    expected: {
+      years: 0,
+      months: 0,
+      weeks: 4,
+      days: 2,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    } as Duration,
+  },
+];
+describe('intervalToPrometheusDuration', () => {
+  it.each(INTERVAL_TO_PROMETHEUS_DURATION)(
+    'returns $expected when time range is $timeRange',
+    (args: IntervalTestCase) => {
+      const { timeRange, expected } = args;
+      expect(intervalToPrometheusDuration(timeRange)).toEqual(expected);
+    }
+  );
+});
+
+const FORMAT_DURATION_TESTS: FormatTestCase[] = [
+  {
+    duration: {
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 1,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    } as Duration,
+    expected: '1d',
+  },
+  {
+    duration: {
+      years: 10,
+      months: 0,
+      weeks: 8,
+      days: 7,
+      hours: 6,
+      minutes: 5,
+      seconds: 4,
+    } as Duration,
+    expected: '10y 8w 7d 6h 5m 4s',
+  },
+  {
+    duration: {
+      years: 0,
+      months: 100, // Months are ignored
+      weeks: 0,
+      days: 1,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    } as Duration,
+    expected: '1d',
+  },
+];
+describe('formatDuration', () => {
+  it.each(FORMAT_DURATION_TESTS)(
+    'returns $expected when $duration formatted as DurationString',
+    (args: FormatTestCase) => {
+      const { duration, expected } = args;
+      expect(formatDuration(duration)).toEqual(expected);
+    }
+  );
 });

--- a/ui/core/src/model/units/time.ts
+++ b/ui/core/src/model/units/time.ts
@@ -83,7 +83,7 @@ export enum PersesTimeToIntlTime {
 const TIME_UNITS_IN_SECONDS: Record<TimeUnitKind, number> = {
   Years: 31536000, // 365 days
   Months: 2592000, // 30 days
-  Weeks: 604800,
+  Weeks: 604800, // 7 days
   Days: 86400,
   Hours: 3600,
   Minutes: 60,

--- a/ui/core/src/model/units/types.ts
+++ b/ui/core/src/model/units/types.ts
@@ -14,6 +14,7 @@
 // Common types needed across individual unit groups and the overall combined
 // units.
 
+import { AbsoluteTimeRange, DurationString } from '../time';
 import { UnitOptions } from './units';
 
 export const UNIT_GROUPS = ['Time', 'Percent', 'Decimal', 'Bytes'] as const;
@@ -65,4 +66,14 @@ export interface UnitTestCase {
   value: number;
   unit: UnitOptions;
   expected: string;
+}
+
+export interface IntervalTestCase {
+  timeRange: AbsoluteTimeRange;
+  expected: Duration;
+}
+
+export interface FormatTestCase {
+  duration: Duration;
+  expected: DurationString;
 }

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -32,8 +32,8 @@ import {
   VariableValue,
   VariableDefinition,
   formatDuration,
+  intervalToPrometheusDuration,
 } from '@perses-dev/core';
-import { intervalToDuration } from 'date-fns';
 import { checkSavedDefaultVariableStatus, findVariableDefinitionByName, mergeVariableDefinitions } from './utils';
 import { hydrateTemplateVariableStates } from './hydrationUtils';
 import { getInitalValuesFromQueryParameters, getURLQueryParamName, useVariableQueryParams } from './query-params';
@@ -209,7 +209,7 @@ function PluginProvider({ children, builtinVariables }: PluginProviderProps) {
     kind: 'BuiltinVariable',
     spec: {
       name: '__range',
-      value: () => formatDuration(intervalToDuration(absoluteTimeRange)),
+      value: () => formatDuration(intervalToPrometheusDuration(absoluteTimeRange)),
       display: {
         name: '__range',
         description: 'The range for the current dashboard in human readable format',

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -26,7 +26,14 @@ import {
   useTimeRange,
   BuiltinVariables,
 } from '@perses-dev/plugin-system';
-import { DEFAULT_ALL_VALUE as ALL_VALUE, VariableName, VariableValue, VariableDefinition } from '@perses-dev/core';
+import {
+  DEFAULT_ALL_VALUE as ALL_VALUE,
+  VariableName,
+  VariableValue,
+  VariableDefinition,
+  formatDuration,
+} from '@perses-dev/core';
+import { intervalToDuration } from 'date-fns';
 import { checkSavedDefaultVariableStatus, findVariableDefinitionByName, mergeVariableDefinitions } from './utils';
 import { hydrateTemplateVariableStates } from './hydrationUtils';
 import { getInitalValuesFromQueryParameters, getURLQueryParamName, useVariableQueryParams } from './query-params';
@@ -194,6 +201,42 @@ function PluginProvider({ children, builtinVariables }: PluginProviderProps) {
       display: {
         name: '__to',
         description: 'End time of the current time range in unix millisecond epoch',
+        hidden: true,
+      },
+    },
+  };
+  allBuiltinVariables['__range'] = {
+    kind: 'BuiltinVariable',
+    spec: {
+      name: '__range',
+      value: () => formatDuration(intervalToDuration(absoluteTimeRange)),
+      display: {
+        name: '__range',
+        description: 'The range for the current dashboard in human readable format',
+        hidden: true,
+      },
+    },
+  };
+  allBuiltinVariables['__range_s'] = {
+    kind: 'BuiltinVariable',
+    spec: {
+      name: '__range_s',
+      value: () => ((absoluteTimeRange.end.valueOf() - absoluteTimeRange.start.valueOf()) / 1000).toString(),
+      display: {
+        name: '__range_s',
+        description: 'The range for the current dashboard in second',
+        hidden: true,
+      },
+    },
+  };
+  allBuiltinVariables['__range_ms'] = {
+    kind: 'BuiltinVariable',
+    spec: {
+      name: '__range_ms',
+      value: () => (absoluteTimeRange.end.valueOf() - absoluteTimeRange.start.valueOf()).toString(),
+      display: {
+        name: '__range_ms',
+        description: 'The range for the current dashboard in millisecond',
         hidden: true,
       },
     },

--- a/ui/plugin-system/src/utils/variables.ts
+++ b/ui/plugin-system/src/utils/variables.ts
@@ -17,18 +17,25 @@ import { VariableStateMap } from '@perses-dev/plugin-system';
 export function replaceTemplateVariables(text: string, variableState: VariableStateMap): string {
   const variables = parseTemplateVariables(text);
   let finalText = text;
-  variables.forEach((v) => {
-    const variable = variableState[v];
-    if (variable && variable?.value) {
-      finalText = replaceTemplateVariable(finalText, v, variable?.value);
-    }
-  });
+  variables
+    // Sorting variables by their length.
+    // In order to not have a variable name have contained in another variable name.
+    // i.e.: $__range replacing $__range_ms => '3600_ms' instead of '3600000'
+    .sort((a, b) => b.length - a.length)
+    .forEach((v) => {
+      const variable = variableState[v];
+      if (variable && variable?.value) {
+        finalText = replaceTemplateVariable(finalText, v, variable?.value);
+      }
+    });
 
   return finalText;
 }
 
 export function replaceTemplateVariable(text: string, varName: string, templateVariableValue: VariableValue) {
   const variableTemplate = '$' + varName;
+  const bracketsVariableTemplate = '${' + varName + '}';
+
   let replaceString = '';
   if (Array.isArray(templateVariableValue)) {
     replaceString = `(${templateVariableValue.join('|')})`; // regex style
@@ -37,12 +44,14 @@ export function replaceTemplateVariable(text: string, varName: string, templateV
     replaceString = templateVariableValue;
   }
 
-  return text.replaceAll(variableTemplate, replaceString);
+  text = text.replaceAll(variableTemplate, replaceString);
+  return text.replaceAll(bracketsVariableTemplate, replaceString);
 }
 
 // This regular expression is designed to identify variable references in a template string.
 // It supports two formats for referencing variables:
 // 1. $variableName - This is a simpler format, and the regular expression captures the variable name (\w+ matches one or more word characters).
+// 2. ${variableName} - Useful for suffixed variables (.i.e: __range_ms is).
 // 2. [COMING SOON] ${variableName:value} - This is a more complex format that allows specifying a format function as well.
 // TODO: Fix this lint error
 // eslint-disable-next-line no-useless-escape
@@ -57,8 +66,15 @@ export const parseTemplateVariables = (text: string) => {
   let match;
 
   while ((match = regex.exec(text)) !== null) {
-    if (match && match.length > 1 && match[1]) {
-      matches.add(match[1]);
+    if (match) {
+      if (match[1]) {
+        // \$(\w+)\
+        matches.add(match[1]);
+      }
+      if (match[2]) {
+        // \${(\w+)}\
+        matches.add(match[2]);
+      }
     }
   }
   // return unique matches

--- a/ui/plugin-system/src/utils/variables.ts
+++ b/ui/plugin-system/src/utils/variables.ts
@@ -51,8 +51,8 @@ export function replaceTemplateVariable(text: string, varName: string, templateV
 // This regular expression is designed to identify variable references in a template string.
 // It supports two formats for referencing variables:
 // 1. $variableName - This is a simpler format, and the regular expression captures the variable name (\w+ matches one or more word characters).
-// 2. ${variableName} - Useful for suffixed variables (.i.e: __range_ms is).
-// 2. [COMING SOON] ${variableName:value} - This is a more complex format that allows specifying a format function as well.
+// 2. ${variableName} - This is a more complex format and the regular expression captures the variable name (\w+ matches one or more word characters) in the curly braces.
+// 3. [COMING SOON] ${variableName:value} - This is a more complex format that allows specifying a format function as well.
 // TODO: Fix this lint error
 // eslint-disable-next-line no-useless-escape
 const TEMPLATE_VARIABLE_REGEX = /\$(\w+)|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/gm;
@@ -70,8 +70,7 @@ export const parseTemplateVariables = (text: string) => {
       if (match[1]) {
         // \$(\w+)\
         matches.add(match[1]);
-      }
-      if (match[2]) {
+      } else if (match[2]) {
         // \${(\w+)}\
         matches.add(match[2]);
       }

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -29,8 +29,6 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   spec,
   context
 ) => {
-  // Register timeseries specific builtin variables
-
   if (spec.query === undefined || spec.query === null || spec.query === '') {
     // Do not make a request to the backend, instead return an empty TimeSeriesData
     return { series: [] };
@@ -50,7 +48,6 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   end = alignedEnd;
 
   // Replace template variable placeholders in PromQL query
-
   let query = spec.query.replace('$__rate_interval', `15s`);
   query = replaceTemplateVariables(query, context.variableState);
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -29,6 +29,8 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   spec,
   context
 ) => {
+  // Register timeseries specific builtin variables
+
   if (spec.query === undefined || spec.query === null || spec.query === '') {
     // Do not make a request to the backend, instead return an empty TimeSeriesData
     return { series: [] };
@@ -48,6 +50,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   end = alignedEnd;
 
   // Replace template variable placeholders in PromQL query
+
   let query = spec.query.replace('$__rate_interval', `15s`);
   query = replaceTemplateVariables(query, context.variableState);
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
- Add builtin variables:
  - `$__range`: The range for the current dashboard in "human" readable format (1y 1w 1d 1h 1m 1s)
  - `$__range_s`: The range for the current dashboard in second
  - `$__range_ms`: The range for the current dashboard in millisecond
 - Add support for curly bracket variables: `$varName` can also be written `${varName}`
 - Fix prefixed variables by other variable name, before `$__range_ms` was parsed `3600_ms` instead of `3600000`. Because `$__range` was applied before `$__range_ms`. Now variables with longer names are applied first.



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).


Closes #1345