### PR TITLE
[FEATURE] Prom DS: allow providing custom allowed endpoints

### DIFF
--- a/schemas/datasources/prometheus/prometheus.cue
+++ b/schemas/datasources/prometheus/prometheus.cue
@@ -29,34 +29,5 @@ spec: {
 }
 
 #proxy: {
-	proxy: commonProxy.#HTTPProxy & {
-		spec: {
-			allowedEndpoints: [
-				{
-					endpointPattern: "/api/v1/labels"
-					method:          "POST"
-				},
-				{
-					endpointPattern: "/api/v1/series"
-					method:          "POST"
-				},
-				{
-					endpointPattern: "/api/v1/metadata"
-					method:          "GET"
-				},
-				{
-					endpointPattern: "/api/v1/query"
-					method:          "POST"
-				},
-				{
-					endpointPattern: "/api/v1/query_range"
-					method:          "POST"
-				},
-				{
-					endpointPattern: "/api/v1/label/([a-zA-Z0-9_-]+)/values"
-					method:          "GET"
-				},
-			]
-		}
-	}
+	proxy: commonProxy.#HTTPProxy
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR is to allow users to provide a custom set of allowed endpoints when creating/editing a Prometheus data source, instead of being forced to an hard-coded set like previously.

The previously-enforced list is still available as a suggestion/default value when creating a new datasource.

# Screenshots

https://github.com/perses/perses/assets/7058693/7bcf7cf0-1b69-4224-bb8f-75c2f1586430

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
