### PR TITLE
[BUGFIX] Fix BE/FE misalignement on threshold datamodel #1389

### DIFF
--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -41,7 +41,7 @@ import (
 	show_points?:   "auto" | "always"
 	palette?:       #palette
 	point_radius?:  number & >=0 & <=6
-	stack?:         "all" | "percent" // TODO: Percent option is disabled until support is added
+	stack?:         "all" | "percent" // TODO: percent option is disabled until support is added
 	connect_nulls?: bool
 }
 

--- a/ui/components/src/ThresholdsEditor/ThresholdInput.tsx
+++ b/ui/components/src/ThresholdsEditor/ThresholdInput.tsx
@@ -61,7 +61,7 @@ export function ThresholdInput({
           }
         }}
         InputProps={{
-          endAdornment: mode === 'Percent' ? <Box paddingX={1}>%</Box> : undefined,
+          endAdornment: mode === 'percent' ? <Box paddingX={1}>%</Box> : undefined,
         }}
       />
       <IconButton aria-label={`delete threshold ${label}`} size="small" onClick={onDelete}>

--- a/ui/components/src/ThresholdsEditor/ThresholdsEditor.test.tsx
+++ b/ui/components/src/ThresholdsEditor/ThresholdsEditor.test.tsx
@@ -145,7 +145,7 @@ describe('ThresholdsEditor', () => {
     userEvent.click(percentageButton);
     expect(onChange).toHaveBeenCalledWith(
       produce(thresholds, (draft) => {
-        draft.mode = 'Percent';
+        draft.mode = 'percent';
       })
     );
 

--- a/ui/components/src/ThresholdsEditor/ThresholdsEditor.tsx
+++ b/ui/components/src/ThresholdsEditor/ThresholdsEditor.tsx
@@ -148,7 +148,7 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
   };
 
   const handleModeChange = (event: React.MouseEvent, value: string): void => {
-    const mode = value === 'Percent' ? 'Percent' : undefined;
+    const mode = value === 'percent' ? 'percent' : undefined;
     if (thresholds !== undefined) {
       onChange(
         produce(thresholds, (draft) => {
@@ -178,14 +178,14 @@ export function ThresholdsEditor({ thresholds, onChange, hideDefault, disablePer
           <ToggleButtonGroup
             exclusive
             disabled={disablePercentMode}
-            value={thresholds?.mode ?? 'Absolute'}
+            value={thresholds?.mode ?? 'absolute'}
             onChange={handleModeChange}
             sx={{ height: '36px', marginLeft: 'auto' }}
           >
-            <ToggleButton aria-label="absolute" value="Absolute" sx={{ fontWeight: 500 }}>
+            <ToggleButton aria-label="absolute" value="absolute" sx={{ fontWeight: 500 }}>
               Absolute
             </ToggleButton>
-            <ToggleButton aria-label="percent" value="Percent" sx={{ fontWeight: 500 }}>
+            <ToggleButton aria-label="percent" value="percent" sx={{ fontWeight: 500 }}>
               Percent
             </ToggleButton>
           </ToggleButtonGroup>

--- a/ui/core/src/model/thresholds.ts
+++ b/ui/core/src/model/thresholds.ts
@@ -18,7 +18,7 @@ export interface StepOptions {
 }
 
 export interface ThresholdOptions {
-  mode?: 'Percent' | 'Absolute';
+  mode?: 'percent' | 'absolute';
   default_color?: string;
   max?: number; // is this same as the max in GaugeChartOptions? can we remove?
   steps?: StepOptions[];

--- a/ui/e2e/src/pages/PanelEditor.ts
+++ b/ui/e2e/src/pages/PanelEditor.ts
@@ -91,7 +91,7 @@ export class PanelEditor {
     await openColorPickerButton.click();
   }
 
-  async toggleThresholdModes(mode: 'Absolute' | 'Percent') {
-    await this.container.getByRole('button', { name: mode === 'Percent' ? 'percent' : 'absolute' }).click();
+  async toggleThresholdModes(mode: 'absolute' | 'percent') {
+    await this.container.getByRole('button', { name: mode === 'percent' ? 'Percent' : 'Absolute' }).click();
   }
 }

--- a/ui/e2e/src/tests/gaugeChartPanel.spec.ts
+++ b/ui/e2e/src/tests/gaugeChartPanel.spec.ts
@@ -77,7 +77,7 @@ test.describe('Dashboard: Gauge Chart Panel', () => {
       await dashboardPage.startEditing();
       await dashboardPage.editPanel('Single Gauge', async (panelEditor) => {
         await panelEditor.selectTab('Settings');
-        await panelEditor.toggleThresholdModes('Percent');
+        await panelEditor.toggleThresholdModes('percent');
         await panelEditor.editThreshold('T1', '50');
         await panelEditor.container.getByLabel('Max').fill('200');
       });

--- a/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartPanel.spec.ts
@@ -131,7 +131,7 @@ test.describe('Dashboard: Time Series Chart Panel', () => {
       await panelEditor.addThreshold();
       await panelEditor.addThreshold();
       await panelEditor.editThreshold('T1', '50');
-      await panelEditor.toggleThresholdModes('Percent');
+      await panelEditor.toggleThresholdModes('percent');
       await panelEditor.container
         .getByRole('spinbutton', {
           name: 'Max',

--- a/ui/panels-plugin/src/model/thresholds.ts
+++ b/ui/panels-plugin/src/model/thresholds.ts
@@ -34,7 +34,7 @@ export function convertThresholds(
     // color segments must be decimal between 0 and 1
     const segmentMax = 1;
     const valuesArr: number[] = thresholds.steps.map((step: StepOptions) => {
-      if (thresholds.mode === 'Percent') {
+      if (thresholds.mode === 'percent') {
         return step.value / 100;
       }
       return step.value / max;

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -246,7 +246,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
           color: thresholdLineColor,
           value:
             // y_axis is passed here since it corresponds to dashboard JSON instead of the already converted ECharts yAxis
-            thresholds.mode === 'Percent'
+            thresholds.mode === 'percent'
               ? convertPercentThreshold(step.value, timeChartData, y_axis?.max, y_axis?.min)
               : step.value,
         };


### PR DESCRIPTION
# Description

Changed casing for thresholds mode to kebab-case on frontend side, to align with the backend datamodel. (This was basically missed in https://github.com/perses/perses/pull/1262).

This fixes #1389.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).