### PR TITLE
[ENHANCEMENT] SignUp page can be deactivated and sign-in page cannot be reached if token exists

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,9 @@ Generic placeholders are defined as follows:
   # It is the time to live of the refresh token. The refresh token is used to get a new access token when it is expired.
   # By default, it is 24 hours.
   [ refresh_token_ttl: <duration> | default = 24h ]
+
+  # With this attribute, you can deactivate the Sign-up page which induces the deactivation of the endpoint that gives the possibility to create a user.
+  [ deactivate_sign_up: <boolean> | default = false ]
 ```
 
 #### `<authorization_config>`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,7 +123,7 @@ Generic placeholders are defined as follows:
   [ refresh_token_ttl: <duration> | default = 24h ]
 
   # With this attribute, you can deactivate the Sign-up page which induces the deactivation of the endpoint that gives the possibility to create a user.
-  [ deactivate_sign_up: <boolean> | default = false ]
+  [ disable_sign_up: <boolean> | default = false ]
 ```
 
 #### `<authorization_config>`

--- a/internal/api/config/config_test.go
+++ b/internal/api/config/config_test.go
@@ -43,7 +43,8 @@ func TestJSONMarshallConfig(t *testing.T) {
     },
     "authentication": {
       "access_token_ttl": "0s",
-      "refresh_token_ttl": "0s"
+      "refresh_token_ttl": "0s",
+      "disable_sign_up": false
     }
   },
   "database": {},
