### PR TITLE
[ENHANCEMENT] Add new `constant` boolean field to the TextVariable to dis/allow user input…

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -62,11 +62,20 @@
             "name": "interval",
             "plugin": {
               "kind": "StaticListVariable",
-              "spec": { "values": ["1m", "5m"] }
+              "spec": {
+                "values": ["1m", "5m"]
+              }
             }
           }
         },
-        { "kind": "TextVariable", "spec": { "name": "text", "value": "test" } }
+        { 
+          "kind": "TextVariable",
+          "spec": {
+            "name": "text",
+            "value": "test",
+            "constant": true
+          }
+        }
       ],
       "panels": {
         "defaultTimeSeriesChart": {
@@ -3059,7 +3068,8 @@
               "name": "Text variable",
               "hidden": false
             },
-            "value": "initial value"
+            "value": "initial value",
+            "constant": false
           }
         }
       ],

--- a/internal/api/shared/migrate/mapping.cuepart
+++ b/internal/api/shared/migrate/mapping.cuepart
@@ -61,10 +61,45 @@ spec: {
             kind: "TextVariable"
             spec: {
                 name: grafanaVar.name
+                display: {
+                    name: [ // switch
+                        if grafanaVar.label != _|_ if grafanaVar.label != "" {
+                            grafanaVar.label
+                        },
+                        grafanaVar.name
+                    ][0]
+                    if grafanaVar.description != _|_ {
+                        description: grafanaVar.description
+                    }
+                    hidden: true
+                }
+                constant: true
                 value: grafanaVar.query
             }
         }
