### PR TITLE
[ENHANCEMENT] Prevent using dashboard datasources before they're saved

### DIFF
--- a/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
@@ -54,6 +54,7 @@ interface TestData {
     // datasources input. Considered empty if not defined
     datasources: {
       local: Record<string, DatasourceSpec | undefined>; // `| undefined` is to make jest accept the type as parametrizable
+      saved?: Record<string, DatasourceSpec | undefined>;
       project: Datasource[];
       global: Datasource[];
     };
@@ -130,6 +131,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
               {
                 name: 'localDatasourceA',
                 overridden: false,
+                saved: true,
                 selector: {
                   group: 'dashboard',
                   kind: FAKE_PLUGIN_KIND,
@@ -244,6 +246,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
               {
                 name: 'localDatasourceA',
                 overridden: false,
+                saved: true,
                 selector: {
                   group: 'dashboard',
                   kind: FAKE_PLUGIN_KIND,
@@ -380,6 +383,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 name: 'datasourceA',
                 overridden: false,
                 overriding: true,
+                saved: true,
                 selector: {
                   group: 'dashboard',
                   kind: FAKE_PLUGIN_KIND,
@@ -442,6 +446,51 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
         ],
       },
     },
+    {
+      title: 'datasource exists locally but not saved yet',
+      input: {
+        datasources: {
+          local: {
+            localDatasourceA: definedInDashboard({ default: false }),
+          },
+          saved: {},
+          project: [],
+          global: [],
+        },
+      },
+      expected: {
+        result: [
+          {
+            editLink: undefined,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            items: [
+              {
+                name: 'Default (localDatasourceA from dashboard)',
+                selector: {
+                  kind: FAKE_PLUGIN_KIND,
+                },
+              },
+            ],
+          },
+          {
+            editLink: undefined,
+            group: 'dashboard',
+            items: [
+              {
+                name: 'localDatasourceA',
+                overridden: false,
+                saved: false,
+                selector: {
+                  group: 'dashboard',
+                  kind: FAKE_PLUGIN_KIND,
+                  name: 'localDatasourceA',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
   ])('$title', async (data: TestData) => {
     const datasourceApiMock = {
       buildProxyUrl: jest.fn().mockReturnValue(''),
@@ -462,6 +511,9 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
               dashboardResource={dashboard}
               projectName={PROJECT}
               datasourceApi={datasourceApiMock}
+              savedDatasources={
+                (data.input.datasources.saved ?? data.input.datasources.local) as Record<string, DatasourceSpec>
+              }
             >
               {children}
             </DatasourceStoreProvider>

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { Box } from '@mui/material';
 import { ChartsProvider, ErrorAlert, ErrorBoundary, useChartsTheme } from '@perses-dev/components';
 import { DashboardResource } from '@perses-dev/core';
+import { useDatasourceStore } from '@perses-dev/plugin-system';
 import {
   PanelDrawer,
   Dashboard,
@@ -57,6 +58,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
   const { setEditMode } = useEditMode();
   const { dashboard, setDashboard } = useDashboard();
   const [originalDashboard, setOriginalDashboard] = useState<DashboardResource | undefined>(undefined);
+  const { setSavedDatasources } = useDatasourceStore();
 
   const { openDiscardChangesConfirmationDialog, closeDiscardChangesConfirmationDialog } =
     useDiscardChangesConfirmationDialog();
@@ -76,6 +78,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
   const onEditButtonClick = () => {
     setEditMode(true);
     setOriginalDashboard(dashboard);
+    setSavedDatasources(dashboard.spec.datasources ?? {});
   };
 
   const onCancelButtonClick = () => {

--- a/ui/plugin-system/src/components/DatasourceSelect.tsx
+++ b/ui/plugin-system/src/components/DatasourceSelect.tsx
@@ -54,6 +54,7 @@ export function DatasourceSelect(props: DatasourceSelectProps) {
         name: item.name,
         overriding: item.overriding,
         overridden: item.overridden,
+        saved: item.saved ?? true,
         group: item.selector.group,
         value: selectorToOptionValue(item.selector),
       })),
@@ -85,7 +86,7 @@ export function DatasourceSelect(props: DatasourceSelectProps) {
       {menuItems.map((menuItemGroup) => [
         <Divider key={`${menuItemGroup.group}-divider`} />,
         ...menuItemGroup.items.map((menuItem) => (
-          <MenuItem key={menuItem.value} value={menuItem.value} disabled={menuItem.overridden}>
+          <MenuItem key={menuItem.value} value={menuItem.value} disabled={menuItem.overridden || !menuItem.saved}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
               <ListItemText>
                 <DatasourceName
@@ -94,6 +95,7 @@ export function DatasourceSelect(props: DatasourceSelectProps) {
                   overriding={menuItem.overriding}
                 />
               </ListItemText>
+              {!menuItem.saved && <ListItemText>Save the dashboard to enable this datasource</ListItemText>}
               <ListItemText style={{ textAlign: 'right' }}>
                 {menuItemGroup.group && menuItemGroup.group.length > 0 && (
                   <Chip

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -38,6 +38,16 @@ export interface DatasourceStore {
    * Sets the list of datasources defined in the dashboard
    */
   setLocalDatasources(datasources: Record<string, DatasourceSpec>): void;
+
+  /**
+   * Gets the list of datasources that are available in the dashboard (i.e. dashboards that have been created on the server side that we can use).
+   */
+  getSavedDatasources(): Record<string, DatasourceSpec>;
+
+  /**
+   * Sets the list of datasources that are saved in the dashboard
+   */
+  setSavedDatasources(datasources: Record<string, DatasourceSpec>): void;
 }
 
 export interface DatasourceSelectItemGroup {
@@ -50,6 +60,7 @@ export interface DatasourceSelectItem {
   name: string;
   overridden?: boolean;
   overriding?: boolean;
+  saved?: boolean;
   selector: DatasourceSelectItemSelector;
 }
 

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
@@ -87,6 +87,12 @@ export const WithPluginSystemDatasourceStore = (Story: StoryFn, context: StoryCo
       }
       throw new Error(`WithDatasourceStore is not configured to support kind: ${datasourcePluginKind}`);
     },
+    getSavedDatasources: (): Record<string, DatasourceSpec> => {
+      return {};
+    },
+    setSavedDatasources: (datasources: Record<string, DatasourceSpec>) => {
+      return datasources;
+    },
     getLocalDatasources: (): Record<string, DatasourceSpec> => {
       return {};
     },

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -70,6 +70,8 @@ const createStubContext = () => {
       listDatasourceSelectItems: jest.fn(),
       getLocalDatasources: jest.fn(),
       setLocalDatasources: jest.fn(),
+      getSavedDatasources: jest.fn(),
+      setSavedDatasources: jest.fn(),
     },
     refreshKey: 'test',
     refreshIntervalInMs: 0,


### PR DESCRIPTION
# Description

Previously, when a dashboard level datasource is added to a dashboard, it is immediately available for use in the dashboard. This causes an error because the server side (e.g. the proxy endpoints) isn't created until the dashboard is saved.

Here we introduce the idea of "saved" datasources, which are the datasources that are available for use in the dashboard because they have been created through a dashboard save.

We then use this list of saved datasources to disable entries in the datasource select dropdown, with an indication that the dashboard needs to be saved before the datasource can be used.

# Screenshots

![image](https://github.com/perses/perses/assets/4386405/5e00872f-1a3c-4f53-99f9-266bd86289d8)

https://github.com/perses/perses/assets/4386405/63a71f53-1636-41fb-8e46-e036bca62643

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
