### PR TITLE
[ENHANCEMENT] Add some throughput units

### DIFF
--- a/schemas/common/format.cue
+++ b/schemas/common/format.cue
@@ -13,7 +13,7 @@
 
 package common
 
-#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
 
 #timeFormat: {
 	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
@@ -33,6 +33,12 @@ package common
 
 #bytesFormat: {
 	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
 	decimalPlaces?: number
 	shortValues?:   bool
 }

--- a/ui/core/src/model/units/throughput.test.ts
+++ b/ui/core/src/model/units/throughput.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { formatValue } from './units';
+import { UnitTestCase } from './types';
+
+const THROUGHPUT_TESTS: UnitTestCase[] = [
+  {
+    value: -4444,
+    format: { unit: 'counts/sec' },
+    expected: '-4.44K counts/sec',
+  },
+  {
+    value: -4444,
+    format: { unit: 'ops/sec', shortValues: false },
+    expected: '-4,444 ops/sec',
+  },
+  {
+    value: -4444,
+    format: { unit: 'requests/sec', shortValues: false, decimalPlaces: 4 },
+    expected: '-4,444.0000 requests/sec',
+  },
+  {
+    value: -4444,
+    format: { unit: 'reads/sec', shortValues: true },
+    expected: '-4.44K reads/sec',
+  },
+  {
+    value: -4444,
+    format: { unit: 'writes/sec', shortValues: true, decimalPlaces: 4 },
+    expected: '-4.4440K writes/sec',
+  },
+  {
+    value: -0.123456789,
+    format: { unit: 'events/sec' },
+    expected: '-0.123 events/sec',
+  },
+  {
+    value: -0.123456789,
+    format: { unit: 'messages/sec', shortValues: false },
+    expected: '-0.123 messages/sec',
+  },
+  {
+    value: -0.123456789,
+    format: { unit: 'records/sec', shortValues: false, decimalPlaces: 4 },
+    expected: '-0.1235 records/sec',
+  },
+  {
+    value: -0.123456789,
+    format: { unit: 'rows/sec', shortValues: true },
+    expected: '-0.123 rows/sec',
+  },
+  { value: 0, format: { unit: 'counts/sec' }, expected: '0 counts/sec' },
+  { value: 1, format: { unit: 'ops/sec' }, expected: '1 ops/sec' },
+];
+
+describe('formatValue', () => {
+  it.each(THROUGHPUT_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
+    const { value, format: format, expected } = args;
+    expect(formatValue(value, format)).toEqual(expected);
+  });
+});

--- a/ui/core/src/model/units/throughput.ts
+++ b/ui/core/src/model/units/throughput.ts
@@ -1,0 +1,105 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { MAX_SIGNIFICANT_DIGITS } from './constants';
+import { UnitGroupConfig, UnitConfig } from './types';
+import { hasDecimalPlaces, limitDecimalPlaces, shouldShortenValues } from './utils';
+
+const throughputUnits = [
+  'counts/sec',
+  'events/sec',
+  'messages/sec',
+  'ops/sec',
+  'packets/sec',
+  'reads/sec',
+  'records/sec',
+  'requests/sec',
+  'rows/sec',
+  'writes/sec',
+] as const;
+type ThroughputUnit = (typeof throughputUnits)[number];
+export type ThroughputFormatOptions = {
+  unit: ThroughputUnit;
+  decimalPlaces?: number;
+  shortValues?: boolean;
+};
+export const THROUGHPUT_GROUP_CONFIG: UnitGroupConfig = {
+  label: 'Throughput',
+  decimalPlaces: true,
+};
+const THROUGHPUT_GROUP = 'Throughput';
+export const THROUGHPUT_UNIT_CONFIG: Readonly<Record<ThroughputUnit, UnitConfig>> = {
+  'counts/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Counts/sec',
+  },
+  'events/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Events/sec',
+  },
+  'messages/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Messages/sec',
+  },
+  'ops/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Ops/sec',
+  },
+  'packets/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Packets/sec',
+  },
+  'reads/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Reads/sec',
+  },
+  'requests/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Requests/sec',
+  },
+  'records/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Records/sec',
+  },
+  'rows/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Rows/sec',
+  },
+  'writes/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Writes/sec',
+  },
+};
+
+export function formatThroughput(value: number, { unit, shortValues, decimalPlaces }: ThroughputFormatOptions): string {
+  const formatterOptions: Intl.NumberFormatOptions = {
+    style: 'decimal',
+    useGrouping: true,
+  };
+
+  if (shouldShortenValues(shortValues)) {
+    formatterOptions.notation = 'compact';
+  }
+
+  if (hasDecimalPlaces(decimalPlaces)) {
+    formatterOptions.minimumFractionDigits = limitDecimalPlaces(decimalPlaces);
+    formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimalPlaces);
+  } else {
+    if (shouldShortenValues(shortValues)) {
+      formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
+    }
+  }
+
+  const formatter = Intl.NumberFormat('en-US', formatterOptions);
+  return formatter.format(value) + ' ' + unit;
+}

