### PR TITLE
[ENHANCEMENT] several display improvements + bring back delete project button

### DIFF
--- a/ui/app/src/components/DashboardCard/DashboardCard.tsx
+++ b/ui/app/src/components/DashboardCard/DashboardCard.tsx
@@ -15,7 +15,7 @@ import { Button, Stack, Typography } from '@mui/material';
 import ViewDashboardIcon from 'mdi-material-ui/ViewDashboard';
 import { DashboardResource } from '@perses-dev/core';
 import { getDashboardDisplayName } from '@perses-dev/core/dist/utils/text';
-import FolderPoundIcon from 'mdi-material-ui/FolderPound';
+import Archive from 'mdi-material-ui/Archive';
 import { Link as RouterLink } from 'react-router-dom';
 
 interface DashboardCardProps {
@@ -43,7 +43,7 @@ export function DashboardCard(props: DashboardCardProps) {
             {getDashboardDisplayName(props.dashboard)}
           </Typography>
           <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, textAlign: 'start' }}>
-            <FolderPoundIcon fontSize={'small'} /> {props.dashboard.metadata.project}
+            <Archive fontSize={'small'} /> {props.dashboard.metadata.project}
           </Typography>
         </Stack>
       </Stack>

--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -31,7 +31,7 @@ import {
 import ChevronDown from 'mdi-material-ui/ChevronDown';
 import AutoFix from 'mdi-material-ui/AutoFix';
 import Cog from 'mdi-material-ui/Cog';
-import Folder from 'mdi-material-ui/Folder';
+import Archive from 'mdi-material-ui/Archive';
 import ShieldAccount from 'mdi-material-ui/ShieldAccount';
 import Menu from 'mdi-material-ui/Menu';
 import React, { MouseEvent, useState } from 'react';
@@ -128,7 +128,7 @@ function ProjectMenu(): JSX.Element {
         color="inherit"
         onClick={handleMenu}
       >
-        <Folder sx={{ marginRight: 0.5 }} />
+        <Archive sx={{ marginRight: 0.5 }} />
         Projects
         <ChevronDown />
       </Button>

--- a/ui/app/src/components/breadcrumbs/AppBreadcrumbs.tsx
+++ b/ui/app/src/components/breadcrumbs/AppBreadcrumbs.tsx
@@ -11,34 +11,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Breadcrumbs, Link, Typography, styled } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
+import { Breadcrumbs, HomeLinkCrumb, StackCrumb, TitleCrumb } from './breadcrumbs';
 
 interface AppBreadcrumbsProps {
   rootPageName: string;
+  icon: React.ReactNode;
 }
-
-export function HomeLinkBreadcrumb() {
-  return (
-    <Link underline={'hover'} variant={'h3'} component={RouterLink} to={'/'}>
-      Home
-    </Link>
-  );
-}
-
-export const StyledBreadcrumbs = styled(Breadcrumbs)({
-  fontSize: 'large',
-  paddingLeft: 0.5,
-  lineHeight: '30px',
-});
 
 function AppBreadcrumbs(props: AppBreadcrumbsProps) {
-  const { rootPageName } = props;
+  const { rootPageName, icon } = props;
   return (
-    <StyledBreadcrumbs sx={{ fontSize: 'large' }}>
-      <HomeLinkBreadcrumb />
-      <Typography variant={'h3'}>{rootPageName}</Typography>
-    </StyledBreadcrumbs>
+    <Breadcrumbs>
+      <HomeLinkCrumb />
+      <StackCrumb>
+        {icon}
+        <TitleCrumb>{rootPageName}</TitleCrumb>
+      </StackCrumb>
+    </Breadcrumbs>
   );
 }
 

--- a/ui/app/src/components/breadcrumbs/ProjectBreadcrumbs.tsx
+++ b/ui/app/src/components/breadcrumbs/ProjectBreadcrumbs.tsx
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Link, Typography } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
-import { HomeLinkBreadcrumb, StyledBreadcrumbs } from './AppBreadcrumbs';
+import { Typography } from '@mui/material';
+import Archive from 'mdi-material-ui/Archive';
+import ViewDashboardIcon from 'mdi-material-ui/ViewDashboard';
+import { HomeLinkCrumb, Breadcrumbs, LinkCrumb, StackCrumb, TitleCrumb } from './breadcrumbs';
 
 interface ProjectBreadcrumbsProps {
   projectName: string;
@@ -25,20 +26,30 @@ function ProjectBreadcrumbs(props: ProjectBreadcrumbsProps) {
 
   if (dashboardName) {
     return (
-      <StyledBreadcrumbs sx={{ fontSize: 'large' }}>
-        <HomeLinkBreadcrumb />
-        <Link underline={'hover'} variant={'h3'} component={RouterLink} to={`/projects/${projectName}`}>
-          {projectName}
-        </Link>
-        <Typography variant={'h3'}>{dashboardName}</Typography>
-      </StyledBreadcrumbs>
+      <Breadcrumbs>
+        <HomeLinkCrumb />
+        <LinkCrumb to={`/projects/${projectName}`}>
+          <StackCrumb>
+            <Archive fontSize={'small'} />
+            {projectName}
+          </StackCrumb>
+        </LinkCrumb>
+        <StackCrumb>
+          <ViewDashboardIcon fontSize={'small'} />
+          <Typography variant={'h3'}>{dashboardName}</Typography>
+        </StackCrumb>
+      </Breadcrumbs>
     );
   }
+
   return (
-    <StyledBreadcrumbs sx={{ fontSize: 'large' }}>
-      <HomeLinkBreadcrumb />
-      <Typography variant={'h3'}>{projectName}</Typography>
-    </StyledBreadcrumbs>
+    <Breadcrumbs>
+      <HomeLinkCrumb />
+      <StackCrumb>
+        <Archive fontSize={'large'} />
+        <TitleCrumb>{projectName}</TitleCrumb>
+      </StackCrumb>
+    </Breadcrumbs>
   );
 }
 

--- a/ui/app/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/ui/app/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,67 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Breadcrumbs as MUIBreadcrumbs, Link, styled, Stack, Typography } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+const BREADCRUMB_HEIGHT = '35px';
+
+export const Breadcrumbs = styled(MUIBreadcrumbs)({
+  fontSize: 'large',
+  paddingLeft: 0.5,
+  height: BREADCRUMB_HEIGHT,
+  lineHeight: BREADCRUMB_HEIGHT,
+});
+
+export function HomeLinkCrumb() {
+  return <LinkCrumb to={'/'}>Home</LinkCrumb>;
+}
+
+export interface StackCrumbProps {
+  children?: React.ReactNode;
+}
+
+export function StackCrumb(props: StackCrumbProps) {
+  const { children } = props;
+
+  return (
+    <Stack direction="row" alignItems="center" gap={0.5}>
+      {children}
+    </Stack>
+  );
+}
+
+export interface LinkCrumbProps {
+  children?: React.ReactNode;
+  to: string;
+}
+
+export function LinkCrumb(props: LinkCrumbProps) {
+  const { children, to } = props;
+
+  return (
+    <Link underline={'hover'} variant={'h3'} component={RouterLink} to={to}>
+      {children}
+    </Link>
+  );
+}
+
+export interface TitleCrumbProps {
+  children?: React.ReactNode;
+}
+
+export function TitleCrumb(props: TitleCrumbProps) {
+  const { children } = props;
+
+  return <Typography variant="h1">{children}</Typography>;
+}

