### PR TITLE
[ENHANCEMENT] File DB is the default choice if no db configuration is provided

### DIFF
--- a/internal/api/config/database.go
+++ b/internal/api/config/database.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/config"
+	"github.com/sirupsen/logrus"
 )
 
 type FileExtension string
@@ -126,7 +127,10 @@ type Database struct {
 
 func (d *Database) Verify() error {
 	if d.File == nil && d.SQL == nil {
-		return fmt.Errorf("you must specify if Perses has to use SQL or filesystem as a database")
+		logrus.Debug("no database has been specified, therefore a file system database is used")
+		d.File = &File{
+			Folder: "./local_db",
+		}
 	}
 	if d.File != nil && d.SQL != nil {
 		return fmt.Errorf("you cannot tel to Perses to use SQL and the filesystem at the same time")

--- a/internal/api/config/database.go
+++ b/internal/api/config/database.go
@@ -22,6 +22,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const defaultFileDBFolder = "./local_db"
+
 type FileExtension string
 
 const (
@@ -129,7 +131,7 @@ func (d *Database) Verify() error {
 	if d.File == nil && d.SQL == nil {
 		logrus.Debug("no database has been specified, therefore a file system database is used")
 		d.File = &File{
-			Folder: "./local_db",
+			Folder: defaultFileDBFolder,
 		}
 	}
 	if d.File != nil && d.SQL != nil {


### PR DESCRIPTION
By adding this default choice, we are able to run `Perses` with no configuration now.