### PR TITLE
[ENHANCEMENT] Allow editing the name of the local resources

### DIFF
--- a/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
+++ b/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
@@ -103,6 +103,7 @@ export function DatasourceEditor(props: {
           isDraft={true}
           onSave={(name: string, spec: DatasourceSpec) => {
             setDatasources((draft) => {
+              delete draft[datasourceEdit.name]; // to tackle the case where datasource name has been changed
               draft[name] = spec;
               setDatasourceEdit(null);
             });

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -157,7 +157,7 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
                   label="Name"
                   InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
                   InputProps={{
-                    disabled: action === 'update',
+                    disabled: action === 'update' && !isDraft,
                     readOnly: action === 'read',
                   }}
                   error={!!fieldState.error}

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -170,7 +170,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   label="Name"
                   InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
                   InputProps={{
-                    disabled: action === 'update',
+                    disabled: action === 'update' && !isDraft,
                     readOnly: action === 'read',
                   }}
                   error={!!fieldState.error}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Closes #1652.

# Screenshots

https://github.com/perses/perses/assets/7058693/c1e85d86-8fd5-4d3a-a328-d2a5a68b53a1

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
