### PR TITLE
[BUGFIX] Fix the token refresh that required a complete refresh of the page to be considered

### DIFF
--- a/ui/app/src/model/fetch.ts
+++ b/ui/app/src/model/fetch.ts
@@ -20,13 +20,16 @@ export async function fetch(...args: Parameters<typeof global.fetch>) {
     if (error.status !== 401) {
       throw error;
     }
-    refreshToken().catch((refreshTokenError: UserFriendlyError | FetchError) => {
-      if (refreshTokenError.status === 400) {
-        window.location.href = SignInRoute;
-      }
-      throw error;
-    });
-    return initialFetch(...args);
+    return refreshToken()
+      .catch((refreshTokenError: UserFriendlyError | FetchError) => {
+        if (refreshTokenError.status === 400) {
+          window.location.href = SignInRoute;
+        }
+        throw error;
+      })
+      .then(() => {
+        return initialFetch(...args);
+      });
   });
 }
 


### PR DESCRIPTION
When the access token expired, you may have noticed that the token is indeed refreshed but there is still an error saying the token is malformed and so you don't have access to the API.

That's because the retry of the query is performed before getting the new token. This is now done with this PR