### PR TITLE
[ENHANCEMENT] add a default encryption key

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,11 +94,11 @@ Generic placeholders are defined as follows:
   # It contains any configuration that changes authorization behavior like default permissions
   [ authorization: <authorization_config> ]
 
-  # The secret key used to encrypt and decrypt sensitive data stored in the database such as any data in the Secret and GlobalSecret object.
-  # Note that if it is not provided, it will be generated. 
-  # When Perses is used in a multi instance mode, you should provide the key, otherwise, each instance will have a different key 
-  # and therefore won't be able to decrypt what the other is encrypting.
-  # Also note that the key must be at least 32 bytes long.
+  # The secret key used to encrypt and decrypt sensitive data stored in the database such as the password of the basic auth for a datasource.
+  # Note that if it is not provided, it will use a default value.
+  # When Perses is used in a multi instance mode, you should provide the key.
+  # Otherwise, each instance will have a different key and therefore won't be able to decrypt what the other is encrypting.
+  # Also note the key must be at least 32 bytes long.
   [ encryption_key: <secret> ]
 
   # The path to the file containing the secret key.

--- a/internal/api/config/security.go
+++ b/internal/api/config/security.go
@@ -16,48 +16,34 @@ package config
 import (
 	"encoding/hex"
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	promConfig "github.com/prometheus/common/config"
 	"github.com/sirupsen/logrus"
 )
 
-const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-func randomString(stringSize uint) string {
-	// gosec is yelling because we are using a weak random generator.
-	// We are generating a string for the encryption key as best effort so the docker image can run without pre-configuration.
-	// So it makes Perses easier to be tested.
-	// People should provide the secret key by their self in the regular flow.
-	// nolint:gosec
-	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	b := make([]byte, stringSize)
-	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
-	}
-	return string(b)
-}
+const defaultEncryptionKey = "e=dz;`M'5Pjvy^Sq3FVBkTC@N9?H/gua"
 
 type Security struct {
 	// Readonly will deactivate any HTTP POST, PUT, DELETE endpoint
 	Readonly bool `json:"readonly" yaml:"readonly"`
-	// EncryptionKey is the secret key used to encrypt and decrypt sensitive data stored in the database such as the password of the basic auth for a datasource
-	// Note that if it is not provided, it will be generated. When Perses is used in a multi instance mode, you should provide the key.
+	// EncryptionKey is the secret key used to encrypt and decrypt sensitive data
+	// stored in the database such as the password of the basic auth for a datasource.
+	// Note that if it is not provided, it will use a default value.
+	// When Perses is used in a multi instance mode, you should provide the key.
 	// Otherwise, each instance will have a different key and therefore won't be able to decrypt what the other is encrypting.
 	// Also note the key must be at least 32 bytes long.
 	EncryptionKey promConfig.Secret `json:"encryption_key,omitempty" yaml:"encryption_key,omitempty"`
 	// EncryptionKeyFile is the path to file containing the secret key
 	EncryptionKeyFile string `json:"encryption_key_file,omitempty" yaml:"encryption_key_file,omitempty"`
-	// Authorization contains all config around rbac (permissions and roles)
+	// Authorization contains all configs around rbac (permissions and roles)
 	Authorization AuthorizationConfig `json:"authorization" yaml:"authorization"`
 }
 
 func (s *Security) Verify() error {
 	if len(s.EncryptionKey) == 0 && len(s.EncryptionKeyFile) == 0 {
-		logrus.Warning("encryption_key is not provided and therefore will be generated. For production instance you should provide a fixed key")
-		s.EncryptionKey = promConfig.Secret(randomString(32))
+		logrus.Warning("encryption_key is not provided and therefore it will use a default one. For production instance you should provide the key.")
+		s.EncryptionKey = defaultEncryptionKey
 	}
 	if len(s.EncryptionKey) > 0 && len(s.EncryptionKeyFile) > 0 {
 		return fmt.Errorf("encryption_key and encryption_key_file are mutually exclusive. Use one or the other not both at the same time")


### PR DESCRIPTION
This PR is adding a default encryption key. I'm doing it that to avoid the situation when you are trying Perses and you reload the instance the encryption key is changing and you need to dumb the database because the backend cannot read it anymore.