### PR TITLE
[IGNORE] push docker image on the main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,6 +187,9 @@ jobs:
           install-only: true
       - name: Build Go binaries and docker images
         run: make cross-build
+      - name: Publish main docker image
+        if: ${{ github.ref_name == 'main' }}
+        run: make push-main-docker-image
       - name: Publish Release and binaries
         ## This step will only run when a new tag is pushed.
         ## It will build the Go binaries and the docker images and then publish:

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,10 @@ generate-changelog:
 generate-goreleaser:
 	$(GO) run ./scripts/generate-goreleaser/generate-goreleaser.go
 
+.PHONY: push-main-docker-image
+push-main-docker-image:
+	$(GO) run ./scripts/push-main-docker-image/push-main-docker-image.go
+
 .PHONY: clean
 clean:
 	rm -rf ./bin

--- a/scripts/generate-goreleaser/generate-goreleaser.go
+++ b/scripts/generate-goreleaser/generate-goreleaser.go
@@ -28,6 +28,8 @@ import (
 
 const dockerBaseImageTemplateName = "docker.io/persesdev/perses"
 
+var date = time.Now().Format("2006-01-02")
+
 //go:embed .goreleaser.base.yaml
 var baseConfig []byte
 
@@ -88,7 +90,6 @@ type goreleaserGenerator struct {
 }
 
 func (g *goreleaserGenerator) generateDockerImageName(arch string, templateLongName string) string {
-	date := time.Now().Format("2006-02-01")
 	if g.currentBranch == "main" {
 		return fmt.Sprintf("%s:main-%s-%s-%s-%s", dockerBaseImageTemplateName, date, g.currentCommit, templateLongName, arch)
 	}
@@ -144,7 +145,6 @@ func (g *goreleaserGenerator) generateDockerManifest() {
 }
 
 func (g *goreleaserGenerator) generateDockerManifestForMainBranch() {
-	date := time.Now().Format("2006-02-01")
 	for _, templateNames := range g.mapDockerfileNameAndTemplateName {
 		var imageTemplate []string
 		for _, arch := range g.dockerSupportedArches {

--- a/scripts/generate-goreleaser/generate-goreleaser.go
+++ b/scripts/generate-goreleaser/generate-goreleaser.go
@@ -17,7 +17,9 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/sirupsen/logrus"
@@ -28,13 +30,22 @@ const dockerBaseImageTemplateName = "docker.io/persesdev/perses"
 
 //go:embed .goreleaser.base.yaml
 var baseConfig []byte
-var (
-	dockerSupportedArches            = []string{"amd64", "arm64"}
-	mapDockerfileNameAndTemplateName = map[string][]string{
-		"Dockerfile":                  {"", "distroless"},
-		"distroless-debug.Dockerfile": {"debug", "distroless-debug"},
+
+func getCurrentBranch() string {
+	branch, err := exec.Command("git", "branch", "--show-current").Output()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to get the current branch")
 	}
-)
+	return strings.TrimSpace(string(branch))
+}
+
+func getCurrentCommit() string {
+	commit, err := exec.Command("git", "log", "-n1", "--format=\"%h\"").Output()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to get the current commit")
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(string(commit)), "\""), "\"")
+}
 
 func join(elems []string, sep string) string {
 	var sb strings.Builder
@@ -63,21 +74,42 @@ func readGoreleaserBaseFile() *config.Project {
 	return c
 }
 
-func generateDockerConfig(c *config.Project) {
+type dockerTemplateName struct {
+	shortName string
+	longName  string
+}
+
+type goreleaserGenerator struct {
+	goreleaserConfig                 *config.Project
+	dockerSupportedArches            []string
+	mapDockerfileNameAndTemplateName map[string]dockerTemplateName
+	currentBranch                    string
+	currentCommit                    string
+}
+
+func (g *goreleaserGenerator) generateDockerImageName(arch string, templateLongName string) string {
+	date := time.Now().Format("2006-02-01")
+	if g.currentBranch == "main" {
+		return fmt.Sprintf("%s:main-%s-%s-%s-%s", dockerBaseImageTemplateName, date, g.currentCommit, templateLongName, arch)
+	}
+	return fmt.Sprintf("%s:{{ .Tag }}-%s-%s", dockerBaseImageTemplateName, templateLongName, arch)
+}
+
+func (g *goreleaserGenerator) generateDockerConfig() {
 	var binaryIDs []string
-	for _, build := range c.Builds {
+	for _, build := range g.goreleaserConfig.Builds {
 		binaryIDs = append(binaryIDs, build.ID)
 	}
-	for dockerfileName, templateNames := range mapDockerfileNameAndTemplateName {
-		for _, arch := range dockerSupportedArches {
-			c.Dockers = append(c.Dockers, config.Docker{
+	for dockerfileName, templateNames := range g.mapDockerfileNameAndTemplateName {
+		for _, arch := range g.dockerSupportedArches {
+			g.goreleaserConfig.Dockers = append(g.goreleaserConfig.Dockers, config.Docker{
 				Goos:       "linux",
 				Goarch:     arch,
 				IDs:        binaryIDs,
 				Dockerfile: dockerfileName,
 				Use:        "buildx",
 				ImageTemplates: []string{
-					fmt.Sprintf("%s:{{ .Tag }}-%s-%s", dockerBaseImageTemplateName, templateNames[1], arch),
+					g.generateDockerImageName(arch, templateNames.longName),
 				},
 				BuildFlagTemplates: []string{
 					"--pull",
@@ -103,19 +135,43 @@ func generateDockerConfig(c *config.Project) {
 	}
 }
 
-func generateDockerManifest(c *config.Project) {
-	for _, templateNames := range mapDockerfileNameAndTemplateName {
+func (g *goreleaserGenerator) generateDockerManifest() {
+	if g.currentBranch == "main" {
+		g.generateDockerManifestForMainBranch()
+	} else {
+		g.generateDockerManifestForReleaseOrSnapshot()
+	}
+}
+
+func (g *goreleaserGenerator) generateDockerManifestForMainBranch() {
+	date := time.Now().Format("2006-02-01")
+	for _, templateNames := range g.mapDockerfileNameAndTemplateName {
 		var imageTemplate []string
-		for _, arch := range dockerSupportedArches {
-			imageTemplate = append(imageTemplate, fmt.Sprintf("%s:{{ .Tag }}-%s-%s", dockerBaseImageTemplateName, templateNames[1], arch))
+		for _, arch := range g.dockerSupportedArches {
+			imageTemplate = append(imageTemplate, g.generateDockerImageName(arch, templateNames.longName))
 		}
-		c.DockerManifests = append(c.DockerManifests,
+		g.goreleaserConfig.DockerManifests = append(g.goreleaserConfig.DockerManifests,
 			config.DockerManifest{
-				NameTemplate:   fmt.Sprintf("%s:%s", dockerBaseImageTemplateName, join([]string{"latest", templateNames[0]}, "-")),
+				NameTemplate:   fmt.Sprintf("%s:main-%s-%s-%s", dockerBaseImageTemplateName, date, g.currentCommit, templateNames.longName),
 				ImageTemplates: imageTemplate,
 			})
-		for _, templateName := range templateNames {
-			c.DockerManifests = append(c.DockerManifests,
+	}
+}
+
+func (g *goreleaserGenerator) generateDockerManifestForReleaseOrSnapshot() {
+	for _, templateNames := range g.mapDockerfileNameAndTemplateName {
+		var imageTemplate []string
+		for _, arch := range g.dockerSupportedArches {
+			imageTemplate = append(imageTemplate, g.generateDockerImageName(arch, templateNames.longName))
+		}
+		g.goreleaserConfig.DockerManifests = append(g.goreleaserConfig.DockerManifests,
+			config.DockerManifest{
+				NameTemplate:   fmt.Sprintf("%s:%s", dockerBaseImageTemplateName, join([]string{"latest", templateNames.shortName}, "-")),
+				ImageTemplates: imageTemplate,
+			})
+		templateNameList := []string{templateNames.shortName, templateNames.longName}
+		for _, templateName := range templateNameList {
+			g.goreleaserConfig.DockerManifests = append(g.goreleaserConfig.DockerManifests,
 				config.DockerManifest{
 					NameTemplate:   fmt.Sprintf("%s:%s", dockerBaseImageTemplateName, join([]string{"{{ .Tag }}", templateName}, "-")),
 					ImageTemplates: imageTemplate,
@@ -131,8 +187,18 @@ func generateDockerManifest(c *config.Project) {
 
 func main() {
 	c := readGoreleaserBaseFile()
-	generateDockerConfig(c)
-	generateDockerManifest(c)
+	generator := &goreleaserGenerator{
+		goreleaserConfig:      c,
+		dockerSupportedArches: []string{"amd64", "arm64"},
+		mapDockerfileNameAndTemplateName: map[string]dockerTemplateName{
+			"Dockerfile":                  {shortName: "", longName: "distroless"},
+			"distroless-debug.Dockerfile": {shortName: "debug", longName: "distroless-debug"},
+		},
+		currentBranch: getCurrentBranch(),
+		currentCommit: getCurrentCommit(),
+	}
+	generator.generateDockerConfig()
+	generator.generateDockerManifest()
 	data, err := yaml.Marshal(c)
 	if err != nil {
 		logrus.Fatal(err)

--- a/scripts/push-main-docker-image/push-main-docker-image.go
+++ b/scripts/push-main-docker-image/push-main-docker-image.go
@@ -54,7 +54,7 @@ func main() {
 		if _, err := exec.Command("docker", args...).Output(); err != nil {
 			logrus.WithError(err).Fatalf("unable to create the docker manifest %q", manifestConfig.NameTemplate)
 		}
-		if _, err := exec.Command("docker", "push", manifestConfig.NameTemplate).Output(); err != nil {
+		if _, err := exec.Command("docker", "manifest", "push", manifestConfig.NameTemplate).Output(); err != nil { //nolint:gosec
 			logrus.WithError(err).Fatalf("unable to push the docker manifest %q", manifestConfig.NameTemplate)
 		}
 	}

--- a/scripts/push-main-docker-image/push-main-docker-image.go
+++ b/scripts/push-main-docker-image/push-main-docker-image.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/perses/perses/internal/cli/file"
+	"github.com/sirupsen/logrus"
+)
+
+const goreleaserFile = ".goreleaser.yaml"
+
+func getCurrentBranch() string {
+	branch, err := exec.Command("git", "branch", "--show-current").Output()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to get the current branch")
+	}
+	return strings.TrimSpace(string(branch))
+}
+
+func main() {
+	if getCurrentBranch() != "main" {
+		logrus.Warning("script has been executed on a branch different than the main branch")
+		return
+	}
+	goreleaserConfig := &config.Project{}
+	if err := file.Unmarshal(goreleaserFile, goreleaserConfig); err != nil {
+		logrus.WithError(err).Fatal("unable to load the goreleaser config")
+	}
+	for _, dockerConfig := range goreleaserConfig.Dockers {
+		for _, image := range dockerConfig.ImageTemplates {
+			if _, err := exec.Command("docker", "push", image).Output(); err != nil {
+				logrus.WithError(err).Fatalf("unable to push the docker image %q", image)
+			}
+		}
+	}
+	for _, manifestConfig := range goreleaserConfig.DockerManifests {
+		args := []string{"manifest", "create", manifestConfig.NameTemplate}
+		args = append(args, manifestConfig.ImageTemplates...)
+		if _, err := exec.Command("docker", args...).Output(); err != nil {
+			logrus.WithError(err).Fatalf("unable to create the docker manifest %q", manifestConfig.NameTemplate)
+		}
+		if _, err := exec.Command("docker", "push", manifestConfig.NameTemplate).Output(); err != nil {
+			logrus.WithError(err).Fatalf("unable to push the docker manifest %q", manifestConfig.NameTemplate)
+		}
+	}
+}


### PR DESCRIPTION
This PR is enabling the possibility to push the docker image built on the main branch.

With that we can try any commit available on the upstream.

I refactor a bit the script `generate-goreleaser` to have something a bit cleaner and easier to test.

The idea here is to generate the docker image with the tag `main-<date>-<short_commit_id>-<distrib>-<arch>`
For example: `docker.io/persesdev/perses:main-2023-10-23-8b1f5d3f-distroless-debug-arm64`

Then since we are generating different image depending on the architecture (arm, amd), we need to create and push the manifest so we can pull the docker image easily