### PR TITLE
[BUGFIX] Fix saved changes to refresh interval not preserved

### DIFF
--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -48,12 +48,13 @@ type DashboardSpec struct {
 	Display *common.Display `json:"display,omitempty" yaml:"display,omitempty"`
 	// Datasources is an optional list of datasource definition.
 	Datasources map[string]*DatasourceSpec `json:"datasources,omitempty" yaml:"datasources,omitempty"`
-	// Duration is the default time you would like to use to looking in the past when getting data to fill the
-	// dashboard
-	Duration  model.Duration       `json:"duration" yaml:"duration"`
-	Variables []dashboard.Variable `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Panels    map[string]*Panel    `json:"panels" yaml:"panels"`
-	Layouts   []dashboard.Layout   `json:"layouts" yaml:"layouts"`
+	Variables   []dashboard.Variable       `json:"variables,omitempty" yaml:"variables,omitempty"`
+	Panels      map[string]*Panel          `json:"panels" yaml:"panels"`
+	Layouts     []dashboard.Layout         `json:"layouts" yaml:"layouts"`
+	// Duration is the default time range to use when getting data to fill the dashboard
+	Duration model.Duration `json:"duration" yaml:"duration"`
+	// RefreshInterval is the default refresh interval to use when landing on the dashboard
+	RefreshInterval model.Duration `json:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty"`
 }
 
 func (d *DashboardSpec) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -49,7 +49,6 @@ func TestMarshalDashboard(t *testing.T) {
 					Project: "perses",
 				},
 				Spec: DashboardSpec{
-					Duration:  model.Duration(6 * time.Hour),
 					Variables: nil,
 					Panels: map[string]*Panel{
 						"MyPanel": {
@@ -87,6 +86,8 @@ func TestMarshalDashboard(t *testing.T) {
 							},
 						},
 					},
+					Duration:        model.Duration(6 * time.Hour),
+					RefreshInterval: model.Duration(20 * time.Second),
 				},
 			},
 			result: `{
@@ -99,7 +100,6 @@ func TestMarshalDashboard(t *testing.T) {
     "project": "perses"
   },
   "spec": {
-    "duration": "6h",
     "panels": {
       "MyPanel": {
         "kind": "Panel",
@@ -136,7 +136,9 @@ func TestMarshalDashboard(t *testing.T) {
           ]
         }
       }
-    ]
+    ],
+    "duration": "6h",
+    "refreshInterval": "20s"
   }
 }`,
 		},
@@ -151,7 +153,6 @@ func TestMarshalDashboard(t *testing.T) {
 					Project: "perses",
 				},
 				Spec: DashboardSpec{
-					Duration: model.Duration(6 * time.Hour),
 					Variables: []dashboard.Variable{
 						{
 							Kind: variable.KindList,
@@ -223,6 +224,8 @@ func TestMarshalDashboard(t *testing.T) {
 							},
 						},
 					},
+					Duration:        model.Duration(6 * time.Hour),
+					RefreshInterval: model.Duration(15 * time.Second),
 				},
 			},
 			result: `{
@@ -235,7 +238,6 @@ func TestMarshalDashboard(t *testing.T) {
     "project": "perses"
   },
   "spec": {
-    "duration": "6h",
     "variables": [
       {
         "kind": "ListVariable",
@@ -307,7 +309,9 @@ func TestMarshalDashboard(t *testing.T) {
           ]
         }
       }
-    ]
+    ],
+    "duration": "6h",
+    "refreshInterval": "15s"
   }
 }`,
 		},
