### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
         with:
           enable_npm: true
       - name: Download react build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ui-libs
           path: ui
@@ -166,7 +166,7 @@ jobs:
         with:
           enable_go: true
       - name: Download react build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ui-libs
           path: ui


### PR DESCRIPTION
Reverts perses/perses#1656

It looks like there is a breaking change on how to upload/download an artifact in the github action version and the documentation is not obvious on how to fix it: https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes

The Github documentation is not yet updated about the new way to upload the files