### PR TITLE
[ENHANCEMENT] Implement the `healthcheck` method for Prometheus datasources

### DIFF
--- a/ui/prometheus-plugin/src/model/prometheus-client.ts
+++ b/ui/prometheus-plugin/src/model/prometheus-client.ts
@@ -44,6 +44,22 @@ export interface QueryOptions {
 }
 
 /**
+ * Calls the `/-/healthy` endpoint to check if the datasource is healthy.
+ */
+export function healthCheck(queryOptions: QueryOptions) {
+  return async () => {
+    const url = `${queryOptions.datasourceUrl}/-/healthy`;
+
+    try {
+      const resp = await fetch(url, { headers: queryOptions.headers });
+      return resp.status === 200;
+    } catch {
+      return false;
+    }
+  };
+}
+
+/**
  * Calls the `/api/v1/query` endpoint to get metrics data.
  */
 export function instantQuery(params: InstantQueryRequestParameters, queryOptions: QueryOptions) {

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
@@ -13,7 +13,7 @@
 
 import { BuiltinVariableDefinition } from '@perses-dev/core';
 import { DatasourcePlugin } from '@perses-dev/plugin-system';
-import { instantQuery, rangeQuery, labelNames, labelValues, PrometheusClient } from '../model';
+import { healthCheck, instantQuery, rangeQuery, labelNames, labelValues, PrometheusClient } from '../model';
 import { PrometheusDatasourceSpec } from './types';
 import { PrometheusDatasourceEditor } from './PrometheusDatasourceEditor';
 
@@ -37,6 +37,7 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
     options: {
       datasourceUrl,
     },
+    healthCheck: healthCheck({ datasourceUrl, headers: specHeaders }),
     instantQuery: (params, headers) => instantQuery(params, { datasourceUrl, headers: headers ?? specHeaders }),
     rangeQuery: (params, headers) => rangeQuery(params, { datasourceUrl, headers: headers ?? specHeaders }),
     labelNames: (params, headers) => labelNames(params, { datasourceUrl, headers: headers ?? specHeaders }),


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

As a first step towards #1542 (and as my first PR, so feedback appreciated), this implements a healthcheck on Prometheus Datasources.

The `DatasourceClient` interface defines a `healthcheck` method, which
hasn't actually been implemented. This implements it for the `PrometheusDatasourceClient`
as a first step towards being able to test the health of a datasource.

The actual implementation calls the [/-/healthy](https://prometheus.io/docs/prometheus/latest/management_api/#health-check)
endpoint in the Prometheus API, rather than running a query. I figured
this was a better way to test the health rather than running a dummy
query and checking the result, as running a query is a more expensive
and subjects us to the vagaries of PromQL, and potential
query timeouts which aren't directly related to whether the datasource
is configured correctly.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).