### PR TITLE
[ENHANCEMENT] Auto input resize for text variables

### DIFF
--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -49,7 +49,7 @@ export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec;
     <Box
       key={spec.name + source ?? ''}
       display={ctx.state?.overridden || spec.display?.hidden ? 'none' : undefined}
-      minWidth={MIN_TEMPLATE_VARIABLE_WIDTH + 'px'}
+      minWidth={`${MIN_TEMPLATE_VARIABLE_WIDTH}px`}
       maxWidth={MAX_TEMPLATE_VARIABLE_WIDTH + 'px'}
       flexShrink={0}
       data-testid={'template-variable-' + spec.name}

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -50,7 +50,7 @@ export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec;
       key={spec.name + source ?? ''}
       display={ctx.state?.overridden || spec.display?.hidden ? 'none' : undefined}
       minWidth={`${MIN_TEMPLATE_VARIABLE_WIDTH}px`}
-      maxWidth={MAX_TEMPLATE_VARIABLE_WIDTH + 'px'}
+      maxWidth={`${MAX_TEMPLATE_VARIABLE_WIDTH}px`}
       flexShrink={0}
       data-testid={'template-variable-' + spec.name}
     >

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -19,10 +19,8 @@ import {
   useTemplateVariable,
   useTemplateVariableDefinitions,
 } from '../../context';
+import { MAX_TEMPLATE_VARIABLE_WIDTH, MIN_TEMPLATE_VARIABLE_WIDTH } from '../../constants';
 import { TemplateVariable } from './TemplateVariable';
-
-const VARIABLE_INPUT_MIN_WIDTH = '120px';
-const VARIABLE_INPUT_MAX_WIDTH = '500px';
 
 export function TemplateVariableList() {
   const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
@@ -51,8 +49,8 @@ export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec;
     <Box
       key={spec.name + source ?? ''}
       display={ctx.state?.overridden || spec.display?.hidden ? 'none' : undefined}
-      minWidth={VARIABLE_INPUT_MIN_WIDTH}
-      maxWidth={VARIABLE_INPUT_MAX_WIDTH}
+      minWidth={MIN_TEMPLATE_VARIABLE_WIDTH + 'px'}
+      maxWidth={MAX_TEMPLATE_VARIABLE_WIDTH + 'px'}
       flexShrink={0}
       data-testid={'template-variable-' + spec.name}
     >

--- a/ui/dashboards/src/constants/styles.ts
+++ b/ui/dashboards/src/constants/styles.ts
@@ -20,3 +20,6 @@ export const editButtonStyle: SxProps<Theme> = {
     marginRight: 0.5,
   },
 };
+
+export const MIN_TEMPLATE_VARIABLE_WIDTH = 120;
+export const MAX_TEMPLATE_VARIABLE_WIDTH = 500;


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Implement dynamic input resize for Text variables, as it was done for List variables in https://github.com/perses/perses/pull/1576.

_As in this past PR, the computed input size doesn't perfectly fit the text content due to the approximation done to consider that each character = 8px. It's still better than before but could for sure be improved._

# Screenshots

https://github.com/perses/perses/assets/7058693/57bcbf30-e479-405d-b600-bfa1bc464de2

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
