### PR TITLE
[FEATURE] UI - Add CRUD for GlobalRoles and GlobalRoleBindings resources

### DIFF
--- a/ui/app/src/components/rolebindings/RoleBindingDrawer.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingDrawer.tsx
@@ -19,6 +19,7 @@ import { RoleBindingEditorForm } from './RoleBindingEditorForm';
 
 interface RoleBindingDrawerProps<T extends RoleBinding> {
   roleBinding: T;
+  roleSuggestions?: string[];
   isOpen: boolean;
   action: Action;
   isReadonly?: boolean;
@@ -28,7 +29,7 @@ interface RoleBindingDrawerProps<T extends RoleBinding> {
 }
 
 export function RoleBindingDrawer<T extends RoleBinding>(props: RoleBindingDrawerProps<T>) {
-  const { roleBinding, isOpen, action, isReadonly, onSave, onClose, onDelete } = props;
+  const { roleBinding, roleSuggestions, isOpen, action, isReadonly, onSave, onClose, onDelete } = props;
   const [isDeleteRoleBindingDialogStateOpened, setDeleteRoleBindingDialogStateOpened] = useState<boolean>(false);
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
@@ -44,6 +45,7 @@ export function RoleBindingDrawer<T extends RoleBinding>(props: RoleBindingDrawe
           <RoleBindingEditorForm
             initialRoleBinding={roleBinding}
             initialAction={action}
+            roleSuggestions={roleSuggestions ?? []}
             isDraft={false}
             isReadonly={isReadonly}
             onSave={onSave as Dispatch<RoleBinding>}

--- a/ui/app/src/components/rolebindings/RoleBindingList.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingList.tsx
@@ -21,6 +21,7 @@ import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
 import { DeleteRoleBindingDialog } from '../dialogs';
 import { useIsReadonly } from '../../context/Config';
+import { subjectsSummary } from '../../utils/role';
 import { RoleBindingDataGrid, Row } from './RoleBindingDataGrid';
 import { RoleBindingDrawer } from './RoleBindingDrawer';
 
@@ -61,6 +62,7 @@ export function RoleBindingList<T extends RoleBinding>(props: RoleBindingListPro
         ({
           project: getMetadataProject(roleBinding.metadata),
           name: roleBinding.metadata.name,
+          subjects: subjectsSummary(roleBinding.spec.subjects, 5),
           version: roleBinding.metadata.version,
           createdAt: roleBinding.metadata.createdAt,
           updatedAt: roleBinding.metadata.updatedAt,
@@ -112,6 +114,7 @@ export function RoleBindingList<T extends RoleBinding>(props: RoleBindingListPro
     () => [
       { field: 'project', headerName: 'Project', type: 'string', flex: 2, minWidth: 150 },
       { field: 'name', headerName: 'Name', type: 'string', flex: 3, minWidth: 150 },
+      { field: 'subjects', headerName: 'Subjects', type: 'string', flex: 3, minWidth: 150 },
       {
         field: 'version',
         headerName: 'Version',

--- a/ui/app/src/components/roles/RoleEditorForm.tsx
+++ b/ui/app/src/components/roles/RoleEditorForm.tsx
@@ -157,7 +157,6 @@ export function RoleEditorForm(props: RoleEditorFormProps) {
                   <IconButton
                     disabled={isReadonly || action === 'read'}
                     style={{ width: 'fit-content', height: 'fit-content' }}
-                    // Add a new permission
                     onClick={() => remove(index)}
                   >
                     <MinusIcon />
@@ -173,7 +172,7 @@ export function RoleEditorForm(props: RoleEditorFormProps) {
           )}
           <IconButton
             disabled={isReadonly || action === 'read'}
-            style={{ width: 'fit-content' }}
+            style={{ width: 'fit-content', height: 'fit-content' }}
             // Add a new subject
             onClick={() => append({ actions: ['read'], scopes: ['*'] })}
           >

--- a/ui/app/src/model/global-role-client.ts
+++ b/ui/app/src/model/global-role-client.ts
@@ -1,0 +1,145 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fetch, fetchJson, GlobalRoleResource } from '@perses-dev/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import buildURL from './url-builder';
+import { HTTPHeader, HTTPMethodDELETE, HTTPMethodGET, HTTPMethodPOST, HTTPMethodPUT } from './http';
+import { buildQueryKey } from './querykey-builder';
+
+export const resource = 'globalroles';
+
+export function createGlobalRole(entity: GlobalRoleResource) {
+  const url = buildURL({ resource });
+  return fetchJson<GlobalRoleResource>(url, {
+    method: HTTPMethodPOST,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+function getGlobalRole(name: string) {
+  const url = buildURL({ resource, name });
+  return fetchJson<GlobalRoleResource>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+function getGlobalRoles() {
+  const url = buildURL({ resource });
+  return fetchJson<GlobalRoleResource[]>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+export function updateGlobalRole(entity: GlobalRoleResource) {
+  const name = entity.metadata.name;
+  const url = buildURL({ resource, name });
+  return fetchJson<GlobalRoleResource>(url, {
+    method: HTTPMethodPUT,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+export function deleteGlobalRole(entity: GlobalRoleResource) {
+  const name = entity.metadata.name;
+  const url = buildURL({ resource, name });
+  return fetch(url, {
+    method: HTTPMethodDELETE,
+    headers: HTTPHeader,
+  });
+}
+
+/**
+ * Used to get a globalRole from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalRole(name: string) {
+  return useQuery<GlobalRoleResource, Error>(buildQueryKey({ resource, name }), () => {
+    return getGlobalRole(name);
+  });
+}
+
+/**
+ * Used to get globalRoles from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalRoleList() {
+  return useQuery<GlobalRoleResource[], Error>(buildQueryKey({ resource }), () => {
+    return getGlobalRoles();
+  });
+}
+
+/**
+ * Returns a mutation that can be used to create a globalRole.
+ * Will automatically refresh the cache for all the list.
+ */
+export function useCreateGlobalRoleMutation() {
+  const queryClient = useQueryClient();
+  const queryKey = buildQueryKey({ resource });
+
+  return useMutation<GlobalRoleResource, Error, GlobalRoleResource>({
+    mutationKey: queryKey,
+    mutationFn: (globalRole: GlobalRoleResource) => {
+      return createGlobalRole(globalRole);
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries([...queryKey]);
+    },
+  });
+}
+
+/**
+ * Returns a mutation that can be used to update a globalRole.
+ * Will automatically refresh the cache for all the list.
+ */
+export function useUpdateGlobalRoleMutation() {
+  const queryClient = useQueryClient();
+  const queryKey = buildQueryKey({ resource });
+  return useMutation<GlobalRoleResource, Error, GlobalRoleResource>({
+    mutationKey: queryKey,
+    mutationFn: (globalRole: GlobalRoleResource) => {
+      return updateGlobalRole(globalRole);
+    },
+    onSuccess: (entity: GlobalRoleResource) => {
+      return Promise.all([
+        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
+        queryClient.invalidateQueries(queryKey),
+      ]);
+    },
+  });
+}
+
+/**
+ * Returns a mutation that can be used to delete a globalRole.
+ * Will automatically refresh the cache for all the list.
+ */
+export function useDeleteGlobalRoleMutation() {
+  const queryClient = useQueryClient();
+  const queryKey = buildQueryKey({ resource });
+
+  return useMutation<GlobalRoleResource, Error, GlobalRoleResource>({
+    mutationKey: queryKey,
+    mutationFn: async (entity: GlobalRoleResource) => {
+      await deleteGlobalRole(entity);
+      return entity;
+    },
+    onSuccess: (entity: GlobalRoleResource) => {
+      queryClient.removeQueries([...queryKey, entity.metadata.name]);
+      return queryClient.invalidateQueries(queryKey);
+    },
+  });
+}

--- a/ui/app/src/model/global-rolebinding-client.ts
+++ b/ui/app/src/model/global-rolebinding-client.ts
@@ -1,0 +1,145 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fetch, fetchJson, GlobalRoleBindingResource } from '@perses-dev/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import buildURL from './url-builder';
+import { HTTPHeader, HTTPMethodDELETE, HTTPMethodGET, HTTPMethodPOST, HTTPMethodPUT } from './http';
+import { buildQueryKey } from './querykey-builder';
+
+export const resource = 'globalrolebindings';
+
+export function createGlobalRoleBinding(entity: GlobalRoleBindingResource) {
+  const url = buildURL({ resource });
+  return fetchJson<GlobalRoleBindingResource>(url, {
+    method: HTTPMethodPOST,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+function getGlobalRoleBinding(name: string) {
+  const url = buildURL({ resource, name });
+  return fetchJson<GlobalRoleBindingResource>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+function getGlobalRoleBindings() {
+  const url = buildURL({ resource });
+  return fetchJson<GlobalRoleBindingResource[]>(url, {
+    method: HTTPMethodGET,
+    headers: HTTPHeader,
+  });
+}
+
+export function updateGlobalRoleBinding(entity: GlobalRoleBindingResource) {
+  const name = entity.metadata.name;
+  const url = buildURL({ resource, name });
+  return fetchJson<GlobalRoleBindingResource>(url, {
+    method: HTTPMethodPUT,
+    headers: HTTPHeader,
+    body: JSON.stringify(entity),
+  });
+}
+
+export function deleteGlobalRoleBinding(entity: GlobalRoleBindingResource) {
+  const name = entity.metadata.name;
+  const url = buildURL({ resource, name });
+  return fetch(url, {
+    method: HTTPMethodDELETE,
+    headers: HTTPHeader,
+  });
+}
+
+/**
+ * Used to get a globalRoleBinding from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalRoleBinding(name: string) {
+  return useQuery<GlobalRoleBindingResource, Error>(buildQueryKey({ resource, name }), () => {
+    return getGlobalRoleBinding(name);
+  });
+}
+
+/**
+ * Used to get globalRoleBindings from the API.
+ * Will automatically be refreshed when cache is invalidated
+ */
+export function useGlobalRoleBindingList() {
+  return useQuery<GlobalRoleBindingResource[], Error>(buildQueryKey({ resource }), () => {
+    return getGlobalRoleBindings();
+  });
+}
+
+/**
+ * Returns a mutation that can be used to create a globalRoleBinding.
+ * Will automatically refresh the cache for all the list.
+ */
+export function useCreateGlobalRoleBindingMutation() {
+  const queryClient = useQueryClient();
+  const queryKey = buildQueryKey({ resource });
+
+  return useMutation<GlobalRoleBindingResource, Error, GlobalRoleBindingResource>({
+    mutationKey: queryKey,
+    mutationFn: (globalRoleBinding: GlobalRoleBindingResource) => {
+      return createGlobalRoleBinding(globalRoleBinding);
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries([...queryKey]);
+    },
+  });
+}
+
+/**
+ * Returns a mutation that can be used to update a globalRoleBinding.
+ * Will automatically refresh the cache for all the list.
+ */
+export function useUpdateGlobalRoleBindingMutation() {
+  const queryClient = useQueryClient();
+  const queryKey = buildQueryKey({ resource });
+  return useMutation<GlobalRoleBindingResource, Error, GlobalRoleBindingResource>({
+    mutationKey: queryKey,
+    mutationFn: (globalRoleBinding: GlobalRoleBindingResource) => {
+      return updateGlobalRoleBinding(globalRoleBinding);
+    },
+    onSuccess: (entity: GlobalRoleBindingResource) => {
+      return Promise.all([
+        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
+        queryClient.invalidateQueries(queryKey),
+      ]);
+    },
+  });
+}
+
+/**
+ * Returns a mutation that can be used to delete a globalRoleBinding.
+ * Will automatically refresh the cache for all the list.
+ */
+export function useDeleteGlobalRoleBindingMutation() {
+  const queryClient = useQueryClient();
+  const queryKey = buildQueryKey({ resource });
+
+  return useMutation<GlobalRoleBindingResource, Error, GlobalRoleBindingResource>({
+    mutationKey: queryKey,
+    mutationFn: async (entity: GlobalRoleBindingResource) => {
+      await deleteGlobalRoleBinding(entity);
+      return entity;
+    },
+    onSuccess: (entity: GlobalRoleBindingResource) => {
+      queryClient.removeQueries([...queryKey, entity.metadata.name]);
+      return queryClient.invalidateQueries(queryKey);
+    },
+  });
+}

--- a/ui/app/src/utils/role.ts
+++ b/ui/app/src/utils/role.ts
@@ -1,0 +1,32 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Subject } from '@perses-dev/core';
+
+// subjectsSummary returns a formatted string of a list of subjects where max is the amount of subject to show with their name
+export function subjectsSummary(subjects: Subject[], max: number) {
+  if (subjects.length === 0) {
+    return 'No subjects';
+  }
+  if (subjects.length < max) {
+    return subjects.map((subject) => subject.name).join(', ');
+  }
+  let result = '';
+  subjects.forEach((subject, index) => {
+    if (index < max) {
+      result += `${subject.name}, `;
+    }
+  });
+  result += `+${subjects.length - max} others`;
+  return result;
+}

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Box, Stack } from '@mui/material';
-import { ReactNode, SyntheticEvent, useCallback, useState } from 'react';
+import { ReactNode, SyntheticEvent, useCallback, useMemo, useState } from 'react';
 import CodeJsonIcon from 'mdi-material-ui/CodeJson';
 import DatabaseIcon from 'mdi-material-ui/Database';
 import KeyIcon from 'mdi-material-ui/Key';
@@ -36,7 +36,7 @@ import { DatasourceDrawer } from '../../components/datasource/DatasourceDrawer';
 import { useIsAuthorizationEnabled, useIsReadonly } from '../../context/Config';
 import { MenuTab, MenuTabs } from '../../components/tabs';
 import { useCreateGlobalRoleBindingMutation } from '../../model/global-rolebinding-client';
-import { useCreateGlobalRoleMutation } from '../../model/global-role-client';
+import { useCreateGlobalRoleMutation, useGlobalRoleList } from '../../model/global-role-client';
 import { RoleDrawer } from '../../components/roles/RoleDrawer';
 import { RoleBindingDrawer } from '../../components/rolebindings/RoleBindingDrawer';
 import { GlobalVariables } from './tabs/GlobalVariables';
@@ -67,6 +67,11 @@ function TabButton(props: TabButtonProps) {
   const [isRoleBindingDrawerOpened, setRoleBindingDrawerOpened] = useState(false);
   const [isVariableDrawerOpened, setVariableDrawerOpened] = useState(false);
   const isReadonly = useIsReadonly();
+
+  const { data } = useGlobalRoleList();
+  const roleSuggestions = useMemo(() => {
+    return (data ?? []).map((role) => role.metadata.name);
+  }, [data]);
 
   const handleGlobalDatasourceCreation = useCallback(
     (datasource: GlobalDatasource) => {
@@ -233,6 +238,7 @@ function TabButton(props: TabButtonProps) {
                 subjects: [],
               },
             }}
+            roleSuggestions={roleSuggestions}
             isOpen={isRoleBindingDrawerOpened}
             action="create"
             isReadonly={isReadonly}

--- a/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
@@ -1,0 +1,98 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Card } from '@mui/material';
+import { useCallback } from 'react';
+import { GlobalRoleBindingResource, RoleBinding } from '@perses-dev/core';
+import { useSnackbar } from '@perses-dev/components';
+import { RoleBindingList } from '../../../components/rolebindings/RoleBindingList';
+import {
+  useDeleteGlobalRoleBindingMutation,
+  useGlobalRoleBindingList,
+  useUpdateGlobalRoleBindingMutation,
+} from '../../../model/global-rolebinding-client';
+
+interface GlobalRoleBindingsProps {
+  id?: string;
+}
+
+export function GlobalRoleBindings(props: GlobalRoleBindingsProps) {
+  const { id } = props;
+
+  const { data, isLoading } = useGlobalRoleBindingList();
+
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const updateRoleBindingMutation = useUpdateGlobalRoleBindingMutation();
+  const deleteRoleBindingMutation = useDeleteGlobalRoleBindingMutation();
+
+  const handleGlobalRoleBindingUpdate = useCallback(
+    (roleBinding: GlobalRoleBindingResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        updateRoleBindingMutation.mutate(roleBinding, {
+          onSuccess: (updatedRoleBinding: RoleBinding) => {
+            successSnackbar(`GlobalRoleBinding ${updatedRoleBinding.metadata.name} has been successfully updated`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, updateRoleBindingMutation]
+  );
+
+  const handleGlobalRoleBindingDelete = useCallback(
+    (roleBinding: GlobalRoleBindingResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        deleteRoleBindingMutation.mutate(roleBinding, {
+          onSuccess: (deletedRoleBinding: RoleBinding) => {
+            successSnackbar(`GlobalRoleBinding ${deletedRoleBinding.metadata.name} has been successfully deleted`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, deleteRoleBindingMutation]
+  );
+
+  return (
+    <Card id={id}>
+      <RoleBindingList
+        data={data ?? []}
+        isLoading={isLoading}
+        onUpdate={handleGlobalRoleBindingUpdate}
+        onDelete={handleGlobalRoleBindingDelete}
+        initialState={{
+          columns: {
+            columnVisibilityModel: {
+              id: false,
+              project: false,
+              version: false,
+              createdAt: false,
+              updatedAt: false,
+            },
+          },
+          sorting: {
+            sortModel: [{ field: 'name', sort: 'asc' }],
+          },
+        }}
+      />
+    </Card>
+  );
+}

--- a/ui/app/src/views/admin/tabs/GlobalRoles.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalRoles.tsx
@@ -1,0 +1,98 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Card } from '@mui/material';
+import { useCallback } from 'react';
+import { GlobalRoleResource, Role } from '@perses-dev/core';
+import { useSnackbar } from '@perses-dev/components';
+import { RoleList } from '../../../components/roles/RoleList';
+import {
+  useDeleteGlobalRoleMutation,
+  useGlobalRoleList,
+  useUpdateGlobalRoleMutation,
+} from '../../../model/global-role-client';
+
+interface GlobalRolesProps {
+  id?: string;
+}
+
+export function GlobalRoles(props: GlobalRolesProps) {
+  const { id } = props;
+
+  const { data, isLoading } = useGlobalRoleList();
+
+  const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const updateRoleMutation = useUpdateGlobalRoleMutation();
+  const deleteRoleMutation = useDeleteGlobalRoleMutation();
+
+  const handleGlobalRoleUpdate = useCallback(
+    (role: GlobalRoleResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        updateRoleMutation.mutate(role, {
+          onSuccess: (updatedRole: Role) => {
+            successSnackbar(`GlobalRole ${updatedRole.metadata.name} has been successfully updated`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, updateRoleMutation]
+  );
+
+  const handleGlobalRoleDelete = useCallback(
+    (role: GlobalRoleResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        deleteRoleMutation.mutate(role, {
+          onSuccess: (deletedRole: Role) => {
+            successSnackbar(`GlobalRole ${deletedRole.metadata.name} has been successfully deleted`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, deleteRoleMutation]
+  );
+
+  return (
+    <Card id={id}>
+      <RoleList
+        data={data ?? []}
+        isLoading={isLoading}
+        onUpdate={handleGlobalRoleUpdate}
+        onDelete={handleGlobalRoleDelete}
+        initialState={{
+          columns: {
+            columnVisibilityModel: {
+              id: false,
+              project: false,
+              version: false,
+              createdAt: false,
+              updatedAt: false,
+            },
+          },
+          sorting: {
+            sortModel: [{ field: 'name', sort: 'asc' }],
+          },
+        }}
+      />
+    </Card>
+  );
+}

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -357,6 +357,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
             iconPosition="start"
             {...a11yProps(rolesTabIndex)}
             value={rolesTabIndex}
+            disabled={!isAuthorizationEnabled}
           />
           <MenuTab
             label="Role Bindings"
@@ -364,6 +365,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
             iconPosition="start"
             {...a11yProps(roleBindingsTabIndex)}
             value={roleBindingsTabIndex}
+            disabled={!isAuthorizationEnabled}
           />
         </MenuTabs>
         <TabButton index={value} projectName={projectName} />

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Box, Stack } from '@mui/material';
-import { ReactNode, SyntheticEvent, useCallback, useState } from 'react';
+import { ReactNode, SyntheticEvent, useCallback, useMemo, useState } from 'react';
 import ViewDashboardIcon from 'mdi-material-ui/ViewDashboard';
 import CodeJsonIcon from 'mdi-material-ui/CodeJson';
 import DatabaseIcon from 'mdi-material-ui/Database';
@@ -39,7 +39,7 @@ import { useCreateVariableMutation } from '../../model/variable-client';
 import { useIsAuthorizationEnabled, useIsReadonly } from '../../context/Config';
 import { MenuTab, MenuTabs } from '../../components/tabs';
 import { useCreateRoleBindingMutation } from '../../model/rolebinding-client';
-import { useCreateRoleMutation } from '../../model/role-client';
+import { useCreateRoleMutation, useRoleList } from '../../model/role-client';
 import { RoleDrawer } from '../../components/roles/RoleDrawer';
 import { RoleBindingDrawer } from '../../components/rolebindings/RoleBindingDrawer';
 import { ProjectDashboards } from './tabs/ProjectDashboards';
@@ -82,21 +82,10 @@ function TabButton(props: TabButtonProps) {
     navigate(`/projects/${dashboardSelector.project}/dashboard/new`, { state: dashboardSelector.dashboard });
   };
 
-  const handleVariableCreation = useCallback(
-    (variable: VariableResource) => {
-      createVariableMutation.mutate(variable, {
-        onSuccess: (updatedVariable: VariableResource) => {
-          successSnackbar(`Variable ${getVariableExtendedDisplayName(updatedVariable)} has been successfully created`);
-          setVariableDrawerOpened(false);
-        },
-        onError: (err) => {
-          exceptionSnackbar(err);
-          throw err;
-        },
-      });
-    },
-    [exceptionSnackbar, successSnackbar, createVariableMutation]
-  );
+  const { data } = useRoleList(props.projectName);
+  const roleSuggestions = useMemo(() => {
+    return (data ?? []).map((role) => role.metadata.name);
+  }, [data]);
 
   const handleDatasourceCreation = useCallback(
     (datasource: ProjectDatasource) => {
@@ -144,6 +133,22 @@ function TabButton(props: TabButtonProps) {
       });
     },
     [exceptionSnackbar, successSnackbar, createRoleBindingMutation]
+  );
+
+  const handleVariableCreation = useCallback(
+    (variable: VariableResource) => {
+      createVariableMutation.mutate(variable, {
+        onSuccess: (updatedVariable: VariableResource) => {
+          successSnackbar(`Variable ${getVariableExtendedDisplayName(updatedVariable)} has been successfully created`);
+          setVariableDrawerOpened(false);
+        },
+        onError: (err) => {
+          exceptionSnackbar(err);
+          throw err;
+        },
+      });
+    },
+    [exceptionSnackbar, successSnackbar, createVariableMutation]
   );
 
   switch (props.index) {
@@ -254,6 +259,7 @@ function TabButton(props: TabButtonProps) {
                 subjects: [],
               },
             }}
+            roleSuggestions={roleSuggestions}
             isOpen={isRoleBindingDrawerOpened}
             action="create"
             isReadonly={isReadonly}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
This PR contains the following:
- Add CRUD for Global Role and Role Bindings at global level. Similar to PR #1601 for project level
- Improve RoleBinding listing
- Improve RoleBinding form with autocomplete for Role name

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.