### PR TITLE
[ENHANCEMENT] Improve variable editor form state update

### DIFF
--- a/ui/app/src/components/breadcrumbs/ProjectBreadcrumbs.tsx
+++ b/ui/app/src/components/breadcrumbs/ProjectBreadcrumbs.tsx
@@ -33,6 +33,7 @@ function ProjectBreadcrumbs(props: ProjectBreadcrumbsProps) {
           scrollbarWidth: 'none' /* Firefox */,
           '& .MuiBreadcrumbs-ol': {
             flexWrap: 'nowrap',
+            whiteSpace: 'nowrap',
           },
           '&::-webkit-scrollbar': {
             display: 'none' /* Safari and Chrome */,
@@ -62,6 +63,7 @@ function ProjectBreadcrumbs(props: ProjectBreadcrumbsProps) {
         scrollbarWidth: 'none' /* Firefox */,
         '& .MuiBreadcrumbs-ol': {
           flexWrap: 'nowrap',
+          whiteSpace: 'nowrap',
         },
         '&::-webkit-scrollbar': {
           display: 'none' /* Safari and Chrome */,

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -25,17 +25,17 @@ import {
   ClickAwayListener,
   Divider,
 } from '@mui/material';
-import { useImmer } from 'use-immer';
 import { VariableDefinition, ListVariableDefinition, Action } from '@perses-dev/core';
 import { DiscardChangesConfirmationDialog, ErrorBoundary } from '@perses-dev/components';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useImmer } from 'use-immer';
 import { getSubmitText, getTitleAction } from '../../../utils';
 import { VARIABLE_TYPES } from '../variable-model';
 import { PluginEditor } from '../../PluginEditor';
-import { variableEditValidationSchema, VariableEditValidationType } from '../../../validation';
+import { variableEditorValidationSchema, VariableEditorValidationType } from '../../../validation';
 import { VariableListPreview, VariablePreview } from './VariablePreview';
-import { VariableEditorState, getVariableDefinitionFromState, getInitialState } from './variable-editor-form-model';
+import { getVariableDefinitionFromState, getInitialState, VariableEditorState } from './variable-editor-form-model';
 
 function FallbackPreview() {
   return <div>Error previewing values</div>;
@@ -76,13 +76,13 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
   const titleAction = getTitleAction(action, isDraft);
   const submitText = getSubmitText(action, isDraft);
 
-  const form = useForm<VariableEditValidationType>({
-    resolver: zodResolver(variableEditValidationSchema),
+  const form = useForm<VariableEditorValidationType>({
+    resolver: zodResolver(variableEditorValidationSchema),
     mode: 'onBlur',
-    defaultValues: state,
+    defaultValues: initialState,
   });
 
-  const processForm: SubmitHandler<VariableEditValidationType> = () => {
+  const processForm: SubmitHandler<VariableEditorValidationType> = () => {
     onSave(getVariableDefinitionFromState(state));
   };
 
@@ -96,7 +96,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
     } else {
       onClose();
     }
-  }, [state, initialState, setDiscardDialogOpened, onClose]);
+  }, [initialState, state, onClose]);
 
   return (
     <FormProvider {...form}>
@@ -168,6 +168,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   }}
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
+                  value={state.name}
                   onChange={(event) => {
                     field.onChange(event);
                     setState((draft) => {
@@ -192,6 +193,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   }}
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
+                  value={state.title ?? ''}
                   onChange={(event) => {
                     field.onChange(event);
                     setState((draft) => {
@@ -216,6 +218,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   }}
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
+                  value={state.description ?? ''}
                   onChange={(event) => {
                     field.onChange(event);
                     setState((draft) => {
@@ -241,6 +244,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   }}
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
+                  value={state.kind}
                   onChange={(event) => {
                     field.onChange(event);
                     setState((draft) => {
@@ -270,33 +274,50 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
               <Box>
                 <VariablePreview values={[state.textVariableFields.value]} />
               </Box>
-              <TextField
-                label="Value"
-                value={state.textVariableFields.value}
-                InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
-                InputProps={{
-                  readOnly: action === 'read',
-                }}
-                onChange={(v) => {
-                  setState((draft) => {
-                    draft.textVariableFields.value = v.target.value;
-                  });
-                }}
-              />
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={state.textVariableFields.constant ?? false}
-                    readOnly={action === 'read'}
-                    onChange={(e) => {
-                      if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
+              <Controller
+                name="textVariableFields.value"
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    label="Value"
+                    InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
+                    InputProps={{
+                      readOnly: action === 'read',
+                    }}
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    value={state.textVariableFields.value}
+                    onChange={(event) => {
+                      field.onChange(event);
                       setState((draft) => {
-                        draft.textVariableFields.constant = e.target.checked;
+                        draft.textVariableFields.value = event.target.value;
                       });
                     }}
                   />
-                }
-                label="Constant"
+                )}
+              />
+              <Controller
+                name="textVariableFields.constant"
+                render={({ field }) => (
+                  <FormControlLabel
+                    label="Constant"
+                    control={
+                      <Switch
+                        {...field}
+                        checked={!!field.value}
+                        readOnly={action === 'read'}
+                        value={state.textVariableFields.constant}
+                        onChange={(event) => {
+                          if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
+                          field.onChange(event);
+                          setState((draft) => {
+                            draft.textVariableFields.constant = event.target.checked;
+                          });
+                        }}
+                      />
+                    }
+                  />
+                )}
               />
             </Stack>
           </>
@@ -324,65 +345,93 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   <Box />
                 </ClickAwayListener>
                 {/** */}
-                <PluginEditor
-                  width="100%"
-                  pluginType="Variable"
-                  pluginKindLabel="Source"
-                  value={state.listVariableFields.plugin}
-                  isReadonly={action === 'read'}
-                  onChange={(val) => {
-                    setState((draft) => {
-                      draft.listVariableFields.plugin = val;
-                    });
-                  }}
+                <Controller
+                  name="listVariableFields.plugin"
+                  render={({ field }) => (
+                    <PluginEditor
+                      width="100%"
+                      pluginType="Variable"
+                      pluginKindLabel="Source"
+                      isReadonly={action === 'read'}
+                      value={state.listVariableFields.plugin}
+                      onChange={(val) => {
+                        field.onChange(val);
+                        setState((draft) => {
+                          draft.listVariableFields.plugin = val;
+                        });
+                      }}
+                    />
+                  )}
                 />
               </Stack>
 
               <Stack>
-                <TextField
-                  label="Capturing Regexp Filter"
-                  value={state.listVariableFields.capturingRegexp ?? ''}
-                  InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
-                  InputProps={{
-                    readOnly: action === 'read',
-                  }}
-                  onChange={(e) => {
-                    setState((draft) => {
-                      if (e.target.value) {
-                        // TODO: do a better fix, if empty string => it should skip the filter
-                        draft.listVariableFields.capturingRegexp = e.target.value;
-                      } else {
-                        draft.listVariableFields.capturingRegexp = undefined;
+                <Controller
+                  name="listVariableFields.capturingRegexp"
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      label="Capturing Regexp Filter"
+                      InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
+                      InputProps={{
+                        readOnly: action === 'read',
+                      }}
+                      error={!!fieldState.error}
+                      value={state.listVariableFields.capturingRegexp ?? ''}
+                      onChange={(event) => {
+                        field.onChange(event);
+                        setState((draft) => {
+                          if (event.target.value) {
+                            // TODO: do a better fix, if empty string => it should skip the filter
+                            draft.listVariableFields.capturingRegexp = event.target.value;
+                          } else {
+                            draft.listVariableFields.capturingRegexp = undefined;
+                          }
+                        });
+                      }}
+                      helperText={
+                        fieldState.error?.message
+                          ? fieldState.error.message
+                          : 'Optional, if you want to filter on captured result.'
                       }
-                    });
-                  }}
-                  helperText="Optional, if you want to filter on captured result."
+                    />
+                  )}
                 />
               </Stack>
 
               <Stack>
-                <TextField
-                  select
-                  label="Sort"
-                  value={state.listVariableFields.sort ?? ''}
-                  InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
-                  InputProps={{
-                    readOnly: isReadonly,
-                  }}
-                  onChange={(e) => {
-                    setState((draft) => {
-                      draft.listVariableFields.sort = e.target.value;
-                    });
-                  }}
-                >
-                  <MenuItem value="none">None</MenuItem>
-                  <MenuItem value="alphabetical-asc">Alphabetical, asc</MenuItem>
-                  <MenuItem value="alphabetical-desc">Alphabetical, desc</MenuItem>
-                  <MenuItem value="numerical-asc">Numerical, asc</MenuItem>
-                  <MenuItem value="numerical-desc">Numerical, desc</MenuItem>
-                  <MenuItem value="alphabetical-ci-asc">Alphabetical, case-insensitive, asc</MenuItem>
-                  <MenuItem value="alphabetical-ci-desc">Alphabetical, case-insensitive, desc</MenuItem>
-                </TextField>
+                <Controller
+                  name="listVariableFields.sort"
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      select
+                      {...field}
+                      fullWidth
+                      label="Sort"
+                      InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
+                      InputProps={{
+                        readOnly: action === 'read',
+                      }}
+                      error={!!fieldState.error}
+                      helperText={fieldState.error?.message}
+                      value={state.listVariableFields.sort ?? 'none'}
+                      onChange={(event) => {
+                        field.onChange(event);
+                        setState((draft) => {
+                          draft.listVariableFields.sort = event.target.value;
+                        });
+                      }}
+                    >
+                      <MenuItem value="none">None</MenuItem>
+                      <MenuItem value="alphabetical-asc">Alphabetical, asc</MenuItem>
+                      <MenuItem value="alphabetical-desc">Alphabetical, desc</MenuItem>
+                      <MenuItem value="numerical-asc">Numerical, asc</MenuItem>
+                      <MenuItem value="numerical-desc">Numerical, desc</MenuItem>
+                      <MenuItem value="alphabetical-ci-asc">Alphabetical, case-insensitive, asc</MenuItem>
+                      <MenuItem value="alphabetical-ci-desc">Alphabetical, case-insensitive, desc</MenuItem>
+                    </TextField>
+                  )}
+                />
               </Stack>
             </Stack>
 
@@ -393,60 +442,89 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
             </Typography>
             <Stack spacing="2">
               <Stack>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={state.listVariableFields.allowMultiple}
-                      readOnly={action === 'read'}
-                      onChange={(e) => {
-                        if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
-                        setState((draft) => {
-                          draft.listVariableFields.allowMultiple = e.target.checked;
-                        });
-                      }}
+                <Controller
+                  name="listVariableFields.allowMultiple"
+                  render={({ field }) => (
+                    <FormControlLabel
+                      label="Allow Multiple Values"
+                      control={
+                        <Switch
+                          {...field}
+                          checked={!!field.value}
+                          readOnly={action === 'read'}
+                          value={state.listVariableFields.allowMultiple}
+                          onChange={(event) => {
+                            if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
+                            field.onChange(event);
+                            setState((draft) => {
+                              draft.listVariableFields.allowMultiple = event.target.checked;
+                            });
+                          }}
+                        />
+                      }
                     />
-                  }
-                  label="Allow Multiple Values"
+                  )}
                 />
                 <Typography variant="caption">Enables multiple values to be selected at the same time</Typography>
               </Stack>
               <Stack>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={state.listVariableFields.allowAll}
-                      readOnly={action === 'read'}
-                      onChange={(e) => {
-                        if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
-                        setState((draft) => {
-                          draft.listVariableFields.allowAll = e.target.checked;
-                        });
-                      }}
+                <Controller
+                  name="listVariableFields.allowAll"
+                  render={({ field }) => (
+                    <FormControlLabel
+                      label="Allow All option"
+                      control={
+                        <Switch
+                          {...field}
+                          checked={!!field.value}
+                          readOnly={action === 'read'}
+                          value={state.listVariableFields.allowAll}
+                          onChange={(event) => {
+                            if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
+                            field.onChange(event);
+                            setState((draft) => {
+                              draft.listVariableFields.allowAll = event.target.checked;
+                            });
+                          }}
+                        />
+                      }
                     />
-                  }
-                  label="Allow All option"
+                  )}
                 />
                 <Typography mb={1} variant="caption">
                   Enables an option to include all variable values
                 </Typography>
                 {state.listVariableFields.allowAll && (
-                  <TextField
-                    label="Custom All Value"
-                    value={state.listVariableFields.customAllValue}
-                    InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
-                    InputProps={{
-                      readOnly: action === 'read',
-                    }}
-                    onChange={(e) => {
-                      setState((draft) => {
-                        if (e.target.value) {
-                          draft.listVariableFields.customAllValue = e.target.value;
-                        } else {
-                          draft.listVariableFields.customAllValue = undefined;
+                  <Controller
+                    name="listVariableFields.customAllValue"
+                    render={({ field, fieldState }) => (
+                      <TextField
+                        {...field}
+                        fullWidth
+                        label="Custom All Value"
+                        InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
+                        InputProps={{
+                          readOnly: action === 'read',
+                        }}
+                        error={!!fieldState.error}
+                        helperText={
+                          fieldState.error?.message
+                            ? fieldState.error.message
+                            : 'When All is selected, this value will be used'
                         }
-                      });
-                    }}
-                    helperText="When All is selected, this value will be used"
+                        value={state.listVariableFields.customAllValue ?? ''}
+                        onChange={(event) => {
+                          field.onChange(event);
+                          setState((draft) => {
+                            if (event.target.value) {
+                              draft.listVariableFields.customAllValue = event.target.value;
+                            } else {
+                              draft.listVariableFields.customAllValue = undefined;
+                            }
+                          });
+                        }}
+                      />
+                    )}
                   />
                 )}
               </Stack>

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -469,7 +469,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
               </Stack>
               <Stack>
                 <Controller
-                  name="listVariableFields.allowAll"
+                  name="listVariableFields.allowAllValue"
                   render={({ field }) => (
                     <FormControlLabel
                       label="Allow All option"
@@ -478,12 +478,12 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                           {...field}
                           checked={!!field.value}
                           readOnly={action === 'read'}
-                          value={state.listVariableFields.allowAll}
+                          value={state.listVariableFields.allowAllValue}
                           onChange={(event) => {
                             if (action === 'read') return; // ReadOnly prop is not blocking user interaction...
                             field.onChange(event);
                             setState((draft) => {
-                              draft.listVariableFields.allowAll = event.target.checked;
+                              draft.listVariableFields.allowAllValue = event.target.checked;
                             });
                           }}
                         />
@@ -494,7 +494,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                 <Typography mb={1} variant="caption">
                   Enables an option to include all variable values
                 </Typography>
-                {state.listVariableFields.allowAll && (
+                {state.listVariableFields.allowAllValue && (
                   <Controller
                     name="listVariableFields.customAllValue"
                     render={({ field, fieldState }) => (

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -11,43 +11,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TextVariableDefinition, VariableDefinition } from '@perses-dev/core';
-
-interface textVariableFields {
-  value: string;
-  constant: boolean;
-}
-
-interface listVariableFields {
-  allowMultiple: boolean;
-  allowAll: boolean;
-  customAllValue?: string;
-  capturingRegexp?: string;
-  sort?: string;
-  plugin: {
-    kind: string;
-    spec: Record<string, unknown>;
-  };
-}
+import {
+  ListVariableSpec,
+  TextVariableDefinition,
+  TextVariableSpec,
+  UnknownSpec,
+  VariableDefinition,
+} from '@perses-dev/core';
 
 export type VariableEditorState = {
   name: string;
   title?: string;
   kind: 'TextVariable' | 'ListVariable' | 'BuiltinVariable';
   description?: string;
-  listVariableFields: listVariableFields;
-  textVariableFields: textVariableFields;
+  listVariableFields: Omit<ListVariableSpec<UnknownSpec>, 'name' | 'display'>;
+  textVariableFields: Omit<TextVariableSpec, 'name' | 'display'>;
 };
 
 export function getInitialState(initialVariableDefinition: VariableDefinition): VariableEditorState {
-  const textVariableFields: textVariableFields = {
+  const textVariableFields: Omit<TextVariableSpec, 'name' | 'display'> = {
     value: (initialVariableDefinition as TextVariableDefinition).spec.value ?? '',
     constant: (initialVariableDefinition as TextVariableDefinition).spec.constant ?? false,
   };
 
-  const listVariableFields: listVariableFields = {
+  const listVariableFields: Omit<ListVariableSpec<UnknownSpec>, 'name' | 'display'> = {
     allowMultiple: false,
-    allowAll: false,
+    allowAllValue: false,
     customAllValue: undefined,
     capturingRegexp: undefined,
     sort: undefined,
@@ -58,7 +47,7 @@ export function getInitialState(initialVariableDefinition: VariableDefinition): 
   };
   if (initialVariableDefinition.kind === 'ListVariable') {
     listVariableFields.allowMultiple = initialVariableDefinition.spec.allowMultiple ?? false;
-    listVariableFields.allowAll = initialVariableDefinition.spec.allowAllValue ?? false;
+    listVariableFields.allowAllValue = initialVariableDefinition.spec.allowAllValue ?? false;
     listVariableFields.customAllValue = initialVariableDefinition.spec.customAllValue;
     listVariableFields.capturingRegexp = initialVariableDefinition.spec.capturingRegexp;
     listVariableFields.sort = initialVariableDefinition.spec.sort;
@@ -98,7 +87,7 @@ export function getVariableDefinitionFromState(state: VariableEditorState): Vari
         name,
         display,
         allowMultiple: state.listVariableFields.allowMultiple,
-        allowAllValue: state.listVariableFields.allowAll,
+        allowAllValue: state.listVariableFields.allowAllValue,
         customAllValue: state.listVariableFields.customAllValue,
         capturingRegexp: state.listVariableFields.capturingRegexp,
         sort: state.listVariableFields.sort,

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -13,18 +13,44 @@
 
 import { TextVariableDefinition, VariableDefinition } from '@perses-dev/core';
 
-export function getInitialState(initialVariableDefinition: VariableDefinition) {
-  const textVariableFields = {
+interface textVariableFields {
+  value: string;
+  constant: boolean;
+}
+
+interface listVariableFields {
+  allowMultiple: boolean;
+  allowAll: boolean;
+  customAllValue?: string;
+  capturingRegexp?: string;
+  sort?: string;
+  plugin: {
+    kind: string;
+    spec: Record<string, unknown>;
+  };
+}
+
+export type VariableEditorState = {
+  name: string;
+  title?: string;
+  kind: 'TextVariable' | 'ListVariable' | 'BuiltinVariable';
+  description?: string;
+  listVariableFields: listVariableFields;
+  textVariableFields: textVariableFields;
+};
+
+export function getInitialState(initialVariableDefinition: VariableDefinition): VariableEditorState {
+  const textVariableFields: textVariableFields = {
     value: (initialVariableDefinition as TextVariableDefinition).spec.value ?? '',
     constant: (initialVariableDefinition as TextVariableDefinition).spec.constant ?? false,
   };
 
-  const listVariableFields = {
+  const listVariableFields: listVariableFields = {
     allowMultiple: false,
     allowAll: false,
-    customAllValue: undefined as string | undefined,
-    capturingRegexp: undefined as string | undefined,
-    sort: undefined as string | undefined,
+    customAllValue: undefined,
+    capturingRegexp: undefined,
+    sort: undefined,
     plugin: {
       kind: '',
       spec: {},
@@ -48,8 +74,6 @@ export function getInitialState(initialVariableDefinition: VariableDefinition) {
     textVariableFields,
   };
 }
-
-export type VariableEditorState = ReturnType<typeof getInitialState>;
 
 export function getVariableDefinitionFromState(state: VariableEditorState): VariableDefinition {
   const { name, title, kind, description } = state;

--- a/ui/plugin-system/src/validation/variable.ts
+++ b/ui/plugin-system/src/validation/variable.ts
@@ -13,15 +13,30 @@
 
 import { z } from 'zod';
 
-export const variableEditValidationSchema = z.object({
+export const variableEditorValidationSchema = z.object({
   name: z
     .string()
     .nonempty('Required')
     .regex(/^\w+$/, 'Must only contains alphanumerical characters and underscores')
     .refine((val) => !val.startsWith('__'), '__ prefix is reserved to builtin variables'),
-  title: z.string().optional(), // display name
+  title: z.string().optional(),
   description: z.string().optional(),
-  kind: z.string().nonempty('Required'),
+  kind: z.enum(['TextVariable', 'ListVariable', 'BuiltinVariable']),
+  textVariableFields: z.object({
+    value: z.string(),
+    constant: z.boolean(),
+  }),
+  listVariableFields: z.object({
+    allowMultiple: z.boolean(),
+    allowAll: z.boolean(),
+    customAllValue: z.string().optional(),
+    capturingRegexp: z.string().optional(),
+    sort: z.string().optional(),
+    plugin: z.object({
+      kind: z.string(),
+      spec: z.object({}),
+    }),
+  }),
 });
 
-export type VariableEditValidationType = z.infer<typeof variableEditValidationSchema>;
+export type VariableEditorValidationType = z.infer<typeof variableEditorValidationSchema>;

--- a/ui/plugin-system/src/validation/variable.ts
+++ b/ui/plugin-system/src/validation/variable.ts
@@ -28,7 +28,7 @@ export const variableEditorValidationSchema = z.object({
   }),
   listVariableFields: z.object({
     allowMultiple: z.boolean(),
-    allowAll: z.boolean(),
+    allowAllValue: z.boolean(),
     customAllValue: z.string().optional(),
     capturingRegexp: z.string().optional(),
     sort: z.string().optional(),


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Similar to PR #1621: all inputs are wrapped around controller and will update the state of the form + validation.
It still not at role / rolebinding form editor level, because of setState stuff (could be removed if all fields have controller associated to, but it will be tricky with the PluginEditor)

# Screenshots

No change on UI side
<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
