### PR TITLE
[BUGFIX] Fix missing tooltip on updated variables

### DIFF
--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useImmer } from 'use-immer';
-import { Action, Display, DatasourceSpec } from '@perses-dev/core';
+import { Action, DatasourceSpec } from '@perses-dev/core';
 import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
 import { DispatchWithoutAction, useCallback, useState } from 'react';
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
@@ -74,16 +74,13 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
   });
 
   const processForm: SubmitHandler<DatasourceEditValidationType> = () => {
-    // reset display name to undefined when empty, because we don't want an empty string as value
-    const name = state.spec.display?.name;
-    const finalDisplay: Display | undefined = {
-      ...state.spec.display,
-      name: name ? name : undefined,
-    };
-
+    // reset display attributes to undefined when empty, because we don't want to save empty strings
     onSave(state.name, {
       ...state.spec,
-      display: finalDisplay,
+      display: {
+        name: state.spec.display?.name === '' ? undefined : state.spec.display?.name,
+        description: state.spec.display?.description === '' ? undefined : state.spec.display?.description,
+      },
     });
   };
 

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -83,7 +83,14 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
   });
 
   const processForm: SubmitHandler<VariableEditorValidationType> = () => {
-    onSave(getVariableDefinitionFromState(state));
+    // reset display attributes to undefined when empty, because we don't want to save empty strings
+    onSave(
+      getVariableDefinitionFromState({
+        ...state,
+        title: state.title === '' ? undefined : state.title,
+        description: state.description === '' ? undefined : state.description,
+      })
+    );
   };
 
   // When user click on cancel, several possibilities:


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Fixes https://github.com/perses/perses/issues/1653.
Empty strings for desc attributes are no longer kept when applying/saving.

# Screenshots

![image](https://github.com/perses/perses/assets/7058693/aded3503-319e-4c56-995b-a9b9e66b7698)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
