### PR TITLE
[BUGFIX] Fix marshalling authorisation config in json

### DIFF
--- a/internal/api/config/authorization.go
+++ b/internal/api/config/authorization.go
@@ -29,7 +29,7 @@ var (
 type jsonAuthorizationConfig struct {
 	EnableAuthorization bool               `json:"enable_authorization"`
 	Interval            string             `json:"interval,omitempty"`
-	GuestPermissions    []*role.Permission `json:"guest_permissions"`
+	GuestPermissions    []*role.Permission `json:"guest_permissions,omitempty"`
 }
 
 type AuthorizationConfig struct {
@@ -38,7 +38,7 @@ type AuthorizationConfig struct {
 	// Interval is the refresh frequency of the cache
 	Interval time.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
 	// Default permissions for guest users (logged-in users)
-	GuestPermissions []*role.Permission `json:"guest_permissions" yaml:"guest_permissions"`
+	GuestPermissions []*role.Permission `json:"guest_permissions,omitempty" yaml:"guest_permissions,omitempty"`
 }
 
 func (a *AuthorizationConfig) Verify() error {
@@ -51,9 +51,11 @@ func (a *AuthorizationConfig) Verify() error {
 	return nil
 }
 
-func (a *AuthorizationConfig) MarshalJSON() ([]byte, error) {
+func (a AuthorizationConfig) MarshalJSON() ([]byte, error) {
 	j := &jsonAuthorizationConfig{
-		Interval: a.Interval.String(),
+		EnableAuthorization: a.EnableAuthorization,
+		Interval:            a.Interval.String(),
+		GuestPermissions:    a.GuestPermissions,
 	}
 	return json.Marshal(j)
 }

--- a/internal/api/config/config_test.go
+++ b/internal/api/config/config_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func defaultConfig() Config {
+	cfg, _ := Resolve("")
+	return cfg
+}
+
+func TestJSONMarshallConfig(t *testing.T) {
+	testSuite := []struct {
+		title string
+		cfg   Config
+		jason string
+	}{
+		{
+			title: "empty config",
+			cfg:   Config{},
+			jason: `{
+  "security": {
+    "readonly": false,
+    "authorization": {
+      "enable_authorization": false,
+      "interval": "0s"
+    }
+  },
+  "database": {},
+  "schemas": {
+    "interval": "0s"
+  },
+  "provisioning": {
+    "interval": "0s"
+  }
+}`,
+		},
+		{
+			title: "default config",
+			cfg:   defaultConfig(),
+			jason: `{
+  "security": {
+    "readonly": false,
+    "encryption_key": "\u003csecret\u003e",
+    "authorization": {
+      "enable_authorization": false,
+      "interval": "10m0s"
+    }
+  },
+  "database": {
+    "file": {
+      "folder": "./local_db",
+      "extension": "yaml"
+    }
+  },
+  "schemas": {
+    "panels_path": "schemas/panels",
+    "queries_path": "schemas/queries",
+    "datasources_path": "schemas/datasources",
+    "variables_path": "schemas/variables",
+    "interval": "1h0m0s"
+  },
+  "provisioning": {
+    "interval": "1h0m0s"
+  }
+}`,
+		},
+	}
+
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			data, err := json.MarshalIndent(test.cfg, "", "  ")
+			assert.NoError(t, err)
+			assert.Equal(t, test.jason, string(data))
+		})
+	}
+}


### PR DESCRIPTION
Marshalling of the config didn't work well for the interval of the authorisation config. The interval wasn't marshall with the proper format (aka "10m0s")
