### PR TITLE
[ENHANCEMENT] Reduce navbars size

### DIFF
--- a/ui/app/src/components/AppBreadcrumbs.tsx
+++ b/ui/app/src/components/AppBreadcrumbs.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Breadcrumbs, Link, Typography } from '@mui/material';
+import { Breadcrumbs, Link, Typography, styled } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 
 interface AppBreadcrumbsProps {
@@ -28,6 +28,12 @@ function HomeLinkBreadcrumb() {
   );
 }
 
+const StyledBreadcrumbs = styled(Breadcrumbs)({
+  fontSize: 'large',
+  paddingLeft: 0.5,
+  lineHeight: '30px',
+});
+
 /*
  * AppBreadcrumbs provide a navigation helper
  * For dashboard breadcrumb, projectName & dashboardName are mandatory
@@ -41,38 +47,38 @@ function AppBreadcrumbs(props: AppBreadcrumbsProps) {
 
   if (dashboardName && projectName) {
     return (
-      <Breadcrumbs sx={{ fontSize: 'large' }}>
+      <StyledBreadcrumbs>
         <HomeLinkBreadcrumb />
         <Link underline={'hover'} variant={'h3'} component={RouterLink} to={`/projects/${projectName}`}>
           {projectName}
         </Link>
         <Typography variant={'h3'}>{dashboardName}</Typography>
-      </Breadcrumbs>
+      </StyledBreadcrumbs>
     );
   }
 
   if (projectName) {
     return (
-      <Breadcrumbs sx={{ fontSize: 'large' }}>
+      <StyledBreadcrumbs>
         <HomeLinkBreadcrumb />
         <Typography variant={'h3'}>{projectName}</Typography>
-      </Breadcrumbs>
+      </StyledBreadcrumbs>
     );
   }
 
   if (admin) {
     return (
-      <Breadcrumbs sx={{ fontSize: 'large' }}>
+      <StyledBreadcrumbs>
         <HomeLinkBreadcrumb />
         <Typography variant={'h3'}>Admin</Typography>
-      </Breadcrumbs>
+      </StyledBreadcrumbs>
     );
   }
 
   return (
-    <Breadcrumbs sx={{ fontSize: 'large' }}>
+    <StyledBreadcrumbs>
       <Typography variant={'h3'}>Home</Typography>
-    </Breadcrumbs>
+    </StyledBreadcrumbs>
   );
 }
 

--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -147,6 +147,11 @@ export default function Header(): JSX.Element {
       <Toolbar
         sx={{
           backgroundColor: (theme) => theme.palette.designSystem.blue[700],
+          '&': {
+            minHeight: '40px',
+            paddingLeft: 0,
+            paddingRight: 0.75,
+          },
         }}
       >
         <Box
@@ -160,6 +165,9 @@ export default function Header(): JSX.Element {
           <Button
             onClick={() => {
               navigate('/');
+            }}
+            sx={{
+              padding: 0,
             }}
           >
             <PersesLogo />

--- a/ui/app/src/components/PersesLogo.tsx
+++ b/ui/app/src/components/PersesLogo.tsx
@@ -20,7 +20,7 @@ interface PersesLogoProps extends SVGProps<SVGSVGElement> {
 export const PersesLogo = (props: PersesLogoProps) => {
   const { title = 'Perses Logo' } = props;
   return (
-    <svg width="130" height="43" viewBox="0 0 367 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="130" height="32" viewBox="0 0 367 120" fill="none" xmlns="http://www.w3.org/2000/svg">
       <title id="perses-banner-title">{title}</title>
       <rect width="367" height="120" />
       <path

--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -40,14 +40,14 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
         sx={{ backgroundColor: 'inherit', ...props.sx }}
       >
         <Box display="flex" justifyContent="space-between">
-          <Box display="flex" flexWrap="wrap" alignItems="start" my={isSticky ? 2 : 0} ml={isSticky ? 2 : 0}>
+          <Box display="flex" flexWrap="wrap" alignItems="start" mt={isSticky ? 1.5 : 0} ml={isSticky ? 2 : 0}>
             <TemplateVariableList></TemplateVariableList>
             {props.initialVariableIsSticky && (
               <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
             )}
           </Box>
           {isSticky && (
-            <Box my={2} mr={2}>
+            <Box mt={1.5} mr={2}>
               <TimeRangeControls></TimeRangeControls>
             </Box>
           )}

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -62,7 +62,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
     <>
       {isEditMode ? (
         <Stack spacing={1} data-testid={testId}>
-          <Box p={2} display="flex" sx={{ backgroundColor: (theme) => theme.palette.primary.main + '30' }}>
+          <Box px={2} py={1} display="flex" sx={{ backgroundColor: (theme) => theme.palette.primary.main + '30' }}>
             {dashboardTitle}
             <Stack direction="row" spacing={1} marginLeft="auto">
               {isReadonly && (
@@ -81,7 +81,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               display: 'flex',
               width: '100%',
               alignItems: 'start',
-              padding: (theme) => theme.spacing(1, 2),
+              padding: (theme) => theme.spacing(1, 2, 0, 2),
             }}
           >
             <ErrorBoundary FallbackComponent={ErrorAlert}>
@@ -93,12 +93,12 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               />
             </ErrorBoundary>
             <Stack ml="auto" direction="row" flexWrap={isBiggerThanLg ? 'nowrap' : 'wrap-reverse'} justifyContent="end">
-              <Stack direction="row" spacing={1} ml={1} mb={1} whiteSpace="nowrap">
+              <Stack direction="row" spacing={1} ml={1} whiteSpace="nowrap">
                 <EditVariablesButton />
                 <AddPanelButton />
                 <AddGroupButton />
               </Stack>
-              <Stack direction="row" spacing={1} ml={1} mb={1}>
+              <Stack direction="row" spacing={1} ml={1}>
                 <TimeRangeControls />
                 <DownloadButton />
                 <EditJsonButton />
@@ -107,7 +107,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
           </Box>
         </Stack>
       ) : (
-        <Stack spacing={1} padding={2} data-testid={testId}>
+        <Stack spacing={1} px={2} pt={1} data-testid={testId}>
           <Box sx={{ display: 'flex', width: '100%' }}>
             {dashboardTitle}
             <Stack direction="row" spacing={1} marginLeft="auto">
@@ -116,7 +116,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               {isBiggerThanSm && <EditButton onClick={onEditButtonClick} />}
             </Stack>
           </Box>
-          <Box paddingY={2}>
+          <Box>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
               <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}


### PR DESCRIPTION
# Description

Reduce the size of the various navbars (top one, the one with breadcrumb & timerange controls in read mode, the one with variables dropdowns & timerange controls in edit mode, also the sticky version of the latter) to spare vertical space for the dashboard content.

# Screenshots

before/after comparison:

![image](https://github.com/perses/perses/assets/7058693/d94672f3-8ba0-479d-8ca0-d138d9c6c765)

![image](https://github.com/perses/perses/assets/7058693/6c9d207b-4bdf-4ceb-91be-5004a846506c)

![2023-10-20_07h42_22](https://github.com/perses/perses/assets/7058693/6f95a6f4-116c-4b44-85d2-015e30c40634)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
