### PR TITLE
[ENHANCEMENT] Support more attributes in Grafana migration

### DIFF
--- a/internal/api/shared/migrate/mapping.cuepart
+++ b/internal/api/shared/migrate/mapping.cuepart
@@ -110,11 +110,12 @@ spec: {
                 }
                 allowAllValue: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
                 allowMultiple: *grafanaVar.multi | false      // the default value tackles the case of variables of type `interval` that don't have such field
-
+                if grafanaVar.allValue != _|_ {
+                    customAllValue: grafanaVar.allValue
+                }
                 if grafanaVar.sort != _|_ if #mapping.sort[grafanaVar.sort] != _|_ {
                     sort: #mapping.sort[grafanaVar.sort]
                 }
-
                 // defaultValue: nothing to map to this field
                 #var: grafanaVar
                 plugin: [ // switch

--- a/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -75,15 +75,7 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": [
-                  "min",
-                  "max",
-                  "mean"
-                ]
-              }
+              "visual": {}
             }
           },
           "queries": [
@@ -97,7 +89,9 @@
                       "kind": "PrometheusDatasource",
                       "name": "$datasource"
                     },
-                    "query": "sum (rate(otf_fe_queue_be_messages_enqueued_total[$__rate_interval]))"
+                    "minStep": "2m",
+                    "query": "sum (rate(otf_fe_queue_be_messages_enqueued_total[$__rate_interval]))",
+                    "seriesNameFormat": "Queueing rate"
                   }
                 }
               }

--- a/internal/api/shared/migrate/testdata/old_grafana_query_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_query_grafana_dashboard.json
@@ -44,7 +44,7 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 5,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -53,7 +53,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "percent"
             },
             "thresholdsStyle": {
               "mode": "off"

--- a/internal/api/shared/migrate/testdata/old_grafana_query_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/old_grafana_query_perses_dashboard.json
@@ -40,6 +40,7 @@
           },
           "allowAllValue": false,
           "allowMultiple": true,
+          "sort": "alphabetical-asc",
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
@@ -47,8 +48,7 @@
               "labelName": "stack"
             }
           },
-          "name": "stack",
-          "sort": "alphabetical-asc"
+          "name": "stack"
         }
       }
     ],
@@ -66,6 +66,13 @@
                 "mode": "list",
                 "position": "bottom",
                 "values": []
+              },
+              "visual": {
+                "areaOpacity": 0,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 3,
+                "stack": "all"
               }
             }
           }

--- a/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_grafana_dashboard.json
@@ -189,7 +189,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -287,7 +287,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
+                "fillOpacity": 85,
                 "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
@@ -338,7 +338,7 @@
               "calcs": [],
               "displayMode": "table",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "tooltip": {
               "mode": "single",
@@ -514,6 +514,7 @@
         "type": "constant"
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": false,
           "text": "All",

--- a/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/shared/migrate/testdata/simple_perses_dashboard.json
@@ -58,6 +58,8 @@
           },
           "allowAllValue": true,
           "allowMultiple": false,
+          "customAllValue": ".*",
+          "sort": "none",
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -65,8 +67,7 @@
               "matchers": []
             }
           },
-          "name": "lv1",
-          "sort": "none"
+          "name": "lv1"
         }
       },
       {
@@ -79,6 +80,7 @@
           },
           "allowAllValue": true,
           "allowMultiple": false,
+          "sort": "none",
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -88,8 +90,7 @@
               ]
             }
           },
-          "name": "lv2",
-          "sort": "none"
+          "name": "lv2"
         }
       },
       {
@@ -102,6 +103,7 @@
           },
           "allowAllValue": true,
           "allowMultiple": false,
+          "sort": "alphabetical-asc",
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -111,8 +113,7 @@
               ]
             }
           },
-          "name": "lv3",
-          "sort": "alphabetical-asc"
+          "name": "lv3"
         }
       },
       {
@@ -125,6 +126,7 @@
           },
           "allowAllValue": true,
           "allowMultiple": false,
+          "sort": "alphabetical-desc",
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -134,8 +136,7 @@
               ]
             }
           },
