### PR TITLE
[BUGFIX] Fix unwanted thresholds when migrating timeseries panels

### DIFF
--- a/internal/api/shared/migrate/testdata/old_grafana_query_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_query_perses_dashboard.json
@@ -65,18 +65,6 @@
                 "mode": "list",
                 "position": "bottom",
                 "values": []
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
               }
             }
           }

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -390,18 +390,6 @@
                   "mean",
                   "sum"
                 ]
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
               }
             }
           },
@@ -438,14 +426,6 @@
                 "mode": "table",
                 "position": "bottom",
                 "values": []
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
               }
             }
           },

--- a/schemas/panels/stat/migrate.cue
+++ b/schemas/panels/stat/migrate.cue
@@ -16,7 +16,7 @@ if #panel.type != _|_ if #panel.type == "stat" {
 
 		if #panel.fieldConfig.defaults.thresholds != _|_ {
 			thresholds: {
-				//defaultColor: TODO how to fill this one?
+				// defaultColor: TODO how to fill this one?
 				steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part? 
 					value: [ // switch
 						if step.value == null { 0 },

--- a/schemas/panels/time-series/migrate.cue
+++ b/schemas/panels/time-series/migrate.cue
@@ -41,9 +41,10 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 			}
 		}
 
-		if #panel.fieldConfig.defaults.thresholds != _|_ {
+		// migrate thresholds only if they are visible
+		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle.mode != "off" {
 			thresholds: {
-				//defaultColor: TODO how to fill this one?
+				// defaultColor: TODO how to fill this one?
 				steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part?
 					value: [ // switch
 						if step.value == null { 0 },


### PR DESCRIPTION
# Description

Since Grafana is putting some thresholds by default on timeseries panels in hidden mode & that we don't have such hidden mode for thresholds, the best way to avoid having unwanted thresholds showing on many graphs is to not migrate them when they are hidden.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