--- a/ui/app/src/components/tabs.tsx
+++ b/ui/app/src/components/tabs.tsx
@@ -11,20 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Stack } from '@mui/material';
-import ShieldAccount from 'mdi-material-ui/ShieldAccount';
-import { useParams } from 'react-router-dom';
-import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
-import { AdminTabs } from './AdminTabs';
+import { Tab, Tabs, styled } from '@mui/material';
 
-function AdminView() {
-  const { tab } = useParams();
-  return (
-    <Stack sx={{ width: '100%' }} mx={2} mb={2} mt={1.5} gap={1}>
-      <AppBreadcrumbs rootPageName="Administration" icon={<ShieldAccount fontSize={'large'} />} />
-      <AdminTabs initialTab={tab} />
-    </Stack>
-  );
-}
+export const MENU_TABS_HEIGHT = '54px';
 
-export default AdminView;
+export const MenuTabs = styled(Tabs)({
+  minHeight: MENU_TABS_HEIGHT,
+});
+
+export const MenuTab = styled(Tab)({
+  minHeight: MENU_TABS_HEIGHT,
+});

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Stack, Tab, Tabs } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { ReactNode, SyntheticEvent, useCallback, useState } from 'react';
 import CodeJsonIcon from 'mdi-material-ui/CodeJson';
 import DatabaseIcon from 'mdi-material-ui/Database';