-        if grafanaVar.type != "constant" {
+        if grafanaVar.type == "textbox" {
+            kind: "TextVariable"
+            spec: {
+                name: grafanaVar.name
+                display: {
+                    name: [ // switch
+                        if grafanaVar.label != _|_ if grafanaVar.label != "" {
+                            grafanaVar.label
+                        },
+                        grafanaVar.name
+                    ][0]
+                    if grafanaVar.description != _|_ {
+                        description: grafanaVar.description
+                    }
+                    if grafanaVar.hide > 0 {
+                        hidden: true
+                    }
+                }
+                constant: false
+                value: grafanaVar.query
+            }
+        }
+        if grafanaVar.type != "constant" && grafanaVar.type != "textbox" {
             kind: "ListVariable"
             spec: {
                 name: grafanaVar.name
@@ -85,7 +120,7 @@ spec: {
                     }
                 }
                 allowAllValue: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
-                allowMultiple: *grafanaVar.multi | false       // the default value tackles the case of variables of type `interval` that don't have such field
+                allowMultiple: *grafanaVar.multi | false      // the default value tackles the case of variables of type `interval` that don't have such field
                 // defaultValue: nothing to map to this field
                 #var: grafanaVar
                 plugin: [ // switch

--- a/internal/api/shared/migrate/migrate.go
+++ b/internal/api/shared/migrate/migrate.go
@@ -168,13 +168,15 @@ func (m *mig) Migrate(userInput []byte) (*v1.Dashboard, error) {
 		logrus.WithError(err).Trace("Unable to compile the migration schema using the received dashboard to resolve the paths")
 		return nil, shared.HandleBadRequestError(fmt.Sprintf("unable to convert to Perses dashboard: %s", err))
 	}
-	logrus.Tracef("final value: %#v", mappingVal)
+	logrus.Tracef("final migration schema: %#v", mappingVal)
 
 	// marshall to JSON then unmarshall in v1.Dashboard struct to pass the final checks & build the final dashboard to return
 	persesDashboardJSON, err := json.Marshal(mappingVal)
 	if err != nil {
 		return nil, fmt.Errorf("%w: Unable to marshall CUE Value to json: %s", shared.InternalError, err)
 	}
+	logrus.Tracef("perses dashboard as JSON: %s", string(persesDashboardJSON))
+
 	var persesDashboard v1.Dashboard
 	err = json.Unmarshal(persesDashboardJSON, &persesDashboard)
 	if err != nil {

--- a/internal/api/shared/migrate/testdata/old_grafana_panels_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_panels_grafana_dashboard.json
@@ -24,7 +24,8 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 34726,
-  "links": [{
+  "links": [
+    {
       "asDropdown": true,
       "icon": "external link",
       "includeVars": true,
@@ -71,7 +72,8 @@
     }
   ],
   "liveNow": false,
-  "panels": [{
+  "panels": [
+    {
       "collapse": true,
       "collapsed": true,
       "datasource": {
@@ -85,7 +87,8 @@
         "y": 0
       },
       "id": 2,
-      "panels": [{
+      "panels": [
+        {
           "content": "<p>This dashboard provides information on OTF Front-End queues.<br/>Minimum OTF FE version required: 18.0.0.68 / 19.0.0.29<br/>\nMore information on FE metrics used here: <a href=\"https://rndwww.nce.amadeus.net/confluence/display/OTFTeam/OTF+Monitoring+-+FE+metrics\">Confluence link</a>\n</p>",
           "datasource": {
             "type": "prometheus",
@@ -146,141 +149,150 @@
         "y": 1
       },
       "id": 5,
-      "panels": [{
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$datasource"
-        },
-        "description": "Messages Enqueued-Dequeued per second.\n\n - Queueing rate: Rate of messages enqueued (no BE instance ready)\n - Dequeueing rate (negative): Rate of messages dequeued (a BE instance became available)",
-        "fieldConfig": {
-          "defaults": {
-            "unit": "msg/s"
-          },
-          "overrides": []
-        },
-        "fill": 0,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 10,
-          "w": 12,
-          "x": 0,
-          "y": 2
-        },
-        "hiddenSeries": false,
-        "id": 6,
-        "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": false,
-          "max": true,
-          "min": true,
-          "rightSide": false,
-          "show": true,
-          "sort": "avg",
-          "sortDesc": true,
-          "total": false,
-          "values": true
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "paceLength": 10,
-        "percentage": false,
-        "pluginVersion": "9.2.6",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [{
-            "alias": "Queueing rate",
-            "color": "#F2CC0C",
-            "fill": 1,
-            "zindex": "-1"
-          },
-          {
-            "alias": "Dequeueing rate (negative)",
-            "color": "#56A64B",
-            "fill": 1,
-            "zindex": "0"
-          },
-          {
-            "alias": "Queue growing rate",
-            "color": "#FF780A",
-            "fill": 1,
-            "zindex": "1"
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [{
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum (rate(otf_fe_queue_be_messages_enqueued_total[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "2m",
-          "intervalFactor": 1,
-          "legendFormat": "Queueing rate",
-          "refId": "queue"
-        }],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "Queueing rate",
-        "tooltip": {
-          "msResolution": true,
-          "shared": true,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "transformations": [{
-          "id": "organize",
-          "options": {
-            "excludeByName": {},
-            "indexByName": {},
-            "renameByName": {}
-          }
-        }],
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [{
-            "format": "msg/s",
-            "logBase": 1,
-            "show": true
+          "description": "Messages Enqueued-Dequeued per second.\n\n - Queueing rate: Rate of messages enqueued (no BE instance ready)\n - Dequeueing rate (negative): Rate of messages dequeued (a BE instance became available)",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "msg/s"
+            },
+            "overrides": []
           },
-          {
-            "format": "short",
-            "logBase": 1,
-            "show": false
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sort": "avg",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [{
+              "alias": "Queueing rate",
+              "color": "#F2CC0C",
+              "fill": 1,
+              "zindex": "-1"
+            },
+            {
+              "alias": "Dequeueing rate (negative)",
+              "color": "#56A64B",
+              "fill": 1,
+              "zindex": "0"
+            },
+            {
+              "alias": "Queue growing rate",
+              "color": "#FF780A",
+              "fill": 1,
+              "zindex": "1"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum (rate(otf_fe_queue_be_messages_enqueued_total[$__rate_interval]))",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "2m",
+              "intervalFactor": 1,
+              "legendFormat": "Queueing rate",
+              "refId": "queue"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Queueing rate",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "msg/s",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
           }
-        ],
-        "yaxis": {
-          "align": false
         }
-      }],
+      ],
       "showTitle": true,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "argos-world"
-        },
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "argos-world"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Overview",
       "titleSize": "h6",
       "type": "row"
@@ -291,24 +303,26 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": [{
-      "current": {
-        "selected": false,
-        "text": "argos-world",
-        "value": "argos-world"
-      },
-      "hide": 2,
-      "includeAll": false,
-      "label": "PaaS",
-      "multi": false,
-      "name": "datasource",
-      "options": [],
-      "query": "prometheus",
-      "refresh": 1,
-      "regex": "/^argos-.+/",
-      "skipUrlSync": false,
-      "type": "datasource"
-    }]
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "argos-world",
+          "value": "argos-world"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "PaaS",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/^argos-.+/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -11,12 +11,10 @@
     "display": {
       "name": "queues-test"
     },
-    "duration": "1h",
     "variables": [
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "datasource",
           "display": {
             "name": "PaaS",
             "hidden": true
@@ -26,9 +24,15 @@
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
-              "values": ["grafana", "migration", "not", "supported"]
+              "values": [
+                "grafana",
+                "migration",
+                "not",
+                "supported"
+              ]
             }
-          }
+          },
+          "name": "datasource"
         }
       }
     ],
@@ -72,9 +76,13 @@
             "kind": "TimeSeriesChart",
             "spec": {
               "legend": {
-                "position": "bottom",
                 "mode": "table",
-                "values": ["min", "max", "mean"]
+                "position": "bottom",
+                "values": [
+                  "min",
+                  "max",
+                  "mean"
+                ]
               }
             }
           },
@@ -158,6 +166,7 @@
           ]
         }
       }
-    ]
+    ],
+    "duration": "1h"
   }
 }

--- a/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
@@ -79,7 +79,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.8",
       "targets": [
         {
           "datasource": {
@@ -144,7 +144,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.8",
       "targets": [
         {
           "datasource": {
@@ -319,8 +319,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -474,10 +473,12 @@
           "text": "one",
           "value": "one"
         },
+        "description": "This Custom variable should be translated into a ListVariable > StaticListVariable in Perses",
         "hide": 0,
         "includeAll": false,
+        "label": "My Custom Variable",
         "multi": false,
-        "name": "listVar",
+        "name": "MyCustom",
         "options": [
           {
             "selected": true,
@@ -500,42 +501,13 @@
         "type": "custom"
       },
       {
+        "description": "This Custom variable should be translated into a TextVariable in Perses, with constant flag set to true",
         "hide": 2,
-        "name": "myConst",
-        "query": "HelloWorld",
+        "label": "My Constant Variable",
+        "name": "MyConst",
+        "query": "const_val",
         "skipUrlSync": false,
         "type": "constant"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "alice",
-          "value": "alice"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "firstNames",
-        "options": [
-          {
-            "selected": true,
-            "text": "alice",
-            "value": "alice"
-          },
-          {
-            "selected": false,
-            "text": "bob",
-            "value": "bob"
-          },
-          {
-            "selected": false,
-            "text": "chris",
-            "value": "chris"
-          }
-        ],
-        "query": "alice,bob,chris",
-        "skipUrlSync": false,
-        "type": "custom"
       },
       {
         "current": {
@@ -723,10 +695,11 @@
           "type": "prometheus",
           "uid": "argos-world"
         },
-        "description": "adHocFilter",
+        "description": "This ad-hoc filter should be replaced by a placeholder in the migration since it's not supported in Perses yet",
         "filters": [],
         "hide": 0,
-        "name": "AHF",
+        "label": "My Ad hoc filter",
+        "name": "AdHocFilter",
         "skipUrlSync": false,
         "type": "adhoc"
       },
@@ -787,8 +760,8 @@
       {
         "current": {
           "selected": false,
-          "text": "{type=\"ACUS\"} 1 1680018176000",
-          "value": "{type=\"ACUS\"} 1 1680018176000"
+          "text": "{type=\"OBE\"} 1 1694769404000",
+          "value": "{type=\"OBE\"} 1 1694769404000"
         },
         "datasource": {
           "type": "prometheus",
@@ -837,6 +810,27 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "<placeholder text>",
+          "value": "<placeholder text>"
+        },
+        "description": "This Text box variable should be translated into a TextVariable in Perses, with constant flag set to false",
+        "hide": 0,
+        "label": "My Text Box Variable",
+        "name": "MyTextBox",
+        "options": [
+          {
+            "selected": true,
+            "text": "<placeholder text>",
+            "value": "<placeholder text>"
+          }
+        ],
+        "query": "<placeholder text>",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },
@@ -848,6 +842,6 @@
   "timezone": "",
   "title": "Perses testing / Simple grafana dashboard",
   "uid": "xRV24sBVk",
-  "version": 2,
+  "version": 6,
   "weekStart": ""
 }

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -11,47 +11,46 @@
     "display": {
       "name": "Perses testing / Simple grafana dashboard"
     },
-    "duration": "1h",
     "variables": [
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "listVar",
+          "display": {
+            "name": "My Custom Variable",
+            "description": "This Custom variable should be translated into a ListVariable > StaticListVariable in Perses",
+            "hidden": false
+          },
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
-              "values": ["one", "two", "three"]
+              "values": [
+                "one",
+                "two",
+                "three"
+              ]
             }
-          }
+          },
+          "name": "MyCustom"
         }
       },
       {
         "kind": "TextVariable",
         "spec": {
-          "name": "myConst",
-          "value": "HelloWorld"
+          "display": {
+            "name": "My Constant Variable",
+            "description": "This Custom variable should be translated into a TextVariable in Perses, with constant flag set to true",
+            "hidden": true
+          },
+          "value": "const_val",
+          "constant": true,
+          "name": "MyConst"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "firstNames",
-          "allowAllValue": false,
-          "allowMultiple": false,
-          "plugin": {
-            "kind": "StaticListVariable",
-            "spec": {
-              "values": ["alice", "bob", "chris"]
-            }
-          }
-        }
-      },
-      {
-        "kind": "ListVariable",
-        "spec": {
-          "name": "lv1",
           "display": {
             "name": "Stack",
             "description": "Label values, 1rst flavor",
@@ -65,13 +64,13 @@
               "labelName": "stack",
               "matchers": []
             }
-          }
+          },
+          "name": "lv1"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "lv2",
           "display": {
             "name": "Stack with Metric",
             "description": "Label values, 2nd flavor",
@@ -83,15 +82,17 @@
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
               "labelName": "stack",
-              "matchers": ["thanos_build_info"]
+              "matchers": [
+                "thanos_build_info"
+              ]
             }
-          }
+          },
+          "name": "lv2"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "lv3",
           "display": {
             "name": "Stack with Timeserie",
             "description": "Label values, 3rd flavor",
@@ -103,15 +104,17 @@
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
               "labelName": "stack",
-              "matchers": ["thanos_build_info{stack=~\"erd.+\"}"]
+              "matchers": [
+                "thanos_build_info{stack=~\"erd.+\"}"
+              ]
             }
