### PR TITLE
[IGNORE] Fix redirection when token expired

### DIFF
--- a/ui/app/src/guard/GuardedAuthRoute.tsx
+++ b/ui/app/src/guard/GuardedAuthRoute.tsx
@@ -16,14 +16,14 @@ import { useSnackbar } from '@perses-dev/components';
 import { Suspense, useEffect, useState } from 'react';
 import { LinearProgress } from '@mui/material';
 import { useGetConfigMutation } from '../model/config-client';
-import { useAuthToken } from '../model/auth-client';
+import { useIsTokenExist } from '../model/auth-client';
 import { SignInRoute } from '../model/route';
 
 function GuardedAuthRoute() {
   const { mutateAsync } = useGetConfigMutation();
   const { exceptionSnackbar } = useSnackbar();
   const navigate = useNavigate();
-  const { isExpired } = useAuthToken();
+  const isTokenExist = useIsTokenExist();
   const [authPromise, setAuthPromise] = useState<Promise<boolean>>();
 
   useEffect(() => {
@@ -40,7 +40,8 @@ function GuardedAuthRoute() {
           if (!conf.security.activate_permission) {
             return true;
           }
-          if (isExpired) {
+          // In case the token is null, it means we weren't able to find the cookie.
+          if (!isTokenExist) {
             navigate(SignInRoute);
             const err = new Error('session has expired');
             exceptionSnackbar(err);
@@ -49,7 +50,7 @@ function GuardedAuthRoute() {
           return true;
         })
     );
-  }, [authPromise, exceptionSnackbar, isExpired, mutateAsync, navigate]);
+  }, [authPromise, exceptionSnackbar, isTokenExist, mutateAsync, navigate]);
   return (
     <Suspense fallback={<LinearProgress />}>
       <Await resolve={authPromise}>

--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -19,6 +19,7 @@ import buildURL from './url-builder';
 import { HTTPHeader, HTTPMethodPOST } from './http';
 
 const authResource = 'auth';
+const jwtPayload = 'jwtPayload';
 
 export interface AuthResponse {
   token: string;
@@ -29,9 +30,17 @@ export interface AuthBody {
   password: string;
 }
 
+export function useIsTokenExist() {
+  const [cookies] = useCookies();
+  return cookies[jwtPayload] !== undefined;
+}
+
 export function useAuthToken() {
   const [cookies] = useCookies();
-  const partialToken = cookies['jwtPayload'];
+  const partialToken = cookies[jwtPayload];
+  // useJWT need a complete token (including a signature) to be able to decode it.
+  // It doesn't need the accurate signature to decode the payload.
+  // That's why we are creating a fake signature.
   const fakeSignature = 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
   return useJwt(`${partialToken}.${fakeSignature}`);
 }


### PR DESCRIPTION
When the token expired, the cookies are removed since we set `maxAge` in the previous PR.

The redirection is currently broken because the cookies are removed when expire.

I think it's cleaner to remove the cookies when they expire and I think it is simpler to check if the cookies exist rather than trying to know if the token has been decoded and if it is expired (for the redirection I mean)