### PR TITLE
[FEATURE] CLI: add a new command  to refresh the access token

### DIFF
--- a/cmd/percli/main.go
+++ b/cmd/percli/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/perses/perses/internal/cli/cmd/login"
 	"github.com/perses/perses/internal/cli/cmd/migrate"
 	"github.com/perses/perses/internal/cli/cmd/project"
+	"github.com/perses/perses/internal/cli/cmd/refresh"
 	"github.com/perses/perses/internal/cli/cmd/remove"
 	"github.com/perses/perses/internal/cli/cmd/version"
 	"github.com/perses/perses/internal/cli/config"
@@ -48,6 +49,7 @@ func newRootCommand() *cobra.Command {
 	cmd.AddCommand(lint.NewCMD())
 	cmd.AddCommand(login.NewCMD())
 	cmd.AddCommand(migrate.NewCMD())
+	cmd.AddCommand(refresh.NewCMD())
 	cmd.AddCommand(project.NewCMD())
 	cmd.AddCommand(remove.NewCMD())
 	cmd.AddCommand(version.NewCMD())

--- a/internal/cli/cmd/project/project.go
+++ b/internal/cli/cmd/project/project.go
@@ -54,11 +54,11 @@ func (o *option) Validate() error {
 
 func (o *option) Execute() error {
 	if len(o.projectName) == 0 {
-		// In that case we simply print the current project used.
+		// In that case, we simply print the current project used.
 		fmt.Printf("Using project %q on server %q\n", config.Global.Project, config.Global.RestClientConfig.URL)
 		return nil
 	}
-	// in case the project is provided we should verify if it exists first
+	// in case the project is provided, we should verify if it exists first
 	_, err := o.apiClient.V1().Project().Get(o.projectName)
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {

--- a/internal/cli/cmd/refresh/refresh.go
+++ b/internal/cli/cmd/refresh/refresh.go
@@ -1,0 +1,77 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package refresh
+
+import (
+	"fmt"
+	"io"
+
+	persesCMD "github.com/perses/perses/internal/cli/cmd"
+	"github.com/perses/perses/internal/cli/config"
+	"github.com/perses/perses/internal/cli/output"
+	"github.com/perses/perses/pkg/client/api"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	persesCMD.Option
+	writer    io.Writer
+	apiClient api.ClientInterface
+}
+
+func (o *option) Complete(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("no args are supported by the command 'apply'")
+	}
+	apiClient, err := config.Global.GetAPIClient()
+	if err != nil {
+		return err
+	}
+	o.apiClient = apiClient
+	return nil
+}
+
+func (o *option) Validate() error {
+	if len(config.Global.RefreshToken) == 0 {
+		return fmt.Errorf("refresh_token doesn't exist in the config, please use the command login to get one")
+	}
+	return nil
+}
+
+func (o *option) Execute() error {
+	response, err := o.apiClient.Auth().Refresh(config.Global.RefreshToken)
+	if err != nil {
+		return err
+	}
+	if writeErr := config.SetAccessToken(response.AccessToken); writeErr != nil {
+		return writeErr
+	}
+	return output.HandleString(o.writer, "access token has been refreshed")
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "refresh",
+		Short: "refresh the access token when it expires",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return persesCMD.Run(o, cmd, args)
+		},
+	}
+	return cmd
+}

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -50,7 +50,8 @@ func Init(configPath string) {
 
 type Config struct {
 	RestClientConfig perseshttp.RestConfigClient `json:"rest_client_config"`
-	Project          string                      `json:"project"`
+	Project          string                      `json:"project,omitempty"`
+	RefreshToken     string                      `json:"refresh_token,omitempty"`
 	filePath         string
 	apiClient        api.ClientInterface
 }
@@ -118,6 +119,12 @@ func SetProject(project string) error {
 	})
 }
 
+func SetAccessToken(token string) error {
+	return Write(&Config{
+		RestClientConfig: perseshttp.RestConfigClient{Token: token},
+	})
+}
+
 // Write writes the configuration file in the path {USER_HOME}/.perses/config
 // if the directory doesn't exist, the function will create it
 func Write(config *Config) error {
@@ -150,6 +157,9 @@ func Write(config *Config) error {
 			}
 			if len(config.Project) > 0 {
 				previousConf.Project = config.Project
+			}
+			if len(config.RefreshToken) > 0 {
+				previousConf.RefreshToken = config.RefreshToken
 			}
 		}
 	} else {

--- a/pkg/client/api/auth.go
+++ b/pkg/client/api/auth.go
@@ -14,6 +14,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/perses/perses/pkg/client/perseshttp"
 	"github.com/perses/perses/pkg/model/api"
 )
@@ -23,6 +25,7 @@ const authResource = "auth"
 // AuthInterface has methods to work with Auth resource
 type AuthInterface interface {
 	Login(user, password string) (*api.AuthResponse, error)
+	Refresh(refreshToken string) (*api.AuthResponse, error)
 }
 
 func newAuth(client *perseshttp.RESTClient) AuthInterface {
@@ -42,16 +45,22 @@ func (c *auth) Login(user string, password string) (*api.AuthResponse, error) {
 	}
 	result := &api.AuthResponse{}
 
-	err := c.client.Post().
+	return result, c.client.Post().
 		APIVersion("").
 		Resource(authResource).
 		Body(body).
 		Do().
 		Object(result)
+}
 
-	if err != nil {
-		return nil, err
-	}
+func (c *auth) Refresh(refreshToken string) (*api.AuthResponse, error) {
+	body := &api.RefreshRequest{RefreshToken: refreshToken}
+	result := &api.AuthResponse{}
 
-	return result, nil
+	return result, c.client.Post().
+		APIVersion("").
+		Resource(fmt.Sprintf("%s/refresh", authResource)).
+		Body(body).
+		Do().
+		Object(result)
 }


### PR DESCRIPTION
when the authentication is enabled, it's quite annoying to login every 15min. 

Since we have a refresh token mecanism, I'm proposing a new command `refresh` that will contact the API to get a new access token

That's a beginning, perhaps for long term we want an automatic way to refresh the token like the UI has.