### PR TITLE
[BUGFIX] Wrap PrometheusDatasourceEditor with react-hook-form Controllers

### DIFF
--- a/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/PrometheusDatasourceEditor.tsx
@@ -16,6 +16,7 @@ import { OptionsEditorRadios } from '@perses-dev/plugin-system';
 import { Grid, IconButton, MenuItem, TextField, Typography } from '@mui/material';
 import React, { Fragment, useState } from 'react';
 import { produce } from 'immer';
+import { Controller } from 'react-hook-form';
 import MinusIcon from 'mdi-material-ui/Minus';
 import PlusIcon from 'mdi-material-ui/Plus';
 import { DEFAULT_SCRAPE_INTERVAL, PrometheusDatasourceSpec } from './types';
@@ -52,48 +53,64 @@ export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProp
     {
       label: strDirect,
       content: (
-        <>
-          <TextField
-            fullWidth
-            label="URL"
-            value={value.directUrl || ''}
-            InputProps={{
-              readOnly: isReadonly,
-            }}
-            InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-            onChange={(e) => {
-              onChange(
-                produce(value, (draft) => {
-                  draft.directUrl = e.target.value;
-                })
-              );
-            }}
-          />
-        </>
+        <Controller
+          name="URL"
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              fullWidth
+              label="URL"
+              value={value.directUrl || ''}
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+              onChange={(e) => {
+                field.onChange(e);
+                onChange(
+                  produce(value, (draft) => {
+                    draft.directUrl = e.target.value;
+                  })
+                );
+              }}
+            />
+          )}
+        />
       ),
     },
     {
       label: strProxy,
       content: (
         <>
-          <TextField
-            fullWidth
-            label="URL"
-            value={value.proxy?.spec.url || ''}
-            InputProps={{
-              readOnly: isReadonly,
-            }}
-            InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-            onChange={(e) => {
-              onChange(
-                produce(value, (draft) => {
-                  if (draft.proxy !== undefined) {
-                    draft.proxy.spec.url = e.target.value;
-                  }
-                })
-              );
-            }}
-            sx={{ mb: 2 }}
+          <Controller
+            name="URL"
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="URL"
+                value={value.proxy?.spec.url || ''}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                InputProps={{
+                  readOnly: isReadonly,
+                }}
+                InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+                onChange={(e) => {
+                  field.onChange(e);
+                  onChange(
+                    produce(value, (draft) => {
+                      if (draft.proxy !== undefined) {
+                        draft.proxy.spec.url = e.target.value;
+                      }
+                    })
+                  );
+                }}
+                sx={{ mb: 2 }}
+              />
+            )}
           />
           <Typography variant="h4" mb={2}>
             Allowed endpoints
