### PR TITLE
[IGNORE] Configure dependabot to rely on ui/api labels instead of go/javascript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,19 @@ updates:
   open-pull-requests-limit: 10
   schedule:
     interval: "weekly"
+  # Raise all gomod pull requests with custom labels
+  labels:
+    - "dependencies"
+    - "api"
 - package-ecosystem: "npm"
   directory: "/ui"
   open-pull-requests-limit: 0
   schedule:
     interval: "monthly"
+  # Raise all npm pull requests with custom labels
+  labels:
+    - "dependencies"
+    - "ui"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
# Description

Configure dependabot to rely on ui/api labels instead of go/javascript.
This is to avoid having these 2 sets of redundant labels coexisting.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).