### PR TITLE
[ENHANCEMENT] Display properly custom auto refresh interval

### DIFF
--- a/ui/components/src/RefreshIntervalPicker/RefreshIntervalPicker.tsx
+++ b/ui/components/src/RefreshIntervalPicker/RefreshIntervalPicker.tsx
@@ -13,6 +13,7 @@
 
 import { Box, FormControl, MenuItem, Select } from '@mui/material';
 import { DurationString } from '@perses-dev/core';
+import { useMemo } from 'react';
 import { TimeOption } from '../model';
 
 interface RefreshIntervalPickerProps {
@@ -25,6 +26,14 @@ interface RefreshIntervalPickerProps {
 export function RefreshIntervalPicker(props: RefreshIntervalPickerProps) {
   const { value, onChange, timeOptions, height } = props;
   const formattedValue = value;
+
+  // If the dashboard refresh interval is not provided in timeOptions, it will create a specific option for the select
+  const customInterval = useMemo(() => {
+    if (value && !timeOptions.some((option) => option.value.pastDuration === value)) {
+      return <MenuItem value={value}>{value}</MenuItem>;
+    }
+  }, [timeOptions, value]);
+
   return (
     <FormControl>
       <Box>
@@ -47,6 +56,7 @@ export function RefreshIntervalPicker(props: RefreshIntervalPickerProps) {
               {item.display}
             </MenuItem>
           ))}
+          {customInterval}
         </Select>
       </Box>
     </FormControl>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Display properly custom auto refresh interval. Previously when the auto refresh interval wasn't using a suggested timerange, the field was empty

# Screenshots

![MicrosoftTeams-image (2)](https://github.com/perses/perses/assets/7058693/57346d1c-41db-4bd6-81cf-15429c60aff3)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