-          }
+          },
+          "name": "lv3"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "lv4",
           "display": {
             "name": "Stack with Timeserie reusing other variable",
             "description": "Label values, 4th flavor",
@@ -123,15 +126,17 @@
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
               "labelName": "stack",
-              "matchers": ["thanos_build_info{stack=~\"$lv1\"}"]
+              "matchers": [
+                "thanos_build_info{stack=~\"$lv1\"}"
+              ]
             }
-          }
+          },
+          "name": "lv4"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "interval",
           "display": {
             "name": "interval",
             "description": "ad hoc filter",
@@ -155,16 +160,16 @@
                 "30d"
               ]
             }
-          }
+          },
+          "name": "interval"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "AHF",
           "display": {
-            "name": "AHF",
-            "description": "adHocFilter",
+            "name": "My Ad hoc filter",
+            "description": "This ad-hoc filter should be replaced by a placeholder in the migration since it's not supported in Perses yet",
             "hidden": false
           },
           "allowAllValue": false,
@@ -172,15 +177,20 @@
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
-              "values": ["grafana", "migration", "not", "supported"]
+              "values": [
+                "grafana",
+                "migration",
+                "not",
+                "supported"
+              ]
             }
-          }
+          },
+          "name": "AdHocFilter"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "LabelNamesTest",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
@@ -188,13 +198,13 @@
             "spec": {
               "matchers": []
             }
