### PR TITLE
[FEATURE] Allow visualizing the dashboard's JSON in read mode

### DIFF
--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -122,7 +122,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps) => {
             <Stack direction="row" spacing={1} mt={1} ml={1}>
               <TimeRangeControls />
               <DownloadButton />
-              {isEditMode && <EditJsonButton />}
+              <EditJsonButton isReadonly={!isEditMode} />
             </Stack>
           </Stack>
         </Box>

--- a/ui/dashboards/src/components/EditJsonButton/EditJsonButton.tsx
+++ b/ui/dashboards/src/components/EditJsonButton/EditJsonButton.tsx
@@ -17,11 +17,19 @@ import { TOOLTIP_TEXT } from '../../constants';
 import { ToolbarIconButton } from '../ToolbarIconButton';
 import { useEditJsonDialog } from '../../context';
 
-export const EditJsonButton = () => {
+export interface EditJsonButtonProps {
+  isReadonly: boolean;
+}
+
+export const EditJsonButton = (props: EditJsonButtonProps) => {
+  const { isReadonly } = props;
   const { openEditJsonDialog } = useEditJsonDialog();
+
+  const info = isReadonly ? TOOLTIP_TEXT.viewJson : TOOLTIP_TEXT.editJson;
+
   return (
-    <InfoTooltip description={TOOLTIP_TEXT.editJson}>
-      <ToolbarIconButton aria-label={TOOLTIP_TEXT.editJson} variant="outlined" onClick={() => openEditJsonDialog()}>
+    <InfoTooltip description={info}>
+      <ToolbarIconButton aria-label={info} variant="outlined" onClick={() => openEditJsonDialog()}>
         <CodeIcon />
       </ToolbarIconButton>
     </InfoTooltip>

--- a/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
+++ b/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
@@ -19,23 +19,26 @@ import { useEditJsonDialog } from '../../context/DashboardProvider';
 import { useDashboard } from '../../context/useDashboard';
 
 export interface EditJsonDialogProps {
+  isReadonly: boolean;
   disableMetadataEdition?: boolean;
 }
 
 export const EditJsonDialog = (props: EditJsonDialogProps) => {
-  const { disableMetadataEdition } = props;
+  const { isReadonly, disableMetadataEdition } = props;
   const { editJsonDialog, closeEditJsonDialog } = useEditJsonDialog();
 
   return (
     <Dialog open={!!editJsonDialog?.isOpen} scroll="paper" fullWidth maxWidth="lg">
-      <Dialog.Header onClose={() => closeEditJsonDialog()}>Edit Dashboard JSON</Dialog.Header>
-      {editJsonDialog?.isOpen && <EditJsonDialogForm disableMetadataEdition={disableMetadataEdition} />}
+      <Dialog.Header onClose={() => closeEditJsonDialog()}>{!isReadonly && 'Edit '} Dashboard JSON</Dialog.Header>
+      {editJsonDialog?.isOpen && (
+        <EditJsonDialogForm isReadonly={isReadonly} disableMetadataEdition={disableMetadataEdition} />
+      )}
     </Dialog>
   );
 };
 
 const EditJsonDialogForm = (props: EditJsonDialogProps) => {
-  const { disableMetadataEdition } = props;
+  const { isReadonly, disableMetadataEdition } = props;
   const { closeEditJsonDialog } = useEditJsonDialog();
   const { setTimeRange, setRefreshInterval } = useTimeRange();
   const { dashboard, setDashboard } = useDashboard();
@@ -63,7 +66,7 @@ const EditJsonDialogForm = (props: EditJsonDialogProps) => {
   return (
     <Dialog.Form onSubmit={handleApply}>
       <Dialog.Content sx={{ width: '100%' }}>
-        {disableMetadataEdition && (
+        {disableMetadataEdition && !isReadonly && (
           <Alert sx={{ marginBottom: (theme) => theme.spacing(1) }} severity="warning">
             Metadata cannot be modified or saved.
           </Alert>
@@ -74,12 +77,15 @@ const EditJsonDialogForm = (props: EditJsonDialogProps) => {
             maxHeight="70vh"
             value={draftDashboard}
             onChange={(value: string) => completeDraftDashboard(value)}
+            readOnly={isReadonly}
           />
         </FormControl>
       </Dialog.Content>
-      <Dialog.Actions>
-        <Dialog.PrimaryButton onClick={handleApply}>Apply</Dialog.PrimaryButton>
-      </Dialog.Actions>
+      {!isReadonly && (
+        <Dialog.Actions>
+          <Dialog.PrimaryButton onClick={handleApply}>Apply</Dialog.PrimaryButton>
+        </Dialog.Actions>
+      )}
     </Dialog.Form>
   );
 };

--- a/ui/dashboards/src/constants/user-interface-text.ts
+++ b/ui/dashboards/src/constants/user-interface-text.ts
@@ -21,6 +21,7 @@ export const TOOLTIP_TEXT = {
   editVariables: 'Edit variables',
   refreshDashboard: 'Refresh dashboard',
   refreshDashboardInterval: 'Auto refresh interval',
+  viewJson: 'View JSON',
   // Group buttons
   addPanelToGroup: 'Add panel to group',
   deleteGroup: 'Delete group',

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -55,7 +55,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
 
   const chartsTheme = useChartsTheme();
 
-  const { setEditMode } = useEditMode();
+  const { isEditMode, setEditMode } = useEditMode();
   const { dashboard, setDashboard } = useDashboard();
   const [originalDashboard, setOriginalDashboard] = useState<DashboardResource | undefined>(undefined);
   const { setSavedDatasources } = useDatasourceStore();
@@ -132,7 +132,7 @@ export const DashboardApp = (props: DashboardAppProps) => {
         <DeletePanelGroupDialog />
         <DeletePanelDialog />
         <DashboardDiscardChangesConfirmationDialog />
-        <EditJsonDialog disableMetadataEdition={!isCreating} />
+        <EditJsonDialog isReadonly={!isEditMode} disableMetadataEdition={!isCreating} />
         <SaveChangesConfirmationDialog />
       </Box>
     </Box>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

The button to access the dashboard's JSON in the toolbar is now accessible in read mode too, allowing the users to view the JSON definition of the dashboard without being able to edit it.

# Screenshots

https://github.com/perses/perses/assets/7058693/c2eb8c44-81d6-432c-9632-aa5e4cde023b

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
