### PR TITLE
[IGNORE] Add authentication details to backend dev script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ The secure way to configure your monitoring.               <\
 
 ```
 
-The API backend is now available on port 8080 :).
+The API backend is now available on port 8080 :). You can log in with user: `admin` and password: `password`.
 
 ### Web App
 

--- a/scripts/api_backend_dev.sh
+++ b/scripts/api_backend_dev.sh
@@ -18,4 +18,5 @@ fi
 
 # Run backend server
 echo ">> start the api server"
+echo '>> Log in with user: `admin` and password: `password`'
 ./bin/perses -config ./dev/config.yaml


### PR DESCRIPTION
# Description

Just submitting this as a quick proposal.

We've had a couple of cases in the chat where folks have been confused about how to log in to the backend dev server. This adds a echo to the script that tells them how to do it.