@@ -331,7 +335,6 @@ func TestUnmarshallDashboard(t *testing.T) {
     "project": "perses"
   },
   "spec": {
-    "duration": "6h",
     "variables": [
       {
         "kind": "ListVariable",
@@ -399,7 +402,9 @@ func TestUnmarshallDashboard(t *testing.T) {
           ]
         }
       }
-    ]
+    ],
+    "duration": "6h",
+    "refreshInterval": "30s"
   }
 }`
 
@@ -429,7 +434,6 @@ func TestUnmarshallDashboard(t *testing.T) {
 			Project: "perses",
 		},
 		Spec: DashboardSpec{
-			Duration: model.Duration(6 * time.Hour),
 			Variables: []dashboard.Variable{
 				{
 					Kind: variable.KindList,
@@ -486,6 +490,8 @@ func TestUnmarshallDashboard(t *testing.T) {
 					},
 				},
 			},
+			Duration:        model.Duration(6 * time.Hour),
+			RefreshInterval: model.Duration(30 * time.Second),
 		},
 	}
 	result := &Dashboard{}

--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -27,8 +27,8 @@
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",
-    "test": "TZ=UTC jest",
-    "test:watch": "TZ=UTC jest --watch",
+    "test": "cross-env TZ=UTC jest",
+    "test:watch": "cross-env TZ=UTC jest --watch",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -23,8 +23,8 @@
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",
-    "test": "TZ=UTC jest",
-    "test:watch": "TZ=UTC jest --watch",
+    "test": "cross-env TZ=UTC jest",
+    "test:watch": "cross-env TZ=UTC jest --watch",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -23,7 +23,7 @@
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",
-    "test": "TZ=UTC jest",
+    "test": "cross-env TZ=UTC jest",
     "test:watch": "npm run test -- --watch",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -18,7 +18,7 @@ import { screen, act } from '@testing-library/react';
 import { TimeRangeProvider } from '@perses-dev/plugin-system';
 import { renderWithContext } from '../../test';
 import testDashboard from '../../test/testDashboard';
-import { DashboardProvider, DashboardStoreProps } from '../../context';
+import { DashboardProvider, DashboardStoreProps, TemplateVariableProvider } from '../../context';
 import { TimeRangeControls } from './TimeRangeControls';
 
 const history = createMemoryHistory({
@@ -44,7 +44,9 @@ describe('TimeRangeControls', () => {
           initialTimeRange={testDefaultTimeRange}
           enabledURLParams={testURLParams}
         >
-          <TimeRangeControls />
+          <TemplateVariableProvider>
+            <TimeRangeControls />
+          </TemplateVariableProvider>
         </TimeRangeProvider>
       </DashboardProvider>,
       undefined,

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -15,10 +15,12 @@ import RefreshIcon from 'mdi-material-ui/Refresh';
 import { Stack } from '@mui/material';
 import { DateTimeRangePicker, RefreshIntervalPicker, InfoTooltip, TimeOption } from '@perses-dev/components';
 import { useTimeRange } from '@perses-dev/plugin-system';
-import { isDurationString } from '@perses-dev/core';
+import { isDurationString, DurationString } from '@perses-dev/core';
+import { useCallback } from 'react';
 import { TOOLTIP_TEXT } from '../../constants';
 import { useDashboardDuration } from '../../context';
 import { ToolbarIconButton } from '../ToolbarIconButton';
+import { useDashboard } from '../../context/useDashboard';
 
 export const DEFAULT_TIME_RANGE_OPTIONS: TimeOption[] = [
   { value: { pastDuration: '5m' }, display: 'Last 5 minutes' },
@@ -62,6 +64,7 @@ export function TimeRangeControls({
   const { timeRange, setTimeRange, refresh, refreshInterval, setRefreshInterval } = useTimeRange();
   // TODO: Remove this since it couples to the dashboard context
   const dashboardDuration = useDashboardDuration();
+  const { dashboard, setDashboard } = useDashboard();
 
   // Convert height to a string, then use the string for styling
   const height = heightPx === undefined ? DEFAULT_HEIGHT : `${heightPx}px`;
@@ -75,6 +78,21 @@ export function TimeRangeControls({
       });
     }
   }
+
+  // set the new refresh interval both in the dashboard context & as query param
+  const handleRefreshIntervalChange = useCallback(
+    (duration: DurationString) => {
+      setDashboard({
+        ...dashboard,
+        spec: {
+          ...dashboard.spec,
+          refreshInterval: duration,
+        },
+      });
+      setRefreshInterval(duration);
+    },
+    [dashboard, setDashboard, setRefreshInterval]
+  );
 
   return (
     <Stack direction="row" spacing={1}>
@@ -92,7 +110,7 @@ export function TimeRangeControls({
         <RefreshIntervalPicker
           timeOptions={DEFAULT_REFRESH_INTERVAL_OPTIONS}
           value={refreshInterval}
-          onChange={setRefreshInterval}
+          onChange={handleRefreshIntervalChange}
           height={height}
         />
       )}

--- a/ui/panels-plugin/package.json
+++ b/ui/panels-plugin/package.json
@@ -23,8 +23,8 @@
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",
-    "test": "TZ=UTC jest",
-    "test:watch": "TZ=UTC jest --watch",
+    "test": "cross-env TZ=UTC jest",
+    "test:watch": "cross-env TZ=UTC jest --watch",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -23,7 +23,7 @@
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",
-    "test": "TZ=UTC jest",
+    "test": "cross-env TZ=UTC jest",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/query-params.ts
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/query-params.ts
@@ -213,7 +213,7 @@ export function useSetRefreshIntervalParams(
   const { refresh } = query;
 
   useEffect(() => {
-    // when dashboard loaded with no params, default to dashboard duration
+    // when dashboard loaded with no params, default to dashboard refresh interval
     if (enabledURLParams && !paramsLoaded && !refresh) {
       setQuery({ refresh: initialRefreshInterval });
       setParamsLoaded(true);

--- a/ui/prometheus-plugin/package.json
+++ b/ui/prometheus-plugin/package.json
@@ -23,8 +23,8 @@
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",
-    "test": "TZ=UTC jest",
-    "test:watch": "TZ=UTC jest --watch",
+    "test": "cross-env TZ=UTC jest",
+    "test:watch": "cross-env TZ=UTC jest --watch",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },


### PR DESCRIPTION
# Description

Fixes https://github.com/perses/perses/issues/1337.

There were 2 underlying issues here:
- `refreshInterval` didn't exist in the backend datamodel
- changing refresh interval via the dropdown was not triggering dashboard context update

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
