### PR TITLE
[IGNORE] override VERSION on the main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,6 +180,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Override version
+        if: ${{ github.ref_name == 'main' }}
+        run: ./scripts/override_version.sh
       - name: install goreleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -193,7 +196,7 @@ jobs:
       - name: Publish Release and binaries
         ## This step will only run when a new tag is pushed.
         ## It will build the Go binaries and the docker images and then publish:
-        ## - the Github release with the archive built
+        ## - the GitHub release with the archive built
         ## - docker images on the different docker registry selected
         if: ${{ github.event_name == 'push' && startsWith(github.ref_name, 'v') }}
         run: make cross-release

--- a/scripts/override_version.sh
+++ b/scripts/override_version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is only useful when running in the github action.
+# It helps to override the VERSION variable in the Makefile that happens when we want to push a docker image from the main branch.
+# On the main branch, we want to highlight that the docker image built is not coming from a standard release
+
+dateNow=$(date +%Y-%m-%d)
+shortCommit=$(git log -n1 --format="%h")
+
+echo "VERSION=main-${dateNow}-${shortCommit}" >>"${GITHUB_ENV}"


### PR DESCRIPTION
As we are pushing a docker image on the branch `main`, it would be nice it is reflected in the version displayed in the footer.

A simple way to do it, is to override the environment variable `VERSION` created in the makefile.