### PR TITLE
[BUGFIX] fix broken type-check on main branch

### DIFF
--- a/ui/tempo-plugin/src/plugins/plugin.test.ts
+++ b/ui/tempo-plugin/src/plugins/plugin.test.ts
@@ -52,6 +52,8 @@ const stubTempoContext: TraceQueryContext = {
     listDatasourceSelectItems: jest.fn(),
     getLocalDatasources: jest.fn(),
     setLocalDatasources: jest.fn(),
+    getSavedDatasources: jest.fn(),
+    setSavedDatasources: jest.fn(),
   },
 };
 


### PR DESCRIPTION
# Description

Fix broken `type-check` step on main branch that happened because of merging https://github.com/perses/perses/pull/1603 right after https://github.com/perses/perses/pull/1561 (thus main branch from #1603 PoV didn't have the changes from #1561).

We might think of adding branch protection or builds triggered automatically after target branch update in order to avoid this to happen again..

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).