### PR TITLE
[BUGFIX] Align camelCase json key in secret

### DIFF
--- a/pkg/model/api/v1/public_secret.go
+++ b/pkg/model/api/v1/public_secret.go
@@ -19,11 +19,11 @@ import (
 )
 
 type PublicSecretSpec struct {
-	BasicAuth *secret.PublicBasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`
+	BasicAuth *secret.PublicBasicAuth `json:"basicAuth,omitempty" yaml:"basicAuth,omitempty"`
 	// The HTTP authorization credentials for the targets.
 	Authorization *secret.PublicAuthorization `yaml:"authorization,omitempty" json:"authorization,omitempty"`
 	// TLSConfig to use to connect to the targets.
-	TLSConfig secret.PublicTLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+	TLSConfig secret.PublicTLSConfig `yaml:"tlsConfig,omitempty" json:"tlsConfig,omitempty"`
 }
 
 func NewPublicSecretSpec(s SecretSpec) PublicSecretSpec {

--- a/pkg/model/api/v1/secret.go
+++ b/pkg/model/api/v1/secret.go
@@ -26,7 +26,7 @@ type SecretSpec struct {
 	// The HTTP authorization credentials for the targets.
 	Authorization *secret.Authorization `yaml:"authorization,omitempty" json:"authorization,omitempty"`
 	// TLSConfig to use to connect to the targets.
-	TLSConfig secret.TLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+	TLSConfig secret.TLSConfig `yaml:"tlsConfig,omitempty" json:"tlsConfig,omitempty"`
 }
 
 func (s *SecretSpec) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/secret/basic_auth.go
+++ b/pkg/model/api/v1/secret/basic_auth.go
@@ -24,7 +24,7 @@ import (
 type PublicBasicAuth struct {
 	Username     string `json:"username" yaml:"username"`
 	Password     Hidden `json:"password,omitempty" yaml:"password,omitempty"`
-	PasswordFile string `json:"password_file,omitempty" yaml:"password_file,omitempty"`
+	PasswordFile string `json:"passwordFile,omitempty" yaml:"passwordFile,omitempty"`
 }
 
 func NewPublicBasicAuth(b *BasicAuth) *PublicBasicAuth {
@@ -42,7 +42,7 @@ type BasicAuth struct {
 	Username string `json:"username" yaml:"username"`
 	Password string `json:"password,omitempty" yaml:"password,omitempty"`
 	// PasswordFile is a path to a file that contains a password
-	PasswordFile string `json:"password_file,omitempty" yaml:"password_file,omitempty"`
+	PasswordFile string `json:"passwordFile,omitempty" yaml:"passwordFile,omitempty"`
 }
 
 func (b *BasicAuth) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/secret/tls_config.go
+++ b/pkg/model/api/v1/secret/tls_config.go
@@ -19,11 +19,11 @@ type PublicTLSConfig struct {
 	CA                 Hidden `yaml:"ca,omitempty" json:"ca,omitempty"`
 	Cert               Hidden `yaml:"cert,omitempty" json:"cert,omitempty"`
 	Key                Hidden `yaml:"key,omitempty" json:"key,omitempty"`
-	CAFile             string `yaml:"ca_file,omitempty" json:"ca_file,omitempty"`
-	CertFile           string `yaml:"cert_file,omitempty" json:"cert_file,omitempty"`
-	KeyFile            string `yaml:"key_file,omitempty" json:"key_file,omitempty"`
-	ServerName         string `yaml:"server_name,omitempty" json:"server_name,omitempty"`
-	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" json:"insecure_skip_verify"`
+	CAFile             string `yaml:"caFile,omitempty" json:"caFile,omitempty"`
+	CertFile           string `yaml:"certFile,omitempty" json:"certFile,omitempty"`
+	KeyFile            string `yaml:"keyFile,omitempty" json:"keyFile,omitempty"`
+	ServerName         string `yaml:"serverName,omitempty" json:"serverName,omitempty"`
+	InsecureSkipVerify bool   `yaml:"insecureSkipVerify" json:"insecureSkipVerify"`
 }
 
 func NewPublicTLSConfig(t TLSConfig) PublicTLSConfig {
@@ -47,13 +47,13 @@ type TLSConfig struct {
 	// Text of the client key file for the targets.
 	Key string `yaml:"key,omitempty" json:"key,omitempty"`
 	// The CA cert to use for the targets.
-	CAFile string `yaml:"ca_file,omitempty" json:"ca_file,omitempty"`
+	CAFile string `yaml:"caFile,omitempty" json:"caFile,omitempty"`
 	// The client cert file for the targets.
-	CertFile string `yaml:"cert_file,omitempty" json:"cert_file,omitempty"`
+	CertFile string `yaml:"certFile,omitempty" json:"certFile,omitempty"`
 	// The client key file for the targets.
-	KeyFile string `yaml:"key_file,omitempty" json:"key_file,omitempty"`
+	KeyFile string `yaml:"keyFile,omitempty" json:"keyFile,omitempty"`
 	// Used to verify the hostname for the targets.
-	ServerName string `yaml:"server_name,omitempty" json:"server_name,omitempty"`
+	ServerName string `yaml:"serverName,omitempty" json:"serverName,omitempty"`
 	// Disable target certificate validation.
-	InsecureSkipVerify bool `yaml:"insecure_skip_verify" json:"insecure_skip_verify"`
+	InsecureSkipVerify bool `yaml:"insecureSkipVerify" json:"insecureSkipVerify"`
 }


### PR DESCRIPTION
I'm just applying the camelCase convention we choose for the json key. It has been missed for the secret.