### PR TITLE
[BUGFIX] Fix delete buttons still clickable in readonly mode

### DIFF
--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -105,7 +105,7 @@ export function DatasourceEditorForm<T extends Datasource>(props: DatasourceEdit
               <Button disabled={isReadonly} variant="contained" onClick={() => setAction('update')}>
                 Edit
               </Button>
-              <Button color="error" variant="outlined" onClick={onDelete}>
+              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
                 Delete
               </Button>
               <Divider

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -115,7 +115,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
               <Button disabled={isReadonly} variant="contained" onClick={() => setAction('update')}>
                 Edit
               </Button>
-              <Button color="error" variant="outlined" onClick={onDelete}>
+              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
                 Delete
               </Button>
               <Divider

--- a/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/PrometheusDatasourceEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor/PrometheusDatasourceEditor.tsx
@@ -337,7 +337,7 @@ export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProp
 
   return (
     <>
-      <Typography variant="h4" mb={1}>
+      <Typography variant="h4" mb={2}>
         General Settings
       </Typography>
       <TextField


### PR DESCRIPTION
# Description

Delete buttons on Datasource & Variable editor form were still clickable in readonly mode.

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
