### PR TITLE
[ENHANCEMENT] Use a context for the config to share it across the whole app

### DIFF
--- a/ui/app/src/components/CRUDButton/CRUDButton.tsx
+++ b/ui/app/src/components/CRUDButton/CRUDButton.tsx
@@ -14,7 +14,7 @@
 import { Button, Tooltip } from '@mui/material';
 import { OverridableStringUnion } from '@mui/types';
 import { ButtonPropsColorOverrides, ButtonPropsVariantOverrides } from '@mui/material/Button/Button';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 
 interface CRUDButtonProps {
   text: string;

--- a/ui/app/src/components/DashboardList/DashboardList.tsx
+++ b/ui/app/src/components/DashboardList/DashboardList.tsx
@@ -20,7 +20,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { intlFormatDistance } from 'date-fns';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
 import { DeleteDashboardDialog, RenameDashboardDialog } from '../dialogs';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 import { DashboardDataGrid, Row } from './DashboardDataGrid';
 
 export interface DashboardListProperties {

--- a/ui/app/src/components/DashboardList/RecentDashboardList.tsx
+++ b/ui/app/src/components/DashboardList/RecentDashboardList.tsx
@@ -20,7 +20,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { intlFormatDistance } from 'date-fns';
 import { DeleteDashboardDialog, RenameDashboardDialog } from '../dialogs';
 import { DatedDashboards } from '../../model/dashboard-client';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 import { DashboardDataGrid, Row } from './DashboardDataGrid';
 
 export interface RecentDashboardListProperties {

--- a/ui/app/src/components/datasource/DatasourceList.tsx
+++ b/ui/app/src/components/datasource/DatasourceList.tsx
@@ -20,7 +20,7 @@ import { intlFormatDistance } from 'date-fns';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 import { DeleteDatasourceDialog } from '../dialogs';
 import { DatasourceDataGrid, Row } from './DatasourceDataGrid';
 import { DatasourceDrawer } from './DatasourceDrawer';

--- a/ui/app/src/components/secret/SecretList.tsx
+++ b/ui/app/src/components/secret/SecretList.tsx
@@ -22,7 +22,7 @@ import CheckIcon from 'mdi-material-ui/Check';
 import CloseIcon from 'mdi-material-ui/Close';
 import ClipboardIcon from 'mdi-material-ui/ClipboardOutline';
 import { useSnackbar } from '@perses-dev/components';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 import { DeleteSecretDialog } from '../dialogs';
 import { SecretDataGrid, Row } from './SecretDataGrid';
 

--- a/ui/app/src/components/variable/VariableList.tsx
+++ b/ui/app/src/components/variable/VariableList.tsx
@@ -22,7 +22,7 @@ import PencilIcon from 'mdi-material-ui/Pencil';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import { useSnackbar } from '@perses-dev/components';
 import Clipboard from 'mdi-material-ui/ClipboardOutline';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 import { DeleteVariableDialog } from '../dialogs';
 import { VariableDataGrid, Row } from './VariableDataGrid';
 import { VariableDrawer } from './VariableDrawer';

--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -1,0 +1,63 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { createContext, useContext, useMemo } from 'react';
+import { marked } from 'marked';
+import * as DOMPurify from 'dompurify';
+import { CircularProgress, Stack } from '@mui/material';
+import { ConfigModel, useConfig } from '../model/config-client';
+
+interface ConfigContextType {
+  config: ConfigModel;
+}
+
+const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
+
+export function ConfigContextProvider(props: { children: React.ReactNode }) {
+  const { data, isLoading } = useConfig();
+  if (isLoading || data === undefined) {
+    return (
+      <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Stack>
+    );
+  }
+  return <ConfigContext.Provider value={{ config: data }}>{props.children}</ConfigContext.Provider>;
+}
+
+export function useConfigContext(): ConfigContextType {
+  const ctx = useContext(ConfigContext);
+  if (ctx === undefined) {
+    throw new Error('No ConfigContext found. Did you forget a Provider?');
+  }
+  return ctx;
+}
+
+export function useIsReadonly() {
+  const { config } = useConfigContext();
+  return config.security.readonly;
+}
+
+export function useImportantDashboardSelectors() {
+  const { config } = useConfigContext();
+  return config.important_dashboards;
+}
+
+export function useInformation() {
+  const { config } = useConfigContext();
+
+  const html = useMemo(() => marked.parse(config.information, { gfm: true }), [config.information]);
+  const sanitizedHTML = useMemo(() => DOMPurify.sanitize(html), [html]);
+
+  return sanitizedHTML;
+}

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -11,12 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { DashboardSelector, fetchJson } from '@perses-dev/core';
-import { useMemo } from 'react';
-import { marked } from 'marked';
-import * as DOMPurify from 'dompurify';
-import { useSnackbar } from '@perses-dev/components';
 import buildURL from './url-builder';
 
 const resource = 'config';
@@ -120,41 +116,7 @@ export function useConfig(options?: ConfigOptions) {
   );
 }
 
-export function useGetConfigMutation() {
-  return useMutation<ConfigModel, Error>({
-    mutationKey: [resource],
-    mutationFn: () => {
-      return fetchConfig();
-    },
-  });
-}
-
 export function fetchConfig() {
   const url = buildURL({ resource: resource, apiPrefix: '/api' });
   return fetchJson<ConfigModel>(url);
-}
-
-export function useIsReadonly() {
-  const { exceptionSnackbar } = useSnackbar();
-  const { data, isLoading } = useConfig({ onError: exceptionSnackbar });
-  if (isLoading || data === undefined) {
-    return undefined;
-  }
-  return data.security.readonly;
-}
-
-export function useImportantDashboardSelectors() {
-  const { exceptionSnackbar } = useSnackbar();
-  const { data, isLoading } = useConfig({ onError: exceptionSnackbar });
-  return { data: data?.important_dashboards || [], isLoading: isLoading };
-}
-
-export function useInformation() {
-  const { exceptionSnackbar } = useSnackbar();
-  const { data, isLoading } = useConfig({ onError: exceptionSnackbar });
-
-  const html = useMemo(() => marked.parse(data?.information || '', { gfm: true }), [data?.information]);
-  const sanitizedHTML = useMemo(() => DOMPurify.sanitize(html), [html]);
-
-  return { data: sanitizedHTML, isLoading: isLoading };
 }

--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -15,9 +15,9 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DashboardResource, fetch, fetchJson } from '@perses-dev/core';
 import { useMemo } from 'react';
 import { useNavHistory } from '../context/DashboardNavHistory';
+import { useImportantDashboardSelectors } from '../context/Config';
 import { HTTPHeader, HTTPMethodDELETE, HTTPMethodGET, HTTPMethodPOST, HTTPMethodPUT } from './http';
 import buildURL from './url-builder';
-import { useImportantDashboardSelectors } from './config-client';
 
 export const resource = 'dashboards';
 
@@ -110,7 +110,7 @@ export function useImportantDashboardList(project?: string) {
 
   const importantDashboards = useMemo(() => {
     const result: DashboardResource[] = [];
-    importantDashboardSelectors.data.forEach((selector) => {
+    importantDashboardSelectors.forEach((selector) => {
       const dashboard = (dashboards.data || []).find(
         (dashboard) => selector.project === dashboard.metadata.project && selector.dashboard === dashboard.metadata.name
       );
@@ -119,9 +119,9 @@ export function useImportantDashboardList(project?: string) {
       }
     });
     return result;
-  }, [dashboards.data, importantDashboardSelectors.data]);
+  }, [dashboards.data, importantDashboardSelectors]);
 
-  return { data: importantDashboards, isLoading: dashboards.isLoading && importantDashboardSelectors.isLoading };
+  return { data: importantDashboards, isLoading: dashboards.isLoading };
 }
 
 /**

--- a/ui/app/src/render-app.tsx
+++ b/ui/app/src/render-app.tsx
@@ -22,6 +22,7 @@ import { CookiesProvider } from 'react-cookie';
 import { DarkModeContextProvider } from './context/DarkMode';
 import App from './App';
 import { NavHistoryProvider } from './context/DashboardNavHistory';
+import { ConfigContextProvider } from './context/Config';
 
 /**
  * Renders the Perses application in the target container.
@@ -50,15 +51,17 @@ export function renderApp(container: Element | null) {
       <BrowserRouter>
         <CookiesProvider>
           <QueryClientProvider client={queryClient}>
-            <QueryParamProvider adapter={ReactRouter6Adapter}>
-              <DarkModeContextProvider>
-                <NavHistoryProvider>
-                  <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
-                    <App />
-                  </SnackbarProvider>
-                </NavHistoryProvider>
-              </DarkModeContextProvider>
-            </QueryParamProvider>
+            <ConfigContextProvider>
+              <QueryParamProvider adapter={ReactRouter6Adapter}>
+                <DarkModeContextProvider>
+                  <NavHistoryProvider>
+                    <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
+                      <App />
+                    </SnackbarProvider>
+                  </NavHistoryProvider>
+                </DarkModeContextProvider>
+              </QueryParamProvider>
+            </ConfigContextProvider>
           </QueryClientProvider>
         </CookiesProvider>
       </BrowserRouter>

--- a/ui/app/src/views/MigrateView.tsx
+++ b/ui/app/src/views/MigrateView.tsx
@@ -30,7 +30,7 @@ import { JSONEditor, useSnackbar } from '@perses-dev/components';
 import { useNavigate } from 'react-router-dom';
 import { useMigrate } from '../model/migrate-client';
 import { useCreateDashboardMutation } from '../model/dashboard-client';
-import { useIsReadonly } from '../model/config-client';
+import { useIsReadonly } from '../context/Config';
 import { useProjectList } from '../model/project-client';
 
 interface GrafanaLightDashboard {

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -29,7 +29,7 @@ import { VariableDrawer } from '../../components/variable/VariableDrawer';
 import { useCreateGlobalVariableMutation } from '../../model/global-variable-client';
 import { useCreateGlobalDatasourceMutation } from '../../model/admin-client';
 import { DatasourceDrawer } from '../../components/datasource/DatasourceDrawer';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 import { MenuTab, MenuTabs } from '../../components/tabs';
 import { GlobalVariables } from './tabs/GlobalVariables';
 import { GlobalDatasources } from './tabs/GlobalDatasources';

--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -11,23 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CircularProgress, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 import Cog from 'mdi-material-ui/Cog';
 import { JSONEditor } from '@perses-dev/components';
 import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
-import { useConfig } from '../../model/config-client';
+import { useConfigContext } from '../../context/Config';
 
 function ConfigView() {
-  const { data, isLoading } = useConfig();
+  const { config } = useConfigContext();
   return (
     <Stack sx={{ width: '100%' }} mx={2} mb={2} mt={1.5} gap={2}>
       <AppBreadcrumbs rootPageName="Configuration" icon={<Cog fontSize={'large'} />} />
-      {isLoading && (
-        <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
-          <CircularProgress />
-        </Stack>
-      )}
-      {data !== undefined && <JSONEditor value={data} readOnly />}
+      <JSONEditor value={config} readOnly />
     </Stack>
   );
 }

--- a/ui/app/src/views/home/InformationSection.tsx
+++ b/ui/app/src/views/home/InformationSection.tsx
@@ -11,37 +11,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Card, CardContent, CircularProgress, Stack } from '@mui/material';
+import { Card, CardContent, Stack } from '@mui/material';
 import InformationIcon from 'mdi-material-ui/Information';
-import { useInformation } from '../../model/config-client';
+import { useInformation } from '../../context/Config';
 
 /*
  * Information section is displayed if there is information provided by the config
  */
 export function InformationSection() {
-  const { data, isLoading } = useInformation();
-
-  if (isLoading) {
-    return (
-      <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
-        <CircularProgress />
+  const data = useInformation();
+  return (
+    <Stack my={2}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <InformationIcon />
+        <h2>Information</h2>
       </Stack>
-    );
-  }
-
-  if (data) {
-    return (
-      <Stack my={2}>
-        <Stack direction="row" alignItems="center" gap={1}>
-          <InformationIcon />
-          <h2>Information</h2>
-        </Stack>
-        <Card>
-          <CardContent dangerouslySetInnerHTML={{ __html: data }}></CardContent>
-        </Card>
-      </Stack>
-    );
-  }
-
-  return <></>;
+      <Card>
+        <CardContent dangerouslySetInnerHTML={{ __html: data }}></CardContent>
+      </Card>
+    </Stack>
+  );
 }

--- a/ui/app/src/views/home/ProjectsAndDashboards.tsx
+++ b/ui/app/src/views/home/ProjectsAndDashboards.tsx
@@ -35,7 +35,7 @@ import FormatListBulletedIcon from 'mdi-material-ui/FormatListBulleted';
 import { useDashboardList } from '../../model/dashboard-client';
 import { DashboardList } from '../../components/DashboardList/DashboardList';
 import { DeleteProjectDialog } from '../../components/dialogs';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 
 interface ProjectRow {
   project: string;

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -32,7 +32,7 @@ import { VariableDrawer } from '../../components/variable/VariableDrawer';
 import { DatasourceDrawer } from '../../components/datasource/DatasourceDrawer';
 import { useCreateDatasourceMutation } from '../../model/datasource-client';
 import { useCreateVariableMutation } from '../../model/variable-client';
-import { useIsReadonly } from '../../model/config-client';
+import { useIsReadonly } from '../../context/Config';
 import { MenuTab, MenuTabs } from '../../components/tabs';
 import { ProjectDashboards } from './tabs/ProjectDashboards';
 import { ProjectVariables } from './tabs/ProjectVariables';

--- a/ui/app/src/views/projects/dashboards/DashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/DashboardView.tsx
@@ -17,7 +17,7 @@ import { useSnackbar } from '@perses-dev/components';
 import { DashboardResource, getDashboardExtendedDisplayName } from '@perses-dev/core';
 import { useCallback, useEffect } from 'react';
 import { useDashboard, useUpdateDashboardMutation } from '../../../model/dashboard-client';
-import { useIsReadonly } from '../../../model/config-client';
+import { useIsReadonly } from '../../../context/Config';
 import { useNavHistoryDispatch } from '../../../context/DashboardNavHistory';
 import { HelperDashboardView } from './HelperDashboardView';
 


### PR DESCRIPTION
This PR is just refactoring the way to access the config. I'm introducing a context so the different component can have access to the config without having to deal with async and network issue.

Today the config is already heavily use and I think it makes sense to simplify the usage and its access of it.

I find the code cleaner with this way (but perhaps it's just matter of test ;))