### PR TITLE
[BUGFIX] Fix broken import on Explore view + some display adjustments

### DIFF
--- a/ui/app/src/views/projects/explore/ExploreView.tsx
+++ b/ui/app/src/views/projects/explore/ExploreView.tsx
@@ -12,8 +12,9 @@
 // limitations under the License.
 
 import { DashboardResource, DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL } from '@perses-dev/core';
+import Compass from 'mdi-material-ui/Compass';
 import { generateMetadataName } from '../../../utils/metadata';
-import AppBreadcrumbs from '../../../components/AppBreadcrumbs';
+import AppBreadcrumbs from '../../../components/breadcrumbs/AppBreadcrumbs';
 import ProjectExploreView from './ProjectExploreView';
 
 const DEFAULT_DASHBOARD_NAME = 'Explore Page';
@@ -41,7 +42,7 @@ function ExploreView() {
   return (
     <ProjectExploreView
       dashboardResource={dashboardResource}
-      exploreTitleComponent={<AppBreadcrumbs rootPageName="Explore" />}
+      exploreTitleComponent={<AppBreadcrumbs rootPageName="Explore" icon={<Compass fontSize={'large'} />} />}
     />
   );
 }

--- a/ui/explore/src/components/ExploreToolbar/ExploreToolbar.tsx
+++ b/ui/explore/src/components/ExploreToolbar/ExploreToolbar.tsx
@@ -11,43 +11,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Stack, Box, useTheme, useMediaQuery, Button } from '@mui/material';
+import { Stack, Box, useTheme, useMediaQuery } from '@mui/material';
 import { TimeRangeControls } from '@perses-dev/dashboards';
-import AddIcon from 'mdi-material-ui/Plus';
 
 export interface ExploreToolbarProps {
   exploreTitleComponent?: JSX.Element;
-  onQueryAdd: () => void;
 }
 
 export const ExploreToolbar = (props: ExploreToolbarProps) => {
-  const { exploreTitleComponent, onQueryAdd } = props;
+  const { exploreTitleComponent } = props;
 
   const isBiggerThanLg = useMediaQuery(useTheme().breakpoints.up('lg'));
 
   const testId = 'explore-toolbar';
 
   return (
-    <Stack spacing={1} data-testid={testId}>
-      <Box px={2} py={1} display="flex">
+    <Stack data-testid={testId}>
+      <Box sx={{ display: 'flex', width: '100%' }}>
         {exploreTitleComponent}
-      </Box>
-
-      <Box
-        sx={{
-          display: 'flex',
-          width: '100%',
-          alignItems: 'start',
-          paddingX: 2,
-        }}
-      >
-        <Stack ml="auto" direction="row" flexWrap={isBiggerThanLg ? 'nowrap' : 'wrap-reverse'} justifyContent="end">
-          <Stack direction="row" spacing={1} ml={1}>
-            <TimeRangeControls />
-            <Button variant="contained" startIcon={<AddIcon />} sx={{ marginLeft: 'auto' }} onClick={onQueryAdd}>
-              Add Query
-            </Button>
-          </Stack>
+        <Stack
+          direction="row"
+          spacing={1}
+          ml="auto"
+          flexWrap={isBiggerThanLg ? 'nowrap' : 'wrap-reverse'}
+          justifyContent="end"
+        >
+          <TimeRangeControls />
         </Stack>
       </Box>
     </Stack>

--- a/ui/explore/src/components/PanelEditor/PanelEditorForm.tsx
+++ b/ui/explore/src/components/PanelEditor/PanelEditorForm.tsx
@@ -14,7 +14,8 @@
 import { PanelEditorValues, PanelPreview } from '@perses-dev/dashboards';
 import { Action, usePluginEditor } from '@perses-dev/plugin-system';
 import { FormProvider, useForm } from 'react-hook-form';
-import { Box, Grid, Typography } from '@mui/material';
+import { Button, Grid, Stack, Typography } from '@mui/material';
+import AddIcon from 'mdi-material-ui/Plus';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { Definition, PanelDefinition, QueryDefinition, UnknownSpec } from '@perses-dev/core';
 import { SetStateAction } from 'react';
@@ -76,37 +77,36 @@ export function PanelEditorForm(props: PanelEditorProps) {
   });
 
   return (
-    <>
-      <ExploreToolbar exploreTitleComponent={exploreTitleComponent} onQueryAdd={handleQueryAdd} />
+    <Stack sx={{ width: '100%' }} px={2} pb={2} pt={1.5} gap={2}>
+      <ExploreToolbar exploreTitleComponent={exploreTitleComponent} />
       <FormProvider {...form}>
         <Grid container spacing={2}>
           <Grid item xs={12}>
-            {/* Maybe in the future we should have something like PanelSpecEditor as we have on the Dashboard System */}
-            <TimeSeriesQueryEditor
-              handleQueryChange={handleQueryChange}
-              handleQueryCollapseExpand={handleQueryCollapseExpand}
-              handleQueryDelete={handleQueryDelete}
-              queriesCollapsed={queriesCollapsed}
-              queries={queries}
-              defaultTimeSeriesQueryKind={defaultTimeSeriesQueryKind}
-            />
+            <Stack gap={1}>
+              {/* Maybe in the future we should have something like PanelSpecEditor as we have on the Dashboard System */}
+              <TimeSeriesQueryEditor
+                handleQueryChange={handleQueryChange}
+                handleQueryCollapseExpand={handleQueryCollapseExpand}
+                handleQueryDelete={handleQueryDelete}
+                queriesCollapsed={queriesCollapsed}
+                queries={queries}
+                defaultTimeSeriesQueryKind={defaultTimeSeriesQueryKind}
+              />
+              <Button variant="contained" startIcon={<AddIcon />} sx={{ marginRight: 'auto' }} onClick={handleQueryAdd}>
+                Add Query
+              </Button>
+            </Stack>
           </Grid>
           <Grid item xs={12}>
-            <Box
-              sx={{
-                paddingX: 1,
-              }}
-            >
-              <Typography variant="h4" marginBottom={1}>
-                Preview
-              </Typography>
+            <Stack gap={1}>
+              <Typography variant="h4">Preview</Typography>
               <ErrorBoundary FallbackComponent={ErrorAlert}>
                 <PanelPreview panelDefinition={panelDefinition} />
               </ErrorBoundary>
-            </Box>
+            </Stack>
           </Grid>
         </Grid>
       </FormProvider>
-    </>
+    </Stack>
   );
 }

