### PR TITLE
[ENHANCEMENT] Autocomplete & filtering for ListVariable

### DIFF
--- a/ui/dashboards/src/components/Variables/TemplateVariable.test.ts
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.test.ts
@@ -53,7 +53,7 @@ interface TestParams {
     value: VariableValue;
     loading: boolean;
     options: VariableOption[];
-    selectedValue: VariableValue;
+    selectedOptions: VariableOption | VariableOption[];
     viewOptions: VariableOption[];
   };
 }
@@ -73,7 +73,7 @@ describe('useListVariableState', () => {
         value: 'hello',
         loading: true,
         options: [option('hello')],
-        selectedValue: 'hello',
+        selectedOptions: option('hello'),
         viewOptions: [option('hello')],
       },
     },
@@ -90,7 +90,7 @@ describe('useListVariableState', () => {
         value: 'hello',
         loading: false,
         options: [option('hello')],
-        selectedValue: 'hello',
+        selectedOptions: option('hello'),
         viewOptions: [option('hello')],
       },
     },
@@ -107,7 +107,7 @@ describe('useListVariableState', () => {
         value: ['hello'],
         loading: false,
         options: [option('hello')],
-        selectedValue: ['hello'],
+        selectedOptions: [option('hello')],
         viewOptions: [allOption(), option('hello')],
       },
     },
@@ -124,7 +124,7 @@ describe('useListVariableState', () => {
         value: 'hello',
         loading: false,
         options: [option('hello')],
-        selectedValue: '', // Not a problem. As long the value is good, next update will set it
+        selectedOptions: option('hello'),
         viewOptions: [option('hello')],
       },
     },
@@ -141,7 +141,7 @@ describe('useListVariableState', () => {
         value: ['hello'],
         loading: false,
         options: [option('hello')],
-        selectedValue: [], // Not a problem. As long the value is good, next update will set it
+        selectedOptions: [option('hello')],
         viewOptions: [allOption(), option('hello')],
       },
     },
@@ -158,7 +158,7 @@ describe('useListVariableState', () => {
         value: 'hello',
         loading: false,
         options: [option('hello')],
-        selectedValue: '', // Not a problem. As long the value is good, next update will set it
+        selectedOptions: option('hello'),
         viewOptions: [option('hello')],
       },
     },
@@ -175,7 +175,7 @@ describe('useListVariableState', () => {
         value: ['hello'],
         loading: false,
         options: [option('hello')],
-        selectedValue: [], // Not a problem. As long the value is good, next update will set it
+        selectedOptions: [option('hello')],
         viewOptions: [allOption(), option('hello')],
       },
     },