-          "name": "lv4",
-          "sort": "alphabetical-desc"
+          "name": "lv4"
         }
       },
       {
@@ -197,14 +198,14 @@
         "spec": {
           "allowAllValue": false,
           "allowMultiple": false,
+          "sort": "none",
           "plugin": {
             "kind": "PrometheusLabelNamesVariable",
             "spec": {
               "matchers": []
             }
           },
-          "name": "LabelNamesTest",
-          "sort": "none"
+          "name": "LabelNamesTest"
         }
       },
       {
@@ -217,6 +218,7 @@
           },
           "allowAllValue": false,
           "allowMultiple": false,
+          "sort": "alphabetical-ci-asc",
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
@@ -224,8 +226,7 @@
               "labelName": "type"
             }
           },
-          "name": "queryResVar",
-          "sort": "alphabetical-ci-asc"
+          "name": "queryResVar"
         }
       },
       {
@@ -238,6 +239,7 @@
           },
           "allowAllValue": false,
           "allowMultiple": false,
+          "sort": "alphabetical-ci-desc",
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
@@ -245,8 +247,7 @@
               "labelName": "type"
             }
           },
-          "name": "queryResVarVolatile",
-          "sort": "alphabetical-ci-desc"
+          "name": "queryResVarVolatile"
         }
       },
       {
@@ -259,6 +260,7 @@
           },
           "allowAllValue": false,
           "allowMultiple": false,
+          "sort": "none",
           "plugin": {
             "kind": "PrometheusPromQLVariable",
             "spec": {
@@ -266,8 +268,7 @@
               "labelName": "migration_from_grafana_not_supported"
             }
           },
-          "name": "queryResVarOther",
-          "sort": "none"
+          "name": "queryResVarOther"
         }
       },
       {
@@ -394,6 +395,12 @@
                   "mean",
                   "sum"
                 ]
+              },
+              "visual": {
+                "areaOpacity": 0,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
               }
             }
           },
@@ -426,10 +433,11 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
+              "visual": {
+                "areaOpacity": 0.85,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
               }
             }
           },

--- a/schemas/panels/time-series/migrate.cue
+++ b/schemas/panels/time-series/migrate.cue
@@ -1,37 +1,41 @@
 if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 	kind: "TimeSeriesChart"
 	spec: {
-		legend: {
-			if #panel.type == "timeseries" {
-				position: [
-					if #panel.options.legend.placement == "bottom" { "bottom" },
-					if #panel.options.legend.placement == "right" { "right" },
-				][0]
-				mode: [
-					if #panel.options.legend.displayMode == "list" { "list" },
-					if #panel.options.legend.displayMode == "table" { "table" },
-				][0]
-				values: [ for calc in #panel.options.legend.calcs 
-					if (#mapping.calc[calc] != _|_) { #mapping.calc[calc] }
-				]
-			}
-			if #panel.type == "graph" {
-				position: [ // switch
-					if #panel.legend.rightSide != _|_ if #panel.legend.rightSide { "right" },
-					{ "bottom" }
-				][0]
-				mode: [
-					if #panel.legend.alignAsTable != _|_ if #panel.legend.alignAsTable { "table" },
-					{ "list" }
-				][0]
-				values: [ for oldCalc, newCalc in #mapping.calc  
-					// Check if the mapping field is set on the legend and 
-					// is true.
-					if #panel.legend[oldCalc] != _|_ if #panel.legend[oldCalc] == true { newCalc }
-				]
+		// legend
+		 // NB: no support of former "show" attribute from Grafana, people should migrate to latest Grafana datamodel before migrating to Perses
+		if #panel.options.legend.showLegend != _|_ if #panel.options.legend.showLegend {
+			legend: {
+				if #panel.type == "timeseries" {
+					position: [
+						if #panel.options.legend.placement == "bottom" { "bottom" },
+						if #panel.options.legend.placement == "right" { "right" },
+					][0]
+					mode: [
+						if #panel.options.legend.displayMode == "list" { "list" },
+						if #panel.options.legend.displayMode == "table" { "table" },
+					][0]
+					values: [ for calc in #panel.options.legend.calcs 
+						if (#mapping.calc[calc] != _|_) { #mapping.calc[calc] }
+					]
+				}
+				if #panel.type == "graph" {
+					position: [ // switch
+						if #panel.legend.rightSide != _|_ if #panel.legend.rightSide { "right" },
+						{ "bottom" }
+					][0]
+					mode: [
+						if #panel.legend.alignAsTable != _|_ if #panel.legend.alignAsTable { "table" },
+						{ "list" }
+					][0]
+					values: [ for oldCalc, newCalc in #mapping.calc  
+						// Check if the mapping field is set on the legend and 
+						// is true.
+						if #panel.legend[oldCalc] != _|_ if #panel.legend[oldCalc] == true { newCalc }
+					]
+				}
 			}
 		}