@@ -68,7 +69,8 @@ func TestJSONMarshallConfig(t *testing.T) {
     },
     "authentication": {
       "access_token_ttl": "15m0s",
-      "refresh_token_ttl": "24h0m0s"
+      "refresh_token_ttl": "24h0m0s",
+      "disable_sign_up": false
     }
   },
   "database": {

--- a/internal/api/config/security.go
+++ b/internal/api/config/security.go
@@ -31,9 +31,9 @@ const (
 )
 
 type jsonAuthenticationConfig struct {
-	AccessTokenTTL   string `json:"access_token_ttl,omitempty"`
-	RefreshTokenTTL  string `json:"refresh_token_ttl,omitempty"`
-	DeactivateSignUp bool   `json:"deactivate_sign_up"`
+	AccessTokenTTL  string `json:"access_token_ttl,omitempty"`
+	RefreshTokenTTL string `json:"refresh_token_ttl,omitempty"`
+	DisableSignUp   bool   `json:"disable_sign_up"`
 }
 
 type AuthenticationConfig struct {
@@ -42,8 +42,10 @@ type AuthenticationConfig struct {
 	// RefreshTokenTTL is the time to live of the refresh token.
 	// The refresh token is used to get a new access token when it is expired.
 	// By default, it is 24 hours.
-	RefreshTokenTTL  time.Duration `json:"refresh_token_ttl,omitempty" yaml:"refresh_token_ttl,omitempty"`
-	DeactivateSignUp bool          `json:"deactivate_sign_up" yaml:"deactivate_sign_up"`
+	RefreshTokenTTL time.Duration `json:"refresh_token_ttl,omitempty" yaml:"refresh_token_ttl,omitempty"`
+	// DisableSignUp deactivates the Sign-up page in the UI.
+	// It also disables the endpoint that gives the possibility to create a user.
+	DisableSignUp bool `json:"disable_sign_up" yaml:"disable_sign_up"`
 }
 
 func (a *AuthenticationConfig) Verify() error {
@@ -58,9 +60,9 @@ func (a *AuthenticationConfig) Verify() error {
 
 func (a AuthenticationConfig) MarshalJSON() ([]byte, error) {
 	j := &jsonAuthenticationConfig{
-		AccessTokenTTL:   a.AccessTokenTTL.String(),
-		RefreshTokenTTL:  a.RefreshTokenTTL.String(),
-		DeactivateSignUp: a.DeactivateSignUp,
+		AccessTokenTTL:  a.AccessTokenTTL.String(),
+		RefreshTokenTTL: a.RefreshTokenTTL.String(),
+		DisableSignUp:   a.DisableSignUp,
 	}
 	return json.Marshal(j)
 }

--- a/internal/api/config/security.go
+++ b/internal/api/config/security.go
@@ -31,8 +31,9 @@ const (
 )
 
 type jsonAuthenticationConfig struct {
-	AccessTokenTTL  string `json:"access_token_ttl,omitempty"`
-	RefreshTokenTTL string `json:"refresh_token_ttl,omitempty"`
+	AccessTokenTTL   string `json:"access_token_ttl,omitempty"`
+	RefreshTokenTTL  string `json:"refresh_token_ttl,omitempty"`
+	DeactivateSignUp bool   `json:"deactivate_sign_up"`
 }
 
 type AuthenticationConfig struct {
@@ -41,7 +42,8 @@ type AuthenticationConfig struct {
 	// RefreshTokenTTL is the time to live of the refresh token.
 	// The refresh token is used to get a new access token when it is expired.
 	// By default, it is 24 hours.
-	RefreshTokenTTL time.Duration `json:"refresh_token_ttl,omitempty" yaml:"refresh_token_ttl,omitempty"`
+	RefreshTokenTTL  time.Duration `json:"refresh_token_ttl,omitempty" yaml:"refresh_token_ttl,omitempty"`
+	DeactivateSignUp bool          `json:"deactivate_sign_up" yaml:"deactivate_sign_up"`
 }
 
 func (a *AuthenticationConfig) Verify() error {
@@ -56,8 +58,9 @@ func (a *AuthenticationConfig) Verify() error {
 
 func (a AuthenticationConfig) MarshalJSON() ([]byte, error) {
 	j := &jsonAuthenticationConfig{
-		AccessTokenTTL:  a.AccessTokenTTL.String(),
-		RefreshTokenTTL: a.RefreshTokenTTL.String(),
+		AccessTokenTTL:   a.AccessTokenTTL.String(),
+		RefreshTokenTTL:  a.RefreshTokenTTL.String(),
+		DeactivateSignUp: a.DeactivateSignUp,
 	}
 	return json.Marshal(j)
 }

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -68,7 +68,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		role.NewEndpoint(serviceManager.GetRole(), serviceManager.GetRBAC(), readonly),
 		rolebinding.NewEndpoint(serviceManager.GetRoleBinding(), serviceManager.GetRBAC(), readonly),
 		secret.NewEndpoint(serviceManager.GetSecret(), serviceManager.GetRBAC(), readonly),
-		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetRBAC(), cfg.Security.Authentication.DeactivateSignUp, readonly),
+		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetRBAC(), cfg.Security.Authentication.DisableSignUp, readonly),
 		variable.NewEndpoint(serviceManager.GetVariable(), serviceManager.GetRBAC(), readonly),
 	}
 	apiEndpoints := []endpoint{

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -68,7 +68,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		role.NewEndpoint(serviceManager.GetRole(), serviceManager.GetRBAC(), readonly),
 		rolebinding.NewEndpoint(serviceManager.GetRoleBinding(), serviceManager.GetRBAC(), readonly),
 		secret.NewEndpoint(serviceManager.GetSecret(), serviceManager.GetRBAC(), readonly),
-		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetRBAC(), readonly),
+		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetRBAC(), cfg.Security.Authentication.DeactivateSignUp, readonly),
 		variable.NewEndpoint(serviceManager.GetVariable(), serviceManager.GetRBAC(), readonly),
 	}
 	apiEndpoints := []endpoint{

--- a/internal/api/impl/v1/user/endpoint.go
+++ b/internal/api/impl/v1/user/endpoint.go
@@ -27,16 +27,16 @@ import (
 )
 
 type Endpoint struct {
-	toolbox          shared.Toolbox
-	readonly         bool
-	deactivateSignUp bool
+	toolbox       shared.Toolbox
+	readonly      bool
+	disableSignUp bool
 }
 
-func NewEndpoint(service user.Service, rbacService authorization.RBAC, deactivateSignUp bool, readonly bool) *Endpoint {
+func NewEndpoint(service user.Service, rbacService authorization.RBAC, disableSignUp bool, readonly bool) *Endpoint {
 	return &Endpoint{
-		toolbox:          shared.NewToolBox(service, rbacService, v1.KindUser),
-		readonly:         readonly,
-		deactivateSignUp: deactivateSignUp,
+		toolbox:       shared.NewToolBox(service, rbacService, v1.KindUser),
+		readonly:      readonly,
+		disableSignUp: disableSignUp,
 	}
 }
 
@@ -44,7 +44,7 @@ func (e *Endpoint) CollectRoutes(g *shared.Group) {
 	group := g.Group(fmt.Sprintf("/%s", utils.PathUser))
 
 	if !e.readonly {
-		if !e.deactivateSignUp {
+		if !e.disableSignUp {
 			group.POST("", e.Create, true)
 		}
 		group.PUT(fmt.Sprintf("/:%s", utils.ParamName), e.Update, false)

--- a/internal/api/impl/v1/user/endpoint.go
+++ b/internal/api/impl/v1/user/endpoint.go
@@ -27,14 +27,16 @@ import (
 )
 
 type Endpoint struct {
-	toolbox  shared.Toolbox
-	readonly bool
+	toolbox          shared.Toolbox
+	readonly         bool
+	deactivateSignUp bool
 }
 
-func NewEndpoint(service user.Service, rbacService authorization.RBAC, readonly bool) *Endpoint {
+func NewEndpoint(service user.Service, rbacService authorization.RBAC, deactivateSignUp bool, readonly bool) *Endpoint {
 	return &Endpoint{
-		toolbox:  shared.NewToolBox(service, rbacService, v1.KindUser),
-		readonly: readonly,
+		toolbox:          shared.NewToolBox(service, rbacService, v1.KindUser),
+		readonly:         readonly,
+		deactivateSignUp: deactivateSignUp,
 	}
 }
 
@@ -42,7 +44,9 @@ func (e *Endpoint) CollectRoutes(g *shared.Group) {
 	group := g.Group(fmt.Sprintf("/%s", utils.PathUser))
 
 	if !e.readonly {
-		group.POST("", e.Create, true)
+		if !e.deactivateSignUp {
+			group.POST("", e.Create, true)
+		}
 		group.PUT(fmt.Sprintf("/:%s", utils.ParamName), e.Update, false)
 		group.DELETE(fmt.Sprintf("/:%s", utils.ParamName), e.Delete, false)
 	}

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -47,7 +47,7 @@ function Router() {
       <Suspense>
         <Routes>
           <Route path={SignInRoute} element={<SignInView />} />
-          {!config.security.authentication.deactivate_sign_up && <Route path={SignUpRoute} element={<SignUpView />} />}
+          {!config.security.authentication.disable_sign_up && <Route path={SignUpRoute} element={<SignUpView />} />}
           <Route path={AdminRoute} element={<AdminView />} />
           <Route path={`${AdminRoute}/:tab`} element={<AdminView />} />
           <Route path={ConfigRoute} element={<ConfigView />} />

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Suspense, lazy } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 // Default route is eagerly loaded
 import HomeView from './views/home/HomeView';
@@ -27,6 +27,7 @@ import {
   SignUpRoute,
   ExploreRoute,
 } from './model/route';
+import { useConfigContext } from './context/Config';
 
 // Other routes are lazy-loaded for code-splitting
 const MigrateView = lazy(() => import('./views/MigrateView'));
@@ -39,13 +40,14 @@ const DashboardView = lazy(() => import('./views/projects/dashboards/DashboardVi
 const ExploreView = lazy(() => import('./views/projects/explore/ExploreView'));
 
 function Router() {
+  const { config } = useConfigContext();
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
       {/* TODO: What sort of loading fallback do we want? */}
       <Suspense>
         <Routes>
           <Route path={SignInRoute} element={<SignInView />} />
-          <Route path={SignUpRoute} element={<SignUpView />} />
+          {!config.security.authentication.deactivate_sign_up && <Route path={SignUpRoute} element={<SignUpView />} />}
           <Route path={AdminRoute} element={<AdminView />} />
           <Route path={`${AdminRoute}/:tab`} element={<AdminView />} />
           <Route path={ConfigRoute} element={<ConfigView />} />
@@ -59,6 +61,7 @@ function Router() {
             <Route path="dashboards/:dashboardName" element={<DashboardView />} />
           </Route>
           <Route path="/" element={<HomeView />} />
+          <Route path="*" element={<Navigate replace to="/" />} />
         </Routes>
       </Suspense>
     </ErrorBoundary>

--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -30,6 +30,11 @@ export interface AuthBody {
   password: string;
 }
 
+export function useIsAccessTokenExist() {
+  const [cookies] = useCookies();
+  return cookies[jwtPayload] !== undefined;
+}
+
 export function useAuthToken() {
   const [cookies] = useCookies();
   const partialToken = cookies[jwtPayload];

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -89,6 +89,7 @@ export interface AuthorizationConfig {
 export interface AuthenticationConfig {
   access_token_ttl: string;
   refresh_token_ttl: string;
+  deactivate_sign_up: boolean;
 }
 
 export interface SecurityConfig {

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -89,7 +89,7 @@ export interface AuthorizationConfig {
 export interface AuthenticationConfig {
   access_token_ttl: string;
   refresh_token_ttl: string;
-  deactivate_sign_up: boolean;
+  disable_sign_up: boolean;
 }
 
 export interface SecurityConfig {

--- a/ui/app/src/views/auth/SignInView.tsx
+++ b/ui/app/src/views/auth/SignInView.tsx
@@ -12,14 +12,17 @@
 // limitations under the License.
 
 import { Button, LinearProgress, Link, TextField, Typography } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSnackbar } from '@perses-dev/components';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
-import { useAuthMutation } from '../../model/auth-client';
+import { useAuthMutation, useIsAccessTokenExist } from '../../model/auth-client';
 import { SignUpRoute } from '../../model/route';
+import { useConfigContext } from '../../context/Config';
 import { SignWrapper } from './SignWrapper';
 
 function SignInView() {
+  const { config } = useConfigContext();
+  const isAccessTokenExist = useIsAccessTokenExist();
   const authMutation = useAuthMutation();
   const navigate = useNavigate();
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
@@ -56,6 +59,12 @@ function SignInView() {
     }
   };
 
+  useEffect(() => {
+    if (isAccessTokenExist) {
+      navigate('/');
+    }
+  });
+
   return (
     <SignWrapper>
       <TextField label="Username" required onChange={(e) => setLogin(e.target.value)} onKeyPress={handleKeypress} />
@@ -70,12 +79,14 @@ function SignInView() {
         Sign in
       </Button>
       {authMutation.isLoading && <LinearProgress />}
-      <Typography sx={{ textAlign: 'center' }}>
-        Don&lsquo;t have an account yet?&nbsp;
-        <Link underline="hover" component={RouterLink} to={SignUpRoute}>
-          Register now
-        </Link>
-      </Typography>
+      {!config.security.authentication.deactivate_sign_up && (
+        <Typography sx={{ textAlign: 'center' }}>
+          Don&lsquo;t have an account yet?&nbsp;
+          <Link underline="hover" component={RouterLink} to={SignUpRoute}>
+            Register now
+          </Link>
+        </Typography>
+      )}
     </SignWrapper>
   );
 }

--- a/ui/app/src/views/auth/SignInView.tsx
+++ b/ui/app/src/views/auth/SignInView.tsx
@@ -79,7 +79,7 @@ function SignInView() {
         Sign in
       </Button>
       {authMutation.isLoading && <LinearProgress />}
-      {!config.security.authentication.deactivate_sign_up && (
+      {!config.security.authentication.disable_sign_up && (
         <Typography sx={{ textAlign: 'center' }}>
           Don&lsquo;t have an account yet?&nbsp;
           <Link underline="hover" component={RouterLink} to={SignUpRoute}>


### PR DESCRIPTION
I'm adding a new entry in the authentication config: `deactivate_sign_up`. With this config we can deactivate the `SignUp` page and the possibility to create a new user.

That should be useful once we are supporting OIDC.

As a side effect, when a route is not known, it is now redirecting to the home page.

Also if there is a valid access token in the cookies, it is not possible to reach the `SignIn` page