@@ -104,94 +121,119 @@ export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProp
                 return (
                   <Fragment key={i}>
                     <Grid item xs={8}>
-                      <TextField
-                        fullWidth
-                        label="Endpoint pattern"
-                        value={endpointPattern}
-                        InputProps={{
-                          readOnly: isReadonly,
-                        }}
-                        InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-                        onChange={(e) => {
-                          onChange(
-                            produce(value, (draft) => {
-                              if (draft.proxy !== undefined) {
-                                draft.proxy.spec.allowedEndpoints = draft.proxy.spec.allowedEndpoints?.map(
-                                  (item, itemIndex) => {
-                                    if (i === itemIndex) {
-                                      return {
-                                        endpointPattern: e.target.value,
-                                        method: item.method,
-                                      };
-                                    } else {
-                                      return item;
-                                    }
+                      <Controller
+                        name={`Endpoint pattern ${i}`}
+                        render={({ field, fieldState }) => (
+                          <TextField
+                            {...field}
+                            fullWidth
+                            label="Endpoint pattern"
+                            value={endpointPattern}
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            InputProps={{
+                              readOnly: isReadonly,
+                            }}
+                            InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+                            onChange={(e) => {
+                              field.onChange(e);
+                              onChange(
+                                produce(value, (draft) => {
+                                  if (draft.proxy !== undefined) {
+                                    draft.proxy.spec.allowedEndpoints = draft.proxy.spec.allowedEndpoints?.map(
+                                      (item, itemIndex) => {
+                                        if (i === itemIndex) {
+                                          return {
+                                            endpointPattern: e.target.value,
+                                            method: item.method,
+                                          };
+                                        } else {
+                                          return item;
+                                        }
+                                      }
+                                    );
                                   }
-                                );
-                              }
-                            })
-                          );
-                        }}
+                                })
+                              );
+                            }}
+                          />
+                        )}
                       />
                     </Grid>
                     <Grid item xs={3}>
-                      <TextField
-                        select
-                        fullWidth
-                        label="Method"
-                        value={method}
-                        InputProps={{
-                          readOnly: isReadonly,
-                        }}
-                        InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-                        onChange={(e) => {
-                          onChange(
-                            produce(value, (draft) => {
-                              if (draft.proxy !== undefined) {
-                                draft.proxy.spec.allowedEndpoints = draft.proxy.spec.allowedEndpoints?.map(
-                                  (item, itemIndex) => {
-                                    if (i === itemIndex) {
-                                      return {
-                                        endpointPattern: item.endpointPattern,
-                                        method: e.target.value,
-                                      };
-                                    } else {
-                                      return item;
-                                    }
+                      <Controller
+                        name={`Method ${i}`}
+                        render={({ field, fieldState }) => (
+                          <TextField
+                            {...field}
+                            select
+                            fullWidth
+                            label="Method"
+                            value={method}
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            InputProps={{
+                              readOnly: isReadonly,
+                            }}
+                            InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+                            onChange={(e) => {
+                              field.onChange(e);
+                              onChange(
+                                produce(value, (draft) => {
+                                  if (draft.proxy !== undefined) {
+                                    draft.proxy.spec.allowedEndpoints = draft.proxy.spec.allowedEndpoints?.map(
+                                      (item, itemIndex) => {
+                                        if (i === itemIndex) {
+                                          return {
+                                            endpointPattern: item.endpointPattern,
+                                            method: e.target.value,
+                                          };
+                                        } else {
+                                          return item;
+                                        }
+                                      }
+                                    );
                                   }
-                                );
-                              }
-                            })
-                          );
-                        }}
-                      >
-                        <MenuItem value="GET">GET</MenuItem>
-                        <MenuItem value="POST">POST</MenuItem>
-                        <MenuItem value="PUT">PUT</MenuItem>
-                        <MenuItem value="PATCH">PATCH</MenuItem>
-                        <MenuItem value="DELETE">DELETE</MenuItem>
-                      </TextField>
+                                })
+                              );
+                            }}
+                          >
+                            <MenuItem value="GET">GET</MenuItem>
+                            <MenuItem value="POST">POST</MenuItem>
+                            <MenuItem value="PUT">PUT</MenuItem>
+                            <MenuItem value="PATCH">PATCH</MenuItem>
+                            <MenuItem value="DELETE">DELETE</MenuItem>
+                          </TextField>
+                        )}
+                      />
                     </Grid>
                     <Grid item xs={1}>
-                      <IconButton
-                        disabled={isReadonly}
-                        // Remove the given allowed endpoint from the list
-                        onClick={() => {
-                          onChange(
-                            produce(value, (draft) => {
-                              if (draft.proxy !== undefined) {
-                                draft.proxy.spec.allowedEndpoints = [
-                                  ...(draft.proxy.spec.allowedEndpoints?.filter((item, itemIndex) => {
-                                    return itemIndex !== i;
-                                  }) || []),
-                                ];
-                              }
-                            })
-                          );
-                        }}
-                      >
-                        <MinusIcon />
-                      </IconButton>
+                      <Controller
+                        name={`Remove Endpoint ${i}`}
+                        render={({ field }) => (
+                          <IconButton
+                            {...field}
+                            disabled={isReadonly}
+                            // Remove the given allowed endpoint from the list
+                            onClick={(e) => {
+                              field.onChange(e);
+                              onChange(
+                                produce(value, (draft) => {
+                                  if (draft.proxy !== undefined) {
+                                    draft.proxy.spec.allowedEndpoints = [
+                                      ...(draft.proxy.spec.allowedEndpoints?.filter((item, itemIndex) => {
+                                        return itemIndex !== i;
+                                      }) || []),
+                                    ];
+                                  }
+                                })
+                              );
+                            }}
+                          >
+                            <MinusIcon />
+                          </IconButton>
+                        )}
+                      />
                     </Grid>
                   </Fragment>
                 );
@@ -231,70 +273,95 @@ export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProp
                 return (
                   <Fragment key={i}>
                     <Grid item xs={4}>
-                      <TextField
-                        fullWidth
-                        label="Header name"
-                        value={headerName}
-                        InputProps={{
-                          readOnly: isReadonly,
-                        }}
-                        InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-                        onChange={(e) =>
-                          onChange(
-                            produce(value, (draft) => {
-                              if (draft.proxy !== undefined) {
-                                draft.proxy.spec.headers = buildNewHeaders(
-                                  draft.proxy.spec.headers,
-                                  headerName,
-                                  e.target.value
-                                );
-                              }
-                            })
-                          )
-                        }
+                      <Controller
+                        name={`Header name ${i}`}
+                        render={({ field, fieldState }) => (
+                          <TextField
+                            {...field}
+                            fullWidth
+                            label="Header name"
+                            value={headerName}
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            InputProps={{
+                              readOnly: isReadonly,
+                            }}
+                            InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+                            onChange={(e) => {
+                              field.onChange(e);
+                              onChange(
+                                produce(value, (draft) => {
+                                  if (draft.proxy !== undefined) {
+                                    draft.proxy.spec.headers = buildNewHeaders(
+                                      draft.proxy.spec.headers,
+                                      headerName,
+                                      e.target.value
+                                    );
+                                  }
+                                })
+                              );
+                            }}
+                          />
+                        )}
                       />
                     </Grid>
                     <Grid item xs={7}>
-                      <TextField
-                        fullWidth
-                        label="Header value"
-                        value={value.proxy?.spec.headers?.[headerName]}
-                        InputProps={{
-                          readOnly: isReadonly,
-                        }}
-                        InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-                        onChange={(e) =>
-                          onChange(
-                            produce(value, (draft) => {
-                              if (draft.proxy !== undefined) {
-                                draft.proxy.spec.headers = {
-                                  ...draft.proxy.spec.headers,
-                                  [headerName]: e.target.value,
-                                };
-                              }
-                            })
-                          )
-                        }
+                      <Controller
+                        name={`Header value ${i}`}
+                        render={({ field, fieldState }) => (
+                          <TextField
+                            {...field}
+                            fullWidth
+                            label="Header value"
+                            value={value.proxy?.spec.headers?.[headerName]}
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            InputProps={{
+                              readOnly: isReadonly,
+                            }}
+                            InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+                            onChange={(e) => {
+                              field.onChange(e);
+                              onChange(
+                                produce(value, (draft) => {
+                                  if (draft.proxy !== undefined) {
+                                    draft.proxy.spec.headers = {
+                                      ...draft.proxy.spec.headers,
+                                      [headerName]: e.target.value,
+                                    };
+                                  }
+                                })
+                              );
+                            }}
+                          />
+                        )}
                       />
                     </Grid>
                     <Grid item xs={1}>
-                      <IconButton
-                        disabled={isReadonly}
-                        // Remove the given header from the list
-                        onClick={() => {
-                          const newHeaders = { ...value.proxy?.spec.headers };
-                          delete newHeaders[headerName];
-                          onChange(
-                            produce(value, (draft) => {
-                              if (draft.proxy !== undefined) {
-                                draft.proxy.spec.headers = newHeaders;
-                              }
-                            })
-                          );
-                        }}
-                      >
-                        <MinusIcon />
-                      </IconButton>
+                      <Controller
+                        name={`Remove Header ${i}`}
+                        render={({ field }) => (
+                          <IconButton
+                            {...field}
+                            disabled={isReadonly}
+                            // Remove the given header from the list
+                            onClick={(e) => {
+                              field.onChange(e);
+                              const newHeaders = { ...value.proxy?.spec.headers };
+                              delete newHeaders[headerName];
+                              onChange(
+                                produce(value, (draft) => {
+                                  if (draft.proxy !== undefined) {
+                                    draft.proxy.spec.headers = newHeaders;
+                                  }
+                                })
+                              );
+                            }}
+                          >
+                            <MinusIcon />
+                          </IconButton>
+                        )}
+                      />
                     </Grid>
                   </Fragment>
                 );
@@ -317,23 +384,33 @@ export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProp
               </IconButton>
             </Grid>
           </Grid>
-          <TextField
-            fullWidth
-            label="Secret"
-            value={value.proxy?.spec.secret || ''}
-            InputProps={{
-              readOnly: isReadonly,
-            }}
-            InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-            onChange={(e) => {
-              onChange(
-                produce(value, (draft) => {
-                  if (draft.proxy !== undefined) {
-                    draft.proxy.spec.secret = e.target.value;
-                  }
-                })
-              );
-            }}
+
+          <Controller
+            name="Secret"
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Secret"
+                value={value.proxy?.spec.secret || ''}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                InputProps={{
+                  readOnly: isReadonly,
+                }}
+                InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+                onChange={(e) => {
+                  field.onChange(e);
+                  onChange(
+                    produce(value, (draft) => {
+                      if (draft.proxy !== undefined) {
+                        draft.proxy.spec.secret = e.target.value;
+                      }
+                    })
+                  );
+                }}
+              />
+            )}
           />
         </>
       ),


### PR DESCRIPTION


<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Previously, the fields created with the PrometheusDatasourceEditor weren't wired into the form infrastructure. This means that, among other things, if you edit the URL of the datasource, the form doesn't know that the datasource has changed and doesn't allow you to save.

This change wraps the PrometheusDatasourceEditor inputs with react-hook-form Controllers, which means that the form is now aware of changes.

# Screenshots

Before: (Editing the URL doesn't allow you to save)

https://github.com/perses/perses/assets/4386405/1d4602f6-b913-40e3-8e8f-c9513623c01c

After:

https://github.com/perses/perses/assets/4386405/fd146205-53b4-4a6c-b492-5fe6818953b7

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky. See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests) and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