-
+		// yAxis
 		#unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
 		if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
 			yAxis: {
@@ -40,8 +44,8 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 				}
 			}
 		}
-
-		// migrate thresholds only if they are visible
+		// thresholds
+		// -> migrate thresholds only if they are visible
 		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle.mode != "off" {
 			thresholds: {
 				// defaultColor: TODO how to fill this one?
@@ -52,6 +56,32 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 					][0]
 					color: step.color
 				}]
+			}
+		}
+		// visual
+		visual: {
+			if #panel.fieldConfig.defaults.custom.lineWidth != _|_ {
+				lineWidth: [ // switch
+					if #panel.fieldConfig.defaults.custom.lineWidth > 3 { 3 }, // line width can't go beyond 3 in Perses
+					{ #panel.fieldConfig.defaults.custom.lineWidth }
+				][0]
+			}
+			if #panel.fieldConfig.defaults.custom.fillOpacity != _|_ {
+				areaOpacity: #panel.fieldConfig.defaults.custom.fillOpacity / 100 // 
+			}
+			// NB: pointRadius skipped because the optimal size is automatically computed by Perses
+			if #panel.fieldConfig.defaults.custom.spanNulls != _|_ if (#panel.fieldConfig.defaults.custom.spanNulls & bool) != _|_ { // ignore in case of "threshold" mode because we don't support it
+				connectNulls: #panel.fieldConfig.defaults.custom.spanNulls
+			}
+			if #panel.fieldConfig.defaults.custom.drawStyle != _|_ {
+				display: [ // switch
+					if #panel.fieldConfig.defaults.custom.drawStyle == "line" { "line" },
+					if #panel.fieldConfig.defaults.custom.drawStyle == "bars" { "bar" },
+					"line"
+				][0]
+			}
+			if #panel.fieldConfig.defaults.custom.stacking != _|_ if #panel.fieldConfig.defaults.custom.stacking.mode != _|_ if #panel.fieldConfig.defaults.custom.stacking.mode != "none" {
+				stack: "all"
 			}
 		}
 	}

--- a/schemas/queries/prometheus/migrate.cue
+++ b/schemas/queries/prometheus/migrate.cue
@@ -8,6 +8,12 @@ if #target.datasource != _|_ if #target.datasource.type != _|_ if #target.dataso
 			name: #target.datasource.uid
 		}
 		query: #target.expr
+		if #target.legendFormat != _|_ if #target.legendFormat != "__auto" {
+			seriesNameFormat: #target.legendFormat
+		}
+		if #target.interval != _|_ {
+			minStep: #target.interval
+		}
 	}
 },
 // The datasource.type may not be present while we are dealing with a prometheus query.
@@ -23,5 +29,11 @@ if #target.expr != _|_ {
 			}
 		}
 		query: #target.expr
+		if #target.legendFormat != _|_ if #target.legendFormat != "__auto" {
+			seriesNameFormat: #target.legendFormat
+		}
+		if #target.interval != _|_ {
+			minStep: #target.interval
+		}
 	}
 },


### PR DESCRIPTION
# Description

Closes https://github.com/perses/perses/issues/1520.

New fields supported when migrating a dashboard from Grafana:

**For List variables:**
- custom All value

**For Timeseries panel:**
- "stacked" property
- show/hide legend
- line width
- fill opacity
- connected nulls
- line vs bar display

**For Prom ts queries:**
- custom legend text
- min step

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).