### PR TITLE
[BREAKINGCHANGE] rename palette's `kind` + change its value to kebab-case

### DIFF
--- a/schemas/panels/time-series/time-series.cue
+++ b/schemas/panels/time-series/time-series.cue
@@ -31,7 +31,8 @@ import (
 }
 
 #palette: {
-	kind: "Auto" | "Categorical"
+	mode: "auto" | "categorical"
+	// colors: [...string]; // TODO: add colors to override ECharts theme
 }
 
 #visual: {

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -468,7 +468,7 @@ const TIMESERIES_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
       ColorPaletteAuto: {
         kind: 'Panel',
         spec: {
-          display: { name: 'Auto Palette (Many Series)', description: 'Time series chart with Auto palette example' },
+          display: { name: 'Auto Palette (Many Series)', description: 'Time series chart with auto palette example' },
           plugin: {
             kind: 'TimeSeriesChart',
             spec: {
@@ -499,7 +499,7 @@ const TIMESERIES_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
         spec: {
           display: {
             name: 'Categorical Palette (Default)',
-            description: 'Time series chart with Categorical palette example',
+            description: 'Time series chart with categorical palette example',
           },
           plugin: {
             kind: 'TimeSeriesChart',
@@ -508,7 +508,7 @@ const TIMESERIES_EXAMPLE_DASHBOARD_RESOURCE: DashboardResource = {
                 position: 'right',
               },
               visual: {
-                palette: { kind: 'Categorical' },
+                palette: { mode: 'categorical' },
                 connectNulls: true,
               },
             },

--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -47,7 +47,7 @@ export interface TooltipSpecOptions {
 }
 
 export interface TimeSeriesChartPaletteOptions {
-  kind: 'Auto' | 'Categorical';
+  mode: 'auto' | 'categorical';
   // colors: string []; // TODO: add colors to override ECharts theme
 }
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.test.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.test.ts
@@ -76,7 +76,7 @@ describe('getSeriesColor', () => {
   it('should return color from the generative Auto palette when visual option is defined', () => {
     const visualOptionAuto: TimeSeriesChartVisualOptions = {
       palette: {
-        kind: 'Auto',
+        mode: 'auto',
       },
     };
     const props: SeriesColorProps = {
@@ -94,7 +94,7 @@ describe('getSeriesColor', () => {
   it('should return color from the Categorical palette when visual option is defined', () => {
     const visualOptionCategorical: TimeSeriesChartVisualOptions = {
       palette: {
-        kind: 'Categorical',
+        mode: 'categorical',
       },
     };
     const props: SeriesColorProps = {

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/palette-gen.ts
@@ -35,12 +35,12 @@ export function getSeriesColor(props: SeriesColorProps) {
       : muiPrimaryColor;
 
   // Explicit way to opt-in to generative palette with consistent colors for same series names.
-  if (visual.palette?.kind === 'Auto') {
+  if (visual.palette?.mode === 'auto') {
     return getAutoPaletteColor(seriesName, fallbackColor);
   }
 
   // Explicit way to always cycle through classical palette instead of changing when based on number of series.
-  if (visual.palette?.kind === 'Categorical') {
+  if (visual.palette?.mode === 'categorical') {
     return getCategoricalPaletteColor(categoricalPalette, seriesIndex, fallbackColor);
   }
 


### PR DESCRIPTION
# Description

As suggested by @sjcobb in https://github.com/perses/perses/pull/1278, this change is to get rid of an inconsistency in our datamodel, here with palette having a `kind` without a `spec`.
At first I changed `palette` to be a simple string with the value of the current `kind` attribute, but in the end I kept it as a struct and changed `kind` to `mode` as there are plans to add more attributes there in the future - for custom colors etc, see current todos.
Also since it's no longer named `kind`, the value is changed to kebab-case.

_Afaiu this palette attribute has currently no use since https://github.com/perses/perses/pull/1150, but kept in the model for later use._

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).