### PR TITLE
[ENHANCEMENT] Remove annoying double scroll on Edit JSON dialog

### DIFF
--- a/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
+++ b/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
@@ -60,7 +60,7 @@ const EditJsonDialogForm = (props: EditJsonDialogProps) => {
         <FormControl fullWidth>
           <JSONEditor
             minHeight="300px"
-            maxHeight="700px"
+            maxHeight="70vh"
             value={draftDashboard}
             onChange={(value) => setDraftDashboard(value)}
           />


### PR DESCRIPTION
# Description

Before:
![2023-09-19_09h02_59](https://github.com/perses/perses/assets/7058693/4aa479c5-f12a-4f1a-904b-81ab285db0c0)

After:
![2023-09-19_09h01_27](https://github.com/perses/perses/assets/7058693/22a8c34d-4d1f-42f3-86b5-ebd3c3f7659f)

NB: A 2nd scrollbar may still appear on smaller screen sizes, but it's much less tall & annoying than before.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
