### PR TITLE
[DOC] Add the screenshot of a Perses dashboard in the README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,6 @@
   See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
   and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
   include:
-    - Is the data inconsistent? You need to mock API requests.
-    - Does the time change? You need to use consistent time values or mock time utilities.
-    - Does it have loading states? You need to wait for loading to complete.
+  - Is the data inconsistent? You need to mock API requests.
+  - Does the time change? You need to use consistent time values or mock time utilities.
+  - Does it have loading states? You need to wait for loading to complete.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<h1 align="center" style="border-bottom: none">
+<div align="center">
+
+<h1 style="border-bottom: none">
     <a href="https://github.com/perses" target="_blank"><img alt="Perses" src="/docs/images/perses_logo_cropped.svg"></a><br>Perses
 </h1>
 
@@ -8,11 +10,16 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/perses/perses)](https://goreportcard.com/report/github.com/perses/perses)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/perses/perses)
 
+</div>
+
 ## Overview
 
 Perses is part of the [CoreDash community](https://github.com/coredashio/community). It belongs to the Linux Foundation.
 At a later stage, we want to promote the project to the [Cloud Native Computing Foundation](https://www.cncf.io/) and be
 part of the monitoring tools like Prometheus or Thanos.
+
+| ![img.png](https://github.com/perses/perses/assets/5657041/3bd8ae57-da7b-4447-9478-cefe19d61a71) | ![img.png](https://github.com/perses/perses/assets/5657041/ba46beab-c8fb-4583-bc2f-71c9893f7906) |
+|:------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------:|
 
 Perses is going to tackle multiple different goals:
 

--- a/docs/design-docs/authorization.md
+++ b/docs/design-docs/authorization.md
@@ -1,7 +1,5 @@
 # Authorization
 
-*WIP: The authorization is still not implemented in Perses*
-
 Perses will use a Role-based access control (RBAC) for regulating access to resources based on the role of the user.
 The RBAC API is based on four kinds of resource: GlobalRole, Role, GlobalRoleBinding and RoleBinding.
 Perses RBAC implementation is highly inspired by K8S RBAC implementation.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Adding screenshot of a Perses dashboard in the readme. Because visitors can't see what Perses look like without running it or going to the demo instance. Fixed by adding the screenshot of a migrated dashboard about node exporter metrics

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/perses/perses/assets/5657041/3bd8ae57-da7b-4447-9478-cefe19d61a71)
![image](https://github.com/perses/perses/assets/5657041/ba46beab-c8fb-4583-bc2f-71c9893f7906)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
