### PR TITLE
[ENHANCEMENT] Panel editor: reposition Add Query button for better UX

### DIFF
--- a/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
+++ b/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
@@ -113,21 +113,23 @@ export function TimeSeriesQueryEditor({ queries = [], onChange }: TimeSeriesQuer
       ];
 
   return (
-    <Stack spacing={1}>
-      <Button variant="contained" startIcon={<AddIcon />} sx={{ marginLeft: 'auto' }} onClick={handleQueryAdd}>
+    <>
+      <Stack spacing={1}>
+        {queryDefinitions.map((query: TimeSeriesQueryDefinition, i: number) => (
+          <TimeSeriesQueryInput
+            key={i}
+            index={i}
+            query={query}
+            isCollapsed={!!queriesCollapsed[i]}
+            onChange={handleQueryChange}
+            onDelete={hasMoreThanOneQuery ? handleQueryDelete : undefined}
+            onCollapseExpand={handleQueryCollapseExpand}
+          />
+        ))}
+      </Stack>
+      <Button variant="contained" startIcon={<AddIcon />} sx={{ marginTop: 1 }} onClick={handleQueryAdd}>
         Add Query
       </Button>
-      {queryDefinitions.map((query: TimeSeriesQueryDefinition, i: number) => (
-        <TimeSeriesQueryInput
-          key={i}
-          index={i}
-          query={query}
-          isCollapsed={!!queriesCollapsed[i]}
-          onChange={handleQueryChange}
-          onDelete={hasMoreThanOneQuery ? handleQueryDelete : undefined}
-          onCollapseExpand={handleQueryCollapseExpand}
-        />
-      ))}
-    </Stack>
+    </>
   );
 }


### PR DESCRIPTION
# Description

Move the Add Query button in the Panel editor from top-right to bottom-left. It doesn't change much when you have 1 query defined or 2, but avoids lots of scrolling when you start to have more.

# Screenshots

![image](https://github.com/perses/perses/assets/7058693/00b5562a-b9f0-4d89-8977-82495b5cc0b4)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
