### PR TITLE
[ENHANCEMENT] Panel json view: add maxheight for better UX

### DIFF
--- a/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
@@ -64,7 +64,10 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
   }
 
   // always show json editor by default
-  tabs.push({ label: 'JSON', content: <JSONEditor value={panelDefinition} onChange={onJSONChange} /> });
+  tabs.push({
+    label: 'JSON',
+    content: <JSONEditor maxHeight="80vh" value={panelDefinition} onChange={onJSONChange} />,
+  });
 
   return <OptionsEditorTabs key={tabs.length} tabs={tabs} />;
 }


### PR DESCRIPTION
# Description

Limit the height just enough to always keep the tabs in sight.
This also avoids having to scroll at the very bottom to be able to scroll horizontally for long lines (e.g query expression).

![image](https://github.com/perses/perses/assets/7058693/47e776a6-80c4-4092-ac6a-379126f10616)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
