### PR TITLE
[BREAKINGCHANGE] Allow TimeRangeProvider and TemplateVariableProvider to live without QueryParamsProvider

### DIFF
--- a/docs/embedded-panels.md
+++ b/docs/embedded-panels.md
@@ -16,7 +16,7 @@ npx create-react-app perses-embedded-panel --template typescript
 npm i --save @perses-dev/components \
   @perses-dev/plugin-system @perses-dev/panels-plugin \
   @tanstack/react-query @perses-dev/dashboards \
-  @mui/material use-query-params @perses-dev/prometheus-plugin react-router-dom \
+  @mui/material @perses-dev/prometheus-plugin \
   @emotion/styled @hookform/resolvers
 ```
 
@@ -36,14 +36,11 @@ import {
   TimeRangeProvider
 } from "@perses-dev/plugin-system";
 import { TimeSeriesChart } from '@perses-dev/panels-plugin';
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 import { ThemeProvider } from "@mui/material";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { QueryParamProvider } from "use-query-params";
 import { DatasourceStoreProvider, TemplateVariableProvider } from "@perses-dev/dashboards";
 import prometheusResource from '@perses-dev/prometheus-plugin/plugin.json';
 import panelsResource from '@perses-dev/panels-plugin/plugin.json';
-import { BrowserRouter } from "react-router-dom";
 import { DashboardResource, GlobalDatasource, ProjectDatasource } from '@perses-dev/core';
 import { DatasourceApi } from '@perses-dev/dashboards';
 
@@ -119,43 +116,35 @@ function App() {
               TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
             }}
           >
-            <BrowserRouter>
-              <QueryParamProvider adapter={ReactRouter6Adapter} options={{ params: {} }}>
-                <QueryClientProvider client={queryClient}>
-                  <TimeRangeProvider
-                    initialRefreshInterval="0s"
-                    initialTimeRange={{ pastDuration: '30m' }}
-                    enabledURLParams={false}
-                  >
-                    <TemplateVariableProvider>
-                      <DatasourceStoreProvider dashboardResource={fakeDashboard} datasourceApi={fakeDatasourceApi}>
-                        <DataQueriesProvider
-                          definitions={[
-                            {
-                              kind: 'PrometheusTimeSeriesQuery',
-                              spec: { query: `up{job="prometheus"}` },
-                            },
-                          ]}
-                        >
-                          <TimeSeriesChart.PanelComponent
-                            contentDimensions={{
-                              width: 1200,
-                              height: 400,
-                            }}
-                            spec={{
-                              legend: {
-                                position: 'bottom',
-                                size: 'medium',
-                              },
-                            }}
-                          />
-                        </DataQueriesProvider>
-                      </DatasourceStoreProvider>
-                    </TemplateVariableProvider>
-                  </TimeRangeProvider>
-                </QueryClientProvider>
-              </QueryParamProvider>
-            </BrowserRouter>
+            <QueryClientProvider client={queryClient}>
+              <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
+                <TemplateVariableProvider>
+                  <DatasourceStoreProvider dashboardResource={fakeDashboard} datasourceApi={fakeDatasourceApi}>
+                    <DataQueriesProvider
+                      definitions={[
+                        {
+                          kind: 'PrometheusTimeSeriesQuery',
+                          spec: { query: `up{job="prometheus"}` },
+                        },
+                      ]}
+                    >
+                      <TimeSeriesChart.PanelComponent
+                        contentDimensions={{
+                          width: 1200,
+                          height: 400,
+                        }}
+                        spec={{
+                          legend: {
+                            position: 'bottom',
+                            size: 'medium',
+                          },
+                        }}
+                      />
+                    </DataQueriesProvider>
+                  </DatasourceStoreProvider>
+                </TemplateVariableProvider>
+              </TimeRangeProvider>
+            </QueryClientProvider>
           </PluginRegistry>
         </SnackbarProvider>
       </ChartsProvider>

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DispatchWithPromise, VariableDefinition, Variable, getVariableProject } from '@perses-dev/core';
+import { DispatchWithPromise, Variable, VariableDefinition, getVariableProject } from '@perses-dev/core';
 import React, { Dispatch, DispatchWithoutAction, useEffect, useMemo, useState } from 'react';
-import { DatasourceStoreProvider, TemplateVariableProvider } from '@perses-dev/dashboards';
+import { DatasourceStoreProvider, TemplateVariableProviderWithQueryParams } from '@perses-dev/dashboards';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import {
   Action,
   PluginRegistry,
-  TimeRangeProvider,
-  useInitialTimeRange,
+  TimeRangeProviderWithQueryParams,
   VariableEditorForm,
+  useInitialTimeRange,
 } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../model/datasource-api';
@@ -81,8 +81,8 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
           }}
         >
           <DatasourceStoreProvider datasourceApi={datasourceApi} projectName={projectName}>
-            <TimeRangeProvider initialTimeRange={initialTimeRange} enabledURLParams={true}>
-              <TemplateVariableProvider initialVariableDefinitions={[]}>
+            <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>
+              <TemplateVariableProviderWithQueryParams initialVariableDefinitions={[]}>
                 <VariableEditorForm
                   initialVariableDefinition={variableDef}
                   initialAction={action}
@@ -92,8 +92,8 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
                   onClose={onClose}
                   onDelete={onDelete ? () => setDeleteVariableDialogStateOpened(true) : undefined}
                 />
-              </TemplateVariableProvider>
-            </TimeRangeProvider>
+              </TemplateVariableProviderWithQueryParams>
+            </TimeRangeProviderWithQueryParams>
           </DatasourceStoreProvider>
         </PluginRegistry>
         {onDelete && (

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -43,7 +43,7 @@ describe('Panel', () => {
     definition ??= createTestPanel();
 
     renderWithContext(
-      <TimeRangeProvider initialTimeRange={{ pastDuration: '1h' }}>
+      <TimeRangeProvider timeRange={{ pastDuration: '1h' }}>
         <TemplateVariableProvider
           initialVariableDefinitions={[
             {

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
@@ -24,7 +24,7 @@ describe('Add Panel Group', () => {
 
     renderWithContext(
       <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
-        <TimeRangeProvider initialTimeRange={{ pastDuration: '1h' }}>
+        <TimeRangeProvider timeRange={{ pastDuration: '1h' }}>
           <TemplateVariableProvider>
             <DashboardProviderSpy />
             <PanelGroupDialog />

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -15,7 +15,7 @@ import { generatePath } from 'react-router';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import { screen, act } from '@testing-library/react';
-import { TimeRangeProvider } from '@perses-dev/plugin-system';
+import { TimeRangeProvider, TimeRangeProviderWithQueryParams } from '@perses-dev/plugin-system';
 import { renderWithContext } from '../../test';
 import testDashboard from '../../test/testDashboard';
 import { DashboardProvider, DashboardStoreProps, TemplateVariableProvider } from '../../context';
@@ -39,15 +39,22 @@ describe('TimeRangeControls', () => {
   const renderTimeRangeControls = (testURLParams: boolean) => {
     renderWithContext(
       <DashboardProvider initialState={initialState}>
-        <TimeRangeProvider
-          initialRefreshInterval={testDefaultRefreshInterval}
-          initialTimeRange={testDefaultTimeRange}
-          enabledURLParams={testURLParams}
-        >
-          <TemplateVariableProvider>
-            <TimeRangeControls />
-          </TemplateVariableProvider>
-        </TimeRangeProvider>
+        {testURLParams ? (
+          <TimeRangeProviderWithQueryParams
+            initialRefreshInterval={testDefaultRefreshInterval}
+            initialTimeRange={testDefaultTimeRange}
+          >
+            <TemplateVariableProvider>
+              <TimeRangeControls />
+            </TemplateVariableProvider>
+          </TimeRangeProviderWithQueryParams>
+        ) : (
+          <TimeRangeProvider refreshInterval={testDefaultRefreshInterval} timeRange={testDefaultTimeRange}>
+            <TemplateVariableProvider>
+              <TimeRangeControls />
+            </TemplateVariableProvider>
+          </TimeRangeProvider>
+        )}
       </DashboardProvider>,
       undefined,
       history

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -424,6 +424,21 @@ export function TemplateVariableProvider({
   externalVariableDefinitions = [],
   builtinVariables = [],
 }: TemplateVariableProviderProps) {
+  const [store] = useState(createTemplateVariableSrvStore({ initialVariableDefinitions, externalVariableDefinitions }));
+
+  return (
+    <TemplateVariableStoreContext.Provider value={store}>
+      <PluginProvider builtinVariables={builtinVariables}>{children}</PluginProvider>
+    </TemplateVariableStoreContext.Provider>
+  );
+}
+
+export function TemplateVariableProviderWithQueryParams({
+  children,
+  initialVariableDefinitions = [],
+  externalVariableDefinitions = [],
+  builtinVariables = [],
+}: TemplateVariableProviderProps) {
   const allVariableDefs = mergeVariableDefinitions(initialVariableDefinitions, externalVariableDefinitions);
   const queryParams = useVariableQueryParams(allVariableDefs);
   const [store] = useState(

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -15,18 +15,18 @@ import { Box, BoxProps } from '@mui/material';
 import { BuiltinVariableDefinition, DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL } from '@perses-dev/core';
 import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import {
-  TimeRangeProvider,
+  TimeRangeProviderWithQueryParams,
   useInitialRefreshInterval,
   useInitialTimeRange,
   usePluginBuiltinVariableDefinitions,
 } from '@perses-dev/plugin-system';
 import { useMemo } from 'react';
 import {
-  TemplateVariableProvider,
   DashboardProvider,
   DatasourceStoreProviderProps,
   DatasourceStoreProvider,
   TemplateVariableProviderProps,
+  TemplateVariableProviderWithQueryParams,
 } from '../../context';
 import { DashboardApp, DashboardAppProps } from './DashboardApp';
 
@@ -101,12 +101,11 @@ export function ViewDashboard(props: ViewDashboardProps) {
   return (
     <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>
       <DashboardProvider initialState={{ dashboardResource, isEditMode: !!isEditing }}>
-        <TimeRangeProvider
+        <TimeRangeProviderWithQueryParams
           initialTimeRange={initialTimeRange}
           initialRefreshInterval={initialRefreshInterval}
-          enabledURLParams={true}
         >
-          <TemplateVariableProvider
+          <TemplateVariableProviderWithQueryParams
             initialVariableDefinitions={spec.variables}
             externalVariableDefinitions={externalVariableDefinitions}
             builtinVariables={builtinVariables}
@@ -137,8 +136,8 @@ export function ViewDashboard(props: ViewDashboardProps) {
                 />
               </ErrorBoundary>
             </Box>
-          </TemplateVariableProvider>
-        </TimeRangeProvider>
+          </TemplateVariableProviderWithQueryParams>
+        </TimeRangeProviderWithQueryParams>
       </DashboardProvider>
     </DatasourceStoreProvider>
   );

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -22,7 +22,7 @@ describe('Panel Groups', () => {
   const renderDashboard = () => {
     renderWithContext(
       <DatasourceStoreProvider {...defaultDatasourceProps}>
-        <TimeRangeProvider initialRefreshInterval="0s" initialTimeRange={{ pastDuration: '30m' }}>
+        <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
           <TemplateVariableProvider>
             <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
               <DashboardApp dashboardResource={getTestDashboard()} isReadonly={false} />

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13265,9 +13265,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
       "engines": {
         "node": ">=0.11"
       },
@@ -28501,6 +28504,7 @@
       "dependencies": {
         "@perses-dev/components": "0.41.1",
         "@perses-dev/core": "0.41.1",
+        "date-fns": "^2.30.0",
         "immer": "^9.0.15",
         "react-hook-form": "^7.46.1",
         "use-immer": "^0.7.0",
@@ -32042,6 +32046,7 @@
         "@perses-dev/components": "0.41.1",
         "@perses-dev/core": "0.41.1",
         "@perses-dev/storybook": "0.41.1",
+        "date-fns": "^2.30.0",
         "immer": "^9.0.15",
         "react-hook-form": "^7.46.1",
         "use-immer": "^0.7.0",
@@ -38354,9 +38359,12 @@
       }
     },
     "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "date-fns-tz": {
       "version": "1.3.7",

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@perses-dev/components": "0.41.1",
     "@perses-dev/core": "0.41.1",
+    "date-fns": "^2.30.0",
     "immer": "^9.0.15",
     "react-hook-form": "^7.46.1",
     "use-immer": "^0.7.0",

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProviderWithQueryParams.tsx
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProviderWithQueryParams.tsx
@@ -1,0 +1,41 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DurationString, TimeRangeValue } from '@perses-dev/core';
+import React from 'react';
+import { TimeRangeProvider } from './TimeRangeProvider';
+import { useSetRefreshIntervalParams, useTimeRangeParams } from './query-params';
+
+export interface TimeRangeFromQueryProps {
+  initialTimeRange: TimeRangeValue;
+  initialRefreshInterval?: DurationString;
+  children?: React.ReactNode;
+}
+
+export function TimeRangeProviderWithQueryParams(props: TimeRangeFromQueryProps) {
+  const { initialTimeRange, initialRefreshInterval, children } = props;
+
+  const { timeRange, setTimeRange } = useTimeRangeParams(initialTimeRange);
+  const { refreshInterval, setRefreshInterval } = useSetRefreshIntervalParams(initialRefreshInterval);
+
+  return (
+    <TimeRangeProvider
+      timeRange={timeRange}
+      refreshInterval={refreshInterval}
+      setTimeRange={setTimeRange}
+      setRefreshInterval={setRefreshInterval}
+    >
+      {children}
+    </TimeRangeProvider>
+  );
+}

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/refresh-interval.ts
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/refresh-interval.ts
@@ -11,6 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './TimeRangeProvider';
-export * from './TimeRangeProviderWithQueryParams';
-export * from './query-params';
+import { DurationString, parseDurationString } from '@perses-dev/core';
+import { milliseconds } from 'date-fns';
+
+/**
+ * Utils function to transform a refresh interval in {@link DurationString} format into a number of ms.
+ * @param refreshInterval
+ */
+export function getRefreshIntervalInMs(refreshInterval?: DurationString) {
+  if (refreshInterval !== undefined && refreshInterval !== null) {
+    return milliseconds(parseDurationString(refreshInterval));
+  }
+  return 0;
+}

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithTimeRange.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithTimeRange.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { StoryFn, StoryContext } from '@storybook/react';
-import { TimeRangeProvider, TimeRangeProviderProps } from '@perses-dev/plugin-system';
+import { TimeRangeProvider, TimeRangeFromQueryProps } from '@perses-dev/plugin-system';
 
 declare module '@storybook/react' {
   interface Parameters {
@@ -21,7 +21,7 @@ declare module '@storybook/react' {
 }
 
 export type WithTimeRangeParameter = {
-  props: Partial<TimeRangeProviderProps>;
+  props: Partial<TimeRangeFromQueryProps>;
 };
 
 // Type guard because storybook types parameters as `any`
@@ -35,7 +35,7 @@ export const WithTimeRange = (Story: StoryFn, context: StoryContext<unknown>) =>
   const props = parameter?.props;
 
   return (
-    <TimeRangeProvider initialRefreshInterval="0s" initialTimeRange={{ pastDuration: '1h' }} {...props}>
+    <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '1h' }} {...props}>
       <Story />
     </TimeRangeProvider>
   );


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR comes from the experience of creating an embedded panel in a separate UI. 

This requires for sure a `TimeRangeProvider`, but even if we set `enabledURLParams` property to `false`, it still requires to define a `QueryParamsProvider` upper, which leads to this kind of non-sense:
```tsx
<BrowserRouter>
  <QueryParamProvider adapter={ReactRouter6Adapter} options={{ params: {} }}>
    <TimeRangeProvider
      initialRefreshInterval="0s"
      initialTimeRange={{ pastDuration: '30m' }}
      enabledURLParams={false}
    >
      <TemplateVariableProvider>
      ...
```

With this PR this PR you can fully decide to use or not query params

- If you don´t want to use them
```tsx
<TimeRangeProvider
  refreshInterval="0s"
  timeRange={{ pastDuration: '30m' }}
>
  <TemplateVariableProvider>
  ...
```
- If you want to use them
```tsx
<BrowserRouter>
  <QueryParamProvider adapter={ReactRouter6Adapter} options={{ params: {} }}>
    <TimeRangeProviderWithQueryParams
      initialRefreshInterval="0s"
      initialTimeRange={{ pastDuration: '30m' }}
    >
      <TemplateVariableProviderWithQueryParams>
  ...
```

# Breaking changes
- The `enabledURLParams` in the `TimeRangeProvider` disappear to let you choose between `TimeRangeProvider` and `TimeRangeProviderWithQueryParams`
- The default behaviour of using query params inside the `TemplateVariableProvider` disappear to let you choose between `TemplateVariableProvider` and `TemplateVariableProviderWithQueryParams`

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