@@ -30,6 +30,7 @@ import { useCreateGlobalVariableMutation } from '../../model/global-variable-cli
 import { useCreateGlobalDatasourceMutation } from '../../model/admin-client';
 import { DatasourceDrawer } from '../../components/datasource/DatasourceDrawer';
 import { useIsReadonly } from '../../model/config-client';
+import { MenuTab, MenuTabs } from '../../components/tabs';
 import { GlobalVariables } from './tabs/GlobalVariables';
 import { GlobalDatasources } from './tabs/GlobalDatasources';
 import { GlobalSecrets } from './tabs/GlobalSecret';
@@ -201,29 +202,29 @@ export function AdminTabs(props: AdminTabsProps) {
         justifyContent="space-between"
         sx={{ borderBottom: 1, borderColor: 'divider' }}
       >
-        <Tabs value={value} onChange={handleChange} aria-label="Admin tabs">
-          <Tab
+        <MenuTabs value={value} onChange={handleChange} aria-label="Admin tabs">
+          <MenuTab
             label="Global variables"
             icon={<CodeJsonIcon />}
             iconPosition="start"
             {...a11yProps(variablesTabIndex)}
             value={variablesTabIndex}
           />
-          <Tab
+          <MenuTab
             label="Global datasources"
             icon={<DatabaseIcon />}
             iconPosition="start"
             {...a11yProps(datasourcesTabIndex)}
             value={datasourcesTabIndex}
           />
-          <Tab
+          <MenuTab
             label="Global secrets"
             icon={<KeyIcon />}
             iconPosition="start"
             {...a11yProps(secretsTabIndex)}
             value={secretsTabIndex}
           />
-        </Tabs>
+        </MenuTabs>
         <TabButton index={value} />
       </Stack>
       <TabPanel value={value} index={variablesTabIndex}>

--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -11,25 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, CircularProgress, Stack, Typography } from '@mui/material';
+import { CircularProgress, Stack } from '@mui/material';
 import Cog from 'mdi-material-ui/Cog';
 import { JSONEditor } from '@perses-dev/components';
