### PR TITLE
[ENHANCEMENT] Reorder navbar button on mobile

### DIFF
--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -19,7 +19,8 @@ import {
   CircularProgress,
   Divider,
   IconButton,
-  Menu,
+  ListItemIcon,
+  Menu as MUIMenu,
   MenuItem,
   Stack,
   Switch,
@@ -32,13 +33,71 @@ import AutoFix from 'mdi-material-ui/AutoFix';
 import Cog from 'mdi-material-ui/Cog';
 import Folder from 'mdi-material-ui/Folder';
 import ShieldAccount from 'mdi-material-ui/ShieldAccount';
-import { MouseEvent, useState } from 'react';
+import Menu from 'mdi-material-ui/Menu';
+import React, { MouseEvent, useState } from 'react';
 import { useSnackbar } from '@perses-dev/components';
 import { useProjectList } from '../model/project-client';
 import { useDarkMode } from '../context/DarkMode';
+import { useIsLaptopSize, useIsMobileSize } from '../utils/browser-size';
+import { AdminRoute, ConfigRoute, MigrateRoute } from '../model/route';
 import WhitePersesLogo from './logo/WhitePersesLogo';
+import PersesLogoCropped from './logo/PersesLogoCropped';
 
 const ITEM_HEIGHT = 48;
+
+function ToolMenu() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleMenu = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+  return (
+    <Box>
+      <IconButton
+        aria-label="Tooling menu"
+        aria-controls="menu-tool-list-appbar"
+        aria-haspopup="true"
+        color="inherit"
+        onClick={handleMenu}
+      >
+        <Menu />
+      </IconButton>
+      <MUIMenu
+        id="menu-tool-list-appbar"
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        keepMounted
+        open={anchorEl !== null}
+        onClose={handleCloseMenu}
+      >
+        <MenuItem component={RouterLink} to={AdminRoute}>
+          <ListItemIcon>
+            <ShieldAccount />
+          </ListItemIcon>
+          <Typography>Admin</Typography>
+        </MenuItem>
+        <MenuItem component={RouterLink} to={ConfigRoute}>
+          <ListItemIcon>
+            <Cog />{' '}
+          </ListItemIcon>
+          <Typography>Config </Typography>
+        </MenuItem>
+        <MenuItem component={RouterLink} to={MigrateRoute}>
+          <ListItemIcon>
+            <AutoFix />
+          </ListItemIcon>
+          <Typography>Migration</Typography>
+        </MenuItem>
+      </MUIMenu>
+    </Box>
+  );
+}
 
 function ProjectMenu(): JSX.Element {
   const { exceptionSnackbar } = useSnackbar();
@@ -73,7 +132,7 @@ function ProjectMenu(): JSX.Element {
         Projects
         <ChevronDown />
       </Button>
-      <Menu
+      <MUIMenu
         id="menu-project-list-appbar"
         anchorEl={anchorEl}
         anchorOrigin={{
@@ -127,12 +186,14 @@ function ProjectMenu(): JSX.Element {
             </Typography>
           </MenuItem>
         )}
-      </Menu>
+      </MUIMenu>
     </Box>
   );
 }
 
 export default function Header(): JSX.Element {
+  const isLaptopSize = useIsLaptopSize();
+  const isMobileSize = useIsMobileSize();
   const { exceptionSnackbar } = useSnackbar();
   const { isDarkModeEnabled, setDarkMode } = useDarkMode();
   const handleDarkModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -170,47 +231,55 @@ export default function Header(): JSX.Element {
               padding: 0,
             }}
           >
-            <WhitePersesLogo />
+            {isLaptopSize ? <WhitePersesLogo /> : <PersesLogoCropped color="white" width={32} height={32} />}
           </Button>
           <Divider
             orientation="vertical"
             flexItem
             sx={{ borderRightColor: 'rgba(255,255,255,0.2)', marginRight: 0.5 }}
           />
-          <Button
-            aria-label="Administration"
-            aria-controls="menu-admin-appbar"
-            aria-haspopup="true"
-            color="inherit"
-            component={RouterLink}
-            to="/admin"
-          >
-            <ShieldAccount sx={{ marginRight: 0.5 }} /> Admin
-          </Button>
-          <Button
-            aria-label="Config"
-            aria-controls="menu-config-appbar"
-            aria-haspopup="true"
-            color="inherit"
-            component={RouterLink}
-            to="/config"
-          >
-            <Cog sx={{ marginRight: 0.5 }} /> Config
-          </Button>
+          {!isMobileSize ? (
+            <>
+              <Button
+                aria-label="Administration"
+                aria-controls="menu-admin-appbar"
+                aria-haspopup="true"
+                color="inherit"
+                component={RouterLink}
+                to={AdminRoute}
+              >
+                <ShieldAccount sx={{ marginRight: 0.5 }} /> Admin
+              </Button>
+              <Button
+                aria-label="Config"
+                aria-controls="menu-config-appbar"
+                aria-haspopup="true"
+                color="inherit"
+                component={RouterLink}
+                to={ConfigRoute}
+              >
+                <Cog sx={{ marginRight: 0.5 }} /> Config
+              </Button>
+            </>
+          ) : (
+            <ToolMenu />
+          )}
           <ProjectMenu />
         </Box>
         <Stack direction={'row'} alignItems={'center'}>
-          <Tooltip title="Migration tool">
-            <IconButton
-              sx={(theme) => ({
-                color: theme.palette.common.white,
-              })}
-              component={RouterLink}
-              to="/migrate"
-            >
-              <AutoFix />
-            </IconButton>
-          </Tooltip>
+          {!isMobileSize && (
+            <Tooltip title="Migration tool">
+              <IconButton
+                sx={(theme) => ({
+                  color: theme.palette.common.white,
+                })}
+                component={RouterLink}
+                to={MigrateRoute}
+              >
+                <AutoFix />
+              </IconButton>
+            </Tooltip>
+          )}
           <Tooltip title="Theme">
             <Switch
               checked={isDarkModeEnabled}

--- a/ui/app/src/components/logo/PersesLogoCropped.tsx
+++ b/ui/app/src/components/logo/PersesLogoCropped.tsx
@@ -11,24 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function PersesLogoCropped() {
+interface PersesLogoCroppedProps {
+  color?: string;
+  width?: number;
+  height?: number;
+}
+
+function PersesLogoCropped(props: PersesLogoCroppedProps) {
+  const { color = '#DE005D', width = 120, height = 120 } = props;
   return (
-    <svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width={width} height={height} viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M71.625 23H29.375C25.8542 23 23 25.8542 23 29.375C23 32.8958 25.8542 35.75 29.375 35.75H71.625C75.1458 35.75 78 32.8958 78 29.375C78 25.8542 75.1458 23 71.625 23Z"
-        fill="#DE005D"
+        fill={color}
       />
       <path
         d="M91.625 43.75H49.375C45.8542 43.75 43 46.6042 43 50.125C43 53.6458 45.8542 56.5 49.375 56.5H91.625C95.1458 56.5 98 53.6458 98 50.125C98 46.6042 95.1458 43.75 91.625 43.75Z"
-        fill="#DE005D"
+        fill={color}
       />
       <path
         d="M71.625 64.5H29.375C25.8542 64.5 23 67.3542 23 70.875C23 74.3958 25.8542 77.25 29.375 77.25H71.625C75.1458 77.25 78 74.3958 78 70.875C78 67.3542 75.1458 64.5 71.625 64.5Z"
-        fill="#DE005D"
+        fill={color}
       />
       <path
         d="M36.625 85.25H29.375C25.8542 85.25 23 88.1042 23 91.625C23 95.1458 25.8542 98 29.375 98H36.625C40.1458 98 43 95.1458 43 91.625C43 88.1042 40.1458 85.25 36.625 85.25Z"
-        fill="#DE005D"
+        fill={color}
       />
     </svg>
   );

--- a/ui/app/src/utils/browser-size.ts
+++ b/ui/app/src/utils/browser-size.ts
@@ -1,0 +1,22 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useMediaQuery, useTheme } from '@mui/material';
+
+export function useIsLaptopSize() {
+  return useMediaQuery(useTheme().breakpoints.up('md'));
+}
+
+export function useIsMobileSize() {
+  return useMediaQuery(useTheme().breakpoints.between('xs', 'sm'));
+}

--- a/ui/app/src/views/auth/SignWrapper.tsx
+++ b/ui/app/src/views/auth/SignWrapper.tsx
@@ -11,16 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Divider, Stack, useMediaQuery, useTheme } from '@mui/material';
+import { Divider, Stack } from '@mui/material';
 import { ReactNode } from 'react';
 import { useDarkMode } from '../../context/DarkMode';
 import PersesLogoCropped from '../../components/logo/PersesLogoCropped';
 import DarkThemePersesLogo from '../../components/logo/DarkThemePersesLogo';
 import LightThemePersesLogo from '../../components/logo/LightThemePersesLogo';
+import { useIsLaptopSize } from '../../utils/browser-size';
 
 export function SignWrapper(props: { children: ReactNode }) {
   const { isDarkModeEnabled } = useDarkMode();
-  const isLaptopSize = useMediaQuery(useTheme().breakpoints.up('md'));
+  const isLaptopSize = useIsLaptopSize();
   return (
     <Stack
       width="100%"


### PR DESCRIPTION
Here is a proposition to reorder the different button when you are on mobile.

- Logo is cropped
- Admin, config and migration button are available in a menu

https://github.com/perses/perses/assets/4548045/2cf46e2d-a763-4f88-8ec3-c6b92bfaf171

The swap of the theme will go in a user menu I think. A bit like GitHub.