-          }
+          },
+          "name": "LabelNamesTest"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "queryResVar",
           "display": {
             "name": "Query Result Variable",
             "description": "variable using query_result clause",
@@ -208,13 +218,13 @@
               "expr": "group by(type) (up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"})",
               "labelName": "type"
             }
-          }
+          },
+          "name": "queryResVar"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "queryResVarVolatile",
           "display": {
             "name": "queryResVarVolatile",
             "description": "query result var for volatile series (relies $__range global var)",
@@ -228,13 +238,13 @@
               "expr": "group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[placeholder]))",
               "labelName": "type"
             }
-          }
+          },
+          "name": "queryResVarVolatile"
         }
       },
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "queryResVarOther",
           "display": {
             "name": "queryResVarOther",
             "description": "query result var with no <aggr> by clause",
@@ -248,7 +258,20 @@
               "expr": "query_result(present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[placeholder]))",
               "labelName": "migration_from_grafana_not_supported"
             }
-          }
+          },
+          "name": "queryResVarOther"
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "display": {
+            "name": "My Text Box Variable",
+            "description": "This Text box variable should be translated into a TextVariable in Perses, with constant flag set to false",
+            "hidden": false
+          },
+          "value": "<placeholder text>",
+          "name": "MyTextBox"
         }
       }
     ],
