### PR TITLE
[IGNORE] Make `last` the default value for the `calculation` attribute

### DIFF
--- a/schemas/common/calculation.cue
+++ b/schemas/common/calculation.cue
@@ -13,4 +13,4 @@
 
 package common
 
-#calculation: "first" | "last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"


### PR DESCRIPTION

# Description

'Doing this as we already have such "last as default" behavior on the UI, and it would make sense to have this as part of the schemas too (useful e.g to mimic the same behavior with the dashboard as code use case).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
