### PR TITLE
[FEATURE] Add Test button to datasource creation

### DIFF
--- a/ui/app/src/model/datasource-api.test.ts
+++ b/ui/app/src/model/datasource-api.test.ts
@@ -17,7 +17,7 @@ interface TestData {
   input: {
     project?: string;
     dashboard?: string;
-    name: string;
+    name?: string;
   };
   expected: string;
 }
@@ -38,6 +38,21 @@ describe('buildProxyUrl', () => {
       title: 'should build dashboard datasource proxy url',
       input: { project: 'projectA', dashboard: 'dashboardA', name: 'datasourceA' },
       expected: '/proxy/projects/projectA/dashboards/dashboardA/datasources/datasourceA',
+    },
+    {
+      title: 'should build unsaved global datasource proxy url',
+      input: { },
+      expected: '/proxy/unsaved/globaldatasources',
+    },
+    {
+      title: 'should build unsaved project datasource proxy url',
+      input: { project: 'projectA' },
+      expected: '/proxy/unsaved/projects/projectA/datasources',
+    },
+    {
+      title: 'should build unsaved dashboard datasource proxy url',
+      input: { project: 'projectA', dashboard: 'dashboardA' },
+      expected: '/proxy/unsaved/projects/projectA/dashboards/dashboardA/datasources',
     },
   ])('$title', (data: TestData) => {
     expect(new HTTPDatasourceAPI().buildProxyUrl(data.input)).toEqual(data.expected);

--- a/ui/app/src/model/datasource-api.test.ts
+++ b/ui/app/src/model/datasource-api.test.ts
@@ -41,7 +41,7 @@ describe('buildProxyUrl', () => {
     },
     {
       title: 'should build unsaved global datasource proxy url',
-      input: { },
+      input: {},
       expected: '/proxy/unsaved/globaldatasources',
     },
     {

--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -34,15 +34,7 @@ export class HTTPDatasourceAPI implements DatasourceApi {
    * @param dashboard
    * @param project
    */
-  buildProxyUrl({
-    project,
-    dashboard,
-    name,
-  }: {
-    project?: string;
-    dashboard?: string;
-    name?: string;
-  }): string {
+  buildProxyUrl({ project, dashboard, name }: { project?: string; dashboard?: string; name?: string }): string {
     const unsaved = name === undefined;
     const prefix = unsaved ? '/proxy/unsaved/' : '/proxy/';
     const type = !project && !dashboard ? 'globaldatasources' : 'datasources';

--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -23,7 +23,10 @@ export class HTTPDatasourceAPI implements DatasourceApi {
    * Give the following output according to the definition or not of the input.
    * - /proxy/globaldatasources/{name}
    * - /proxy/projects/{project}/datasources/{name}
-   * - /proxy/projects/{project}/dashboards/{dashboard}/{name}
+   * - /proxy/projects/{project}/dashboards/{dashboard}/datasources/{name}
+   * - /proxy/unsaved/globaldatasources
+   * - /proxy/unsaved/{project}/datasources
+   * - /proxy/unsaved/{project}/dashboards/{dashboard}/datasources
    *
    * NB: despite the fact it's possible, it is useless to give a dashboard without a project as the url will for sure
    * correspond to nothing.
@@ -31,15 +34,29 @@ export class HTTPDatasourceAPI implements DatasourceApi {
    * @param dashboard
    * @param project
    */
-  buildProxyUrl({ project, dashboard, name }: { project?: string; dashboard?: string; name: string }): string {
-    let url = `${!project && !dashboard ? 'globaldatasources' : 'datasources'}/${encodeURIComponent(name)}`;
+  buildProxyUrl({
+    project,
+    dashboard,
+    name,
+  }: {
+    project?: string;
+    dashboard?: string;
+    name?: string;
+  }): string {
+    const unsaved = name === undefined;
+    const prefix = unsaved ? '/proxy/unsaved/' : '/proxy/';
+    const type = !project && !dashboard ? 'globaldatasources' : 'datasources';
+    let url = unsaved ? `${type}` : `${type}/${encodeURIComponent(name || '')}`;
+
     if (dashboard) {
       url = `dashboards/${encodeURIComponent(dashboard)}/${url}`;
     }
+
     if (project) {
       url = `projects/${encodeURIComponent(project)}/${url}`;
     }
-    return `/proxy/${url}`;
+
+    return `${prefix}${url}`;
   }
 
   getDatasource(project: string, selector: DatasourceSelector): Promise<ProjectDatasource | undefined> {

--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -56,3 +56,9 @@ export interface DatasourceSelector {
    */
   name?: string;
 }
+
+export interface UnsavedDatasourceSelector {
+  spec: DatasourceSpec;
+  project?: string;
+  dashboard?: string;
+}

--- a/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
+++ b/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
@@ -31,7 +31,7 @@ import { Action, DatasourceSpec } from '@perses-dev/core';
 import { DatasourceEditorForm } from '@perses-dev/plugin-system';
 import { useState } from 'react';
 import { useImmer } from 'use-immer';
-import { useDiscardChangesConfirmationDialog } from '../../context';
+import { useDiscardChangesConfirmationDialog, useDashboard } from '../../context';
 
 export function DatasourceEditor(props: {
   datasources: Record<string, DatasourceSpec>;
@@ -41,6 +41,7 @@ export function DatasourceEditor(props: {
   const [datasources, setDatasources] = useImmer(props.datasources);
   const [datasourceFormAction, setDatasourceFormAction] = useState<Action>('update');
   const [datasourceEdit, setDatasourceEdit] = useState<{ name: string; spec: DatasourceSpec } | null>(null);
+  const { dashboard } = useDashboard();
   const defaultSpec: DatasourceSpec = {
     default: false,
     plugin: {
@@ -100,6 +101,8 @@ export function DatasourceEditor(props: {
           initialName={datasourceEdit.name}
           initialSpec={datasourceEdit.spec}
           initialAction={datasourceFormAction}
+          project={dashboard.metadata.project}
+          dashboard={dashboard.metadata.name}
           isDraft={true}
           onSave={(name: string, spec: DatasourceSpec) => {
             setDatasources((draft) => {

--- a/ui/plugin-system/src/model/datasource.ts
+++ b/ui/plugin-system/src/model/datasource.ts
@@ -25,6 +25,7 @@ export interface DatasourcePlugin<Spec = UnknownSpec, Client = unknown> extends 
 
 export interface DatasourceClientOptions {
   proxyUrl?: string;
+  fetch: typeof fetch;
 }
 
 /**

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DatasourceSelector, DatasourceSpec } from '@perses-dev/core';
+import { DatasourceSelector, DatasourceSpec, UnsavedDatasourceSelector } from '@perses-dev/core';
 import { useQuery } from '@tanstack/react-query';
 import { createContext, useContext } from 'react';
 
@@ -22,7 +22,7 @@ export interface DatasourceStore {
   /**
    * Given a DatasourceSelector, gets a `Client` object from the corresponding Datasource plugin.
    */
-  getDatasourceClient<Client>(selector: DatasourceSelector): Promise<Client>;
+  getDatasourceClient<Client>(selector: DatasourceSelector | UnsavedDatasourceSelector): Promise<Client>;
 
   /**
    * Gets a list of datasource selection items for a plugin kind.

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
@@ -67,7 +67,10 @@ export const WithPluginSystemDatasourceStore = (Story: StoryFn, context: StoryCo
     getDatasourceClient: async <Client,>(selector: DatasourceSelector) => {
       if (selector.kind === 'PrometheusDatasource') {
         const plugin = await getPlugin('Datasource', 'PrometheusDatasource');
-        const client = plugin.createClient({ directUrl: prometheusDemoUrl }, { proxyUrl: prometheusDemoUrl, fetch }) as Client;
+        const client = plugin.createClient(
+          { directUrl: prometheusDemoUrl },
+          { proxyUrl: prometheusDemoUrl, fetch }
+        ) as Client;
         return client;
       }
       throw new Error(`WithDatasourceStore is not configured to support kind: ${selector.kind}`);

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
@@ -67,7 +67,7 @@ export const WithPluginSystemDatasourceStore = (Story: StoryFn, context: StoryCo
     getDatasourceClient: async <Client,>(selector: DatasourceSelector) => {
       if (selector.kind === 'PrometheusDatasource') {
         const plugin = await getPlugin('Datasource', 'PrometheusDatasource');
-        const client = plugin.createClient({ directUrl: prometheusDemoUrl }, { proxyUrl: prometheusDemoUrl }) as Client;
+        const client = plugin.createClient({ directUrl: prometheusDemoUrl }, { proxyUrl: prometheusDemoUrl, fetch }) as Client;
         return client;
       }
       throw new Error(`WithDatasourceStore is not configured to support kind: ${selector.kind}`);

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
@@ -22,7 +22,7 @@ import { PrometheusDatasourceEditor } from './PrometheusDatasourceEditor';
  */
 const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>['createClient'] = (spec, options) => {
   const { directUrl, proxy } = spec;
-  const { proxyUrl } = options;
+  const { proxyUrl, fetch } = options;
 
   // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
   const datasourceUrl = directUrl ?? proxyUrl;
@@ -37,11 +37,11 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
     options: {
       datasourceUrl,
     },
-    healthCheck: healthCheck({ datasourceUrl, headers: specHeaders }),
-    instantQuery: (params, headers) => instantQuery(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    rangeQuery: (params, headers) => rangeQuery(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    labelNames: (params, headers) => labelNames(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    labelValues: (params, headers) => labelValues(params, { datasourceUrl, headers: headers ?? specHeaders }),
+    healthCheck: healthCheck({ fetch, datasourceUrl, headers: specHeaders }),
+    instantQuery: (params, headers) => instantQuery(params, { fetch, datasourceUrl, headers: headers ?? specHeaders }),
+    rangeQuery: (params, headers) => rangeQuery(params, { fetch, datasourceUrl, headers: headers ?? specHeaders }),
+    labelNames: (params, headers) => labelNames(params, { fetch, datasourceUrl, headers: headers ?? specHeaders }),
+    labelValues: (params, headers) => labelValues(params, { fetch, datasourceUrl, headers: headers ?? specHeaders }),
   };
 };
 


### PR DESCRIPTION
# Description

This is the UI work for utilising the previously created Unsaved Datasources framework to be able to test datasources before they're saved.

There's a few components to this:

 - Work in the datasource provider to take two different types of selector. A "Saved" selector, which functions as previously - loading the datasource from the API and using that, and an "Unsaved" selector which generates datasource clients from the spec included in the selector.

- This is the one I'm least sure about. A change to the datasource client api to allow us to handle both saved and unsaved datasources. Because unsaved datasources have more complicated semantics than unsaved ones (they need to package the spec, method, and request body into the body of the request), we need to be able to process the requests sent by datasource clients. To do this, we add in another argument - `fetch` to the query options of datasources. For saved datasources, again, this is the same. For unsaved ones, it's a wrapper around `globals.fetch` that allows us to intercept and repackage requests.

- Adding the button and wiring it into the DatasourceStoreProvider

# Screenshots

## Global Datasources

https://github.com/perses/perses/assets/4386405/3ed021a9-3a08-4977-b7e2-7abcb5b17c99

## Project Datasources


https://github.com/perses/perses/assets/4386405/829b740f-d4dd-4dd4-bb13-e46ae16816b7

## Dashboard datasources ( + requests to saved datasources still working)

https://github.com/perses/perses/assets/4386405/83a7a293-6428-479d-b505-5b7b8a25b6dd


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
