### PR TITLE
[FEATURE] display the server config

### DIFF
--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -19,6 +19,7 @@ import HomeView from './views/home/HomeView';
 // Other routes are lazy-loaded for code-splitting
 const MigrateView = lazy(() => import('./views/MigrateView'));
 const AdminView = lazy(() => import('./views/admin/AdminView'));
+const ConfigView = lazy(() => import('./views/config/ConfigView'));
 const GuardedProjectRoute = lazy(() => import('./GuardedProjectRoute'));
 const ProjectView = lazy(() => import('./views/projects/ProjectView'));
 const CreateDashboardView = lazy(() => import('./views/projects/dashboards/CreateDashboardView'));
@@ -32,6 +33,7 @@ function Router() {
         <Routes>
           <Route path="/admin" element={<AdminView />} />
           <Route path="/admin/:tab" element={<AdminView />} />
+          <Route path="/config" element={<ConfigView />} />
           <Route path="/migrate" element={<MigrateView />} />
           <Route path="/projects" element={<HomeView />} />
           <Route path="/projects/:projectName" element={<GuardedProjectRoute />}>

--- a/ui/app/src/components/AppBreadcrumbs.tsx
+++ b/ui/app/src/components/AppBreadcrumbs.tsx
@@ -15,12 +15,10 @@ import { Breadcrumbs, Link, Typography, styled } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 
 interface AppBreadcrumbsProps {
-  projectName?: string;
-  dashboardName?: string;
-  admin?: boolean;
+  rootPageName: string;
 }
 
-function HomeLinkBreadcrumb() {
+export function HomeLinkBreadcrumb() {
   return (
     <Link underline={'hover'} variant={'h3'} component={RouterLink} to={'/'}>
       Home
@@ -28,56 +26,18 @@ function HomeLinkBreadcrumb() {
   );
 }
 
-const StyledBreadcrumbs = styled(Breadcrumbs)({
+export const StyledBreadcrumbs = styled(Breadcrumbs)({
   fontSize: 'large',
   paddingLeft: 0.5,
   lineHeight: '30px',
 });
 
-/*
- * AppBreadcrumbs provide a navigation helper
- * For dashboard breadcrumb, projectName & dashboardName are mandatory
- * For project breadcrumb, projectName is mandatory
- * For admin breadcrumb, admin flag needs to be true
- * For home breadcrumb, all props need to be empty or undefined
- */
-// TODO: this component should probably be split, maybe this wrapper is not useful in some cases (e.g Home and Admin?)
 function AppBreadcrumbs(props: AppBreadcrumbsProps) {
-  const { projectName, dashboardName, admin } = props;
-
-  if (dashboardName && projectName) {
-    return (
-      <StyledBreadcrumbs>
-        <HomeLinkBreadcrumb />
-        <Link underline={'hover'} variant={'h3'} component={RouterLink} to={`/projects/${projectName}`}>
-          {projectName}
-        </Link>
-        <Typography variant={'h3'}>{dashboardName}</Typography>
-      </StyledBreadcrumbs>
-    );
-  }
-
-  if (projectName) {
-    return (
-      <StyledBreadcrumbs>
-        <HomeLinkBreadcrumb />
-        <Typography variant={'h3'}>{projectName}</Typography>
-      </StyledBreadcrumbs>
-    );
-  }
-
-  if (admin) {
-    return (
-      <StyledBreadcrumbs>
-        <HomeLinkBreadcrumb />
-        <Typography variant={'h3'}>Admin</Typography>
-      </StyledBreadcrumbs>
-    );
-  }
-
+  const { rootPageName } = props;
   return (
-    <StyledBreadcrumbs>
-      <Typography variant={'h3'}>Home</Typography>
+    <StyledBreadcrumbs sx={{ fontSize: 'large' }}>
+      <HomeLinkBreadcrumb />
+      <Typography variant={'h3'}>{rootPageName}</Typography>
     </StyledBreadcrumbs>
   );
 }

--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -31,6 +31,7 @@ import ChevronDown from 'mdi-material-ui/ChevronDown';
 import AutoFix from 'mdi-material-ui/AutoFix';
 import Cog from 'mdi-material-ui/Cog';
 import Folder from 'mdi-material-ui/Folder';
+import ShieldAccount from 'mdi-material-ui/ShieldAccount';
 import { MouseEvent, useState } from 'react';
 import { useSnackbar } from '@perses-dev/components';
 import { useProjectList } from '../model/project-client';
@@ -186,7 +187,18 @@ export default function Header(): JSX.Element {
               navigate('/admin');
             }}
           >
-            <Cog sx={{ marginRight: 0.5 }} /> Admin
+            <ShieldAccount sx={{ marginRight: 0.5 }} /> Admin
+          </Button>
+          <Button
+            aria-label="Config"
+            aria-controls="menu-config-appbar"
+            aria-haspopup="true"
+            color="inherit"
+            onClick={() => {
+              navigate('/config');
+            }}
+          >
+            <Cog sx={{ marginRight: 0.5 }} /> Config
           </Button>
           <ProjectMenu />
         </Box>

--- a/ui/app/src/components/ProjectBreadcrumbs.tsx
+++ b/ui/app/src/components/ProjectBreadcrumbs.tsx
@@ -1,0 +1,45 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Link, Typography } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { HomeLinkBreadcrumb, StyledBreadcrumbs } from './AppBreadcrumbs';
+
+interface ProjectBreadcrumbsProps {
+  projectName: string;
+  dashboardName?: string;
+}
+
+function ProjectBreadcrumbs(props: ProjectBreadcrumbsProps) {
+  const { projectName, dashboardName } = props;
+
+  if (dashboardName) {
+    return (
+      <StyledBreadcrumbs sx={{ fontSize: 'large' }}>
+        <HomeLinkBreadcrumb />
+        <Link underline={'hover'} variant={'h3'} component={RouterLink} to={`/projects/${projectName}`}>
+          {projectName}
+        </Link>
+        <Typography variant={'h3'}>{dashboardName}</Typography>
+      </StyledBreadcrumbs>
+    );
+  }
+  return (
+    <StyledBreadcrumbs sx={{ fontSize: 'large' }}>
+      <HomeLinkBreadcrumb />
+      <Typography variant={'h3'}>{projectName}</Typography>
+    </StyledBreadcrumbs>
+  );
+}
+
+export default ProjectBreadcrumbs;

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -29,8 +29,63 @@ export interface ConfigSchemasModel {
   interval: string;
 }
 
+export interface DatabaseFile {
+  folder: string;
+  extension: 'yaml' | 'json';
+}
+
+export interface TLSConfig {
+  ca?: string;
+  ca_file?: string;
+  cert?: string;
+  cert_file?: string;
+  key?: string;
+  key_file?: string;
+  server_name?: string;
+  insecure_skip_verify: boolean;
+  min_version: string;
+  max_version: string;
+}
+
+export interface DatabaseSQL {
+  tls_config?: TLSConfig;
+  user?: string;
+  password?: string;
+  password_file?: string;
+  net?: string;
+  addr?: string;
+  db_name?: string;
+  collation?: string;
+  max_allowed_packet?: number;
+  server_pub_key?: string;
+  timeout?: string;
+  read_timeout?: string;
+  write_timeout?: string;
+  allow_all_files: boolean;
+  allow_cleartext_passwords: boolean;
+  allow_fallback_to_plaintext: boolean;
+  allow_native_passwords: boolean;
+  allow_old_passwords: boolean;
+  check_conn_liveness: boolean;
+  client_found_rows: boolean;
+  columns_with_alias: boolean;
+  interpolate_params: boolean;
+  multi_statements: boolean;
+  parse_time: boolean;
+  reject_read_only: boolean;
+}
+
+export interface Database {
+  file?: DatabaseFile;
+  sql?: DatabaseSQL;
+}
+
 export interface ConfigModel {
   readonly: boolean;
+  activate_permission: boolean;
+  encryption_key?: string;
+  encryption_key_file?: string;
+  database: Database;
   schemas: ConfigSchemasModel;
   important_dashboards: DashboardSelector[];
   information: string;

--- a/ui/app/src/views/admin/AdminView.tsx
+++ b/ui/app/src/views/admin/AdminView.tsx
@@ -21,7 +21,7 @@ function AdminView() {
   const { tab } = useParams();
   return (
     <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <AppBreadcrumbs rootPageName="Admin" />
+      <AppBreadcrumbs rootPageName="Administration" />
       <Box>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Stack direction="row" alignItems="center" gap={1}>

--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -12,27 +12,27 @@
 // limitations under the License.
 
 import { Box, Stack, Typography } from '@mui/material';
-import ShieldAccount from 'mdi-material-ui/ShieldAccount';
-import { useParams } from 'react-router-dom';
+import Cog from 'mdi-material-ui/Cog';
+import { JSONEditor } from '@perses-dev/components';
 import AppBreadcrumbs from '../../components/AppBreadcrumbs';
-import { AdminTabs } from './AdminTabs';
+import { useConfig } from '../../model/config-client';
 
-function AdminView() {
-  const { tab } = useParams();
+function ConfigView() {
+  const cfg = useConfig();
   return (
     <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <AppBreadcrumbs rootPageName="Admin" />
+      <AppBreadcrumbs rootPageName="Config" />
       <Box>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Stack direction="row" alignItems="center" gap={1}>
-            <ShieldAccount fontSize={'large'} />
-            <Typography variant="h1">Administration</Typography>
+            <Cog fontSize={'large'} />
+            <Typography variant="h1">Configuration</Typography>
           </Stack>
         </Stack>
       </Box>
-      <AdminTabs initialTab={tab} />
+      <JSONEditor value={cfg.data} />
     </Stack>
   );
 }
 
-export default AdminView;
+export default ConfigView;

--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -11,17 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, CircularProgress, Stack, Typography } from '@mui/material';
 import Cog from 'mdi-material-ui/Cog';
 import { JSONEditor } from '@perses-dev/components';
 import AppBreadcrumbs from '../../components/AppBreadcrumbs';
 import { useConfig } from '../../model/config-client';
 
 function ConfigView() {
-  const cfg = useConfig();
+  const { data, isLoading } = useConfig();
   return (
     <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <AppBreadcrumbs rootPageName="Config" />
+      <AppBreadcrumbs rootPageName="Configuration" />
       <Box>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Stack direction="row" alignItems="center" gap={1}>
@@ -30,7 +30,12 @@ function ConfigView() {
           </Stack>
         </Stack>
       </Box>
-      <JSONEditor value={cfg.data} />
+      {isLoading && (
+        <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress />
+        </Stack>
+      )}
+      {data !== undefined && <JSONEditor value={data} />}
     </Stack>
   );
 }

--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -35,7 +35,7 @@ function ConfigView() {
           <CircularProgress />
         </Stack>
       )}
-      {data !== undefined && <JSONEditor value={data} />}
+      {data !== undefined && <JSONEditor value={data} readOnly />}
     </Stack>
   );
 }

--- a/ui/app/src/views/home/HomeView.tsx
+++ b/ui/app/src/views/home/HomeView.tsx
@@ -11,14 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Grid, Stack, Typography } from '@mui/material';
+import { Box, Breadcrumbs, Grid, Stack, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import HomeIcon from 'mdi-material-ui/Home';
 import { useNavigate } from 'react-router-dom';
 import { DashboardSelector, ProjectResource } from '@perses-dev/core';
 import { useProjectList } from '../../model/project-client';
 import { CreateProjectDialog, CreateDashboardDialog } from '../../components/dialogs';
-import AppBreadcrumbs from '../../components/AppBreadcrumbs';
 import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
 import { InformationSection } from './InformationSection';
 import { RecentDashboards } from './RecentDashboards';
@@ -58,7 +57,9 @@ function HomeView() {
 
   return (
     <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <AppBreadcrumbs />
+      <Breadcrumbs sx={{ fontSize: 'large' }}>
+        <Typography variant={'h3'}>Home</Typography>
+      </Breadcrumbs>
       <Box sx={{ width: '100%' }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Stack direction="row" alignItems="center" gap={1}>

--- a/ui/app/src/views/projects/ProjectView.tsx
+++ b/ui/app/src/views/projects/ProjectView.tsx
@@ -16,7 +16,7 @@ import { Box, Stack, Typography, Grid } from '@mui/material';
 import FolderPound from 'mdi-material-ui/FolderPound';
 import { useCallback, useState } from 'react';
 import { DeleteProjectDialog } from '../../components/dialogs';
-import AppBreadcrumbs from '../../components/AppBreadcrumbs';
+import ProjectBreadcrumbs from '../../components/ProjectBreadcrumbs';
 import { RecentlyViewedDashboards } from './RecentlyViewedDashboards';
 import { ProjectTabs } from './ProjectTabs';
 
@@ -36,7 +36,7 @@ function ProjectView() {
 
   return (
     <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <AppBreadcrumbs projectName={projectName} />
+      <ProjectBreadcrumbs projectName={projectName} />
       <Box>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Stack direction="row" alignItems="center" gap={1}>

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -18,11 +18,11 @@ import { PluginRegistry } from '@perses-dev/plugin-system';
 import { DashboardResource, getDashboardDisplayName } from '@perses-dev/core';
 import { useEffect, useMemo, useState } from 'react';
 import { bundledPluginLoader } from '../../../model/bundled-plugins';
-import AppBreadcrumbs from '../../../components/AppBreadcrumbs';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasource-api';
 import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
 import { useVariableList } from '../../../model/variable-client';
 import { useGlobalVariableList } from '../../../model/global-variable-client';
+import ProjectBreadcrumbs from '../../../components/ProjectBreadcrumbs';
 
 export interface GenericDashboardViewProps {
   dashboardResource: DashboardResource;
@@ -81,7 +81,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps) {
               datasourceApi={datasourceApi}
               externalVariableDefinitions={externalVariableDefinitions}
               dashboardTitleComponent={
-                <AppBreadcrumbs
+                <ProjectBreadcrumbs
                   dashboardName={getDashboardDisplayName(dashboardResource)}
                   projectName={dashboardResource.metadata.project}
                 />

--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -32,6 +32,7 @@ var (
 		"/admin",
 		"/projects",
 		"/migrate",
+		"/config",
 	}
 )
 


### PR DESCRIPTION
This PR is adding a new page to display the backend config.

Maybe we should put every button in a menu on the right corner.

I took the opportunity to split the breadcrumbs wrapper we have in two different components. I changed also the icon for the admin panel

<img width="873" alt="image" src="https://github.com/perses/perses/assets/4548045/0a7d3498-87f7-4bc3-b044-55a9af9e5408">
