### PR TITLE
[ENHANCEMENT] Reconcile variables & datasources CRUD

### DIFF
--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -31,9 +31,8 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
   const { datasource, isOpen, action, onSave, onClose, onDelete } = props;
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
 
-  // When user clicks out of the drawer, do not close it, just do nothing
-  // This is a quick-win solution to avoid losing draft changes
-  // -> TODO find a way to enable closing by clicking-out, with a discard confirmation modal popping up
+  // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
+  // -> TODO find a way to enable closing by clicking-out in edit view, with a discard confirmation modal popping up
   const handleClickOut = () => {
     /* do nothing */
   };
@@ -52,10 +51,10 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
           {isOpen && (
             <DatasourceEditorForm
               initialDatasource={datasource}
-              action={action}
+              initialAction={action}
               onSave={onSave}
               onClose={onClose}
-              onDelete={action == 'update' && onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
+              onDelete={onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
             />
           )}
         </PluginRegistry>

--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -52,6 +52,7 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
             <DatasourceEditorForm
               initialDatasource={datasource}
               initialAction={action}
+              isDraft={false}
               onSave={onSave}
               onClose={onClose}
               onDelete={onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}

--- a/ui/app/src/components/dialogs/index.ts
+++ b/ui/app/src/components/dialogs/index.ts
@@ -14,6 +14,7 @@
 export * from './CreateDashboardDialog';
 export * from './CreateProjectDialog';
 export * from './DeleteDashboardDialog';
+export * from './DeleteDatasourceDialog';
 export * from './DeleteProjectDialog';
 export * from './DeleteVariableDialog';
 export * from './RenameDashboardDialog';

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -85,6 +85,7 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
                 <VariableEditorForm
                   initialVariableDefinition={variableDef}
                   initialAction={action}
+                  isDraft={false}
                   onSave={handleSave}
                   onClose={onClose}
                   onDelete={onDelete ? () => setDeleteVariableDialogStateOpened(true) : undefined}

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -39,22 +39,22 @@ interface TabButtonProps {
 }
 
 function TabButton(props: TabButtonProps) {
-  const createDatasourceMutation = useCreateGlobalDatasourceMutation();
+  const createGlobalDatasourceMutation = useCreateGlobalDatasourceMutation();
   const createGlobalVariableMutation = useCreateGlobalVariableMutation();
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
 
-  const [isCreateGlobalDatasourceDrawerStateOpened, setCreateGlobalDatasourceFormStateOpened] = useState(false);
-  const [openCreateVariableDrawerState, setOpenCreateVariableDrawerState] = useState(false);
+  const [isDatasourceDrawerOpened, setDatasourceDrawerOpened] = useState(false);
+  const [isVariableDrawerOpened, setVariableDrawerOpened] = useState(false);
 
-  const handleVariableCreation = useCallback(
+  const handleGlobalVariableCreation = useCallback(
     (variable: GlobalVariableResource) => {
       createGlobalVariableMutation.mutate(variable, {
         onSuccess: (updatedVariable: GlobalVariableResource) => {
           successSnackbar(
             `Global Variable ${getVariableExtendedDisplayName(updatedVariable)} have been successfully created`
           );
-          setOpenCreateVariableDrawerState(false);
+          setVariableDrawerOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);
@@ -67,10 +67,10 @@ function TabButton(props: TabButtonProps) {
 
   const handleGlobalDatasourceCreation = useCallback(
     (datasource: GlobalDatasource) => {
-      createDatasourceMutation.mutate(datasource, {
+      createGlobalDatasourceMutation.mutate(datasource, {
         onSuccess: (createdDatasource: GlobalDatasource) => {
           successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
-          setCreateGlobalDatasourceFormStateOpened(false);
+          setDatasourceDrawerOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);
@@ -78,18 +78,14 @@ function TabButton(props: TabButtonProps) {
         },
       });
     },
-    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
+    [exceptionSnackbar, successSnackbar, createGlobalDatasourceMutation]
   );
 
   switch (props.index) {
     case variablesTabIndex:
       return (
         <>
-          <CRUDButton
-            text="Add Global Variable"
-            variant="contained"
-            onClick={() => setOpenCreateVariableDrawerState(true)}
-          />
+          <CRUDButton text="Add Global Variable" variant="contained" onClick={() => setVariableDrawerOpened(true)} />
           <VariableDrawer
             variable={{
               kind: 'GlobalVariable',
@@ -104,10 +100,10 @@ function TabButton(props: TabButtonProps) {
                 },
               },
             }}
-            isOpen={openCreateVariableDrawerState}
-            onChange={handleVariableCreation}
-            onClose={() => setOpenCreateVariableDrawerState(false)}
+            isOpen={isVariableDrawerOpened}
             action="create"
+            onSave={handleGlobalVariableCreation}
+            onClose={() => setVariableDrawerOpened(false)}
           />
         </>
       );
@@ -117,7 +113,7 @@ function TabButton(props: TabButtonProps) {
           <CRUDButton
             text="Add Global Datasource"
             variant="contained"
-            onClick={() => setCreateGlobalDatasourceFormStateOpened(true)}
+            onClick={() => setDatasourceDrawerOpened(true)}
           />
           <DatasourceDrawer
             datasource={{
@@ -134,10 +130,10 @@ function TabButton(props: TabButtonProps) {
                 },
               },
             }}
-            isOpen={isCreateGlobalDatasourceDrawerStateOpened}
+            isOpen={isDatasourceDrawerOpened}
             action="create"
             onSave={handleGlobalDatasourceCreation}
-            onClose={() => setCreateGlobalDatasourceFormStateOpened(false)}
+            onClose={() => setDatasourceDrawerOpened(false)}
           />
         </>
       );

--- a/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
@@ -90,6 +90,8 @@ export function GlobalDatasources(props: GlobalDatasourcesProps) {
             columnVisibilityModel: {
               project: false,
               version: false,
+              createdAt: false,
+              updatedAt: false,
             },
           },
         }}

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -50,9 +50,9 @@ function TabButton(props: TabButtonProps) {
   const createDatasourceMutation = useCreateDatasourceMutation(props.projectName);
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
 
-  const [openCreateDashboardDialogState, setOpenCreateDashboardDialogState] = useState(false);
-  const [openCreateVariableDrawerState, setOpenCreateVariableDrawerState] = useState(false);
-  const [isCreateDatasourceDrawerStateOpened, setCreateDatasourceDrawerStateOpened] = useState(false);
+  const [isCreateDashboardDialogOpened, setCreateDashboardDialogOpened] = useState(false);
+  const [isVariableDrawerOpened, setVariableDrawerOpened] = useState(false);
+  const [isDatasourceDrawerOpened, setDatasourceDrawerOpened] = useState(false);
 
   const handleDashboardCreation = (dashboardSelector: DashboardSelector) => {
     navigate(`/projects/${dashboardSelector.project}/dashboards/${dashboardSelector.dashboard}/create`);
@@ -63,7 +63,7 @@ function TabButton(props: TabButtonProps) {
       createVariableMutation.mutate(variable, {
         onSuccess: (updatedVariable: VariableResource) => {
           successSnackbar(`Variable ${getVariableExtendedDisplayName(updatedVariable)} have been successfully created`);
-          setOpenCreateVariableDrawerState(false);
+          setVariableDrawerOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);
@@ -79,7 +79,7 @@ function TabButton(props: TabButtonProps) {
       createDatasourceMutation.mutate(datasource, {
         onSuccess: (createdDatasource: ProjectDatasource) => {
           successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
-          setCreateDatasourceDrawerStateOpened(false);
+          setDatasourceDrawerOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);
@@ -94,15 +94,11 @@ function TabButton(props: TabButtonProps) {
     case dashboardsTabIndex:
       return (
         <>
-          <CRUDButton
-            text="Add Dashboard"
-            variant="contained"
-            onClick={() => setOpenCreateDashboardDialogState(true)}
-          />
+          <CRUDButton text="Add Dashboard" variant="contained" onClick={() => setCreateDashboardDialogOpened(true)} />
           <CreateDashboardDialog
-            open={openCreateDashboardDialogState}
+            open={isCreateDashboardDialogOpened}
             projectOptions={[props.projectName]}
-            onClose={() => setOpenCreateDashboardDialogState(false)}
+            onClose={() => setCreateDashboardDialogOpened(false)}
             onSuccess={handleDashboardCreation}
           />
         </>
@@ -110,7 +106,7 @@ function TabButton(props: TabButtonProps) {
     case variablesTabIndex:
       return (
         <>
-          <CRUDButton text="Add Variable" variant="contained" onClick={() => setOpenCreateVariableDrawerState(true)} />
+          <CRUDButton text="Add Variable" variant="contained" onClick={() => setVariableDrawerOpened(true)} />
           <VariableDrawer
             variable={{
               kind: 'Variable',
@@ -126,9 +122,9 @@ function TabButton(props: TabButtonProps) {
                 },
               },
             }}
-            isOpen={openCreateVariableDrawerState}
-            onChange={handleVariableCreation}
-            onClose={() => setOpenCreateVariableDrawerState(false)}
+            isOpen={isVariableDrawerOpened}
+            onSave={handleVariableCreation}
+            onClose={() => setVariableDrawerOpened(false)}
             action="create"
           />
         </>
@@ -136,11 +132,7 @@ function TabButton(props: TabButtonProps) {
     case datasourcesTabIndex:
       return (
         <>
-          <CRUDButton
-            text="Add Datasource"
-            variant="contained"
-            onClick={() => setCreateDatasourceDrawerStateOpened(true)}
-          />
+          <CRUDButton text="Add Datasource" variant="contained" onClick={() => setDatasourceDrawerOpened(true)} />
           <DatasourceDrawer
             datasource={{
               kind: 'Datasource',
@@ -157,10 +149,10 @@ function TabButton(props: TabButtonProps) {
                 },
               },
             }}
-            isOpen={isCreateDatasourceDrawerStateOpened}
+            isOpen={isDatasourceDrawerOpened}
             action="create"
             onSave={handleDatasourceCreation}
-            onClose={() => setCreateDatasourceDrawerStateOpened(false)}
+            onClose={() => setDatasourceDrawerOpened(false)}
           />
         </>
       );

--- a/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
@@ -42,9 +42,7 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
       return new Promise((resolve, reject) => {
         updateDatasourceMutation.mutate(datasource, {
           onSuccess: (updatedDatasource: ProjectDatasource) => {
-            successSnackbar(
-              `Global Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`
-            );
+            successSnackbar(`Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`);
             resolve();
           },
           onError: (err) => {
@@ -63,9 +61,7 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
       return new Promise((resolve, reject) => {
         deleteDatasourceMutation.mutate(datasource, {
           onSuccess: (deletedDatasource: ProjectDatasource) => {
-            successSnackbar(
-              `Global Datasource ${getDatasourceDisplayName(deletedDatasource)} has been successfully deleted`
-            );
+            successSnackbar(`Datasource ${getDatasourceDisplayName(deletedDatasource)} has been successfully deleted`);
             resolve();
           },
           onError: (err) => {
@@ -92,6 +88,8 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
             columnVisibilityModel: {
               project: false,
               version: false,
+              createdAt: false,
+              updatedAt: false,
             },
           },
         }}

--- a/ui/app/src/views/projects/tabs/ProjectVariables.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectVariables.tsx
@@ -45,7 +45,7 @@ export function ProjectVariables(props: ProjectVariablesProps) {
         updateVariableMutation.mutate(variable, {
           onSuccess: (updatedVariable: Variable) => {
             successSnackbar(
-              `Global Variable ${getVariableExtendedDisplayName(updatedVariable)} has been successfully updated`
+              `Variable ${getVariableExtendedDisplayName(updatedVariable)} has been successfully updated`
             );
             resolve();
           },
@@ -65,7 +65,7 @@ export function ProjectVariables(props: ProjectVariablesProps) {
         deleteVariableMutation.mutate(variable, {
           onSuccess: (deletedVariable: Variable) => {
             successSnackbar(
-              `Global Variable ${getVariableExtendedDisplayName(deletedVariable)} has been successfully deleted`
+              `Variable ${getVariableExtendedDisplayName(deletedVariable)} has been successfully deleted`
             );
             resolve();
           },

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -182,6 +182,7 @@ export function VariableEditor(props: {
         <VariableEditorForm
           initialVariableDefinition={currentEditingVariableDefinition}
           initialAction={variableFormAction}
+          isDraft={true}
           onSave={(definition: VariableDefinition) => {
             setVariableDefinitions((draft) => {
               draft[variableEditIdx] = definition;

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -181,19 +181,19 @@ export function VariableEditor(props: {
       {currentEditingVariableDefinition && (
         <VariableEditorForm
           initialVariableDefinition={currentEditingVariableDefinition}
-          onChange={(definition) => {
+          initialAction={variableFormAction}
+          onSave={(definition: VariableDefinition) => {
             setVariableDefinitions((draft) => {
               draft[variableEditIdx] = definition;
               setVariableEditIdx(null);
             });
           }}
-          onCancel={() => {
+          onClose={() => {
             if (variableFormAction === 'create') {
               removeVariable(variableEditIdx);
             }
             setVariableEditIdx(null);
           }}
-          action={variableFormAction}
         />
       )}
       {!currentEditingVariableDefinition && (

--- a/ui/e2e/src/pages/DatasourceEditor.ts
+++ b/ui/e2e/src/pages/DatasourceEditor.ts
@@ -16,7 +16,7 @@ import { Locator } from '@playwright/test';
 export class DatasourceEditor {
   readonly container: Locator;
 
-  readonly createButton: Locator;
+  readonly saveButton: Locator;
 
   readonly nameInput: Locator;
   readonly displayLabelInput: Locator;
@@ -27,7 +27,7 @@ export class DatasourceEditor {
   constructor(container: Locator) {
     this.container = container;
 
-    this.createButton = container.getByRole('button', { name: 'Create' });
+    this.saveButton = container.getByRole('button', { name: 'Save' });
 
     this.nameInput = container.getByLabel('Name');
     this.displayLabelInput = container.getByLabel('Display Label');

--- a/ui/e2e/src/pages/VariableEditor.ts
+++ b/ui/e2e/src/pages/VariableEditor.ts
@@ -18,8 +18,8 @@ export class VariableEditor {
   readonly container: Locator;
 
   readonly addVariableButton: Locator;
-  readonly createButton: Locator;
-  readonly updateButton: Locator;
+  readonly saveButton: Locator;
+  readonly addButton: Locator;
   readonly applyButton: Locator;
 
   readonly table: Locator;
@@ -33,8 +33,8 @@ export class VariableEditor {
     this.container = container;
 
     this.addVariableButton = container.getByRole('button', { name: 'Add Variable' });
-    this.createButton = container.getByRole('button', { name: 'Create' });
-    this.updateButton = container.getByRole('button', { name: 'Update' });
+    this.saveButton = container.getByRole('button', { name: 'Save' });
+    this.addButton = container.getByRole('button', { name: 'Add' });
     this.applyButton = container.getByRole('button', { name: 'Apply' });
 
     this.table = container.getByRole('table', {

--- a/ui/e2e/src/tests/projectView.spec.ts
+++ b/ui/e2e/src/tests/projectView.spec.ts
@@ -77,7 +77,7 @@ test.describe('ProjectView', () => {
     await variableEditor.setDisplayLabel('List Var');
     await variableEditor.selectType('list');
     await variableEditor.selectSource('Custom List');
-    await variableEditor.createButton.click();
+    await variableEditor.saveButton.click();
 
     await expect(projectPage.variableList).toContainText('$list_var');
   });
@@ -94,7 +94,7 @@ test.describe('ProjectView', () => {
     await datasourceEditor.setDisplayLabel('My personal datasource');
     await datasourceEditor.setDescription('This is a datasource for personal use');
     await datasourceEditor.setDefault(false);
-    await datasourceEditor.createButton.click();
+    await datasourceEditor.saveButton.click();
 
     await expect(projectPage.datasourceList).toContainText('my_ds');
   });

--- a/ui/e2e/src/tests/variables.spec.ts
+++ b/ui/e2e/src/tests/variables.spec.ts
@@ -31,7 +31,7 @@ test.describe('Dashboard: Variables', () => {
     await variableEditor.setDisplayLabel('Text Var');
     await variableEditor.selectType('Text');
     await variableEditor.setTextValue('test value');
-    await variableEditor.createButton.click();
+    await variableEditor.addButton.click();
 
     // Includes one for the table header.
     await expect(variableEditor.tableRows).toHaveCount(2);
@@ -55,7 +55,7 @@ test.describe('Dashboard: Variables', () => {
     await variableEditor.setDisplayLabel('List Var');
     await variableEditor.selectType('list');
     await variableEditor.selectSource('Custom List');
-    await variableEditor.createButton.click();
+    await variableEditor.addButton.click();
 
     // Includes one for the table header.
     await expect(variableEditor.tableRows).toHaveCount(2);

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -13,18 +13,7 @@
 
 import { useImmer } from 'use-immer';
 import { Display, Datasource } from '@perses-dev/core';
-import {
-  Box,
-  Button,
-  Divider,
-  FormControlLabel,
-  Grid,
-  Stack,
-  Switch,
-  TextField,
-  Typography,
-  capitalize,
-} from '@mui/material';
+import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
 import { Dispatch, DispatchWithoutAction, useCallback, useMemo, useState } from 'react';
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import { PluginEditor } from '../PluginEditor';
@@ -76,18 +65,19 @@ function getInitialState<T extends Datasource>(datasource: T): T {
 
 interface DatasourceEditorFormProps<T extends Datasource> {
   initialDatasource: T;
-  action: Action;
+  initialAction: Action;
   onSave: Dispatch<T>;
   onClose: DispatchWithoutAction;
   onDelete?: DispatchWithoutAction;
 }
 
 export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEditorFormProps<T>) {
-  const { initialDatasource, action, onSave, onClose, onDelete } = props;
+  const { initialDatasource, initialAction, onSave, onClose, onDelete } = props;
 
   const patchedInitialDatasource = getInitialState(initialDatasource);
   const [state, setState] = useImmer(patchedInitialDatasource);
-  const [isDiscardDialogStateOpened, setDiscardDialogStateOpened] = useState<boolean>(false);
+  const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
+  const [action, setAction] = useState(initialAction);
   const validation = useMemo(() => getValidation(state), [state]);
 
   const title = useMemo(() => {
@@ -111,11 +101,12 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
   // When the user clicks on cancel, ask for discard approval if anything was changed
   const handleCancel = useCallback(() => {
     if (JSON.stringify(patchedInitialDatasource) !== JSON.stringify(state)) {
-      setDiscardDialogStateOpened(true);
+      setDiscardDialogOpened(true);
     } else {
       onClose();
     }
-  }, [state, patchedInitialDatasource, setDiscardDialogStateOpened, onClose]);
+  }, [state, patchedInitialDatasource, setDiscardDialogOpened, onClose]);
+
   return (
     <>
       <Box
@@ -128,18 +119,39 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
       >
         <Typography variant="h2">{title}</Typography>
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          {action !== 'read' && (
-            <Button disabled={!validation.isValid} variant="contained" onClick={handleSave}>
-              {capitalize(action)}
-            </Button>
+          {action === 'read' && (
+            <>
+              <Button disabled={!validation.isValid} variant="contained" onClick={() => setAction('update')}>
+                Edit
+              </Button>
+              <Button color="error" variant="outlined" onClick={onDelete}>
+                Delete
+              </Button>
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={(theme) => ({
+                  borderColor: theme.palette.grey['500'],
+                  '&.MuiDivider-root': {
+                    marginLeft: 2,
+                    marginRight: 1,
+                  },
+                })}
+              />
+              <Button color="secondary" variant="outlined" onClick={onClose}>
+                Close
+              </Button>
+            </>
           )}
-          <Button color="secondary" variant="outlined" onClick={handleCancel}>
-            {action === 'read' ? 'Close' : 'Cancel'}
-          </Button>
-          {onDelete && (
-            <Button disabled={action === 'read'} color="error" variant="outlined" onClick={onDelete}>
-              Delete
-            </Button>
+          {action !== 'read' && (
+            <>
+              <Button disabled={!validation.isValid} variant="contained" onClick={handleSave}>
+                Save
+              </Button>
+              <Button color="secondary" variant="outlined" onClick={handleCancel}>
+                Cancel
+              </Button>
+            </>
           )}
         </Stack>
       </Box>
@@ -206,6 +218,7 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
                     checked={state.spec.default}
                     readOnly={action === 'read'}
                     onChange={(v) => {
+                      if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
                       setState((draft) => {
                         draft.spec.default = v.target.checked;
                       });
@@ -239,10 +252,10 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
       </Box>
       <DiscardChangesConfirmationDialog
         description="Are you sure you want to discard your changes? Changes cannot be recovered."
-        isOpen={isDiscardDialogStateOpened}
-        onCancel={() => setDiscardDialogStateOpened(false)}
+        isOpen={isDiscardDialogOpened}
+        onCancel={() => setDiscardDialogOpened(false)}
         onDiscardChanges={() => {
-          setDiscardDialogStateOpened(false);
+          setDiscardDialogOpened(false);
           onClose();
         }}
       />

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -17,7 +17,7 @@ import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField,
 import { Dispatch, DispatchWithoutAction, useCallback, useMemo, useState } from 'react';
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import { PluginEditor } from '../PluginEditor';
-import { Action } from '../../utils';
+import { Action, getSubmitText, getTitleAction } from '../../utils';
 
 // TODO: Replace with proper validation library
 function getValidation(state: Datasource) {
@@ -66,26 +66,22 @@ function getInitialState<T extends Datasource>(datasource: T): T {
 interface DatasourceEditorFormProps<T extends Datasource> {
   initialDatasource: T;
   initialAction: Action;
+  isDraft: boolean;
   onSave: Dispatch<T>;
   onClose: DispatchWithoutAction;
   onDelete?: DispatchWithoutAction;
 }
 
 export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEditorFormProps<T>) {
-  const { initialDatasource, initialAction, onSave, onClose, onDelete } = props;
+  const { initialDatasource, initialAction, isDraft, onSave, onClose, onDelete } = props;
 
   const patchedInitialDatasource = getInitialState(initialDatasource);
   const [state, setState] = useImmer(patchedInitialDatasource);
   const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
   const [action, setAction] = useState(initialAction);
   const validation = useMemo(() => getValidation(state), [state]);
-
-  const title = useMemo(() => {
-    if (action === 'read') return 'View Datasource';
-    if (action === 'create') return 'Create Datasource';
-    if (action === 'update') return 'Edit Datasource';
-    return '';
-  }, [action]);
+  const titleAction = getTitleAction(action, isDraft);
+  const submitText = getSubmitText(action, isDraft);
 
   // When saving, remove the display property if ever display.name is empty, then pass the value upstream
   const handleSave = () => {
@@ -117,7 +113,7 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
           borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
         }}
       >
-        <Typography variant="h2">{title}</Typography>
+        <Typography variant="h2">{titleAction} Datasource</Typography>
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
           {action === 'read' && (
             <>
@@ -146,7 +142,7 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
           {action !== 'read' && (
             <>
               <Button disabled={!validation.isValid} variant="contained" onClick={handleSave}>
-                Save
+                {submitText}
               </Button>
               <Button color="secondary" variant="outlined" onClick={handleCancel}>
                 Cancel

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -31,7 +31,7 @@ import {
 import { useImmer } from 'use-immer';
 import { VariableDefinition, ListVariableDefinition } from '@perses-dev/core';
 import { DiscardChangesConfirmationDialog, ErrorBoundary } from '@perses-dev/components';
-import { Action } from '../../../utils';
+import { Action, getSubmitText, getTitleAction } from '../../../utils';
 import { VARIABLE_TYPES } from '../variable-model';
 import { PluginEditor } from '../../PluginEditor';
 import { VariableListPreview, VariablePreview } from './VariablePreview';
@@ -62,13 +62,14 @@ function FallbackPreview() {
 interface VariableEditorFormProps {
   initialVariableDefinition: VariableDefinition;
   initialAction: Action;
+  isDraft: boolean;
   onSave: (def: VariableDefinition) => void;
   onClose: () => void;
   onDelete?: DispatchWithoutAction;
 }
 
 export function VariableEditorForm(props: VariableEditorFormProps) {
-  const { initialVariableDefinition, initialAction, onSave, onClose, onDelete } = props;
+  const { initialVariableDefinition, initialAction, isDraft, onSave, onClose, onDelete } = props;
 
   const initialState = getInitialState(initialVariableDefinition);
   const [state, setState] = useImmer(initialState);
@@ -90,12 +91,8 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [previewKey]);
 
-  const title = useMemo(() => {
-    if (action === 'read') return 'View Variable';
-    if (action === 'create') return 'Create Variable';
-    if (action === 'update') return 'Edit Variable';
-    return '';
-  }, [action]);
+  const titleAction = getTitleAction(action, isDraft);
+  const submitText = getSubmitText(action, isDraft);
 
   // When user click on cancel, several possibilities:
   // - create action: ask for discard approval
@@ -119,7 +116,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
           borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
         }}
       >
-        <Typography variant="h2">{title}</Typography>
+        <Typography variant="h2">{titleAction} Variable</Typography>
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
           {action === 'read' && (
             <>
@@ -154,7 +151,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   onSave(getVariableDefinitionFromState(state));
                 }}
               >
-                Save
+                {submitText}
               </Button>
               <Button color="secondary" variant="outlined" onClick={handleCancel}>
                 Cancel

--- a/ui/plugin-system/src/utils/action.ts
+++ b/ui/plugin-system/src/utils/action.ts
@@ -12,3 +12,18 @@
 // limitations under the License.
 
 export type Action = 'create' | 'read' | 'update';
+
+export function getTitleAction(action: Action, isDraft: boolean): string {
+  if (action === 'read') return 'View';
+  if (isDraft && action === 'create') return 'Add';
+  if (!isDraft && action === 'create') return 'Create';
+  if (action === 'update') return 'Edit';
+  return '';
+}
+
+export function getSubmitText(action: Action, isDraft: boolean): string {
+  if (isDraft && action === 'create') return 'Add';
+  if (isDraft && action === 'update') return 'Apply';
+  if (!isDraft) return 'Save';
+  return '';
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Resolves #1390.

This PR unifies the user experience when dealing with variables & datasources CRUD. Basically it consists in:
- adding action buttons in the list view for datasources
- adding action buttons in the form view for variables

It also fixes a minor issue with some snackbar messages showing "global \<resource\> updated" while it's a project one.

# Screenshots

![2023-08-29_17h45_31](https://github.com/perses/perses/assets/7058693/13a25fce-1e6a-4677-bee2-9337351c2760)

- **External resources forms:**
![2023-08-29_17h45_46](https://github.com/perses/perses/assets/7058693/e6853f5f-8be8-4f67-9f26-9518d458d54c)
![2023-08-29_17h45_56](https://github.com/perses/perses/assets/7058693/e26702a8-6bff-4b8c-944a-8c7922666612)
![2023-08-30_08h38_59](https://github.com/perses/perses/assets/7058693/82e75f5d-139d-4299-adde-28f2f251b48d)

- **Local resources forms:**
![2023-08-30_14h47_59](https://github.com/perses/perses/assets/7058693/784e1aac-66a2-4a33-8c84-6b61a8e634f4)
![2023-08-30_14h48_27](https://github.com/perses/perses/assets/7058693/b9fd787d-f53f-4e3c-8bce-814ecdfaac75)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
