### PR TITLE
[ENHANCEMENT] Add tooltip to auto refresh dashboard select

### DIFF
--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -107,12 +107,14 @@ export function TimeRangeControls({
         </InfoTooltip>
       )}
       {showRefreshInterval && (
-        <RefreshIntervalPicker
-          timeOptions={DEFAULT_REFRESH_INTERVAL_OPTIONS}
-          value={refreshInterval}
-          onChange={handleRefreshIntervalChange}
-          height={height}
-        />
+        <InfoTooltip description={TOOLTIP_TEXT.refreshDashboardInterval}>
+          <RefreshIntervalPicker
+            timeOptions={DEFAULT_REFRESH_INTERVAL_OPTIONS}
+            value={refreshInterval}
+            onChange={handleRefreshIntervalChange}
+            height={height}
+          />
+        </InfoTooltip>
       )}
     </Stack>
   );

--- a/ui/dashboards/src/constants/user-interface-text.ts
+++ b/ui/dashboards/src/constants/user-interface-text.ts
@@ -19,6 +19,7 @@ export const TOOLTIP_TEXT = {
   editJson: 'Edit JSON',
   editVariables: 'Edit variables',
   refreshDashboard: 'Refresh dashboard',
+  refreshDashboardInterval: 'Auto refresh interval',
   // Group buttons
   addPanelToGroup: 'Add panel to group',
   deleteGroup: 'Delete group',


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Add a tooltip to the auto refresh select, it will be easier for users to understand what this select is doing 😄 

# Screenshots

![MicrosoftTeams-image (1)](https://github.com/perses/perses/assets/7058693/f6f5a778-99c4-4ce8-8f49-0bd91170d63b)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
