### PR TITLE
[BUGFIX] Prom DS: change to XOR between `directUrl` and `proxy`

### DIFF
--- a/schemas/common/proxy/http.cue
+++ b/schemas/common/proxy/http.cue
@@ -13,6 +13,10 @@
 
 package proxy
 
+import (
+	"github.com/perses/perses/schemas/common"
+)
+
 #HTTPAllowedEndpoint: {
 	endpointPattern: string
 	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
@@ -23,7 +27,7 @@ package proxy
 	spec: {
 		// url is the url of the datasource. It is not the url of the proxy.
 		// The Perses server is the proxy, so it needs to know where to redirect the request.
-		url: string
+		url: common.#url
 		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
 		// Leave it empty if you don't want to restrict the access to the datasource.
 		allowedEndpoints?: [ ...#HTTPAllowedEndpoint]

--- a/schemas/common/url.cue
+++ b/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\\/\\/[a-z]+(?:\\.[a-z]+)*(:\\d+)?(?:\\/[a-z\\d]+)*$"

--- a/schemas/datasources/prometheus/prometheus.cue
+++ b/schemas/datasources/prometheus/prometheus.cue
@@ -19,8 +19,16 @@ import (
 
 kind: "PrometheusDatasource"
 spec: {
-	directUrl?: string
-	proxy?:     commonProxy.#HTTPProxy & {
+	#directUrl | #proxy
+	scrapeInterval?: =~"^(?:(\\d+)y)?(?:(\\d+)w)?(?:(\\d+)d)?(?:(\\d+)h)?(?:(\\d+)m)?(?:(\\d+)s)?(?:(\\d+)ms)?$"
+}
+
+#directUrl: {
+	directUrl: string
+}
+
+#proxy: {
+	proxy: commonProxy.#HTTPProxy & {
 		spec: {
 			allowedEndpoints: [
 				{
@@ -50,5 +58,4 @@ spec: {
 			]
 		}
 	}
-	scrapeInterval?: =~"^(?:(\\d+)y)?(?:(\\d+)w)?(?:(\\d+)d)?(?:(\\d+)h)?(?:(\\d+)m)?(?:(\\d+)s)?(?:(\\d+)ms)?$"
 }

--- a/schemas/datasources/prometheus/prometheus.cue
+++ b/schemas/datasources/prometheus/prometheus.cue
@@ -14,6 +14,7 @@
 package prometheus
 
 import (
+	"github.com/perses/perses/schemas/common"
 	commonProxy "github.com/perses/perses/schemas/common/proxy"
 )
 
@@ -24,7 +25,7 @@ spec: {
 }
 
 #directUrl: {
-	directUrl: string
+	directUrl: common.#url
 }
 
 #proxy: {

--- a/schemas/datasources/prometheus/prometheus.json
+++ b/schemas/datasources/prometheus/prometheus.json
@@ -1,7 +1,7 @@
 {
   "kind": "PrometheusDatasource",
   "spec": {
-    "directUrl": "http://localhost:8080",
+    "directUrl": "http://localhost:9090",
     "scrapeInterval": "15s"
   }
 }

--- a/ui/e2e/src/pages/DatasourceEditor.ts
+++ b/ui/e2e/src/pages/DatasourceEditor.ts
@@ -24,6 +24,10 @@ export class DatasourceEditor {
 
   readonly isDefaultSwitch: Locator;
 
+  // TODO the below locators are specific to the Prom datasource and should be moved to a plugin package instead
+  readonly scrapeIntervalInput: Locator;
+  readonly urlInput: Locator;
+
   constructor(container: Locator) {
     this.container = container;
 
@@ -34,6 +38,9 @@ export class DatasourceEditor {
     this.descriptionInput = container.getByLabel('Description');
 
     this.isDefaultSwitch = container.getByLabel('Set as default');
+
+    this.scrapeIntervalInput = container.getByLabel('Scrape Interval');
+    this.urlInput = container.getByLabel('URL');
   }
 
   async setName(name: string) {
@@ -57,5 +64,15 @@ export class DatasourceEditor {
     } else {
       await this.isDefaultSwitch.uncheck();
     }
+  }
+
+  async setScrapeInterval(scrapeInterval: string) {
+    await this.scrapeIntervalInput.clear();
+    await this.scrapeIntervalInput.type(scrapeInterval);
+  }
+
+  async setURL(url: string) {
+    await this.urlInput.clear();
+    await this.urlInput.type(url);
   }
 }

--- a/ui/e2e/src/tests/projectView.spec.ts
+++ b/ui/e2e/src/tests/projectView.spec.ts
@@ -94,6 +94,8 @@ test.describe('ProjectView', () => {
     await datasourceEditor.setDisplayLabel('My personal datasource');
     await datasourceEditor.setDescription('This is a datasource for personal use');
     await datasourceEditor.setDefault(false);
+    await datasourceEditor.setScrapeInterval('1m');
+    await datasourceEditor.setURL('http://localhost:9090');
     await datasourceEditor.saveButton.click();
 
     await expect(projectPage.datasourceList).toContainText('my_ds');


### PR DESCRIPTION
# Description

This PR brings changes to the PrometheusDatasource cuelang schema:
- XOR condition to ensure either `directUrl` or `proxy` is present. It's not supposed to be able to provide either both or none of them.
- format validation for the url fields.

_NB: this is the error you'd now see if you try to create a datasource without direct URL or proxy config set:_
![image](https://github.com/perses/perses/assets/7058693/d29cc52d-f2cf-4406-82d8-e4c11b09fb92)
_So the cue validation is working as expected but the error message is not very intelligible. Imho this is not a problem since we also want field validation on the frontend side, which would prevent submitting the form with no or wrongly-formatted URL provided. The latter is not tackled by this PR but instead should come with https://github.com/perses/perses/pull/1438._

ℹ️ This change is technically a breaking change, however I don't expect it to have a real impact at this stage, + on the frontend side it was already a XOR (the radio buttons force you to chose between the 2 configs).
-> Because of this FE/BE misalignment, in the end we decided to categorize this PR as bugfix.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
