### PR TITLE
[ENHANCEMENT] align recently dash view table

### DIFF
--- a/ui/app/src/views/projects/RecentlyViewedDashboards.tsx
+++ b/ui/app/src/views/projects/RecentlyViewedDashboards.tsx
@@ -27,14 +27,23 @@ export function RecentlyViewedDashboards(props: RecentlyViewedDashboardsProps) {
 
   return (
     <Box id={props.id}>
-      <Stack direction="row" alignItems="center" justifyContent="space-between">
+      <Stack
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+          width: '100%',
+          height: '72px',
+          justifyContent: 'space-between',
+          flexDirection: 'row',
+        }}
+      >
         <Stack direction="row" alignItems="center" gap={1} my={2}>
           <HistoryIcon />
           <Typography variant="h3">Recently Viewed Dashboards</Typography>
         </Stack>
       </Stack>
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <Card>
+        <Card sx={{ marginTop: 2 }}>
           <RecentDashboardList dashboardList={data} isLoading={isLoading} />
         </Card>
       </ErrorBoundary>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Align recently dash view table with left side table.

<!-- Context useful to a reviewer -->

# Screenshots

## Before
![image](https://github.com/perses/perses/assets/8205546/7d76c891-6aa2-4268-9223-b2a975c6b027)

## After

![image](https://github.com/perses/perses/assets/8205546/1917b168-c121-4f65-89c3-d2ca84275e44)

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
