### PR TITLE
[REFACTOR] Separate the datasource selector frontend from backend

### DIFF
--- a/internal/api/shared/schemas/base_def_query.cue
+++ b/internal/api/shared/schemas/base_def_query.cue
@@ -15,9 +15,9 @@ package base
 
 kind: string
 spec: {
-	datasource?: {
+	datasource?: close({
 		kind:  string
 		name?: string
-	}
+	})
 	// additional fields allowed
 }

--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -49,15 +49,7 @@ export interface DatasourceSelector {
    * Kind of the datasource.
    */
   kind: string;
-  /**
-   * Group of the datasource.
-   * Omit it if you don't store datasource by group.
-   * TODO: This group field is fairly ignored by the backend data model.
-   *   We need to decouple properly the backend and frontend data models.
-   *   A Zustand store would certainly help here to decouple definition from the backend and state from the UI.
-   *   => See Variable Store
-   */
-  group?: string;
+
   /**
    * Name of the datasource.
    * If omitted, it's assumed that you target the default datasource for the specified kind (and group, if set)

--- a/ui/plugin-system/src/components/DatasourceSelect.tsx
+++ b/ui/plugin-system/src/components/DatasourceSelect.tsx
@@ -15,7 +15,7 @@ import OpenInNewIcon from 'mdi-material-ui/OpenInNew';
 import { Select, SelectProps, MenuItem, Stack, Divider, ListItemText, Chip, IconButton, Box } from '@mui/material';
 import { DatasourceSelector } from '@perses-dev/core';
 import { useMemo } from 'react';
-import { useListDatasourceSelectItems } from '../runtime';
+import { DatasourceSelectItemSelector, useListDatasourceSelectItems } from '../runtime';
 
 // Props on MUI Select that we don't want people to pass because we're either redefining them or providing them in
 // this component
@@ -137,20 +137,29 @@ export function DatasourceName(props: { name: string; overridden?: boolean; over
 // Delimiter used to stringify/parse option values
 const OPTION_VALUE_DELIMITER = '_____';
 
-// Given a DatasourceSelector, returns a string value like `{kind}_____{name}` that can be used as a Select input value
-function selectorToOptionValue(selector: DatasourceSelector): string {
+/**
+ * Given a DatasourceSelectItemSelector,
+ * returns a string value like `{kind}_____{group}_____{name}` that can be used as a Select input value.
+ * @param selector
+ */
+function selectorToOptionValue(selector: DatasourceSelectItemSelector): string {
   return [selector.kind, selector.group ?? '', selector.name ?? ''].join(OPTION_VALUE_DELIMITER);
 }
 
-// Given an option value name like `{kind}_____{name}`, returns a DatasourceSelector
+/**
+ * Given an option value name like `{kind}_____{group}_____{name}`,
+ * returns a DatasourceSelector to be used by the query data model.
+ * @param optionValue
+ */
 function optionValueToSelector(optionValue: string): DatasourceSelector {
-  const [kind, group, name] = optionValue.split(OPTION_VALUE_DELIMITER);
-  if (kind === undefined || group === undefined || name === undefined) {
+  const words = optionValue.split(OPTION_VALUE_DELIMITER);
+  const kind = words[0];
+  const name = words[2];
+  if (kind === undefined || name === undefined) {
     throw new Error('Invalid optionValue string');
   }
   return {
     kind,
-    group: group === '' ? undefined : group,
     name: name === '' ? undefined : name,
   };
 }

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -40,7 +40,18 @@ export interface DatasourceSelectItem {
   name: string;
   overridden?: boolean;
   overriding?: boolean;
-  selector: DatasourceSelector;
+  selector: DatasourceSelectItemSelector;
+}
+
+/**
+ * Datasource Selector used by the frontend only to differentiate datasources coming from different group.
+ */
+export interface DatasourceSelectItemSelector extends DatasourceSelector {
+  /**
+   * Group of the datasource.
+   * Omit it if you don't store datasource by group.
+   */
+  group?: string;
 }
 
 export const DatasourceStoreContext = createContext<DatasourceStore | undefined>(undefined);

--- a/ui/prometheus-plugin/src/model/prometheus-selectors.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-selectors.ts
@@ -31,7 +31,7 @@ export const DEFAULT_PROM: PrometheusDatasourceSelector = { kind: PROM_DATASOURC
  * Returns true if the provided PrometheusDatasourceSelector is the default one.
  */
 export function isDefaultPromSelector(selector: PrometheusDatasourceSelector) {
-  return selector.name === undefined && selector.group === undefined;
+  return selector.name === undefined;
 }
 
 /**


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

In a [previous PR](https://github.com/perses/perses/pull/1360), we allowed the frontend to choose between global/project/local datasources. In this context, we reused the same classes for backend requests datamodel and datasource selection in the frontend, which introduced the group field, not interpreted in the backend.

With that code, we split the datamodels:
- The ``DatasourceSelectItemSelector`` is used by the frontend only in the datasource selection form. With group field to know by advance which one would be used by the frontend at T time.
- The ``DatasourceSelector`` remains the one used in the backend requests. Without group field as the backend does not have this notion.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
