### PR TITLE
[BUGFIX] Fix grafana migration failing in some corner cases

### DIFF
--- a/internal/api/shared/migrate/migrate_test.go
+++ b/internal/api/shared/migrate/migrate_test.go
@@ -46,6 +46,18 @@ func TestMigrate(t *testing.T) {
 			expectedPersesDashboardFile: "old_grafana_panels_perses_dashboard.json",
 			expectedErrorStr:            "",
 		},
+		{
+			title:                       "dashboard embeddind a library panel",
+			inputGrafanaDashboardFile:   "library_panel_grafana_dashboard.json",
+			expectedPersesDashboardFile: "library_panel_perses_dashboard.json",
+			expectedErrorStr:            "",
+		},
+		{
+			title:                       "dashboard with old query format used (i.e query string instead of struct with query + refId)",
+			inputGrafanaDashboardFile:   "old_grafana_query_grafana_dashboard.json",
+			expectedPersesDashboardFile: "old_grafana_query_perses_dashboard.json",
+			expectedErrorStr:            "",
+		},
 	}
 
 	for _, test := range testSuite {

--- a/internal/api/shared/migrate/testdata/library_panel_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/library_panel_grafana_dashboard.json
@@ -1,0 +1,70 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 57081,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "panels": [],
+      "title": "Dashboard Information",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "libraryPanel": {
+        "name": "",
+        "uid": "0O3Uv304k"
+      },
+      "title": "Point of Contact"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Perses testing / Dashboard with library panel",
+  "uid": "a5867867-7a6f-4834-8247-51844c4b975f",
+  "version": 2,
+  "weekStart": ""
+}

--- a/internal/api/shared/migrate/testdata/library_panel_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/library_panel_perses_dashboard.json
@@ -1,0 +1,62 @@
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "a5867867-7a6f-4834-8247-51844c4b975f",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "Perses testing / Dashboard with library panel"
+    },
+    "panels": {
+      "0_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Point of Contact"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "**Migration from Grafana not supported !**"
+            }
+          }
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": []
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Dashboard Information",
+            "collapse": {
+              "open": true
+            }
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/0_0"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/internal/api/shared/migrate/testdata/old_grafana_query_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_query_grafana_dashboard.json
@@ -1,0 +1,189 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "dummy description",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 57082,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "title": "Panel Title",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "argos-world",
+          "value": "argos-world"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "argos-world",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "prd1",
+          "value": "prd1"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Paas",
+        "multi": true,
+        "name": "stack",
+        "options": [],
+        "query": "query_result(max by (stack) (thanos_build_info{prometheus=\"argos\",federation=\"\"}) or ( label_replace(vector(1), \"stack\", \"external\", \"\", \"\") ) )",
+        "refresh": 2,
+        "regex": ".*stack=\"([^\"]*)\".*",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Perses testing / old query format",
+  "uid": "perses-testing-old-query",
+  "version": 3,
+  "weekStart": ""
+}

--- a/internal/api/shared/migrate/testdata/old_grafana_query_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_query_perses_dashboard.json
@@ -1,0 +1,106 @@
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "perses-testing-old-query",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "Perses testing / old query format"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "grafana",
+                "migration",
+                "not",
+                "supported"
+              ]
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Paas",
+            "hidden": false
+          },
+          "allowAllValue": false,
+          "allowMultiple": true,
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "max by (stack) (thanos_build_info{prometheus=\"argos\",federation=\"\"}) or ( label_replace(vector(1), \"stack\", \"external\", \"\", \"\") ) ",
+              "labelName": "stack"
+            }
+          },
+          "name": "stack"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Panel Title"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": []
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -235,7 +235,7 @@
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
-              "expr": "group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[placeholder]))",
+              "expr": "group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range]))",
               "labelName": "type"
             }
           },
@@ -255,7 +255,7 @@
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
-              "expr": "query_result(present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[placeholder]))",
+              "expr": "query_result(present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range]))",
               "labelName": "migration_from_grafana_not_supported"
             }
           },