--- a/ui/core/src/model/units/types.ts
+++ b/ui/core/src/model/units/types.ts
@@ -17,7 +17,7 @@
 import { AbsoluteTimeRange, DurationString } from '../time';
 import { FormatOptions } from './units';
 
-export const UNIT_GROUPS = ['Time', 'Percent', 'Decimal', 'Bytes'] as const;
+export const UNIT_GROUPS = ['Time', 'Percent', 'Decimal', 'Bytes', 'Throughput'] as const;
 export type UnitGroup = (typeof UNIT_GROUPS)[number];
 
 /**

--- a/ui/core/src/model/units/units.ts
+++ b/ui/core/src/model/units/units.ts
@@ -26,6 +26,12 @@ import {
 } from './percent';
 import { formatTime, TimeFormatOptions as TimeFormatOptions, TIME_GROUP_CONFIG, TIME_UNIT_CONFIG } from './time';
 import { UnitGroup, UnitGroupConfig, UnitConfig } from './types';
+import {
+  formatThroughput,
+  THROUGHPUT_GROUP_CONFIG,
+  THROUGHPUT_UNIT_CONFIG,
+  ThroughputFormatOptions,
+} from './throughput';
 
 /**
  * Most of the number formatting is based on Intl.NumberFormat, which is built into JavaScript.
@@ -40,15 +46,22 @@ export const UNIT_GROUP_CONFIG: Readonly<Record<UnitGroup, UnitGroupConfig>> = {
   Percent: PERCENT_GROUP_CONFIG,
   Decimal: DECIMAL_GROUP_CONFIG,
   Bytes: BYTES_GROUP_CONFIG,
+  Throughput: THROUGHPUT_GROUP_CONFIG,
 };
 export const UNIT_CONFIG = {
   ...TIME_UNIT_CONFIG,
   ...PERCENT_UNIT_CONFIG,
   ...DECIMAL_UNIT_CONFIG,
   ...BYTES_UNIT_CONFIG,
+  ...THROUGHPUT_UNIT_CONFIG,
 } as const;
 
-export type FormatOptions = TimeFormatOptions | PercentFormatOptions | DecimalFormatOptions | BytesFormatOptions;
+export type FormatOptions =
+  | TimeFormatOptions
+  | PercentFormatOptions
+  | DecimalFormatOptions
+  | BytesFormatOptions
+  | ThroughputFormatOptions;
 
 type HasDecimalPlaces<UnitOpt> = UnitOpt extends { decimalPlaces?: number } ? UnitOpt : never;
 type HasShortValues<UnitOpt> = UnitOpt extends { shortValues?: boolean } ? UnitOpt : never;
@@ -72,6 +85,10 @@ export function formatValue(value: number, formatOptions?: FormatOptions): strin
 
   if (isTimeUnit(formatOptions)) {
     return formatTime(value, formatOptions);
+  }
+
+  if (isThroughputUnit(formatOptions)) {
+    return formatThroughput(value, formatOptions);
   }
 
   const exhaustive: never = formatOptions;
@@ -120,4 +137,8 @@ export function isUnitWithShortValues(formatOptions: FormatOptions): formatOptio
   const groupConfig = getUnitGroupConfig(formatOptions);
 
   return !!groupConfig.shortValues;
+}
+
+export function isThroughputUnit(formatOptions: FormatOptions): formatOptions is ThroughputFormatOptions {
+  return getUnitGroup(formatOptions) == 'Throughput';
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Adding some throughput units. I wonder if it's not better to have a custom string unit and the user set whatever he wants 🤔 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
