### PR TITLE
[BUGFIX] Remove extra call to `setDatasourceDrawerOpened` in DatasourceList

### DIFF
--- a/ui/app/src/components/datasource/DatasourceList.tsx
+++ b/ui/app/src/components/datasource/DatasourceList.tsx
@@ -204,7 +204,7 @@ export function DatasourceList<T extends Datasource>(props: DatasourceListProper
             isOpen={isDatasourceDrawerOpened}
             action={action}
             isReadonly={isReadonly}
-            onSave={(v: T) => handleDatasourceUpdate(v).then(() => setDatasourceDrawerOpened(false))}
+            onSave={handleDatasourceUpdate}
             onDelete={onDelete}
             onClose={() => setDatasourceDrawerOpened(false)}
           />


### PR DESCRIPTION
# Description

In the `onSave` for the DataSourceDrawer in the DatasourceList, we call `handleDatasourceUpdate`, which calls `setDatasourceDrawerOpened` https://github.com/perses/perses/blob/1e889c657e2fba79b0ba2563e4aa972ed1d747c5/ui/app/src/components/datasource/DatasourceList.tsx#L80-L86, but we then call it again in the callback. This removes the extra call.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).