### PR TITLE
[BUGFIX] Fix panel preview unresponsive after query error

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -118,7 +118,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
         }}
         ref={setContentElement}
       >
-        <ErrorBoundary FallbackComponent={ErrorAlert} resetKeys={[definition.spec.plugin.spec]}>
+        <ErrorBoundary FallbackComponent={ErrorAlert} resetKeys={[definition.spec]}>
           <PanelContent
             panelPluginKind={definition.spec.plugin.kind}
             spec={definition.spec.plugin.spec}


### PR DESCRIPTION
# Description

Fixes https://github.com/perses/perses/issues/1342.
Fixes https://github.com/perses/perses/issues/1402.

This bug was most probably introduced with https://github.com/perses/perses/pull/1032, since before this the queries definition was located within the panel's plugin spec, thus relying on `plugin.spec` as resetKeys for the ErrorBoundary component was fine at this time.

# Screenshots

https://github.com/perses/perses/assets/7058693/38e7dc56-ee16-478e-81fd-be9126201b31

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
