### PR TITLE
[BUGFIX] Fix several issues with JSON views

### DIFF
--- a/ui/app/src/model/migrate-client.ts
+++ b/ui/app/src/model/migrate-client.ts
@@ -20,7 +20,7 @@ const resource = 'migrate';
 
 export interface MigrateBodyRequest {
   input?: Record<string, string>;
-  grafanaDashboard: string;
+  grafanaDashboard: Record<string, unknown>;
 }
 
 export function useMigrate() {
@@ -31,9 +31,9 @@ export function useMigrate() {
       return fetchJson<DashboardResource>(url, {
         method: HTTPMethodPOST,
         headers: HTTPHeader,
-        body: `{"input":${body.input ? JSON.stringify(body.input) : '{}'}, "grafanaDashboard": ${
+        body: `{"input":${body.input ? JSON.stringify(body.input) : '{}'}, "grafanaDashboard": ${JSON.stringify(
           body.grafanaDashboard
-        }}`,
+        )}}`,
       });
     },
   });

--- a/ui/components/src/JSONEditor.tsx
+++ b/ui/components/src/JSONEditor.tsx
@@ -20,7 +20,8 @@ import { ReactCodeMirrorProps } from '@uiw/react-codemirror/src';
 
 type JSONEditorProps<T> = Omit<ReactCodeMirrorProps, 'onBlur' | 'theme' | 'extensions' | 'onChange' | 'value'> & {
   value: T;
-  onChange?: (next: T) => void;
+  placeholder?: string;
+  onChange?: (next: string) => void;
 };
 
 export function JSONEditor<T>(props: JSONEditorProps<T>) {
@@ -28,6 +29,7 @@ export function JSONEditor<T>(props: JSONEditorProps<T>) {
   const isDarkMode = theme.palette.mode === 'dark';
 
   const [value, setValue] = useState(() => JSON.stringify(props.value, null, 2));
+  const [lastProcessedValue, setLastProcessedValue] = useState<string>(value);
 
   useEffect(() => {
     setValue(JSON.stringify(props.value, null, 2));
@@ -44,15 +46,14 @@ export function JSONEditor<T>(props: JSONEditorProps<T>) {
         setValue(newValue);
       }}
       onBlur={() => {
-        try {
-          const json = JSON.parse(value ?? '{}');
-          if (props.onChange !== undefined) {
-            props.onChange(json);
-          }
-        } catch (e) {
-          // ignore this error
+        // Avoid triggering the provided onChange if the last processed value is equal to the current value.
+        // Without this, the find & replace interface (showing up when typing CTRL+F, which triggers onBlur) closes immediately.
+        if (lastProcessedValue !== value && props.onChange !== undefined) {
+          props.onChange(value);
+          setLastProcessedValue(value);
         }
       }}
+      placeholder={props.placeholder}
     />
   );
 }

--- a/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
+++ b/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
@@ -49,6 +49,15 @@ const EditJsonDialogForm = (props: EditJsonDialogProps) => {
     closeEditJsonDialog();
   };
 
+  const completeDraftDashboard = (dashboard: string | undefined) => {
+    try {
+      const json = JSON.parse(dashboard ?? '{}');
+      setDraftDashboard(json);
+    } catch (e) {
+      // do nothing
+    }
+  };
+
   return (
     <Dialog.Form onSubmit={handleApply}>
       <Dialog.Content sx={{ width: '100%' }}>
@@ -62,7 +71,7 @@ const EditJsonDialogForm = (props: EditJsonDialogProps) => {
             minHeight="300px"
             maxHeight="70vh"
             value={draftDashboard}
-            onChange={(value) => setDraftDashboard(value)}
+            onChange={(value: string) => completeDraftDashboard(value)}
           />
         </FormControl>
       </Dialog.Content>

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -98,7 +98,8 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
     }
   }
 
-  const handlePanelDefinitionChange = (nextPanelDef: PanelDefinition) => {
+  const handlePanelDefinitionChange = (nextPanelDefStr: string) => {
+    const nextPanelDef: PanelDefinition = JSON.parse(nextPanelDefStr);
     const { kind: pluginKind, spec: pluginSpec } = nextPanelDef.spec.plugin;
     // if panel plugin kind and spec are modified, then need to save current spec
     if (

--- a/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
@@ -22,7 +22,7 @@ export interface PanelSpecEditorProps {
   panelDefinition: PanelDefinition;
   onQueriesChange: (queries: QueryDefinition[]) => void;
   onPluginSpecChange: (spec: UnknownSpec) => void;
-  onJSONChange: (panelDefinition: PanelDefinition) => void;
+  onJSONChange: (panelDefinitionStr: string) => void;
 }
 
 export function PanelSpecEditor(props: PanelSpecEditorProps) {


### PR DESCRIPTION
# Description

All JSON views:
- find & replace interface is now showing up correctly. Fixes https://github.com/perses/perses/issues/1518.

Migrate screen:
- Grafana input: changed from **TextField** to **JSONEditor**. No more weird behavior when trying to modify things after initial copy-paste, & better UX overall.
- Migrate button: stronger checks for enabling (JSON parse should succeed).
- Migration output: it's now readonly. Fixes https://github.com/perses/perses/issues/1551.

# Screenshots

![image](https://github.com/perses/perses/assets/7058693/5d35d6ee-8a8b-45f2-83b9-2d3414e24656)

![image](https://github.com/perses/perses/assets/7058693/0277b8fa-bfa3-490a-aad1-ff27c936d759)

![image](https://github.com/perses/perses/assets/7058693/bd2db797-32eb-4fec-ba3c-c641d2e0b08b)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