@@ -308,6 +331,9 @@
             "kind": "GaugeChart",
             "spec": {
               "calculation": "last-number",
+              "format": {
+                "unit": "hours"
+              },
               "thresholds": {
                 "steps": [
                   {
@@ -319,9 +345,6 @@
                     "value": 80
                   }
                 ]
-              },
-              "format": {
-                "unit": "hours"
               }
             }
           },
@@ -355,8 +378,8 @@
             "kind": "TimeSeriesChart",
             "spec": {
               "legend": {
-                "position": "bottom",
                 "mode": "list",
+                "position": "bottom",
                 "values": [
                   "min",
                   "max",
@@ -412,16 +435,12 @@
             "kind": "TimeSeriesChart",
             "spec": {
               "legend": {
-                "position": "bottom",
                 "mode": "table",
+                "position": "bottom",
                 "values": []
               },
               "thresholds": {
                 "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
                   {
                     "color": "red",
                     "value": 80
@@ -553,6 +572,7 @@
           ]
         }
       }
-    ]
+    ],
+    "duration": "1h"
   }
 }

--- a/internal/api/shared/schemas/schemas.go
+++ b/internal/api/shared/schemas/schemas.go
@@ -190,9 +190,9 @@ func (s *sch) ValidateGlobalVariable(v modelV1.VariableSpec) error {
 	return s.ValidateVariable(listVariableSpec.Plugin, "")
 }
 
-// ValidateDashboardVariables verify a list of variables defines in a dashboard.
+// ValidateDashboardVariables verify a list of variables defined in a dashboard.
 // The variables are matched against the known list of CUE definitions (schemas)
