### PR TITLE
[ENHANCEMENT] Healthcheck datasources when they're saved

### DIFF
--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Action, Datasource, DatasourceSpec, DispatchWithPromise } from '@perses-dev/core';
-import { Dispatch, DispatchWithoutAction, useState } from 'react';
+import { DispatchWithoutAction, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DatasourceEditorForm, PluginRegistry } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
@@ -23,7 +23,8 @@ interface DatasourceDrawerProps<T extends Datasource> {
   isOpen: boolean;
   action: Action;
   isReadonly?: boolean;
-  onSave: Dispatch<T>;
+  shouldTest?: boolean;
+  onSave: DispatchWithPromise<T>;
   onDelete?: DispatchWithPromise<T>;
   onClose: DispatchWithoutAction;
 }
@@ -38,12 +39,10 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
     /* do nothing */
   };
 
-  const handleSave = (name: string, spec: DatasourceSpec) => {
+  const handleSave = async (name: string, spec: DatasourceSpec) => {
     datasource.spec = spec;
     datasource.metadata.name = name;
-    if (onSave) {
-      onSave(datasource);
-    }
+    return onSave(datasource);
   };
 
   return (

--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -15,8 +15,10 @@ import { Action, Datasource, DatasourceSpec, DispatchWithPromise } from '@perses
 import { DispatchWithoutAction, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DatasourceEditorForm, PluginRegistry } from '@perses-dev/plugin-system';
+import { DatasourceStoreProvider } from '@perses-dev/dashboards';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
 import { DeleteDatasourceDialog } from '../dialogs/DeleteDatasourceDialog';
+import { HTTPDatasourceAPI } from '../../model/datasource-api';
 
 interface DatasourceDrawerProps<T extends Datasource> {
   datasource: T;
@@ -45,6 +47,8 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
     return onSave(datasource);
   };
 
+  const [datasourceApi] = useState(() => new HTTPDatasourceAPI());
+
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
@@ -57,16 +61,19 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
           }}
         >
           {isOpen && (
-            <DatasourceEditorForm
-              initialName={datasource.metadata.name}
-              initialSpec={datasource.spec}
-              initialAction={action}
-              isDraft={false}
-              isReadonly={isReadonly}
-              onSave={handleSave}
-              onClose={onClose}
-              onDelete={onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
-            />
+            <DatasourceStoreProvider datasourceApi={datasourceApi}>
+              <DatasourceEditorForm
+                initialName={datasource.metadata.name}
+                initialSpec={datasource.spec}
+                initialAction={action}
+                isDraft={false}
+                isReadonly={isReadonly}
+                shouldTest={true}
+                onSave={handleSave}
+                onClose={onClose}
+                onDelete={onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}
+              />
+            </DatasourceStoreProvider>
           )}
         </PluginRegistry>
         {onDelete && (

--- a/ui/app/src/components/datasource/DatasourceList.tsx
+++ b/ui/app/src/components/datasource/DatasourceList.tsx
@@ -82,14 +82,6 @@ export function DatasourceList<T extends Datasource>(props: DatasourceListProper
   const [isDatasourceDrawerOpened, setDatasourceDrawerOpened] = useState<boolean>(false);
   const [isDeleteDatasourceDialogOpened, setDeleteDatasourceDialogOpened] = useState<boolean>(false);
 
-  const handleDatasourceUpdate = useCallback(
-    async (datasource: T) => {
-      await onUpdate(datasource);
-      setDatasourceDrawerOpened(false);
-    },
-    [onUpdate]
-  );
-
   const handleRowClick = useCallback(
     (name: string, project?: string) => {
       setTargetedDatasource(findDatasource(name, project));
@@ -209,7 +201,7 @@ export function DatasourceList<T extends Datasource>(props: DatasourceListProper
             isOpen={isDatasourceDrawerOpened}
             action={action}
             isReadonly={isReadonly}
-            onSave={handleDatasourceUpdate}
+            onSave={onUpdate}
             onDelete={onDelete}
             onClose={() => setDatasourceDrawerOpened(false)}
           />

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -74,11 +74,10 @@ function TabButton(props: TabButtonProps) {
   }, [data]);
 
   const handleGlobalDatasourceCreation = useCallback(
-    (datasource: GlobalDatasource) => {
-      createGlobalDatasourceMutation.mutate(datasource, {
+    async (datasource: GlobalDatasource) => {
+      await createGlobalDatasourceMutation.mutateAsync(datasource, {
         onSuccess: (createdDatasource: GlobalDatasource) => {
           successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
-          setDatasourceDrawerOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);

--- a/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
@@ -36,21 +36,17 @@ export function GlobalDatasources(props: GlobalDatasourcesProps) {
   const updateDatasourceMutation = useUpdateGlobalDatasourceMutation();
 
   const handleDatasourceUpdate = useCallback(
-    (datasource: GlobalDatasource): Promise<void> => {
-      return new Promise((resolve, reject) => {
-        updateDatasourceMutation.mutate(datasource, {
-          onSuccess: (updatedDatasource: GlobalDatasource) => {
-            successSnackbar(
-              `Global Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`
-            );
-            resolve();
-          },
-          onError: (err) => {
-            exceptionSnackbar(err);
-            reject();
-            throw err;
-          },
-        });
+    async (datasource: GlobalDatasource) => {
+      await updateDatasourceMutation.mutateAsync(datasource, {
+        onSuccess: (updatedDatasource: GlobalDatasource) => {
+          successSnackbar(
+            `Global Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`
+          );
+        },
+        onError: (err) => {
+          exceptionSnackbar(err);
+          throw err;
+        },
       });
     },
     [exceptionSnackbar, successSnackbar, updateDatasourceMutation]

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -88,11 +88,10 @@ function TabButton(props: TabButtonProps) {
   }, [data]);
 
   const handleDatasourceCreation = useCallback(
-    (datasource: ProjectDatasource) => {
-      createDatasourceMutation.mutate(datasource, {
+    async (datasource: ProjectDatasource) => {
+      await createDatasourceMutation.mutateAsync(datasource, {
         onSuccess: (createdDatasource: ProjectDatasource) => {
           successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
-          setDatasourceDrawerOpened(false);
         },
         onError: (err) => {
           exceptionSnackbar(err);

--- a/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
@@ -38,19 +38,15 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
   const updateDatasourceMutation = useUpdateDatasourceMutation(projectName);
 
   const handleDatasourceUpdate = useCallback(
-    (datasource: ProjectDatasource): Promise<void> => {
-      return new Promise((resolve, reject) => {
-        updateDatasourceMutation.mutate(datasource, {
-          onSuccess: (updatedDatasource: ProjectDatasource) => {
-            successSnackbar(`Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`);
-            resolve();
-          },
-          onError: (err) => {
-            exceptionSnackbar(err);
-            reject();
-            throw err;
-          },
-        });
+    async (datasource: ProjectDatasource): Promise<void> => {
+      await updateDatasourceMutation.mutateAsync(datasource, {
+        onSuccess: (updatedDatasource: ProjectDatasource) => {
+          successSnackbar(`Datasource ${getDatasourceDisplayName(updatedDatasource)} has been successfully updated`);
+        },
+        onError: (err) => {
+          exceptionSnackbar(err);
+          throw err;
+        },
       });
     },
     [exceptionSnackbar, successSnackbar, updateDatasourceMutation]

--- a/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
+++ b/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
@@ -101,10 +101,9 @@ export function DatasourceEditor(props: {
           initialSpec={datasourceEdit.spec}
           initialAction={datasourceFormAction}
           isDraft={true}
-          onSave={(name: string, spec: DatasourceSpec) => {
+          onSave={async (name: string, spec: DatasourceSpec) => {
             setDatasources((draft) => {
               draft[name] = spec;
-              setDatasourceEdit(null);
             });
           }}
           onClose={() => {

--- a/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
+++ b/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
@@ -35,6 +35,7 @@ import { useDiscardChangesConfirmationDialog } from '../../context';
 
 export function DatasourceEditor(props: {
   datasources: Record<string, DatasourceSpec>;
+  shouldTest?: boolean;
   onChange: (datasources: Record<string, DatasourceSpec>) => void;
   onCancel: () => void;
 }) {
@@ -101,6 +102,7 @@ export function DatasourceEditor(props: {
           initialSpec={datasourceEdit.spec}
           initialAction={datasourceFormAction}
           isDraft={true}
+          shouldTest={props.shouldTest}
           onSave={async (name: string, spec: DatasourceSpec) => {
             setDatasources((draft) => {
               draft[name] = spec;

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -47,7 +47,7 @@ interface DatasourceEditorFormProps {
   initialAction: Action;
   isDraft: boolean;
   isReadonly?: boolean;
-  onSave: (name: string, spec: DatasourceSpec) => void;
+  onSave: (name: string, spec: DatasourceSpec) => Promise<void>;
   onClose: DispatchWithoutAction;
   onDelete?: DispatchWithoutAction;
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This updates the datasource editor to test the datasource when it's
saved. This pretty much mirrors how Grafana does this, with a "Save and Test"
button when editing datasources that saves the datasource and then runs
a test.

Most of this PR is making the saving process properly async so that we can call the test 
_after_ the datasource is saved.

There's a few things of note:

- Users of the <DatasourceEditorForm /> component no longer need to call
their `onClose` when the datasource is saved - the editor will call
it when the health check is sucessful.

- Dashboard local datasources _are not healthchecked_, for mostly the
same reasons as why they can't be immediately used - they don't exist
serverside until the dashboard is saved.

Signed-off-by: sinkingpoint <colin@quirl.co.nz>

# Screenshots


https://github.com/perses/perses/assets/4386405/eb9fc27a-bf80-4b80-a351-8b27ef8f24e5



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