@@ -203,7 +203,7 @@ describe('useListVariableState', () => {
       value: params.output.value,
       loading: params.output.loading,
       options: params.output.options,
-      selectedValue: params.output.selectedValue,
+      selectedOptions: params.output.selectedOptions,
       viewOptions: params.output.viewOptions,
     });
   });

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useEffect, useMemo, useState } from 'react';
-import { Select, FormControl, InputLabel, MenuItem, Box, LinearProgress, TextField } from '@mui/material';
+import { Box, LinearProgress, TextField, Autocomplete, Checkbox } from '@mui/material';
 import {
   DEFAULT_ALL_VALUE,
   ListVariableDefinition,
@@ -30,6 +30,18 @@ type TemplateVariableProps = {
   name: VariableName;
   source?: string;
 };
+
+function variableOptionToVariableValue(options: VariableOption | VariableOption[] | null): VariableValue {
+  if (options === null) {
+    return null;
+  }
+  if (Array.isArray(options)) {
+    return options.map((v) => {
+      return v.value;
+    });
+  }
+  return options.value;
+}
 
 export function TemplateVariable({ name, source }: TemplateVariableProps) {
   const ctx = useTemplateVariable(name, source);
@@ -173,44 +185,24 @@ function ListVariable({ name, source }: TemplateVariableProps) {
 
   return (
     <Box display={'flex'}>
-      <FormControl fullWidth>
-        <InputLabel id={name}>{title}</InputLabel>
-        <Select
-          id={name}
-          title={selectedValue as string}
-          label={title}
-          value={selectedValue}
-          onChange={(e) => {
-            // Must be selected
-            if (e.target.value === null || e.target.value.length === 0) {
-              if (allowAllValue) {
-                setVariableValue(name, DEFAULT_ALL_VALUE, source);
-              }
-              return;
-            }
-            setVariableValue(name, e.target.value as VariableValue, source);
-          }}
-          multiple={allowMultiple}
-        >
-          {loading && (
-            <MenuItem value="loading" disabled>
-              Loading
-            </MenuItem>
-          )}
-
-          {viewOptions.length === 0 && (
-            <MenuItem value="empty" disabled>
-              No options
-            </MenuItem>
-          )}
-          {viewOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </Select>
-        {loading && <LinearProgress />}
-      </FormControl>
+      <Autocomplete
+        disablePortal
+        disableCloseOnSelect={allowMultiple}
+        multiple={allowMultiple}
+        fullWidth
+        onChange={(e, value) => {
+          // Must be selected
+          if ((value === null || (Array.isArray(value) && value.length === 0)) && allowAllValue) {
+            setVariableValue(name, DEFAULT_ALL_VALUE, source);
+            return;
+          }
+          setVariableValue(name, variableOptionToVariableValue(value), source);
+        }}
+        options={viewOptions}
+        getOptionLabel={(option) => option.label}
+        renderInput={(params) => <TextField {...params} value={selectedValue} label={title} />}
+      />
+      {loading && <LinearProgress />}
     </Box>
   );
 }

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -65,9 +65,9 @@ export function useListVariableState(
   value: VariableValue | undefined;
   loading: boolean;
   options: VariableOption[] | undefined;
-  // selectedValue is the value(s) that will be used in the view only
-  selectedValue: VariableValue;
-  // viewOptions are the options used in the view only (options + All if allowed)
+  // selectedOptions is/are the option(s) selected in the view
+  selectedOptions: VariableOption | VariableOption[];
+  // viewOptions are the options used in the view only (= options + All if allowed)
   viewOptions: VariableOption[];
 } {
   const allowMultiple = spec?.allowMultiple === true;
@@ -143,10 +143,23 @@ export function useListVariableState(
     return value;
   }, [viewOptions, value, valueIsInOptions, allowMultiple, allowAllValue]);
 
-  // Once we computed value, we set it as the selected one, if it is available in the options
-  const selectedValue = value && valueIsInOptions ? value : allowMultiple ? [] : '';
+  const selectedOptions = useMemo(() => {
+    // In the case Autocomplete.multiple equals false, Autocomplete.value expects a single object, not
+    // an array, hence this conditional
+    if (Array.isArray(value)) {
+      return viewOptions.filter((o) => {
+        return value?.includes(o.value);
+      });
+    } else {
+      return (
+        viewOptions.find((o) => {
+          return value === o.value;
+        }) ?? { value: '', label: '' }
+      );
+    }
+  }, [value, viewOptions]);
 
-  return { value, loading, options, selectedValue, viewOptions };
+  return { value, loading, options, selectedOptions, viewOptions };
 }
 
 function ListVariable({ name, source }: TemplateVariableProps) {
@@ -154,11 +167,12 @@ function ListVariable({ name, source }: TemplateVariableProps) {
   const definition = ctx.definition as ListVariableDefinition;
   const variablesOptionsQuery = useListVariablePluginValues(definition);
   const { setVariableValue, setVariableLoading, setVariableOptions } = useTemplateVariableActions();
-  const { selectedValue, value, loading, options, viewOptions } = useListVariableState(
+  const { selectedOptions, value, loading, options, viewOptions } = useListVariableState(
     definition?.spec,
     ctx.state,
     variablesOptionsQuery
   );
+  const [inputValue, setInputValue] = useState<string>('');
 
   const title = definition?.spec.display?.name ?? name;
   const allowMultiple = definition?.spec.allowMultiple === true;
@@ -190,17 +204,21 @@ function ListVariable({ name, source }: TemplateVariableProps) {
         disableCloseOnSelect={allowMultiple}
         multiple={allowMultiple}
         fullWidth
-        onChange={(e, value) => {
+        value={selectedOptions}
+        onChange={(_, value) => {
           // Must be selected
           if ((value === null || (Array.isArray(value) && value.length === 0)) && allowAllValue) {
             setVariableValue(name, DEFAULT_ALL_VALUE, source);
-            return;
+          } else {
+            setVariableValue(name, variableOptionToVariableValue(value), source);
           }
-          setVariableValue(name, variableOptionToVariableValue(value), source);
+        }}
+        inputValue={inputValue}
+        onInputChange={(_, newInputValue) => {
+          setInputValue(newInputValue);
         }}
         options={viewOptions}
-        getOptionLabel={(option) => option.label}
-        renderInput={(params) => <TextField {...params} value={selectedValue} label={title} />}
+        renderInput={(params) => <TextField {...params} label={title} />}
       />
       {loading && <LinearProgress />}
     </Box>

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useEffect, useMemo, useState } from 'react';
-import { Box, LinearProgress, TextField, Autocomplete, Checkbox } from '@mui/material';
+import { Box, LinearProgress, TextField, Autocomplete } from '@mui/material';
 import {
   DEFAULT_ALL_VALUE,
   ListVariableDefinition,

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -55,7 +55,7 @@ export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec;
       maxWidth={VARIABLE_INPUT_MAX_WIDTH}
       marginBottom={1}
       marginRight={1}
-      data-testid="template-variable"
+      data-testid={'template-variable-' + spec.name}
     >
       <TemplateVariable key={spec.name + source ?? ''} name={spec.name} source={source} />
     </Box>

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -80,7 +80,6 @@ export class DashboardPage {
   readonly panelGroupHeadings: Locator;
 
   readonly variableList: Locator;
-  readonly variableListItems: Locator;
 
   readonly panelEditor: Locator;
   readonly variableEditor: Locator;
@@ -112,7 +111,6 @@ export class DashboardPage {
     this.panelGroupHeadings = this.panelGroups.getByTestId('panel-group-header').getByRole('heading', { level: 2 });
 
     this.variableList = page.getByTestId('variable-list');
-    this.variableListItems = this.variableList.getByTestId('template-variable');
 
     this.panelEditor = page.getByTestId('panel-editor');
     this.variableEditor = page.getByTestId('variable-editor');
@@ -135,6 +133,10 @@ export class DashboardPage {
     return this.page.getByRole('dialog', {
       name: name,
     });
+  }
+
+  getTemplateVariable(name: string) {
+    return this.page.getByTestId('template-variable-' + name).getByRole('combobox');
   }
 
   /**

--- a/ui/e2e/src/tests/jsonEditor.spec.ts
+++ b/ui/e2e/src/tests/jsonEditor.spec.ts
@@ -30,6 +30,6 @@ test.describe('Dashboard: EditJson', () => {
     await dashboardPage.saveChanges();
     await expect(page.url()).toContain('start=5m');
     await expect(dashboardPage.timePicker).toContainText('Last 5 minutes');
-    await expect(dashboardPage.page.getByRole('button', { name: 'interval', exact: true })).toContainText('5m');
+    await expect(dashboardPage.page.getByTestId('template-variable-interval').getByRole('combobox')).toHaveValue('5m');
   });
 });

--- a/ui/e2e/src/tests/saveDefaults.spec.ts
+++ b/ui/e2e/src/tests/saveDefaults.spec.ts
@@ -34,13 +34,8 @@ test.describe('Dashboard: Defaults', () => {
     await expect(page.url()).toContain('start=6h');
 
     // Changed selected interval variable
-    await expect(dashboardPage.variableListItems).toContainText(['1m']);
-    await dashboardPage.page
-      .getByRole('button', {
-        name: 'interval',
-        exact: true,
-      })
-      .click();
+    await expect(dashboardPage.getTemplateVariable('interval')).toHaveValue('1m');
+    await dashboardPage.getTemplateVariable('interval').click();
     await page.getByRole('option', { name: '5m' }).click();
 
     // Change text variable
@@ -68,7 +63,7 @@ test.describe('Dashboard: Defaults', () => {
     await page.getByRole('button', { name: 'Refresh dashboard' }).click();
     await expect(page.url()).toContain('start=6h');
     await expect(dashboardPage.timePicker).toContainText('Last 6 hours');
-    await expect(dashboardPage.variableListItems).toContainText(['5m']);
+    await expect(dashboardPage.getTemplateVariable('interval')).toHaveValue('5m');
 
     // Confirm text variable value is persisted
     const newTextVariableInput = await page.getByRole('textbox', { name: 'Text variable' });

--- a/ui/e2e/src/tests/variables.spec.ts
+++ b/ui/e2e/src/tests/variables.spec.ts
@@ -20,7 +20,7 @@ test.use({
 
 test.describe('Dashboard: Variables', () => {
   test('can add simple text variable', async ({ dashboardPage }) => {
-    const initialCount = await dashboardPage.variableListItems.count(); // Builtin variables are hidden
+    const initialCount = await dashboardPage.variableList.count(); // Builtin variables are hidden
 
     await dashboardPage.startEditing();
     await dashboardPage.startEditingVariables();
@@ -40,12 +40,12 @@ test.describe('Dashboard: Variables', () => {
     await variableEditor.applyChanges();
     await dashboardPage.saveChanges();
 
-    await expect(dashboardPage.variableListItems).toHaveCount(initialCount + 1);
-    await expect(dashboardPage.variableListItems).toContainText([/Text Var/]);
+    await expect(dashboardPage.variableList).toHaveCount(initialCount + 1);
+    await expect(dashboardPage.variableList).toContainText([/Text Var/]);
   });
 
   test('can add simple list variable', async ({ dashboardPage }) => {
-    const initialCount = await dashboardPage.variableListItems.count(); // Builtin variables are hidden
+    const initialCount = await dashboardPage.variableList.count(); // Builtin variables are hidden
     await dashboardPage.startEditing();
     await dashboardPage.startEditingVariables();
     const variableEditor = dashboardPage.getVariableEditor();
@@ -67,7 +67,7 @@ test.describe('Dashboard: Variables', () => {
     const toolbarSaveButton = await dashboardPage.page.getByRole('button', { name: 'Save' });
     await toolbarSaveButton.click();
 
-    await expect(dashboardPage.variableListItems).toHaveCount(initialCount + 1);
-    await expect(dashboardPage.variableListItems).toContainText([/List Var/]);
+    await expect(dashboardPage.variableList).toHaveCount(initialCount + 1);
+    await expect(dashboardPage.variableList).toContainText([/List Var/]);
   });
 });


### PR DESCRIPTION
# Description

This PR changes ListVariable to rely on MUI's Autocomplete, in order to provide autocomplete & filtering.

https://github.com/perses/perses/assets/7058693/c3a3b4df-40ab-4ec0-b22b-2e83844c6b07

Making the display fit well & adapt to the content as much as possible was not easy.. a remaining pain point is that the input grows vertically with the content (especially annoying in case of long variable values for which `limitTags={3}` is not enough, eg:
![2023-11-08_18h29_13](https://github.com/perses/perses/assets/7058693/17ffc739-f1a6-4f1b-b333-a2a078dc8a77)

Besides there's an annoying bug with the Autocomplete, the scroll goes to the top each time you click a value. This should be solved by upgrading the MUI dependency (see https://github.com/mui/material-ui/issues/29508). I'm planning to tackle this in a next PR.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
