### PR TITLE
[BUGFIX] Fix memory leak caused by a cue context kept during the load of the schemas

### DIFF
--- a/internal/api/shared/migrate/loader.go
+++ b/internal/api/shared/migrate/loader.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"sync"
 
-	"cuelang.org/go/cue"
 	"github.com/fsnotify/fsnotify"
 	"github.com/perses/common/async"
 	"github.com/perses/perses/internal/api/shared/schemas"
@@ -56,7 +55,6 @@ type loader interface {
 }
 
 type migCuePart struct {
-	context          *cue.Context
 	listOfConditions string
 	schemasPath      string
 	defaultValue     string

--- a/internal/api/shared/migrate/migrate.go
+++ b/internal/api/shared/migrate/migrate.go
@@ -81,24 +81,19 @@ type Migration interface {
 }
 
 func New(schemasConf config.Schemas) (Migration, error) {
-	cueContext := cuecontext.New()
 	m := &mig{
-		cuectx: cueContext,
 		loaders: []loader{
 			&migCuePart{
-				context:         cueContext,
 				schemasPath:     schemasConf.VariablesPath,
 				defaultValue:    variableDefaultValue,
 				placeholderText: variablePlaceholderText,
 			},
 			&migCuePart{
-				context:         cueContext,
 				schemasPath:     schemasConf.PanelsPath,
 				defaultValue:    panelDefaultValue,
 				placeholderText: panelPlaceholderText,
 			},
 			&migCuePart{
-				context:         cueContext,
 				schemasPath:     schemasConf.QueriesPath,
 				defaultValue:    queryDefaultValue,
 				placeholderText: queryPlaceholderText,
@@ -112,7 +107,6 @@ func New(schemasConf config.Schemas) (Migration, error) {
 }
 
 type mig struct {
-	cuectx                *cue.Context
 	migrationSchemaString string
 	loaders               []loader
 	mutex                 sync.RWMutex
@@ -142,6 +136,7 @@ func (m *mig) BuildMigrationSchemaString() {
 }
 
 func (m *mig) Migrate(userInput []byte) (*v1.Dashboard, error) {
+	cueContext := cuecontext.New()
 	// preprocessing in Go before passing it to CUE
 	grafanaDashboard := rearrangeGrafanaPanelsWithinExpandedRows(userInput)
 
@@ -149,10 +144,10 @@ func (m *mig) Migrate(userInput []byte) (*v1.Dashboard, error) {
 	// fields from the Grafana dashboard together in a common namespace, so that they are not mixed with the ones from the
 	// migration schema. This make sure we have no wrong overlapping between Grafana & Perses objects, and also makes the
 	// remapping operations more explicit, with e.g `name: #grafanaDashboard.title` instead of `name: title`.
-	grafanaDashboardVal := m.cuectx.CompileString(fmt.Sprintf("%s: _", grafanaDefID))
+	grafanaDashboardVal := cueContext.CompileString(fmt.Sprintf("%s: _", grafanaDefID))
 	grafanaDashboardVal = grafanaDashboardVal.FillPath(
 		cue.ParsePath(grafanaDefID),
-		m.cuectx.CompileBytes(grafanaDashboard),
+		cueContext.CompileBytes(grafanaDashboard),
 	)
 	if err := grafanaDashboardVal.Validate(cue.Final()); err != nil {
 		logrus.WithError(err).Trace("Unable to wrap the received json into a CUE definition")
@@ -161,7 +156,7 @@ func (m *mig) Migrate(userInput []byte) (*v1.Dashboard, error) {
 
 	// Compile the migration schema using the grafana def to resolve the paths
 	m.mutex.RLock()
-	mappingVal := m.cuectx.CompileString(m.migrationSchemaString, cue.Scope(grafanaDashboardVal))
+	mappingVal := cueContext.CompileString(m.migrationSchemaString, cue.Scope(grafanaDashboardVal))
 	m.mutex.RUnlock()
 	err := mappingVal.Err()
 	if err != nil {

--- a/internal/api/shared/schemas/loader.go
+++ b/internal/api/shared/schemas/loader.go
@@ -131,6 +131,18 @@ func (c *cueDefs) Load() error {
 	return nil
 }
 
+func (c *cueDefs) getContext() *cue.Context {
+	c.contextMutex.RLock()
+	defer c.contextMutex.RUnlock()
+	return c.context
+}
+
+func (c *cueDefs) getSchemas() map[string]cue.Value {
+	c.schemaMutex.RLock()
+	defer c.schemaMutex.RUnlock()
+	return c.schemas
+}
+
 func NewHotReloaders(loaders []Loader) (async.SimpleTask, async.SimpleTask, error) {
 	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/internal/api/shared/schemas/loader.go
+++ b/internal/api/shared/schemas/loader.go
@@ -36,10 +36,12 @@ type Loader interface {
 
 type cueDefs struct {
 	Loader
-	baseDef     *cue.Value
-	schemas     map[string]cue.Value
-	schemasPath string
-	schemaMutex *sync.RWMutex
+	context      *cue.Context
+	baseDef      *cue.Value
+	schemas      map[string]cue.Value
+	schemasPath  string
+	schemaMutex  sync.RWMutex
+	contextMutex sync.RWMutex
 }
 
 func (c *cueDefs) GetSchemaPath() string {
@@ -118,9 +120,13 @@ func (c *cueDefs) Load() error {
 	}
 
 	if !isError {
+		// in case there is no error we are saving the schemas loaded and the cue context that will be used during the plugin validation phase
 		c.schemaMutex.Lock()
 		c.schemas = newSchemas
 		c.schemaMutex.Unlock()
+		c.contextMutex.Lock()
+		c.context = cueContext
+		c.contextMutex.Unlock()
 	}
 	return nil
 }

--- a/internal/api/shared/schemas/schemas.go
+++ b/internal/api/shared/schemas/schemas.go
@@ -80,7 +80,6 @@ func New(conf config.Schemas) (Schemas, error) {
 	var loaders []Loader
 	if len(conf.PanelsPath) != 0 {
 		panels := &cueDefs{
-			schemas:     make(map[string]cue.Value),
 			schemasPath: conf.PanelsPath,
 		}
 		loaders = append(loaders, panels)
@@ -89,7 +88,6 @@ func New(conf config.Schemas) (Schemas, error) {
 	if len(conf.QueriesPath) != 0 {
 		queries := &cueDefs{
 			baseDef:     &baseQueryDefVal,
-			schemas:     make(map[string]cue.Value),
 			schemasPath: conf.QueriesPath,
 		}
 		loaders = append(loaders, queries)
@@ -97,7 +95,6 @@ func New(conf config.Schemas) (Schemas, error) {
 	}
 	if len(conf.DatasourcesPath) != 0 {
 		dts := &cueDefs{
-			schemas:     make(map[string]cue.Value),
 			schemasPath: conf.DatasourcesPath,
 		}
 		loaders = append(loaders, dts)
@@ -105,7 +102,6 @@ func New(conf config.Schemas) (Schemas, error) {
 	}
 	if len(conf.VariablesPath) != 0 {
 		vars := &cueDefs{
-			schemas:     make(map[string]cue.Value),
 			schemasPath: conf.VariablesPath,
 		}
 		loaders = append(loaders, vars)
@@ -226,11 +222,10 @@ func (s *sch) validatePlugin(plugin common.Plugin, modelKind string, modelName s
 		return err
 	}
 	// compile the JSON plugin into a CUE Value
-	cueContext := cueDefs.getContext()
-	value := cueContext.CompileBytes(pluginData)
+	value := cueDefs.context.Load().CompileBytes(pluginData)
 
 	// retrieve the corresponding schema
-	pluginSchema, err := retrieveSchemaForKind(modelKind, modelName, value, cueDefs.getSchemas())
+	pluginSchema, err := retrieveSchemaForKind(modelKind, modelName, value, *cueDefs.schemas.Load())
 	if err != nil {
 		return err
 	}

--- a/internal/api/shared/schemas/schemas.go
+++ b/internal/api/shared/schemas/schemas.go
@@ -226,15 +226,11 @@ func (s *sch) validatePlugin(plugin common.Plugin, modelKind string, modelName s
 		return err
 	}
 	// compile the JSON plugin into a CUE Value
-	cueDefs.contextMutex.RLock()
-	cueContext := cueDefs.context
-	cueDefs.contextMutex.RUnlock()
+	cueContext := cueDefs.getContext()
 	value := cueContext.CompileBytes(pluginData)
 
 	// retrieve the corresponding schema
-	cueDefs.schemaMutex.RLock()
-	pluginSchema, err := retrieveSchemaForKind(modelKind, modelName, value, cueDefs.schemas)
-	cueDefs.schemaMutex.RUnlock()
+	pluginSchema, err := retrieveSchemaForKind(modelKind, modelName, value, cueDefs.getSchemas())
 	if err != nil {
 		return err
 	}

--- a/internal/api/shared/schemas/schemas.go
+++ b/internal/api/shared/schemas/schemas.go
@@ -247,8 +247,7 @@ func (s *sch) validatePlugin(plugin common.Plugin, modelKind string, modelName s
 	if err != nil {
 		logrus.Debug(errors.Details(err, nil))
 		//TODO: return errors.Details(err, nil) to get a more meaningful error, but should be cleaned of line numbers & server file paths!
-		err = fmt.Errorf("invalid %s %s: %s", modelKind, modelName, err) // enrich the error message returned by cue lib
-		return err
+		return fmt.Errorf("invalid %s %s: %w", modelKind, modelName, err) // enrich the error message returned by cue lib
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixed #1440 

We are loading every 5min the cuelang schema. And we never reset the cue schema during this reload. The cue context is tracking every loaded instances of the schema, which made the memory increasing during every loop.

Even if we don't want to keep a cue context forever, we still need to keep one that would have in memory the different schema loaded. The cue context is then used during the validation phase.

It also removed the usage of the sync map. 
Explanations are described here: https://teivah.medium.com/maps-and-memory-leaks-in-go-a85ebe6e7e69