--- a/schemas/panels/gauge/mig.cuepart
+++ b/schemas/panels/gauge/mig.cuepart
@@ -1,4 +1,4 @@
-if #panel.type == "gauge" {
+if #panel.type != _|_ if #panel.type == "gauge" {
     kind: "GaugeChart"
     spec: {
         #calcName: "\(#panel.options.reduceOptions.calcs[0])" // only consider [0] here as Perses's GaugeChart doesn't support multi queries

--- a/schemas/panels/markdown/mig.cuepart
+++ b/schemas/panels/markdown/mig.cuepart
@@ -1,6 +1,6 @@
 
 // NB: Convert text panels with mode=html as markdown panels as best effort while we dont provide a proper panel type for this
-if #panel.type == "text" {
+if #panel.type != _|_ if #panel.type == "text" {
     if #panel.mode != _|_ {
         kind: "Markdown"
         spec: {

--- a/schemas/panels/stat/mig.cuepart
+++ b/schemas/panels/stat/mig.cuepart
@@ -1,4 +1,4 @@
-if #panel.type == "stat" {
+if #panel.type != _|_ if #panel.type == "stat" {
     kind: "StatChart"
     spec: {
         #calcPath: "\(#panel.options.reduceOptions.calcs[0])" // only consider [0] here as Perses's StatChart doesn't support multi queries

--- a/schemas/panels/time-series/mig.cuepart
+++ b/schemas/panels/time-series/mig.cuepart
@@ -1,4 +1,4 @@
-if #panel.type == "timeseries" || #panel.type == "graph" {
+if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
     kind: "TimeSeriesChart"
     spec: {
         legend: {

--- a/schemas/queries/prometheus/mig.cuepart
+++ b/schemas/queries/prometheus/mig.cuepart
@@ -1,4 +1,4 @@
-if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" { // the first condition tackles the weird case where datasource type may not be present
+if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" { // the first condition avoids validation error in the weird case where datasource type is not present
     kind: "PrometheusTimeSeriesQuery"
     spec: {
         datasource: {

--- a/schemas/variables/prometheus-label-names/mig.cuepart
+++ b/schemas/variables/prometheus-label-names/mig.cuepart
@@ -1,4 +1,12 @@
-if #var.type == "query" if #var.query.query =~ "^label_names\\(\\)$" {
+// NB we would need `if` to support short-circuit in order to avoid code duplication here.
+//    See https://github.com/cue-lang/cue/issues/2232
+if #var.type == "query" if (#var.query & string) != _|_ if #var.query =~ "^label_names\\(\\)$" {
+    kind: "PrometheusLabelNamesVariable"
+    spec: {
+        matchers: []
+    }
+},
+if #var.type == "query" if (#var.query & {}) != _|_ if #var.query.query =~ "^label_names\\(\\)$" {
     kind: "PrometheusLabelNamesVariable"
     spec: {
         matchers: []

--- a/schemas/variables/prometheus-label-values/mig.cuepart
+++ b/schemas/variables/prometheus-label-values/mig.cuepart
@@ -1,4 +1,14 @@
-if #var.type == "query" if #var.query.query =~ "^label_values\\(.*\\)$" {
+// NB we would need `if` to support short-circuit in order to avoid code duplication here.
+//    See https://github.com/cue-lang/cue/issues/2232
+if #var.type == "query" if (#var.query & string) != _|_ if #var.query =~ "^label_values\\(.*\\)$" {
+    kind: "PrometheusLabelValuesVariable"
+    spec: {
+        #matches: regexp.FindSubmatch("^label_values\\(((.*),)?\\s*?([a-zA-Z0-9-_]+)\\)$", #var.query)
+        labelName: #matches[3]
+        matchers: [ if #matches[2] != "" { #matches[2] } ]
+    }
+},
+if #var.type == "query" if (#var.query & {}) != _|_ if #var.query.query =~ "^label_values\\(.*\\)$" {
     kind: "PrometheusLabelValuesVariable"
     spec: {
         #matches: regexp.FindSubmatch("^label_values\\(((.*),)?\\s*?([a-zA-Z0-9-_]+)\\)$", #var.query.query)

--- a/schemas/variables/prometheus-promql/mig.cuepart
+++ b/schemas/variables/prometheus-promql/mig.cuepart
@@ -1,20 +1,29 @@
-if #var.type == "query" {
-    #qResRegexp: "^query_result\\((.*by\\s*\\((\\w+).*)\\)$"
-    #cleanedQuery: strings.Replace(#var.query.query, "$__range", "placeholder", -1) // this removes the grafana global vars that'd be causing validation issues later (e.g "__range is used but not defined")
-    // TODO replace above assignation by below one once we'll rely on cue > v0.5 (regexp.ReplaceAll was added in v0.4.3)
-    // #cleanedQuery: regexp.ReplaceAll("\\$__\\w+", #var.query.query, "placeholder") // this removes the grafana global vars that'd be causing validation issues later (e.g "__range is used but not defined")
-
-    if #var.query.query =~ #qResRegexp {
-        kind:          "PrometheusPromQLVariable"
-        spec: {
-            expr:      regexp.FindSubmatch(#qResRegexp, #cleanedQuery)[1]
-            labelName: regexp.FindSubmatch(#qResRegexp, #cleanedQuery)[2]
+// NB we would need `if` to support short-circuit in order to avoid code duplication here.
+//    See https://github.com/cue-lang/cue/issues/2232
+if #var.type == "query" if (#var.query & string) != _|_ if #var.query =~ "^query_result" {
+    kind: "PrometheusPromQLVariable"
+    spec: {
+        #qResRegexp: "^query_result\\((.*by\\s*\\((\\w+).*)\\)$"
+        if #var.query =~ #qResRegexp {
+            expr:      regexp.FindSubmatch(#qResRegexp, #var.query)[1]
+            labelName: regexp.FindSubmatch(#qResRegexp, #var.query)[2]
+        }
+        if #var.query !~ #qResRegexp {
+            expr:       #var.query
+            labelName: "migration_from_grafana_not_supported"
         }
     }
-    if #var.query.query !~ #qResRegexp {
-        kind:          "PrometheusPromQLVariable"
-        spec: {
-            expr:       #cleanedQuery
+},
+if #var.type == "query" if (#var.query & {}) != _|_ if #var.query.query =~ "^query_result" {
+    kind: "PrometheusPromQLVariable"
+    spec: {
+        #qResRegexp: "^query_result\\((.*by\\s*\\((\\w+).*)\\)$"
+        if #var.query.query =~ #qResRegexp {
+            expr:      regexp.FindSubmatch(#qResRegexp, #var.query.query)[1]
+            labelName: regexp.FindSubmatch(#qResRegexp, #var.query.query)[2]
+        }
+        if #var.query.query !~ #qResRegexp {
+            expr:       #var.query.query
             labelName: "migration_from_grafana_not_supported"
         }
     }

--- a/ui/app/src/views/MigrateView.tsx
+++ b/ui/app/src/views/MigrateView.tsx
@@ -94,12 +94,6 @@ function MigrateView() {
             dashboard structure.
           </Typography>
         </Alert>
-        <Alert variant={'outlined'} severity={'warning'}>
-          <Typography>
-            If your dashboard contains Library panels, in order to migrate these nicely you should collapse their
-            respective parent row (if applicable) before pasting the JSON here.
-          </Typography>
-        </Alert>
         <Typography variant="h2" sx={{ paddingTop: 2 }}>
           1. Provide a Grafana dashboard
         </Typography>


### PR DESCRIPTION
# Description

2 different issues were making the grafana migration fail:
- Library panels: looks like "collapse them to make it work" is no longer valid, so we were trying to access a `type` attribute that doesn't exist in their case. It's now properly tackled (placeholder panel gets applied). Warning on the Migrate UI removed accordingly.
- Old query datamodel: nowadays the `query` attribute from the prometheus template variables is a struct and no longer a string. Grafana is not automatically doing the conversion so we have to support both here.

This also comes with some improvements for PromQL variables migration: stronger checks + no more replacement of builtin vars like `$__range` since we properly support them now.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).