### PR TITLE
[BUGFIX] Fix wrong error check in proxy

### DIFF
--- a/internal/api/core/middleware/proxy.go
+++ b/internal/api/core/middleware/proxy.go
@@ -260,7 +260,7 @@ func newProxy(spec v1.DatasourceSpec, path string, crypto crypto.Crypto, retriev
 	var scrt *v1.SecretSpec
 	if len(cfg.Secret) > 0 {
 		scrt, err = retrieveSecret(cfg.Secret)
-		if err == nil {
+		if err != nil {
 			return nil, err
 		}
 		if decryptErr := crypto.Decrypt(scrt); decryptErr != nil {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This was causing wrong behavior & nil pointer exception as one may expect..

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