-// This applies to the ListVariable type only (TextVariable is skipped)
+// This applies to the ListVariable type only (TextVariable is skipped as there are no plugins for this kind)
 // If no schema matches for at least 1 variable, the validation fails.
 func (s *sch) ValidateDashboardVariables(variables []dashboard.Variable) error {
 	if s.vars == nil {

--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -37,7 +37,8 @@ func TestUnmarshalJSONVariable(t *testing.T) {
   "kind": "TextVariable",
   "spec": {
     "name": "SimpleText",
-    "value": "value"
+    "value": "value",
+	"constant": true
   }
 }
 `,
@@ -45,7 +46,8 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 				Kind: variable.KindText,
 				Spec: &TextVariableSpec{
 					TextSpec: variable.TextSpec{
-						Value: "value",
+						Value:    "value",
+						Constant: true,
 					},
 					Name: "SimpleText",
 				},
@@ -281,12 +283,14 @@ kind: "TextVariable"
 spec:
   name: "SimpleText"
   value: "value"
+  constant: true
 `,
 			result: &Variable{
 				Kind: variable.KindText,
 				Spec: &TextVariableSpec{
 					TextSpec: variable.TextSpec{
-						Value: "value",
+						Value:    "value",
+						Constant: true,
 					},
 					Name: "SimpleText",
 				},

--- a/pkg/model/api/v1/variable/text.go
+++ b/pkg/model/api/v1/variable/text.go
@@ -18,8 +18,9 @@ import (
 )
 
 type TextSpec struct {
-	Display *Display `json:"display,omitempty" yaml:"display,omitempty"`
-	Value   string   `json:"value" yaml:"value"`
+	Display  *Display `json:"display,omitempty" yaml:"display,omitempty"`
+	Value    string   `json:"value" yaml:"value"`
+	Constant bool     `json:"constant,omitempty" yaml:"constant,omitempty"`
 }
 
 func (v *TextSpec) Validate() error {

--- a/schemas/variables/prometheus-promql/mig.cuepart
+++ b/schemas/variables/prometheus-promql/mig.cuepart
@@ -7,7 +7,7 @@ if #var.type == "query" {
     if #var.query.query =~ #qResRegexp {
         kind:          "PrometheusPromQLVariable"
         spec: {
-            expr:       regexp.FindSubmatch(#qResRegexp, #cleanedQuery)[1]
+            expr:      regexp.FindSubmatch(#qResRegexp, #cleanedQuery)[1]
             labelName: regexp.FindSubmatch(#qResRegexp, #cleanedQuery)[2]
         }
     }

--- a/ui/core/src/model/variables.ts
+++ b/ui/core/src/model/variables.ts
@@ -32,6 +32,7 @@ export interface TextVariableDefinition extends Definition<TextVariableSpec> {
 
 export interface TextVariableSpec extends VariableSpec {
   value: string;
+  constant?: boolean;
 }
 
 export interface ListVariableDefinition<PluginSpec = UnknownSpec> extends Definition<ListVariableSpec<PluginSpec>> {

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -164,7 +164,14 @@ const DEFAULT_ALL_DASHBOARD: DashboardResource = {
       },
     ],
     variables: [
-      { kind: 'TextVariable', spec: { name: 'job', value: 'node' } },
+      {
+        kind: 'TextVariable',
+        spec: {
+          name: 'job',
+          value: 'node',
+          constant: true,
+        },
+      },
       {
         kind: 'ListVariable',
         spec: {

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -17,6 +17,7 @@ import {
   DEFAULT_ALL_VALUE,
   ListVariableDefinition,
   ListVariableSpec,
+  TextVariableDefinition,
   UnknownSpec,
   VariableName,
   VariableValue,
@@ -190,7 +191,9 @@ function ListVariable({ name, source }: TemplateVariableProps) {
 }
 
 function TextVariable({ name, source }: TemplateVariableProps) {
-  const { state, definition } = useTemplateVariable(name, source);
+  const ctx = useTemplateVariable(name, source);
+  const state = ctx.state;
+  const definition = ctx.definition as TextVariableDefinition;
   const [tempValue, setTempValue] = useState(state?.value ?? '');
   const { setVariableValue } = useTemplateVariableActions();
 
@@ -205,6 +208,9 @@ function TextVariable({ name, source }: TemplateVariableProps) {
       onBlur={() => setVariableValue(name, tempValue, source)}
       placeholder={name}
       label={definition?.spec.display?.name ?? name}
+      InputProps={{
+        readOnly: definition?.spec.constant ?? false,
+      }}
     />
   );
 }

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -260,7 +260,7 @@ export function VariableEditor(props: {
                           </TableCell>
                           <TableCell>{getVariableLabelByKind(v.kind) ?? v.kind}</TableCell>
                           <TableCell>{v.spec.display?.description ?? ''}</TableCell>
-                          <TableCell align="right">
+                          <TableCell align="right" sx={{ display: 'flex', flexDirection: 'row', flexGrow: 1 }}>
                             <IconButton onClick={() => changeVariableOrder(idx, 'up')} disabled={idx === 0}>
                               <ArrowUp />
                             </IconButton>
@@ -270,7 +270,6 @@ export function VariableEditor(props: {
                             >
                               <ArrowDown />
                             </IconButton>
-
                             <IconButton onClick={() => editVariable(idx)}>
                               <PencilIcon />
                             </IconButton>

--- a/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
+++ b/ui/dashboards/src/context/TemplateVariableProvider/utils.test.ts
@@ -74,6 +74,7 @@ describe('checkSavedDefaultVariableStatus', () => {
             name: 'Text display',
             hidden: false,
           },
+          constant: true,
           value: 'first text value',
         },
       },
@@ -210,6 +211,7 @@ describe('checkSavedDefaultVariableStatus', () => {
             name: 'Text display',
             hidden: false,
           },
+          constant: true,
           value: 'first text value',
         },
       },
@@ -269,6 +271,7 @@ describe('checkSavedDefaultVariableStatus', () => {
               display: {
                 name: 'Greetings(project)',
               },
+              constant: false,
               value: 'hello',
             },
           },
@@ -291,6 +294,7 @@ describe('checkSavedDefaultVariableStatus', () => {
               display: {
                 name: 'Greetings(global)',
               },
+              constant: true,
               value: 'hello',
             },
           },
@@ -320,6 +324,7 @@ describe('checkSavedDefaultVariableStatus', () => {
           display: {
             name: 'Greetings(project)',
           },
+          constant: false,
           value: 'hello',
         },
       },
@@ -337,6 +342,7 @@ describe('checkSavedDefaultVariableStatus', () => {
           display: {
             name: 'Greetings(global)',
           },
+          constant: true,
           value: 'hello',
         },
       },

--- a/ui/e2e/src/data/updatedDefaultsDashboard.json
+++ b/ui/e2e/src/data/updatedDefaultsDashboard.json
@@ -118,6 +118,7 @@
             "name": "Text variable",
             "hidden": false
           },
+          "constant": true,
           "value": "initial value"
         }
       }

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -259,6 +259,21 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   });
                 }}
               />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={state.textVariableFields.constant ?? false}
+                    readOnly={action === 'read'}
+                    onChange={(e) => {
+                      if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
+                      setState((draft) => {
+                        draft.textVariableFields.constant = e.target.checked;
+                      });
+                    }}
+                  />
+                }
+                label="Constant"
+              />
             </Stack>
           </>
         )}

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -16,6 +16,7 @@ import { TextVariableDefinition, VariableDefinition } from '@perses-dev/core';
 export function getInitialState(initialVariableDefinition: VariableDefinition) {
   const textVariableFields = {
     value: (initialVariableDefinition as TextVariableDefinition).spec.value ?? '',
+    constant: (initialVariableDefinition as TextVariableDefinition).spec.constant ?? false,
   };
 
   const listVariableFields = {


### PR DESCRIPTION
… + improve grafana migration for Constant & TextBox variables accordingly.

# Description

Resolves #1423.

This PR adds a new optional attribute `constant` to the spec of the TextVariable. This solves a weird behavior we had previously where the current TextVariable was meant to have constant value, while on the dashboard the field value was editable. After internal discussion we considered it was still interesting to have such "textbox" variable feature, so instead of just fixing this UI incoherence and losing this capability, it was agreed to add a new flag to the spec to allow or disallow user input.

By doing this our TextVariable now corresponds to both the Constant & Text box variable types of Grafana, thus the migration logic has been reworked accordingly (also I took advantage of this to add the migration logic for the display fields of the TextVariable, which were missing).

# Screenshots

_(isConst was renamed into constant since)_
https://github.com/perses/perses/assets/7058693/5aaf9b45-d500-4eac-9286-b8bce98f319a

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
