### PR TITLE
[ENHANCEMENT] Improve dashboard toolbar UX

### DIFF
--- a/ui/dashboards/src/components/AddGroupButton/AddGroupButton.tsx
+++ b/ui/dashboards/src/components/AddGroupButton/AddGroupButton.tsx
@@ -14,7 +14,7 @@
 import { Button } from '@mui/material';
 import AddGroupIcon from 'mdi-material-ui/PlusBoxOutline';
 import { InfoTooltip } from '@perses-dev/components';
-import { TOOLTIP_TEXT } from '../../constants';
+import { TOOLTIP_TEXT, editButtonStyle } from '../../constants';
 import { useDashboardActions } from '../../context';
 
 export const AddGroupButton = () => {
@@ -22,7 +22,12 @@ export const AddGroupButton = () => {
 
   return (
     <InfoTooltip description={TOOLTIP_TEXT.addGroup}>
-      <Button startIcon={<AddGroupIcon />} onClick={openAddPanelGroup} aria-label={TOOLTIP_TEXT.addGroup}>
+      <Button
+        startIcon={<AddGroupIcon />}
+        onClick={openAddPanelGroup}
+        aria-label={TOOLTIP_TEXT.addGroup}
+        sx={editButtonStyle}
+      >
         Panel Group
       </Button>
     </InfoTooltip>

--- a/ui/dashboards/src/components/AddPanelButton/AddPanelButton.tsx
+++ b/ui/dashboards/src/components/AddPanelButton/AddPanelButton.tsx
@@ -14,7 +14,7 @@
 import { Button, ButtonProps } from '@mui/material';
 import AddPanelIcon from 'mdi-material-ui/ChartBoxPlusOutline';
 import { InfoTooltip } from '@perses-dev/components';
-import { TOOLTIP_TEXT } from '../../constants';
+import { TOOLTIP_TEXT, editButtonStyle } from '../../constants';
 import { useDashboardActions } from '../../context';
 
 export interface AddPanelButtonProps extends Pick<ButtonProps, 'fullWidth'> {
@@ -51,7 +51,7 @@ export const AddPanelButton = ({
         variant={variant}
         color={color}
         fullWidth={fullWidth}
-        sx={{ whiteSpace: 'nowrap', minWidth: 'auto' }}
+        sx={editButtonStyle}
       >
         {label}
       </Button>

--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -12,7 +12,17 @@
 // limitations under the License.
 
 import { useState } from 'react';
-import { AppBar, Box, IconButton, Stack, SxProps, Theme, useMediaQuery, useScrollTrigger, useTheme } from '@mui/material';
+import {
+  AppBar,
+  Box,
+  IconButton,
+  Stack,
+  SxProps,
+  Theme,
+  useMediaQuery,
+  useScrollTrigger,
+  useTheme,
+} from '@mui/material';
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
 import { TemplateVariableList } from '../Variables';

--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -73,7 +73,9 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
           >
             <TemplateVariableList></TemplateVariableList>
             {props.initialVariableIsSticky && (
-              <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
+              <IconButton style={{ width: 'fit-content', height: 'fit-content' }} onClick={() => setIsPin(!isPin)}>
+                {isPin ? <PinOutline /> : <PinOffOutline />}
+              </IconButton>
             )}
           </Box>
           {isSticky && (

--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -70,6 +70,7 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
                 background: (theme) => theme.palette.grey['600'],
               },
             }}
+            gap={1}
           >
             <TemplateVariableList></TemplateVariableList>
             {props.initialVariableIsSticky && (
@@ -81,9 +82,9 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
           {isSticky && (
             <Stack
               m={isBiggerThanMd ? 1.5 : 1}
-              mt={isBiggerThanMd ? 1.5 : 1}
+              mt={isBiggerThanMd ? 1.5 : 0}
+              ml={isBiggerThanMd ? 1.5 : 'auto'}
               direction="row"
-              ml="auto"
               justifyContent="end"
             >
               <TimeRangeControls></TimeRangeControls>

--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useState } from 'react';
-import { AppBar, Box, IconButton, SxProps, Theme, useScrollTrigger } from '@mui/material';
+import { AppBar, Box, IconButton, SxProps, Theme, useMediaQuery, useScrollTrigger, useTheme } from '@mui/material';
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
 import { TemplateVariableList } from '../Variables';
@@ -29,6 +29,8 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
   const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
 
+  const isBiggerThanMd = useMediaQuery(useTheme().breakpoints.up('md'));
+
   return (
     // marginBottom={-1} counteracts the marginBottom={1} on every variable input.
     // The margin on the inputs is for spacing between inputs, but is not meant to add space to bottom of the container.
@@ -39,15 +41,43 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
         elevation={isSticky ? 4 : 0}
         sx={{ backgroundColor: 'inherit', ...props.sx }}
       >
-        <Box display="flex" justifyContent="space-between">
-          <Box display="flex" flexWrap="wrap" alignItems="start" mt={isSticky ? 1.5 : 0} ml={isSticky ? 2 : 0}>
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          sx={{
+            flexDirection: isBiggerThanMd ? 'row' : 'column',
+          }}
+        >
+          <Box
+            display="flex"
+            flexWrap={!isSticky && isBiggerThanMd ? 'wrap' : 'nowrap'}
+            maxWidth={isSticky || !isBiggerThanMd ? '100vw' : '100%'}
+            maxHeight="150px" // Limit the vertical space used to ~3 rows of variables
+            pt={1}
+            pl={isSticky ? 1 : 0}
+            mt={isSticky && isBiggerThanMd ? 0.5 : 0}
+            ml={isSticky && isBiggerThanMd ? 0.5 : 0}
+            sx={{
+              overflowX: !isSticky && isBiggerThanMd ? 'hidden' : 'auto',
+              // Firefox:
+              scrollbarWidth: 'thin',
+              // Safari and Chrome:
+              '&::-webkit-scrollbar': {
+                height: '8px',
+                backgroundColor: (theme) => theme.palette.grey['300'],
+              },
+              '&::-webkit-scrollbar-thumb': {
+                background: (theme) => theme.palette.grey['600'],
+              },
+            }}
+          >
             <TemplateVariableList></TemplateVariableList>
             {props.initialVariableIsSticky && (
               <IconButton onClick={() => setIsPin(!isPin)}>{isPin ? <PinOutline /> : <PinOffOutline />}</IconButton>
             )}
           </Box>
           {isSticky && (
-            <Box mt={1.5} mr={2}>
+            <Box m={isBiggerThanMd ? 1.5 : 1} mt={isBiggerThanMd ? 1.5 : 0.5}>
               <TimeRangeControls></TimeRangeControls>
             </Box>
           )}

--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useState } from 'react';
-import { AppBar, Box, IconButton, SxProps, Theme, useMediaQuery, useScrollTrigger, useTheme } from '@mui/material';
+import { AppBar, Box, IconButton, Stack, SxProps, Theme, useMediaQuery, useScrollTrigger, useTheme } from '@mui/material';
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
 import { TemplateVariableList } from '../Variables';
@@ -77,9 +77,15 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
             )}
           </Box>
           {isSticky && (
-            <Box m={isBiggerThanMd ? 1.5 : 1} mt={isBiggerThanMd ? 1.5 : 0.5}>
+            <Stack
+              m={isBiggerThanMd ? 1.5 : 1}
+              mt={isBiggerThanMd ? 1.5 : 1}
+              direction="row"
+              ml="auto"
+              justifyContent="end"
+            >
               <TimeRangeControls></TimeRangeControls>
-            </Box>
+            </Stack>
           )}
         </Box>
       </AppBar>

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -76,6 +76,12 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
                   Dashboard managed via code only. Download JSON and commit changes to save.
                 </Alert>
               )}
+              <Stack direction="row" spacing={0.5} ml={1} whiteSpace="nowrap">
+                <EditVariablesButton />
+                <EditDatasourcesButton />
+                <AddPanelButton />
+                <AddGroupButton />
+              </Stack>
               <SaveDashboardButton onSave={onSave} isDisabled={isReadonly} />
               <Button variant="outlined" onClick={onCancelButtonClick}>
                 Cancel
@@ -113,14 +119,6 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             </ErrorBoundary>
           </Box>
           <Stack direction="row" ml="auto" flexWrap="wrap" justifyContent="end">
-            {isEditMode && (
-              <Stack mt={1} direction="row" spacing={1} ml={1} whiteSpace="nowrap">
-                <EditVariablesButton />
-                <EditDatasourcesButton />
-                <AddPanelButton />
-                <AddGroupButton />
-              </Stack>
-            )}
             <Stack direction="row" spacing={1} mt={1} ml={1}>
               <TimeRangeControls />
               <DownloadButton />

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -49,7 +49,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
   const { isEditMode } = useEditMode();
 
   const isBiggerThanSm = useMediaQuery(useTheme().breakpoints.up('sm'));
-  const isBiggerThanLg = useMediaQuery(useTheme().breakpoints.up('lg'));
+  const isBiggerThanMd = useMediaQuery(useTheme().breakpoints.up('md'));
 
   const dashboardTitle = dashboardTitleComponent ? (
     dashboardTitleComponent
@@ -61,7 +61,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
 
   return (
     <>
-      <Stack spacing={1} data-testid={testId}>
+      <Stack data-testid={testId}>
         <Box
           px={2}
           py={1.5}
@@ -97,26 +97,31 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             width: '100%',
             alignItems: 'start',
             padding: (theme) => theme.spacing(1, 2, 0, 2),
+            flexDirection: isBiggerThanMd ? 'row' : 'column',
+            flexWrap: 'nowrap',
+            gap: 1,
           }}
         >
-          <ErrorBoundary FallbackComponent={ErrorAlert}>
-            <DashboardStickyToolbar
-              initialVariableIsSticky={initialVariableIsSticky}
-              sx={{
-                backgroundColor: ({ palette }) => palette.background.default,
-              }}
-            />
-          </ErrorBoundary>
-          <Stack ml="auto" direction="row" flexWrap={isBiggerThanLg ? 'nowrap' : 'wrap-reverse'} justifyContent="end">
+          <Box flexGrow={1} flexShrink={1}>
+            <ErrorBoundary FallbackComponent={ErrorAlert}>
+              <DashboardStickyToolbar
+                initialVariableIsSticky={initialVariableIsSticky}
+                sx={{
+                  backgroundColor: ({ palette }) => palette.background.default,
+                }}
+              />
+            </ErrorBoundary>
+          </Box>
+          <Stack direction="row" ml="auto" flexWrap="wrap" justifyContent="end">
             {isEditMode && (
-              <Stack direction="row" spacing={1} ml={1} whiteSpace="nowrap">
+              <Stack mt={1} direction="row" spacing={1} ml={1} whiteSpace="nowrap">
                 <EditVariablesButton />
                 <EditDatasourcesButton />
                 <AddPanelButton />
                 <AddGroupButton />
               </Stack>
             )}
-            <Stack direction="row" spacing={1} ml={1}>
+            <Stack direction="row" spacing={1} mt={1} ml={1}>
               <TimeRangeControls />
               <DownloadButton />
               {isEditMode && <EditJsonButton />}

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -108,7 +108,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             gap: 1,
           }}
         >
-          <Box>
+          <Box width="100%">
             <ErrorBoundary FallbackComponent={ErrorAlert}>
               <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -61,10 +61,15 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
 
   return (
     <>
-      {isEditMode ? (
-        <Stack spacing={1} data-testid={testId}>
-          <Box px={2} py={1.5} display="flex" sx={{ backgroundColor: (theme) => theme.palette.primary.main + '30' }}>
-            {dashboardTitle}
+      <Stack spacing={1} data-testid={testId}>
+        <Box
+          px={2}
+          py={1.5}
+          display="flex"
+          sx={{ backgroundColor: (theme) => theme.palette.primary.main + (isEditMode ? '30' : '0') }}
+        >
+          {dashboardTitle}
+          {isEditMode ? (
             <Stack direction="row" gap={1} ml="auto">
               {isReadonly && (
                 <Alert severity={'warning'} sx={{ backgroundColor: 'transparent', padding: 0 }}>
@@ -76,60 +81,49 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
                 Cancel
               </Button>
             </Stack>
-          </Box>
-          <Box
-            sx={{
-              display: 'flex',
-              width: '100%',
-              alignItems: 'start',
-              padding: (theme) => theme.spacing(1, 2, 0, 2),
-            }}
-          >
-            <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <DashboardStickyToolbar
-                initialVariableIsSticky={initialVariableIsSticky}
-                sx={{
-                  backgroundColor: ({ palette }) => palette.background.default,
-                }}
-              />
-            </ErrorBoundary>
-            <Stack ml="auto" direction="row" flexWrap={isBiggerThanLg ? 'nowrap' : 'wrap-reverse'} justifyContent="end">
+          ) : (
+            <>
+              {isBiggerThanSm && (
+                <Stack direction="row" gap={1} ml="auto">
+                  <EditButton onClick={onEditButtonClick} />
+                </Stack>
+              )}
+            </>
+          )}
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            width: '100%',
+            alignItems: 'start',
+            padding: (theme) => theme.spacing(1, 2, 0, 2),
+          }}
+        >
+          <ErrorBoundary FallbackComponent={ErrorAlert}>
+            <DashboardStickyToolbar
+              initialVariableIsSticky={initialVariableIsSticky}
+              sx={{
+                backgroundColor: ({ palette }) => palette.background.default,
+              }}
+            />
+          </ErrorBoundary>
+          <Stack ml="auto" direction="row" flexWrap={isBiggerThanLg ? 'nowrap' : 'wrap-reverse'} justifyContent="end">
+            {isEditMode && (
               <Stack direction="row" spacing={1} ml={1} whiteSpace="nowrap">
                 <EditVariablesButton />
                 <EditDatasourcesButton />
                 <AddPanelButton />
                 <AddGroupButton />
               </Stack>
-              <Stack direction="row" spacing={1} ml={1}>
-                <TimeRangeControls />
-                <DownloadButton />
-                <EditJsonButton />
-              </Stack>
-            </Stack>
-          </Box>
-        </Stack>
-      ) : (
-        <Stack gap={1} mx={2} mt={1.5} data-testid={testId}>
-          <Box sx={{ display: 'flex', width: '100%' }}>
-            {dashboardTitle}
-            <Stack direction="row" spacing={1} marginLeft="auto">
+            )}
+            <Stack direction="row" spacing={1} ml={1}>
               <TimeRangeControls />
               <DownloadButton />
-              {isBiggerThanSm && <EditButton onClick={onEditButtonClick} />}
+              {isEditMode && <EditJsonButton />}
             </Stack>
-          </Box>
-          <Box mt={1}>
-            <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <DashboardStickyToolbar
-                initialVariableIsSticky={initialVariableIsSticky}
-                sx={{
-                  backgroundColor: ({ palette }) => palette.background.default,
-                }}
-              />
-            </ErrorBoundary>
-          </Box>
-        </Stack>
-      )}
+          </Stack>
+        </Box>
+      </Stack>
     </>
   );
 };

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -108,7 +108,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             gap: 1,
           }}
         >
