### PR TITLE
[IGNORE] Fix e2e tests and usage of enable_auth in the UI

### DIFF
--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -75,7 +75,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		configendpoint.New(cfg),
 		migrateendpoint.New(serviceManager.GetMigration()),
 		validateendpoint.New(serviceManager.GetSchemas(), serviceManager.GetDashboard()),
-		authendpoint.New(persistenceManager.GetUser(), serviceManager.GetJWT()),
+		authendpoint.New(persistenceManager.GetUser(), serviceManager.GetJWT(), cfg.Security.EnableAuth),
 	}
 	return &api{
 		apiV1Endpoints: apiV1Endpoints,

--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestAuth(t *testing.T) {
-	e2eframework.WithServer(t, func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, serverAuthConfig(), func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usrEntity := e2eframework.NewUser("foo")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).

--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -27,20 +27,24 @@ import (
 )
 
 type Endpoint struct {
-	dao user.DAO
-	jwt crypto.JWT
+	dao          user.DAO
+	jwt          crypto.JWT
+	isAuthEnable bool
 }
 
-func New(dao user.DAO, jwt crypto.JWT) *Endpoint {
+func New(dao user.DAO, jwt crypto.JWT, isAuthEnable bool) *Endpoint {
 	return &Endpoint{
-		dao: dao,
-		jwt: jwt,
+		dao:          dao,
+		jwt:          jwt,
+		isAuthEnable: isAuthEnable,
 	}
 }
 
 func (e *Endpoint) CollectRoutes(g *shared.Group) {
-	g.POST("/auth", e.auth, true)
-	g.POST("/auth/refresh", e.refresh, true)
+	if e.isAuthEnable {
+		g.POST("/auth", e.auth, true)
+		g.POST("/auth/refresh", e.refresh, true)
+	}
 }
 
 func (e *Endpoint) auth(ctx echo.Context) error {

--- a/scripts/api_backend_dev.sh
+++ b/scripts/api_backend_dev.sh
@@ -12,7 +12,7 @@ if [[ $1 == "--e2e" ]]; then
   previous_file="./dev/config.previous.yaml"
   config_file="./dev/config.yaml"
   cp ${config_file} ${previous_file}
-  sed 's/enable_authorization: true/enable_authorization: false/g' ${previous_file} >${config_file}
+  sed 's/enable_auth: true/enable_auth: false/g' ${previous_file} >${config_file}
   rm ${previous_file}
 fi
 

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -27,7 +27,7 @@ import {
   SignUpRoute,
   ExploreRoute,
 } from './model/route';
-import { useConfigContext } from './context/Config';
+import { useIsAuthEnable, useIsSignUpDisable } from './context/Config';
 
 // Other routes are lazy-loaded for code-splitting
 const MigrateView = lazy(() => import('./views/MigrateView'));
@@ -40,14 +40,15 @@ const DashboardView = lazy(() => import('./views/projects/dashboards/DashboardVi
 const ExploreView = lazy(() => import('./views/projects/explore/ExploreView'));
 
 function Router() {
-  const { config } = useConfigContext();
+  const isAuthEnable = useIsAuthEnable();
+  const isSignUpDisable = useIsSignUpDisable();
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
       {/* TODO: What sort of loading fallback do we want? */}
       <Suspense>
         <Routes>
-          <Route path={SignInRoute} element={<SignInView />} />
-          {!config.security.authentication.disable_sign_up && <Route path={SignUpRoute} element={<SignUpView />} />}
+          {isAuthEnable && <Route path={SignInRoute} element={<SignInView />} />}
+          {isAuthEnable && !isSignUpDisable && <Route path={SignUpRoute} element={<SignUpView />} />}
           <Route path={AdminRoute} element={<AdminView />} />
           <Route path={`${AdminRoute}/:tab`} element={<AdminView />} />
           <Route path={ConfigRoute} element={<ConfigView />} />

--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -53,6 +53,11 @@ export function useIsAuthEnable() {
   return config.security.enable_auth;
 }
 
+export function useIsSignUpDisable() {
+  const { config } = useConfigContext();
+  return config.security.authentication.disable_sign_up;
+}
+
 export function useImportantDashboardSelectors() {
   const { config } = useConfigContext();
   return config.important_dashboards ?? [];

--- a/ui/app/src/views/auth/SignInView.tsx
+++ b/ui/app/src/views/auth/SignInView.tsx
@@ -17,11 +17,11 @@ import { useSnackbar } from '@perses-dev/components';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { useAuthMutation, useIsAccessTokenExist } from '../../model/auth-client';
 import { SignUpRoute } from '../../model/route';
-import { useConfigContext } from '../../context/Config';
+import { useIsSignUpDisable } from '../../context/Config';
 import { SignWrapper } from './SignWrapper';
 
 function SignInView() {
-  const { config } = useConfigContext();
+  const isSignUpDisable = useIsSignUpDisable();
   const isAccessTokenExist = useIsAccessTokenExist();
   const authMutation = useAuthMutation();
   const navigate = useNavigate();
@@ -79,7 +79,7 @@ function SignInView() {
         Sign in
       </Button>
       {authMutation.isLoading && <LinearProgress />}
-      {!config.security.authentication.disable_sign_up && (
+      {!isSignUpDisable && (
         <Typography sx={{ textAlign: 'center' }}>
           Don&lsquo;t have an account yet?&nbsp;
           <Link underline="hover" component={RouterLink} to={SignUpRoute}>


### PR DESCRIPTION
e2e tests has been broken with my previous PR (#1612), because the configuration change and reactivated the required authentication.

I also took the opportunity to deactivate the route `/sign-in` and `/sign-out` when the config `security.enable_auth` is false.
It doesn't make sense to be able to reach these pages when there is no authentification.