### PR TITLE
[BUGFIX] Avoid failing grafana migration in multiple cases

### DIFF
--- a/dev/data/dashboard.json
+++ b/dev/data/dashboard.json
@@ -10705,12 +10705,6 @@
         {
           "kind": "Grid",
           "spec": {
-            "items": []
-          }
-        },
-        {
-          "kind": "Grid",
-          "spec": {
             "display": {
               "title": "Quick CPU / Mem / Disk",
               "collapse": {

--- a/internal/api/shared/migrate/mapping.cuepart
+++ b/internal/api/shared/migrate/mapping.cuepart
@@ -62,67 +62,53 @@ spec: {
         name: #grafanaDashboard.title
     }
     variables: [ for _, grafanaVar in #grafanaDashboard.templating.list {
-        if grafanaVar.type == "constant" {
-            kind: "TextVariable"
-            spec: {
-                name: grafanaVar.name
-                display: {
-                    name: [ // switch
-                        if grafanaVar.label != _|_ if grafanaVar.label != "" {
-                            grafanaVar.label
-                        },
-                        grafanaVar.name
-                    ][0]
-                    if grafanaVar.description != _|_ {
-                        description: grafanaVar.description
-                    }
-                    hidden: true
-                }
-                constant: true
-                value: grafanaVar.query
+        _displayConversion: {
+            // for some reason it's required to change the inputs names for each nested "function call",
+            // hence #var2 here to not conflict with #var from _singleVarConversion
+            #var2: _
+
+            name: [ // switch
+                if #var2.label != _|_ if #var2.label != "" {
+                    #var2.label
+                },
+                #var2.name
+            ][0]
+            if #var2.description != _|_ {
+                description: #var2.description
+            }
+            if #var2.hide != _|_ {
+                hidden: [ // switch
+                    if #var2.hide > 0 {
+                        true
+                    },
+                    false
+                ][0]
             }
         }
-        if grafanaVar.type == "textbox" {
+        _singleVarConversion: {
+            #var: _
+            #constant: _
+
             kind: "TextVariable"
             spec: {
-                name: grafanaVar.name
-                display: {
-                    name: [ // switch
-                        if grafanaVar.label != _|_ if grafanaVar.label != "" {
-                            grafanaVar.label
-                        },
-                        grafanaVar.name
-                    ][0]
-                    if grafanaVar.description != _|_ {
-                        description: grafanaVar.description
-                    }
-                    if grafanaVar.hide > 0 {
-                        hidden: true
-                    }
-                }
-                constant: false
-                value: grafanaVar.query
+                name: #var.name
+                display: _displayConversion & {#var2: #var}
+                constant: #constant
+                value: #var.query
             }
+        }
+        if grafanaVar.type == "constant" {
+            _singleVarConversion & {#var: grafanaVar, #constant: true}
+        }
+        if grafanaVar.type == "textbox" {
+            _singleVarConversion & {#var: grafanaVar, #constant: false}
         }
         if grafanaVar.type != "constant" && grafanaVar.type != "textbox" {
             kind: "ListVariable"
             spec: {
                 name: grafanaVar.name
                 if grafanaVar.label != _|_ || grafanaVar.description != _|_ || grafanaVar.hide > 0 {
-                    display: {
-                        name: [ // switch
-                            if grafanaVar.label != _|_ if grafanaVar.label != "" {
-                                grafanaVar.label
-                            },
-                            grafanaVar.name
-                        ][0]
-                        if grafanaVar.description != _|_ {
-                            description: grafanaVar.description
-                        }
-                        if grafanaVar.hide > 0 {
-                            hidden: true
-                        }
-                    }
+                    display: _displayConversion & {#var2: grafanaVar}
                 }
                 allowAllValue: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
                 allowMultiple: *grafanaVar.multi | false      // the default value tackles the case of variables of type `interval` that don't have such field
@@ -141,59 +127,59 @@ spec: {
     }]
     // go through the top-level panels 1st time, to fill the panels section of Perses
     panels: { for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels {
+        // function-like pattern to factorize the panel conversion logic
+        #panelConversion: {
+            #panel: _
+
+            kind: "Panel"
+            spec: {
+                display: {
+                    name: *#panel.title | "empty"
+                    description: *#panel.description | ""
+                }
+                plugin: [ // switch
+                    %(conditional_panels)
+                ][0]
+                // in case of no targets, the resulting empty array will be removed via unmarshaling in Go (omitempty)
+                queries: [ if #panel.targets != _|_ for _, target in #panel.targets {
+                    kind: "TimeSeriesQuery"
+                    spec: {
+                        #target: target
+                        plugin: [ // switch
+                            %(conditional_timeseries_queries)
+                        ][0]
+                    }
+                }]
+            }
+        }
         // if the current panel is a row, go through its children panels
         if grafanaPanel.panels != _|_ {
             for innerPanelId, innerPanel in grafanaPanel.panels { 
                 "\(grafanaPanelId)_\(innerPanelId)": {
-                    kind: "Panel"
-                    spec: {
-                        display: {
-                            name: *innerPanel.title | "empty"
-                            description: *innerPanel.description | ""
-                        }
-                        #panel: innerPanel
-                        plugin: [ // switch
-                            %(conditional_panels)
-                        ][0]
-                        // in case of no targets, the resulting empty array will be removed via unmarshaling in Go (omitempty)
-                        queries: [ if innerPanel.targets != _|_ for _, target in innerPanel.targets {
-                            kind: "TimeSeriesQuery"
-                            spec: {
-                                #target: target
-                                plugin: [ // switch
-                                    %(conditional_timeseries_queries)
-                                ][0]
-                            }
-                        }]
-                    }
+                    #panelConversion & {#panel: innerPanel}
                 }
             }
         }
-        if grafanaPanel.panels == _|_ { // else
+        // else
+        if grafanaPanel.panels == _|_ { 
             "\(grafanaPanelId)": {
-                kind: "Panel"
-                spec: {
-                    display: {
-                        name: *grafanaPanel.title | "empty"
-                        description: *grafanaPanel.description | ""
-                    }
-                    #panel: grafanaPanel
-                    plugin: [ // switch
-                        %(conditional_panels)
-                    ][0]
-                    queries: [ if grafanaPanel.targets != _|_ for _, target in grafanaPanel.targets {
-                        kind: "TimeSeriesQuery"
-                        spec: {
-                            #target: target
-                            plugin: [ // switch
-                                %(conditional_timeseries_queries)
-                            ][0]
-                        }
-                    }]
-                }
+                #panelConversion & {#panel: grafanaPanel}
             }
         }
-    }},
+    }}
+    // function-like pattern to factorize the position conversion logic
+    #positionConversion: {
+        #gridPos: _
+        #id: _
+        // it may happen that a grafana panel coordinate has a decimal, which we have to get rid of
+        x: math.Round(#gridPos.x)
+        y: math.Round(#gridPos.y)
+        width: math.Round(#gridPos.w)
+        height: math.Round(#gridPos.h)
+        content: {
+            "$ref": "#/spec/panels/\(#id)"
+        }
+    }
     // we have to go through the panels again here, since in Grafana a panel embeds its position info while in Perses panels & layouts are split
     layouts: [
         // create a first grid to gather standalone panels
@@ -202,38 +188,23 @@ spec: {
             spec: {
                 // go through the top-level panels a 2nd time and append an item only for the ones that are not rows neither belong to a row
                 items: [ for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels if grafanaPanel.panels == _|_ {
-                    // it may happen that a grafana panel coordinate has a decimal
-                    x: math.Round(grafanaPanel.gridPos.x)
-                    y: math.Round(grafanaPanel.gridPos.y)
-                    width: math.Round(grafanaPanel.gridPos.w)
-                    height: math.Round(grafanaPanel.gridPos.h)
-                    content: {
-                        "$ref": "#/spec/panels/\(grafanaPanelId)"
-                    }
+                    #positionConversion & {#gridPos: grafanaPanel.gridPos, #id: grafanaPanelId}
                 }]
             }
         },
         // go through the top-level panels a 3rd time & match only the rows, to create the corresponding grids
         for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels if grafanaPanel.panels != _|_ { // if the panel is a row
-            #row: grafanaPanel
             kind: "Grid"
             spec: {
                 display: {
-                    title: #row.title,
+                    title: grafanaPanel.title,
                     collapse: {
-                        open: !#row.collapsed
+                        open: !grafanaPanel.collapsed
                     }
                 }
                 // go through the children panels of the current row
-                items: [ for innerPanelId, innnerPanel in #row.panels {
-                    // it may happen that a grafana panel coordinate has a decimal
-                    x: math.Round(innnerPanel.gridPos.x)
-                    y: math.Round(innnerPanel.gridPos.y)
-                    width: math.Round(innnerPanel.gridPos.w)
-                    height: math.Round(innnerPanel.gridPos.h)
-                    content: {
-                        "$ref": "#/spec/panels/\(grafanaPanelId)_\(innerPanelId)"
-                    }
+                items: [ for innerPanelId, innnerPanel in grafanaPanel.panels {
+                    #positionConversion & {#gridPos: innnerPanel.gridPos, #id: "\(grafanaPanelId)_\(innerPanelId)"}
                 }]
             }
         }

--- a/internal/api/shared/migrate/mapping.cuepart
+++ b/internal/api/shared/migrate/mapping.cuepart
@@ -128,7 +128,7 @@ spec: {
     // go through the top-level panels 1st time, to fill the panels section of Perses
     panels: { for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels {
         // function-like pattern to factorize the panel conversion logic
-        #panelConversion: {
+        _panelConversion: {
             #panel: _
 
             kind: "Panel"
@@ -161,19 +161,19 @@ spec: {
         if grafanaPanel.panels != _|_ {
             for innerPanelId, innerPanel in grafanaPanel.panels { 
                 "\(grafanaPanelId)_\(innerPanelId)": {
-                    #panelConversion & {#panel: innerPanel}
+                    _panelConversion & {#panel: innerPanel}
                 }
             }
         }
         // else
         if grafanaPanel.panels == _|_ { 
             "\(grafanaPanelId)": {
-                #panelConversion & {#panel: grafanaPanel}
+                _panelConversion & {#panel: grafanaPanel}
             }
         }
     }}
     // function-like pattern to factorize the position conversion logic
-    #positionConversion: {
+    _positionConversion: {
         #gridPos: _
         #id: _
         // it may happen that a grafana panel coordinate has a decimal, which we have to get rid of
@@ -194,7 +194,7 @@ spec: {
                 spec: {
                     // go through the top-level panels a 2nd time and append an item only for the ones that are not rows neither belong to a row
                     items: [ for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels if grafanaPanel.panels == _|_ {
-                        #positionConversion & {#gridPos: grafanaPanel.gridPos, #id: grafanaPanelId}
+                        _positionConversion & {#gridPos: grafanaPanel.gridPos, #id: grafanaPanelId}
                     }]
                 }
             }
@@ -211,7 +211,7 @@ spec: {
                 }
                 // go through the children panels of the current row
                 items: [ for innerPanelId, innnerPanel in grafanaPanel.panels {
-                    #positionConversion & {#gridPos: innnerPanel.gridPos, #id: "\(grafanaPanelId)_\(innerPanelId)"}
+                    _positionConversion & {#gridPos: innnerPanel.gridPos, #id: "\(grafanaPanelId)_\(innerPanelId)"}
                 }]
             }
         }

--- a/internal/api/shared/migrate/mapping.cuepart
+++ b/internal/api/shared/migrate/mapping.cuepart
@@ -182,14 +182,16 @@ spec: {
     }
     // we have to go through the panels again here, since in Grafana a panel embeds its position info while in Perses panels & layouts are split
     layouts: [
-        // create a first grid to gather standalone panels
-        {
-            kind: "Grid"
-            spec: {
-                // go through the top-level panels a 2nd time and append an item only for the ones that are not rows neither belong to a row
-                items: [ for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels if grafanaPanel.panels == _|_ {
-                    #positionConversion & {#gridPos: grafanaPanel.gridPos, #id: grafanaPanelId}
-                }]
+        // create a first grid to gather standalone panels, if there are some (= only if first encountered panel is not a row)
+        if #grafanaDashboard.panels[0] != _|_ if #grafanaDashboard.panels[0].panels == _|_ {
+            {
+                kind: "Grid"
+                spec: {
+                    // go through the top-level panels a 2nd time and append an item only for the ones that are not rows neither belong to a row
+                    items: [ for grafanaPanelId, grafanaPanel in #grafanaDashboard.panels if grafanaPanel.panels == _|_ {
+                        #positionConversion & {#gridPos: grafanaPanel.gridPos, #id: grafanaPanelId}
+                    }]
+                }
             }
         },
         // go through the top-level panels a 3rd time & match only the rows, to create the corresponding grids

--- a/internal/api/shared/migrate/mapping.cuepart
+++ b/internal/api/shared/migrate/mapping.cuepart
@@ -134,7 +134,12 @@ spec: {
             kind: "Panel"
             spec: {
                 display: {
-                    name: *#panel.title | "empty"
+                    name: [ // switch
+                        if #panel.title != _|_ if #panel.title != "" {
+                            #panel.title
+                        },
+                        "empty"
+                    ][0]
                     description: *#panel.description | ""
                 }
                 plugin: [ // switch

--- a/internal/api/shared/migrate/testdata/library_panel_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/library_panel_perses_dashboard.json
@@ -31,12 +31,6 @@
       {
         "kind": "Grid",
         "spec": {
-          "items": []
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
           "display": {
             "title": "Dashboard Information",
             "collapse": {

--- a/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -110,12 +110,6 @@
       {
         "kind": "Grid",
         "spec": {
-          "items": []
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
           "display": {
             "title": "Dashboard Info",
             "collapse": {

--- a/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -95,9 +95,9 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "MigrationFromGrafanaNotSupported"
+                      "name": "$datasource"
                     },
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum (rate(otf_fe_queue_be_messages_enqueued_total[$__rate_interval]))"
                   }
                 }
               }

--- a/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
@@ -82,10 +82,6 @@
       "pluginVersion": "9.5.8",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "argos-world"
-          },
           "editorMode": "code",
           "expr": "vector(4)",
           "legendFormat": "__auto",

--- a/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
@@ -352,7 +352,6 @@
           "targets": [
             {
               "datasource": {
-                "type": "prometheus",
                 "uid": "argos-world"
               },
               "editorMode": "code",
@@ -544,7 +543,6 @@
           "value": "$__all"
         },
         "datasource": {
-          "type": "prometheus",
           "uid": "argos-world"
         },
         "definition": "label_values(thanos_build_info, stack)",

--- a/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
@@ -451,6 +451,15 @@
           "type": "text"
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "argos-world"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "My row title",
       "type": "row"
     }

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -316,10 +316,6 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "argos-world"
-                    },
                     "query": "vector(4)"
                   }
                 }

--- a/schemas/queries/prometheus/migrate.cue
+++ b/schemas/queries/prometheus/migrate.cue
@@ -1,4 +1,19 @@
-if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" { // the first condition avoids validation error in the weird case where datasource type is not present
+// NB we would need `if` to support short-circuit in order to avoid code duplication here.
+//    See https://github.com/cue-lang/cue/issues/2232
+if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" {
+	kind: "PrometheusTimeSeriesQuery"
+	spec: {
+		datasource: {
+			kind: "PrometheusDatasource"
+			name: #target.datasource.uid
+		}
+		query: #target.expr
+	}
+},
+// The datasource.type may not be present while we are dealing with a prometheus query.
+// In such case, rely on the "expr" field, whose presence likely indicates that this is a prometheus query.
+// /!\ This is a best-effort conversion logic and may wrongly convert not-prometheus queries to PrometheusTimeSeriesQuery
+if #target.expr != _|_ {
 	kind: "PrometheusTimeSeriesQuery"
 	spec: {
 		datasource: {

--- a/schemas/queries/prometheus/migrate.cue
+++ b/schemas/queries/prometheus/migrate.cue
@@ -1,6 +1,6 @@
 // NB we would need `if` to support short-circuit in order to avoid code duplication here.
 //    See https://github.com/cue-lang/cue/issues/2232
-if #target.datasource != _|_ if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" {
+if #target.datasource != _|_ if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" && #target.expr != _|_ {
 	kind: "PrometheusTimeSeriesQuery"
 	spec: {
 		datasource: {

--- a/schemas/queries/prometheus/migrate.cue
+++ b/schemas/queries/prometheus/migrate.cue
@@ -1,6 +1,6 @@
 // NB we would need `if` to support short-circuit in order to avoid code duplication here.
 //    See https://github.com/cue-lang/cue/issues/2232
-if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" {
+if #target.datasource != _|_ if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" {
 	kind: "PrometheusTimeSeriesQuery"
 	spec: {
 		datasource: {
@@ -16,9 +16,11 @@ if #target.datasource.type != _|_ if #target.datasource.type == "prometheus" {
 if #target.expr != _|_ {
 	kind: "PrometheusTimeSeriesQuery"
 	spec: {
-		datasource: {
-			kind: "PrometheusDatasource"
-			name: #target.datasource.uid
+		if #target.datasource != _|_ {
+			datasource: {
+				kind: "PrometheusDatasource"
+				name: #target.datasource.uid
+			}
 		}
 		query: #target.expr
 	}


### PR DESCRIPTION
# Description

This PR tackles many corner cases that were causing the grafana migration to fail:
- `target.datasource.type` not present when migrating queries
- `datasource` field not present when migrating queries
- empty panel title when migrating panels
- row with targets defined (should be ignored)

It also comes with:
- an improvement to stop appending an empty grid when migrating dashboards without standalone panels (this empty grid was consuming vertical space on the screen for no purpose),
- some refactoring in mapping.cuepart to reduce code duplication by using [function pattern](https://cuetorials.com/patterns/functions/).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).