### PR TITLE
[ENHANCEMENT] Submit sign-in & sign-up forms on pressing Enter key

### DIFF
--- a/ui/app/src/views/auth/SignInView.tsx
+++ b/ui/app/src/views/auth/SignInView.tsx
@@ -41,16 +41,12 @@ function SignInView() {
     );
   };
 
-  const canSignInUser = () => {
-    if (authMutation.isLoading || login === '' || password === '') {
-      return false;
-    }
-
-    return true;
+  const isSignInDisabled = () => {
+    return authMutation.isLoading || login === '' || password === '';
   };
 
   const handleKeypress = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!canSignInUser()) {
+    if (isSignInDisabled()) {
       return;
     }
 
@@ -70,7 +66,7 @@ function SignInView() {
         onChange={(e) => setPassword(e.target.value)}
         onKeyPress={handleKeypress}
       />
-      <Button variant="contained" disabled={!canSignInUser()} onClick={() => handleLogin()}>
+      <Button variant="contained" disabled={isSignInDisabled()} onClick={() => handleLogin()}>
         Sign in
       </Button>
       {authMutation.isLoading && <LinearProgress />}

--- a/ui/app/src/views/auth/SignInView.tsx
+++ b/ui/app/src/views/auth/SignInView.tsx
@@ -41,15 +41,36 @@ function SignInView() {
     );
   };
 
+  const canSignInUser = () => {
+    if (authMutation.isLoading || login === '' || password === '') {
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleKeypress = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!canSignInUser()) {
+      return;
+    }
+
+    // Sign in on pressing Enter button
+    if (e.charCode === 13) {
+      handleLogin();
+    }
+  };
+
   return (
     <SignWrapper>
-      <TextField label="Username" required onChange={(e) => setLogin(e.target.value)} />
-      <TextField type="password" label="Password" required onChange={(e) => setPassword(e.target.value)} />
-      <Button
-        variant="contained"
-        disabled={authMutation.isLoading || login === '' || password === ''}
-        onClick={() => handleLogin()}
-      >
+      <TextField label="Username" required onChange={(e) => setLogin(e.target.value)} onKeyPress={handleKeypress} />
+      <TextField
+        type="password"
+        label="Password"
+        required
+        onChange={(e) => setPassword(e.target.value)}
+        onKeyPress={handleKeypress}
+      />
+      <Button variant="contained" disabled={!canSignInUser()} onClick={() => handleLogin()}>
         Sign in
       </Button>
       {authMutation.isLoading && <LinearProgress />}

--- a/ui/app/src/views/auth/SignUpView.tsx
+++ b/ui/app/src/views/auth/SignUpView.tsx
@@ -47,19 +47,36 @@ function SignUpView() {
     );
   };
 
+  const isSignUpDisabled = () => {
+    return createUserMutation.isLoading || login === '' || password === '';
+  };
+
+  const handleKeypress = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isSignUpDisabled()) {
+      return;
+    }
+
+    // Sign up on pressing Enter button
+    if (e.charCode === 13) {
+      handleRegister();
+    }
+  };
+
   return (
     <SignWrapper>
       <Stack direction="row" gap={1}>
-        <TextField label="First name" onChange={(e) => setFirstname(e.target.value)} />
-        <TextField label="Last name" onChange={(e) => setLastname(e.target.value)} />
+        <TextField label="First name" onChange={(e) => setFirstname(e.target.value)} onKeyPress={handleKeypress} />
+        <TextField label="Last name" onChange={(e) => setLastname(e.target.value)} onKeyPress={handleKeypress} />
       </Stack>
-      <TextField label="Username" required onChange={(e) => setLogin(e.target.value)} />
-      <TextField type="password" label="Password" required onChange={(e) => setPassword(e.target.value)} />
-      <Button
-        variant="contained"
-        disabled={createUserMutation.isLoading || login === '' || password === ''}
-        onClick={() => handleRegister()}
-      >
+      <TextField label="Username" required onChange={(e) => setLogin(e.target.value)} onKeyPress={handleKeypress} />
+      <TextField
+        type="password"
+        label="Password"
+        required
+        onChange={(e) => setPassword(e.target.value)}
+        onKeyPress={handleKeypress}
+      />
+      <Button variant="contained" disabled={isSignUpDisabled()} onClick={() => handleRegister()}>
         Register
       </Button>
       {createUserMutation.isLoading && <LinearProgress />}


### PR DESCRIPTION
# Description

This PR adds the ability for users to sign in and sign up by hitting the `Enter` key after entering their username & password.
Before this a user has to switch from the keyboard to the mouse and click the "Sign in" / "Register" button, which is inconvenient.

IMPORTANT: Currently this is only my idea how to do it as I'm not very familiar in React. Any feedback is appreciated. I also tried using an HTML `<form>` but it breaks the design, hence this a bit more complex approach.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