--- a/ui/explore/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
+++ b/ui/explore/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from '@mui/material';
 import { QueryDefinition, TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { TimeSeriesQueryInput } from './TimeSeriesQueryInput';
 
@@ -52,11 +51,7 @@ export function TimeSeriesQueryEditor(props: TimeSeriesQueryEditorProps) {
       ];
 
   return (
-    <Box
-      sx={{
-        padding: (theme) => theme.spacing(1),
-      }}
-    >
+    <>
       {queryDefinitions.map((query: TimeSeriesQueryDefinition, i: number) => (
         <TimeSeriesQueryInput
           key={i}
@@ -68,6 +63,6 @@ export function TimeSeriesQueryEditor(props: TimeSeriesQueryEditorProps) {
           onCollapseExpand={handleQueryCollapseExpand}
         />
       ))}
-    </Box>
+    </>
   );
 }

--- a/ui/explore/src/views/ViewExplore/ViewExploreApp.tsx
+++ b/ui/explore/src/views/ViewExplore/ViewExploreApp.tsx
@@ -51,11 +51,9 @@ export function ViewExploreApp(props: ViewAppProps) {
         flexDirection: 'column',
       }}
     >
-      <Box sx={{ padding: (theme) => theme.spacing(1), height: '100%' }}>
-        <ChartsProvider chartsTheme={chartsTheme} enablePinning={false}>
-          <PanelEditorForm initialAction="update" initialValues={data} exploreTitleComponent={exploreTitleComponent} />
-        </ChartsProvider>
-      </Box>
+      <ChartsProvider chartsTheme={chartsTheme} enablePinning={false}>
+        <PanelEditorForm initialAction="update" initialValues={data} exploreTitleComponent={exploreTitleComponent} />
+      </ChartsProvider>
     </Box>
   );
 }


### PR DESCRIPTION
# Description

![image](https://github.com/perses/perses/assets/7058693/80ed9de2-8202-4bc6-b6fd-c8b3f291d9cd)
This build issue arrived on the main branch because https://github.com/perses/perses/pull/1590 was not rebased on latest main state after https://github.com/perses/perses/pull/1477 was merged..

I also did some adjustments to the Explore page layout at the same time (align breadcrumb & base margin with the other pages + move Add Query button down).

# Screenshots

![image](https://github.com/perses/perses/assets/7058693/af8fe7cc-7396-4974-904b-127d7a1bb912)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
