### PR TITLE
[BREAKINGCHANGE] generateChartsTheme can override any value

### DIFF
--- a/ui/app/src/context/DarkMode.tsx
+++ b/ui/app/src/context/DarkMode.tsx
@@ -48,7 +48,7 @@ export function DarkModeContextProvider(props: { children: React.ReactNode }) {
 
   const theme = useMemo(() => getTheme(isDarkModeEnabled ? 'dark' : 'light'), [isDarkModeEnabled]);
   const chartsTheme: PersesChartsTheme = useMemo(() => {
-    return generateChartsTheme(theme, ECHARTS_THEME_OVERRIDES);
+    return generateChartsTheme(theme, { echartsTheme: ECHARTS_THEME_OVERRIDES });
   }, [theme]);
 
   return (

--- a/ui/components/src/test-utils/theme.ts
+++ b/ui/components/src/test-utils/theme.ts
@@ -34,7 +34,9 @@ const TEST_ECHARTS_THEME_OVERRIDES: EChartsTheme = {
   },
 };
 
-export const testChartsTheme: PersesChartsTheme = generateChartsTheme(createMuiTheme({}), TEST_ECHARTS_THEME_OVERRIDES);
+export const testChartsTheme: PersesChartsTheme = generateChartsTheme(createMuiTheme({}), {
+  echartsTheme: TEST_ECHARTS_THEME_OVERRIDES,
+});
 
 export const mockChartsContext: SharedChartsState = {
   chartsTheme: testChartsTheme,

--- a/ui/components/src/utils/theme-gen.test.ts
+++ b/ui/components/src/utils/theme-gen.test.ts
@@ -28,7 +28,7 @@ describe('generateChartsTheme', () => {
       smooth: true,
     },
   };
-  const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, echartsThemeOverrides);
+  const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, { echartsTheme: echartsThemeOverrides });
 
   it('should return perses specific charts theme from converted MUI theme', () => {
     expect(chartsTheme).toMatchInlineSnapshot(`
@@ -271,7 +271,6 @@ describe('generateChartsTheme', () => {
             "#d32f2f",
           ],
         },
-        "tooltipPortalContainerId": undefined,
       }
     `);
   });

--- a/ui/components/src/utils/theme-gen.ts
+++ b/ui/components/src/utils/theme-gen.ts
@@ -22,12 +22,7 @@ type MuiTheme = Omit<Theme, 'components'>;
 
 export function generateChartsTheme(
   muiTheme: MuiTheme,
-  echartsTheme: EChartsTheme,
-  /**
-   * The id of the container that will have the chart tooltip appended to it.
-   * By default, chart tooltip uses the body of the top-level document object.
-   */
-  tooltipPortalContainerId?: string
+  persesChartsThemeOverride: Partial<PersesChartsTheme>
 ): PersesChartsTheme {
   const primaryTextColor = muiTheme.palette.text?.primary ?? DEFAULT_TEXT_COLOR;
 
@@ -231,40 +226,42 @@ export function generateChartsTheme(
     },
   };
 
-  return {
-    tooltipPortalContainerId,
-    echartsTheme: merge(muiConvertedTheme, echartsTheme),
-    noDataOption: {
-      title: {
-        show: true,
-        textStyle: {
-          color: primaryTextColor,
-          fontSize: 16,
-          fontWeight: 400,
+  return merge(
+    {
+      echartsTheme: muiConvertedTheme,
+      noDataOption: {
+        title: {
+          show: true,
+          textStyle: {
+            color: primaryTextColor,
+            fontSize: 16,
+            fontWeight: 400,
+          },
+          text: 'No data',
+          left: 'center',
+          top: 'center',
         },
-        text: 'No data',
-        left: 'center',
-        top: 'center',
+        xAxis: {
+          show: false,
+        },
+        yAxis: {
+          show: false,
+        },
       },
-      xAxis: {
-        show: false,
+      sparkline: {
+        width: 2,
+        color: '#1976d2',
       },
-      yAxis: {
-        show: false,
+      container: {
+        padding: {
+          default: parseInt(muiTheme.spacing(1.5), 10),
+        },
+      },
+      thresholds: {
+        defaultColor: muiTheme.palette.success.main,
+        palette: ['#FFCC00', muiTheme.palette.warning.main, muiTheme.palette.error.main],
       },
     },
-    sparkline: {
-      width: 2,
-      color: '#1976d2',
-    },
-    container: {
-      padding: {
-        default: parseInt(muiTheme.spacing(1.5), 10),
-      },
-    },
-    thresholds: {
-      defaultColor: muiTheme.palette.success.main,
-      palette: ['#FFCC00', muiTheme.palette.warning.main, muiTheme.palette.error.main],
-    },
-  };
+    persesChartsThemeOverride
+  );
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

``generateChartsTheme`` function is very practical, but I would like to propose the ability to override a bit more fields. This is a breaking change as the function is exposed and potentially used by users? @jgbernalp are you using it in Redhat?

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
