### PR TITLE
[BUGFIX] Fix reaching directly the page explorer without using the react router

### DIFF
--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -35,6 +35,7 @@ var (
 		"/projects",
 		"/migrate",
 		"/config",
+		"/explore",
 	}
 )
 


### PR DESCRIPTION
When you are using the binary `perses` and going to the explore page with the URL, the page is not loaded.
This PR is fixing that.