-import AppBreadcrumbs from '../../components/AppBreadcrumbs';
+import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
 import { useConfig } from '../../model/config-client';
 
 function ConfigView() {
   const { data, isLoading } = useConfig();
   return (
-    <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <AppBreadcrumbs rootPageName="Configuration" />
-      <Box>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Stack direction="row" alignItems="center" gap={1}>
-            <Cog fontSize={'large'} />
-            <Typography variant="h1">Configuration</Typography>
-          </Stack>
-        </Stack>
-      </Box>
+    <Stack sx={{ width: '100%' }} mx={2} mb={2} mt={1.5} gap={2}>
+      <AppBreadcrumbs rootPageName="Configuration" icon={<Cog fontSize={'large'} />} />
       {isLoading && (
         <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
           <CircularProgress />

--- a/ui/app/src/views/home/HomeView.tsx
+++ b/ui/app/src/views/home/HomeView.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Breadcrumbs, Grid, Stack, Typography } from '@mui/material';
+import { Box, Grid, Stack } from '@mui/material';
 import { useMemo, useState } from 'react';
 import HomeIcon from 'mdi-material-ui/Home';
 import { useNavigate } from 'react-router-dom';
@@ -19,6 +19,7 @@ import { DashboardSelector, ProjectResource } from '@perses-dev/core';
 import { useProjectList } from '../../model/project-client';
 import { CreateProjectDialog, CreateDashboardDialog } from '../../components/dialogs';
 import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
+import { StackCrumb, TitleCrumb } from '../../components/breadcrumbs/breadcrumbs';
 import { InformationSection } from './InformationSection';
 import { RecentDashboards } from './RecentDashboards';
 import { ProjectsAndDashboards } from './ProjectsAndDashboards';
@@ -56,16 +57,13 @@ function HomeView() {
   };
 
   return (
-    <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <Breadcrumbs sx={{ fontSize: 'large' }}>
-        <Typography variant={'h3'}>Home</Typography>
-      </Breadcrumbs>
+    <Stack sx={{ width: '100%' }} m={2} gap={1}>
       <Box sx={{ width: '100%' }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Stack direction="row" alignItems="center" gap={1}>
+          <StackCrumb>
             <HomeIcon fontSize={'large'} />
-            <Typography variant="h1">Home</Typography>
-          </Stack>
+            <TitleCrumb>Home</TitleCrumb>
+          </StackCrumb>
           <Stack direction="row" gap={2}>
             <CRUDButton text="Add Project" variant="contained" onClick={handleAddProjectDialogOpen} />
             <CRUDButton

--- a/ui/app/src/views/home/ProjectsAndDashboards.tsx
+++ b/ui/app/src/views/home/ProjectsAndDashboards.tsx
@@ -27,7 +27,7 @@ import { ChangeEvent, MouseEvent, useCallback, useMemo, useState } from 'react';
 import { DashboardResource } from '@perses-dev/core';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import ChevronDown from 'mdi-material-ui/ChevronDown';
-import FolderPoundIcon from 'mdi-material-ui/FolderPound';
+import Archive from 'mdi-material-ui/Archive';
 import DeleteOutline from 'mdi-material-ui/DeleteOutline';
 import { Link as RouterLink } from 'react-router-dom';
 import { KVSearch } from '@nexucis/kvsearch';
@@ -71,7 +71,7 @@ function RenderDashboardList(props: RenderDashboardListProps) {
           <AccordionSummary expandIcon={<ChevronDown />}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
               <Stack direction="row" alignItems="center" gap={1}>
-                <FolderPoundIcon />
+                <Archive />
                 <Link component={RouterLink} to={projectLink} variant="h3" underline="hover">
                   {row.project}
                 </Link>

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Stack, Tab, Tabs } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { ReactNode, SyntheticEvent, useCallback, useState } from 'react';
 import ViewDashboardIcon from 'mdi-material-ui/ViewDashboard';
 import CodeJsonIcon from 'mdi-material-ui/CodeJson';
@@ -33,6 +33,7 @@ import { DatasourceDrawer } from '../../components/datasource/DatasourceDrawer';
 import { useCreateDatasourceMutation } from '../../model/datasource-client';
 import { useCreateVariableMutation } from '../../model/variable-client';
 import { useIsReadonly } from '../../model/config-client';
+import { MenuTab, MenuTabs } from '../../components/tabs';
 import { ProjectDashboards } from './tabs/ProjectDashboards';
 import { ProjectVariables } from './tabs/ProjectVariables';
 import { ProjectDatasources } from './tabs/ProjectDatasources';
@@ -223,36 +224,36 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
         justifyContent="space-between"
         sx={{ borderBottom: 1, borderColor: 'divider' }}
       >
-        <Tabs value={value} onChange={handleChange} aria-label="Project tabs">
-          <Tab
+        <MenuTabs value={value} onChange={handleChange} aria-label="Project tabs">
+          <MenuTab
             label="Dashboards"
             icon={<ViewDashboardIcon />}
             iconPosition="start"
             {...a11yProps(dashboardsTabIndex)}
             value={dashboardsTabIndex}
           />
-          <Tab
+          <MenuTab
             label="Variables"
             icon={<CodeJsonIcon />}
             iconPosition="start"
             {...a11yProps(variablesTabIndex)}
             value={variablesTabIndex}
           />
-          <Tab
+          <MenuTab
             label="Datasources"
             icon={<DatabaseIcon />}
             iconPosition="start"
             {...a11yProps(datasourcesTabIndex)}
             value={datasourcesTabIndex}
           />
-          <Tab
+          <MenuTab
             label="Secrets"
             icon={<KeyIcon />}
             iconPosition="start"
             {...a11yProps(secretsTabIndex)}
             value={secretsTabIndex}
           />
-        </Tabs>
+        </MenuTabs>
         <TabButton index={value} projectName={projectName} />
       </Stack>
       <TabPanel value={value} index={dashboardsTabIndex}>

--- a/ui/app/src/views/projects/ProjectView.tsx
+++ b/ui/app/src/views/projects/ProjectView.tsx
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 import { useNavigate, useParams } from 'react-router-dom';
-import { Box, Stack, Typography, Grid } from '@mui/material';
-import FolderPound from 'mdi-material-ui/FolderPound';
+import { Box, Stack, Grid } from '@mui/material';
 import { useCallback, useState } from 'react';
 import { DeleteProjectDialog } from '../../components/dialogs';
-import ProjectBreadcrumbs from '../../components/ProjectBreadcrumbs';
+import ProjectBreadcrumbs from '../../components/breadcrumbs/ProjectBreadcrumbs';
+import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
 import { RecentlyViewedDashboards } from './RecentlyViewedDashboards';
 import { ProjectTabs } from './ProjectTabs';
 
@@ -35,21 +35,23 @@ function ProjectView() {
   const [isDeleteProjectDialogOpen, setIsDeleteProjectDialogOpen] = useState<boolean>(false);
 
   return (
-    <Stack sx={{ width: '100%' }} m={2} gap={2}>
-      <ProjectBreadcrumbs projectName={projectName} />
-      <Box>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Stack direction="row" alignItems="center" gap={1}>
-            <FolderPound fontSize={'large'} />
-            <Typography variant="h1">{projectName}</Typography>
-          </Stack>
-          <DeleteProjectDialog
-            name={projectName}
-            open={isDeleteProjectDialogOpen}
-            onClose={() => setIsDeleteProjectDialogOpen(false)}
-            onSuccess={handleDeleteProjectDialogSuccess}
+    <Stack sx={{ width: '100%' }} mx={2} mb={2} mt={1.5} gap={1}>
+      <Box display="flex" justifyContent="space-between">
+        <ProjectBreadcrumbs projectName={projectName} />
+        <Box mt={0.5}>
+          <CRUDButton
+            text="Delete Project"
+            variant="outlined"
+            color="error"
+            onClick={() => setIsDeleteProjectDialogOpen(true)}
           />
-        </Stack>
+        </Box>
+        <DeleteProjectDialog
+          name={projectName}
+          open={isDeleteProjectDialogOpen}
+          onClose={() => setIsDeleteProjectDialogOpen(false)}
+          onSuccess={handleDeleteProjectDialogSuccess}
+        />
       </Box>
       <Grid container columnSpacing={8}>
         <Grid item xs={12} lg={8}>

--- a/ui/app/src/views/projects/RecentlyViewedDashboards.tsx
+++ b/ui/app/src/views/projects/RecentlyViewedDashboards.tsx
@@ -16,6 +16,7 @@ import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import HistoryIcon from 'mdi-material-ui/History';
 import { useRecentDashboardList } from '../../model/dashboard-client';
 import { RecentDashboardList } from '../../components/DashboardList/RecentDashboardList';
+import { MENU_TABS_HEIGHT } from '../../components/tabs';
 
 interface RecentlyViewedDashboardsProps {
   projectName: string;
@@ -28,18 +29,24 @@ export function RecentlyViewedDashboards(props: RecentlyViewedDashboardsProps) {
   return (
     <Box id={props.id}>
       <Stack
+        alignItems="center"
         sx={{
           borderBottom: 1,
           borderColor: 'divider',
-          width: '100%',
-          height: '72px',
-          justifyContent: 'space-between',
-          flexDirection: 'row',
         }}
       >
-        <Stack direction="row" alignItems="center" gap={1} my={2}>
+        <Stack
+          alignItems="center"
+          sx={{
+            width: '100%',
+            height: MENU_TABS_HEIGHT,
+            flexDirection: 'row',
+          }}
+        >
           <HistoryIcon />
-          <Typography variant="h3">Recently Viewed Dashboards</Typography>
+          <Typography ml={1} variant="h3">
+            Recently Viewed Dashboards
+          </Typography>
         </Stack>
       </Stack>
       <ErrorBoundary FallbackComponent={ErrorAlert}>

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -22,7 +22,7 @@ import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasourc
 import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
 import { useVariableList } from '../../../model/variable-client';
 import { useGlobalVariableList } from '../../../model/global-variable-client';
-import ProjectBreadcrumbs from '../../../components/ProjectBreadcrumbs';
+import ProjectBreadcrumbs from '../../../components/breadcrumbs/ProjectBreadcrumbs';
 
 export interface GenericDashboardViewProps {
   dashboardResource: DashboardResource;

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -62,9 +62,9 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
     <>
       {isEditMode ? (
         <Stack spacing={1} data-testid={testId}>
-          <Box px={2} py={1} display="flex" sx={{ backgroundColor: (theme) => theme.palette.primary.main + '30' }}>
+          <Box px={2} py={1.5} display="flex" sx={{ backgroundColor: (theme) => theme.palette.primary.main + '30' }}>
             {dashboardTitle}
-            <Stack direction="row" spacing={1} marginLeft="auto">
+            <Stack direction="row" gap={1} ml="auto">
               {isReadonly && (
                 <Alert severity={'warning'} sx={{ backgroundColor: 'transparent', padding: 0 }}>
                   Dashboard managed via code only. Download JSON and commit changes to save.
@@ -107,7 +107,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
           </Box>
         </Stack>
       ) : (
-        <Stack spacing={1} px={2} pt={1} data-testid={testId}>
+        <Stack gap={1} mx={2} mt={1.5} data-testid={testId}>
           <Box sx={{ display: 'flex', width: '100%' }}>
             {dashboardTitle}
             <Stack direction="row" spacing={1} marginLeft="auto">
@@ -116,7 +116,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
               {isBiggerThanSm && <EditButton onClick={onEditButtonClick} />}
             </Stack>
           </Box>
-          <Box>
+          <Box mt={1}>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
               <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}


### PR DESCRIPTION
# Description

This PR:
- merges the section title with the breadcrumb on all pages (Admin, Project etc.) to save some vertical space
![image](https://github.com/perses/perses/assets/7058693/00fc7b7f-084a-4896-b1b9-661e0677d2d1)
- reduces the tabs size on the project & admin page (see above screenshots)
- changes the project icon from "folder" to archive" (see above screenshots)
- adds icons in the dashboard breadcrumb
![2023-11-16_09h37_05](https://github.com/perses/perses/assets/7058693/95228c23-a3a4-4922-a709-572ee79dd586)
- brings back the delete project button on the Project page, which was unintentionally removed by https://github.com/perses/perses/pull/1267
![image](https://github.com/perses/perses/assets/7058693/5c43c336-e49c-4e11-897d-5a12c15a7951)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
