### PR TITLE
[FEATURE] Display name is optional for variables

### DIFF
--- a/pkg/model/api/v1/common/display.go
+++ b/pkg/model/api/v1/common/display.go
@@ -13,45 +13,7 @@
 
 package common
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 type Display struct {
-	Name        string `json:"name" yaml:"name"`
+	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-}
-
-func (d *Display) UnmarshalJSON(data []byte) error {
-	var tmp Display
-	type plain Display
-	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
-		return err
-	}
-	if err := (&tmp).validate(); err != nil {
-		return err
-	}
-	*d = tmp
-	return nil
-}
-
-func (d *Display) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var tmp Display
-	type plain Display
-	if err := unmarshal((*plain)(&tmp)); err != nil {
-		return err
-	}
-	if err := (&tmp).validate(); err != nil {
-		return err
-	}
-	*d = tmp
-	return nil
-}
-
-func (d *Display) validate() error {
-	if len(d.Name) == 0 {
-		return fmt.Errorf("display.name cannot be empty")
-	}
-	return nil
 }

--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -24,10 +24,48 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+type PanelDisplay struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+func (d *PanelDisplay) UnmarshalJSON(data []byte) error {
+	var tmp PanelDisplay
+	type plain PanelDisplay
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *PanelDisplay) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp PanelDisplay
+	type plain PanelDisplay
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+	if err := (&tmp).validate(); err != nil {
+		return err
+	}
+	*d = tmp
+	return nil
+}
+
+func (d *PanelDisplay) validate() error {
+	if len(d.Name) == 0 {
+		return fmt.Errorf("display.name cannot be empty")
+	}
+	return nil
+}
+
 type PanelSpec struct {
-	Display common.Display `json:"display" yaml:"display"`
-	Plugin  common.Plugin  `json:"plugin" yaml:"plugin"`
-	Queries []Query        `json:"queries,omitempty" yaml:"queries,omitempty"`
+	Display PanelDisplay  `json:"display" yaml:"display"`
+	Plugin  common.Plugin `json:"plugin" yaml:"plugin"`
+	Queries []Query       `json:"queries,omitempty" yaml:"queries,omitempty"`
 }
 
 type Panel struct {

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -54,7 +54,7 @@ func TestMarshalDashboard(t *testing.T) {
 						"MyPanel": {
 							Kind: "Panel",
 							Spec: PanelSpec{
-								Display: common.Display{
+								Display: PanelDisplay{
 									Name: "simple line chart",
 								},
 								Plugin: common.Plugin{
@@ -192,7 +192,7 @@ func TestMarshalDashboard(t *testing.T) {
 						"MyPanel": {
 							Kind: "Panel",
 							Spec: PanelSpec{
-								Display: common.Display{
+								Display: PanelDisplay{
 									Name: "simple line chart",
 								},
 								Plugin: common.Plugin{
@@ -411,7 +411,7 @@ func TestUnmarshallDashboard(t *testing.T) {
 	panel := &Panel{
 		Kind: "Panel",
 		Spec: PanelSpec{
-			Display: common.Display{
+			Display: PanelDisplay{
 				Name: "simple line chart",
 			},
 			Plugin: common.Plugin{

--- a/pkg/model/api/v1/variable/variable.go
+++ b/pkg/model/api/v1/variable/variable.go
@@ -67,40 +67,7 @@ func (k *Kind) validate() error {
 }
 
 type Display struct {
-	Name        string `json:"name" yaml:"name"`
+	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	Hidden      bool   `json:"hidden" yaml:"hidden"`
-}
-
-func (d *Display) UnmarshalJSON(data []byte) error {
-	var tmp Display
-	type plain Display
-	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
-		return err
-	}
-	if err := (&tmp).validate(); err != nil {
-		return err
-	}
-	*d = tmp
-	return nil
-}
-
-func (d *Display) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var tmp Display
-	type plain Display
-	if err := unmarshal((*plain)(&tmp)); err != nil {
-		return err
-	}
-	if err := (&tmp).validate(); err != nil {
-		return err
-	}
-	*d = tmp
-	return nil
-}
-
-func (d *Display) validate() error {
-	if len(d.Name) == 0 {
-		return fmt.Errorf("variables[].display.name cannot be empty")
-	}
-	return nil
 }

--- a/ui/core/src/model/display.ts
+++ b/ui/core/src/model/display.ts
@@ -12,6 +12,6 @@
 // limitations under the License.
 
 export interface Display {
-  name: string;
+  name?: string;
   description?: string;
 }

--- a/ui/core/src/model/panels.ts
+++ b/ui/core/src/model/panels.ts
@@ -12,14 +12,19 @@
 // limitations under the License.
 
 import { Definition, UnknownSpec } from './definitions';
-import { Display } from './display';
 import { QueryDefinition } from './query';
+
+export interface PanelDisplay {
+  name: string;
+  description?: string;
+}
+
 export interface PanelDefinition<PluginSpec = UnknownSpec> extends Definition<PanelSpec<PluginSpec>> {
   kind: 'Panel';
 }
 
 export interface PanelSpec<PluginSpec> {
-  display: Display;
+  display: PanelDisplay;
   plugin: Definition<PluginSpec>;
   queries?: QueryDefinition[];
 }

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -43,16 +43,9 @@ function getValidation(state: Datasource) {
  */
 function getInitialState<T extends Datasource>(datasource: T): T {
   const patchedDisplay: Display = {
-    name: '',
-    description: '',
+    name: datasource.spec.display?.name ?? '',
+    description: datasource.spec.display?.description ?? '',
   };
-
-  if (datasource.spec.display) {
-    patchedDisplay.name = datasource.spec.display.name;
-    if (datasource.spec.display.description) {
-      patchedDisplay.description = datasource.spec.display.description;
-    }
-  }
 
   return {
     ...datasource,

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Display, TextVariableDefinition, VariableDefinition } from '@perses-dev/core';
+import { TextVariableDefinition, VariableDefinition } from '@perses-dev/core';
 
 export function getInitialState(initialVariableDefinition: VariableDefinition) {
   const textVariableFields = {
@@ -51,15 +51,7 @@ export type VariableEditorState = ReturnType<typeof getInitialState>;
 export function getVariableDefinitionFromState(state: VariableEditorState): VariableDefinition {
   const { name, title, kind, description } = state;
 
-  let display: Display | undefined = title ? { name: title } : undefined;
-  if (description) {
-    if (display) {
-      display.description = description;
-    } else {
-      // Name is mandatory if you want to add a description, autofilled by the metadata name if undefined
-      display = { name: name, description: description };
-    }
-  }
+  const display = { name: title, description: description };
 
   if (kind === 'TextVariable') {
     return {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
You can't set a description without having a display name for variables & datasources. This requirement is removed with this PR. 
Closes #1384

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