-          <Box flexGrow={1} flexShrink={1}>
+          <Box>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
               <DashboardStickyToolbar
                 initialVariableIsSticky={initialVariableIsSticky}

--- a/ui/dashboards/src/components/Datasources/EditDatasourcesButton.tsx
+++ b/ui/dashboards/src/components/Datasources/EditDatasourcesButton.tsx
@@ -17,7 +17,7 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import { Drawer, InfoTooltip } from '@perses-dev/components';
 import { DatasourceSpec } from '@perses-dev/core';
 import { useDatasourceStore } from '@perses-dev/plugin-system';
-import { TOOLTIP_TEXT } from '../../constants';
+import { TOOLTIP_TEXT, editButtonStyle } from '../../constants';
 import { useDashboard } from '../../context';
 import { DatasourceEditor } from './DatasourceEditor';
 
@@ -77,7 +77,7 @@ export function EditDatasourcesButton() {
           aria-label={TOOLTIP_TEXT.editDatasources}
           variant="text"
           color="primary"
-          sx={{ whiteSpace: 'nowrap', minWidth: 'auto' }}
+          sx={editButtonStyle}
         >
           Datasources
         </Button>

--- a/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
+++ b/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
@@ -17,7 +17,7 @@ import PencilIcon from 'mdi-material-ui/PencilOutline';
 import { Drawer, InfoTooltip } from '@perses-dev/components';
 import { BuiltinVariableDefinition, VariableDefinition } from '@perses-dev/core';
 import { useBuiltinVariableDefinitions } from '@perses-dev/plugin-system';
-import { TOOLTIP_TEXT } from '../../constants';
+import { TOOLTIP_TEXT, editButtonStyle } from '../../constants';
 import {
   ExternalVariableDefinition,
   useTemplateExternalVariableDefinitions,
@@ -73,7 +73,7 @@ export function EditVariablesButton({
           variant={variant}
           color={color}
           fullWidth={fullWidth}
-          sx={{ whiteSpace: 'nowrap', minWidth: 'auto' }}
+          sx={editButtonStyle}
         >
           {label}
         </Button>

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -53,8 +53,6 @@ export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec;
       display={ctx.state?.overridden || spec.display?.hidden ? 'none' : undefined}
       minWidth={VARIABLE_INPUT_MIN_WIDTH}
       maxWidth={VARIABLE_INPUT_MAX_WIDTH}
-      marginBottom={1}
-      marginRight={1}
       flexShrink={0}
       data-testid={'template-variable-' + spec.name}
     >

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -55,6 +55,7 @@ export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec;
       maxWidth={VARIABLE_INPUT_MAX_WIDTH}
       marginBottom={1}
       marginRight={1}
+      flexShrink={0}
       data-testid={'template-variable-' + spec.name}
     >
       <TemplateVariable key={spec.name + source ?? ''} name={spec.name} source={source} />

--- a/ui/dashboards/src/constants/styles.ts
+++ b/ui/dashboards/src/constants/styles.ts
@@ -11,6 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './grid-layout-config';
-export * from './styles';
-export * from './user-interface-text';
+import { SxProps, Theme } from '@mui/material';
+
+export const editButtonStyle: SxProps<Theme> = {
+  whiteSpace: 'nowrap',
+  minWidth: 'auto',
+  '& .MuiButton-startIcon': {
+    marginRight: 0.5,
+  },
+};


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Improve the dashboard toolbar UX by:
- repositioning the buttons to have less difference between read & edit modes,
- improving its responsiveness: variables take more advantage of the space available + put some limit to the vertical space used when there are many of them, by adding scrolling (basically vertical when not sticky, horizontal when sticky).

_FYI I'm planning to make the JSON view available in the read mode too in a future PR, this is also going to reduce the visual difference between the two modes._ 

# Screenshots

Buttons position:

| Before | After |
:-------------------------:|:-------------------------:
![2023-12-13_09h06_33](https://github.com/perses/perses/assets/7058693/414440f4-07de-4a18-a76d-0e7a5dbaf973) | ![2023-12-15_15h21_20](https://github.com/perses/perses/assets/7058693/34e42837-9b49-4381-90e5-60381704ba09)
![2023-12-13_09h07_19](https://github.com/perses/perses/assets/7058693/f7c845d1-ae91-4235-b729-e8e859cee18c) | ![2023-12-15_15h21_34](https://github.com/perses/perses/assets/7058693/dd4b0e5d-b6a0-4523-b384-885607ecc1c6)

Responsiveness:

https://github.com/perses/perses/assets/7058693/bdb22e34-d6cf-44da-9fb4-9469ed9f86de

⚠️ something I didn't take time to improve in this PR is the space used by the edit buttons now that they are on the same row as the breadcrumb: on small screens the latter gets hidden, see demo:

https://github.com/perses/perses/assets/7058693/bd8c01a9-b8d4-4b61-b176-c0d8812f3d29

We should probably group the buttons under a menu in this case as we did for the buttons in the navbar.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
