### PR TITLE
[ENHANCEMENT]: Some improvements around OIDC/OAuth provider configuration

### DIFF
--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -133,7 +133,7 @@ Generic placeholders are defined as follows:
 
 ```yaml
   # Enable the native authentication providers
-  [ enable_auth: <boolean> | default = false ]
+  [ enable_native: <boolean> | default = false ]
   
   # List of the OIDC authentication providers
   oidc:
@@ -167,6 +167,12 @@ Generic placeholders are defined as follows:
 
   # The provider issuer URL
   [ issuer: <string> ]
+
+  # A custom discovery URL if different from {issuer}/.well-known/openid-configuration
+  [ discovery_url: <string> ]
+
+  # Disable PKCE verification
+  [ disable_pkce: <boolean> | default = false ]
   
   # The additional url params that will be appended to /authorize provider's endpoint
   [ url_params:

--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -210,6 +210,9 @@ Generic placeholders are defined as follows:
   # The provider User Infos URL
   [ user_infos_url: <string> ]
 
+  # Name of the property to get "login" from user infos API (if not in the default list ["login", "username"] )
+  # The login is mandatory to store in the database the name of the user.
+  [ custom_login_property: <string>]
 ```
 
 #### `<authorization_config>`

--- a/internal/api/impl/auth/native.go
+++ b/internal/api/impl/auth/native.go
@@ -55,6 +55,7 @@ func (e *nativeEndpoint) auth(ctx echo.Context) error {
 		if databaseModel.IsKeyNotFound(err) {
 			return shared.HandleBadRequestError("wrong login or password ")
 		}
+		return shared.InternalError
 	}
 
 	if !crypto.ComparePasswords(usr.Spec.Password, body.Password) {

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -36,7 +36,7 @@ import (
 const stateParam = "state"
 const codeVerifierParam = "code_verifier"
 
-var defaultLoginProps = []string{"login"}
+var defaultLoginProps = []string{"login", "username"}
 
 type oauthUserInfo struct {
 	externalUserInfoProfile

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -215,12 +215,14 @@ func (e *oAuthEndpoint) authHandler(ctx echo.Context) error {
 	// Save the state cookie, will be verified in the codeExchangeHandler
 	state := uuid.NewString()
 	if err := e.saveStateCookie(ctx, state); err != nil {
+		e.logWithError(err).Error("Failed to save state in a cookie.")
 		return shared.InternalError
 	}
 
 	// Save the PKCE code verifier cookie, will be verified in the codeExchangeHandler
 	verifier := oauth2.GenerateVerifier()
 	if err := e.saveCodeVerifierCookie(ctx, verifier); err != nil {
+		e.logWithError(err).Error("Failed to save code verifier in a cookie.")
 		return shared.InternalError
 	}
 
@@ -280,10 +282,12 @@ func (e *oAuthEndpoint) codeExchangeHandler(ctx echo.Context) error {
 	username := user.GetMetadata().GetName()
 	_, err = e.tokenManagement.accessToken(username, ctx.SetCookie)
 	if err != nil {
+		e.logWithError(err).Error("Failed to generate and save access token.")
 		return shared.InternalError
 	}
 	_, err = e.tokenManagement.refreshToken(username, ctx.SetCookie)
 	if err != nil {
+		e.logWithError(err).Error("Failed to generate and save refresh token.")
 		return shared.InternalError
 	}
 

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -144,8 +144,8 @@ func (e *oIDCEndpoint) buildCodeExchangeHandler() echo.HandlerFunc {
 
 		user, err := e.svc.SyncUser(info)
 		if err != nil {
-			w.WriteHeader(500)
-			writeResponse(w, []byte(shared.UnauthorizedError.Error()))
+			w.WriteHeader(http.StatusInternalServerError)
+			writeResponse(w, []byte(shared.InternalError.Error()))
 		}
 
 		username := user.GetMetadata().GetName()
@@ -153,13 +153,13 @@ func (e *oIDCEndpoint) buildCodeExchangeHandler() echo.HandlerFunc {
 			http.SetCookie(w, cookie)
 		}
 		if _, err := e.tokenManagement.accessToken(username, setCookie); err != nil {
-			w.WriteHeader(500)
-			writeResponse(w, []byte(shared.UnauthorizedError.Error()))
+			w.WriteHeader(http.StatusInternalServerError)
+			writeResponse(w, []byte(shared.InternalError.Error()))
 			return
 		}
 		if _, err := e.tokenManagement.refreshToken(username, setCookie); err != nil {
-			w.WriteHeader(500)
-			writeResponse(w, []byte(shared.UnauthorizedError.Error()))
+			w.WriteHeader(http.StatusInternalServerError)
+			writeResponse(w, []byte(shared.InternalError.Error()))
 			return
 		}
 

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -56,7 +56,10 @@ func newOIDCEndpoint(provider config.OIDCProvider, jwt crypto.JWT) (route.Endpoi
 	options := []rp.Option{
 		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),
 		rp.WithHTTPClient(client),
-		rp.WithPKCE(cookieHandler),
+		rp.WithCookieHandler(cookieHandler),
+	}
+	if !provider.DisablePKCE {
+		options = append(options, rp.WithPKCE(cookieHandler))
 	}
 	if provider.DiscoveryURL != "" {
 		options = append(options, rp.WithCustomDiscoveryUrl(provider.DiscoveryURL))

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -58,9 +58,12 @@ func newOIDCEndpoint(provider config.OIDCProvider, jwt crypto.JWT) (route.Endpoi
 		rp.WithHTTPClient(client),
 		rp.WithPKCE(cookieHandler),
 	}
+	if provider.DiscoveryURL != "" {
+		options = append(options, rp.WithCustomDiscoveryUrl(provider.DiscoveryURL))
+	}
 	relyingParty, err := rp.NewRelyingPartyOIDC(
 		context.Background(),
-		string(provider.Issuer), string(provider.ClientID), string(provider.ClientSecret),
+		provider.Issuer, string(provider.ClientID), string(provider.ClientSecret),
 		provider.RedirectURI, provider.Scopes, options...,
 	)
 	if err != nil {

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -100,7 +100,7 @@ func (e *oIDCEndpoint) buildAuthHandler() echo.HandlerFunc {
 
 func (e *oIDCEndpoint) buildCodeExchangeHandler() echo.HandlerFunc {
 	// TODO(cegarcia): Make a user synchronization operation on the database
-	marshalUserinfo := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty, info *oidc.UserInfo) {
+	marshalUserinfo := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty, info *UserInfo) {
 		redirectURI := r.URL.Query().Get("redirect_uri")
 		if redirectURI == "" {
 			redirectURI = "/"

--- a/internal/api/impl/auth/userinfo.go
+++ b/internal/api/impl/auth/userinfo.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/api/impl/auth/userinfo.go
+++ b/internal/api/impl/auth/userinfo.go
@@ -1,0 +1,34 @@
+package auth
+
+import "github.com/zitadel/oidc/v3/pkg/oidc"
+
+// UserInfoProfile is a simplified version of the oidc.UserInfoProfile structure.
+// It's been created as we want only a limited amount of user information in Perses and some data like locale can be
+// provided wrongly by some OIDC providers.
+type UserInfoProfile struct {
+	Name              string `json:"name,omitempty"`
+	GivenName         string `json:"given_name,omitempty"`
+	FamilyName        string `json:"family_name,omitempty"`
+	MiddleName        string `json:"middle_name,omitempty"`
+	Nickname          string `json:"nickname,omitempty"`
+	Profile           string `json:"profile,omitempty"`
+	Picture           string `json:"picture,omitempty"`
+	PreferredUsername string `json:"preferred_username,omitempty"`
+}
+
+// UserInfo is a simplified version of the oidc.UserInfo structure.
+// It's been created as we want only a limited amount of user information in Perses and some data like locale can be
+// provided wrongly by some OIDC providers.
+// It is also an opportunity to use the same structure to parse OIDC and OAuth provider's user information.
+type UserInfo struct {
+	Subject string `json:"sub,omitempty"`
+	UserInfoProfile
+	oidc.UserInfoEmail
+
+	Claims map[string]any `json:"-"`
+}
+
+// GetSubject implements [rp.SubjectGetter]
+func (u *UserInfo) GetSubject() string {
+	return u.Subject
+}

--- a/internal/api/impl/auth/userinfo.go
+++ b/internal/api/impl/auth/userinfo.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package auth
 
 import "github.com/zitadel/oidc/v3/pkg/oidc"

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -36,6 +36,7 @@ type OIDCProvider struct {
 	Scopes       []string          `json:"scopes" yaml:"scopes"`
 	Issuer       string            `json:"issuer" yaml:"issuer"`
 	DiscoveryURL string            `json:"discovery_url" yaml:"discovery_url"`
+	DisablePKCE  bool              `json:"disable_pkce" yaml:"disable_pkce"`
 	URLParams    map[string]string `json:"url_params" yaml:"url_params"`
 }
 

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -73,11 +73,11 @@ func (p *OIDCProvider) Verify() error {
 }
 
 type OAuthProvider struct {
-	Provider              `json:",inline" yaml:",inline"`
-	AuthURL               common.URL `json:"auth_url" yaml:"auth_url"`
-	TokenURL              common.URL `json:"token_url" yaml:"token_url"`
-	UserInfosURL          common.URL `json:"user_infos_url" yaml:"user_infos_url"`
-	CustomLoginProperty   string     `json:"custom_login_property" yaml:"custom_login_property"`
+	Provider            `json:",inline" yaml:",inline"`
+	AuthURL             common.URL `json:"auth_url" yaml:"auth_url"`
+	TokenURL            common.URL `json:"token_url" yaml:"token_url"`
+	UserInfosURL        common.URL `json:"user_infos_url" yaml:"user_infos_url"`
+	CustomLoginProperty string     `json:"custom_login_property" yaml:"custom_login_property"`
 }
 
 func (p *OAuthProvider) Verify() error {

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/perses/perses/internal/api/shared/utils"
+	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/secret"
-	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 )
 
@@ -33,8 +33,8 @@ type Provider struct {
 	SlugID       string        `json:"slug_id" yaml:"slug_id"`
 	Name         string        `json:"name" yaml:"name"`
 	ClientID     secret.Hidden `json:"client_id" yaml:"client_id"`
-	ClientSecret config.Secret `json:"client_secret" yaml:"client_secret"`
-	RedirectURI  string        `json:"redirect_uri" yaml:"redirect_uri"`
+	ClientSecret secret.Hidden `json:"client_secret" yaml:"client_secret"`
+	RedirectURI  common.URL    `json:"redirect_uri" yaml:"redirect_uri"`
 	Scopes       []string      `json:"scopes" yaml:"scopes"`
 	DisablePKCE  bool          `json:"disable_pkce" yaml:"disable_pkce"`
 }
@@ -52,39 +52,42 @@ func (p *Provider) Verify() error {
 	if p.ClientSecret == "" {
 		return errors.New("provider's `client_secret` is mandatory")
 	}
+	if p.RedirectURI.IsNilOrEmpty() {
+		return errors.New("provider's `redirect_uri` is mandatory")
+	}
 	return nil
 }
 
 type OIDCProvider struct {
 	Provider     `json:",inline" yaml:",inline"`
-	Issuer       string            `json:"issuer" yaml:"issuer"`
-	DiscoveryURL string            `json:"discovery_url" yaml:"discovery_url"`
+	Issuer       common.URL        `json:"issuer" yaml:"issuer"`
+	DiscoveryURL common.URL        `json:"discovery_url" yaml:"discovery_url"`
 	URLParams    map[string]string `json:"url_params" yaml:"url_params"`
 }
 
 func (p *OIDCProvider) Verify() error {
-	if p.Issuer == "" {
+	if p.Issuer.IsNilOrEmpty() {
 		return errors.New("provider's `issuer` is mandatory")
 	}
 	return nil
 }
 
 type OAuthProvider struct {
-	Provider            `json:",inline" yaml:",inline"`
-	AuthURL             string `json:"auth_url" yaml:"auth_url"`
-	TokenURL            string `json:"token_url" yaml:"token_url"`
-	UserInfosURL        string `json:"user_infos_url" yaml:"user_infos_url"`
-	CustomLoginProperty string `json:"custom_login_property" yaml:"custom_login_property"`
+	Provider              `json:",inline" yaml:",inline"`
+	AuthURL               common.URL `json:"auth_url" yaml:"auth_url"`
+	TokenURL              common.URL `json:"token_url" yaml:"token_url"`
+	UserInfosURL          common.URL `json:"user_infos_url" yaml:"user_infos_url"`
+	CustomLoginProperty   string     `json:"custom_login_property" yaml:"custom_login_property"`
 }
 
 func (p *OAuthProvider) Verify() error {
-	if p.AuthURL == "" {
+	if p.AuthURL.IsNilOrEmpty() {
 		return errors.New("provider's `auth_url` is mandatory")
 	}
-	if p.TokenURL == "" {
+	if p.TokenURL.IsNilOrEmpty() {
 		return errors.New("provider's `token_url` is mandatory")
 	}
-	if p.UserInfosURL == "" {
+	if p.UserInfosURL.IsNilOrEmpty() {
 		return errors.New("provider's `user_infos_url` is mandatory")
 	}
 	return nil

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -34,7 +34,8 @@ type OIDCProvider struct {
 	ClientSecret config.Secret     `json:"client_secret" yaml:"client_secret"`
 	RedirectURI  string            `json:"redirect_uri" yaml:"redirect_uri"`
 	Scopes       []string          `json:"scopes" yaml:"scopes"`
-	Issuer       config.Secret     `json:"issuer" yaml:"issuer"`
+	Issuer       string            `json:"issuer" yaml:"issuer"`
+	DiscoveryURL string            `json:"discovery_url" yaml:"discovery_url"`
 	URLParams    map[string]string `json:"url_params" yaml:"url_params"`
 }
 

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -14,10 +14,12 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/perses/perses/internal/api/shared/utils"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 )
@@ -27,30 +29,65 @@ const (
 	DefaultRefreshTokenTTL = time.Hour * 24
 )
 
-type OIDCProvider struct {
-	SlugID       string            `json:"slug_id" yaml:"slug_id"`
-	Name         string            `json:"name" yaml:"name"`
-	ClientID     config.Secret     `json:"client_id" yaml:"client_id"`
-	ClientSecret config.Secret     `json:"client_secret" yaml:"client_secret"`
-	RedirectURI  string            `json:"redirect_uri" yaml:"redirect_uri"`
-	Scopes       []string          `json:"scopes" yaml:"scopes"`
-	Issuer       string            `json:"issuer" yaml:"issuer"`
-	DiscoveryURL string            `json:"discovery_url" yaml:"discovery_url"`
-	DisablePKCE  bool              `json:"disable_pkce" yaml:"disable_pkce"`
-	URLParams    map[string]string `json:"url_params" yaml:"url_params"`
-}
-
-type OAuthProvider struct {
+type Provider struct {
 	SlugID       string        `json:"slug_id" yaml:"slug_id"`
 	Name         string        `json:"name" yaml:"name"`
-	ClientID     config.Secret `json:"client_id" yaml:"client_id"`
+	ClientID     secret.Hidden `json:"client_id" yaml:"client_id"`
 	ClientSecret config.Secret `json:"client_secret" yaml:"client_secret"`
 	RedirectURI  string        `json:"redirect_uri" yaml:"redirect_uri"`
 	Scopes       []string      `json:"scopes" yaml:"scopes"`
-	AuthURL      string        `json:"auth_url" yaml:"auth_url"`
-	TokenURL     string        `json:"token_url" yaml:"token_url"`
-	LogoutURL    string        `json:"logout_url" yaml:"logout_url"`
-	UserInfosURL string        `json:"user_infos_url" yaml:"user_infos_url"`
+	DisablePKCE  bool          `json:"disable_pkce" yaml:"disable_pkce"`
+}
+
+func (p *Provider) Verify() error {
+	if p.SlugID == "" {
+		return errors.New("provider's `slug_id` is mandatory")
+	}
+	if p.Name == "" {
+		return errors.New("provider's `name` is mandatory")
+	}
+	if p.ClientID == "" {
+		return errors.New("provider's `client_id` is mandatory")
+	}
+	if p.ClientSecret == "" {
+		return errors.New("provider's `client_secret` is mandatory")
+	}
+	return nil
+}
+
+type OIDCProvider struct {
+	Provider     `json:",inline" yaml:",inline"`
+	Issuer       string            `json:"issuer" yaml:"issuer"`
+	DiscoveryURL string            `json:"discovery_url" yaml:"discovery_url"`
+	URLParams    map[string]string `json:"url_params" yaml:"url_params"`
+}
+
+func (p *OIDCProvider) Verify() error {
+	if p.Issuer == "" {
+		return errors.New("provider's `issuer` is mandatory")
+	}
+	return nil
+}
+
+type OAuthProvider struct {
+	Provider            `json:",inline" yaml:",inline"`
+	AuthURL             string `json:"auth_url" yaml:"auth_url"`
+	TokenURL            string `json:"token_url" yaml:"token_url"`
+	UserInfosURL        string `json:"user_infos_url" yaml:"user_infos_url"`
+	CustomLoginProperty string `json:"custom_login_property" yaml:"custom_login_property"`
+}
+
+func (p *OAuthProvider) Verify() error {
+	if p.AuthURL == "" {
+		return errors.New("provider's `auth_url` is mandatory")
+	}
+	if p.TokenURL == "" {
+		return errors.New("provider's `token_url` is mandatory")
+	}
+	if p.UserInfosURL == "" {
+		return errors.New("provider's `user_infos_url` is mandatory")
+	}
+	return nil
 }
 
 type AuthProviders struct {

--- a/pkg/model/api/config/authentication_test.go
+++ b/pkg/model/api/config/authentication_test.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/perses/common/config"
@@ -29,8 +30,8 @@ func TestAuthProviders_Verify(t *testing.T) {
 }
 
 // TestProvider_Verify makes sure the Verify of parent struct is well called by the config Resolver
-func TestProvider_Verify(t *testing.T) {
-	// Make sure it a valid OIDCProvider but not a valid Provider (Verify of the son is call before the parent's one)
+func TestProvider_VerifyParent(t *testing.T) {
+	// Make sure it is a valid OIDCProvider but not a valid Provider (Verify of the child is called before the parent's one)
 	testYamlInput := `issuer: "http://localhost:4200"`
 
 	// Run the resolver
@@ -41,4 +42,48 @@ func TestProvider_Verify(t *testing.T) {
 
 	// Check the error is well an error coming from the parent "Provider" struct
 	assert.ErrorContains(t, err, "`slug_id` is mandatory")
+}
+
+// TestProvider_Verify makes sure the Verify of child struct is well called by the config Resolver
+func TestProvider_VerifyChild(t *testing.T) {
+	// Make sure it is a valid Provider but not a valid OIDCProvider (Verify of the child is called before the parent's one)
+	testYamlInput := `
+slug_id: "github"
+name: "Github"
+client_id: "secretthing"
+client_secret: "secretthing"
+redirect_uri: "http://localhost:8080"
+`
+
+	// Run the resolver
+	err := config.NewResolver[OIDCProvider]().
+		SetConfigData([]byte(testYamlInput)).
+		Resolve(&OIDCProvider{}).
+		Verify()
+
+	// Check the error is well an error coming from the parent "Provider" struct
+	assert.ErrorContains(t, err, "`issuer` is mandatory")
+}
+
+// TestProvider_EnvVar ensures env var are well parsed for an embedded common.URL (child and parent)
+func TestProvider_EnvVar(t *testing.T) {
+	testYamlInput := `
+slug_id: "github"
+name: "Github"
+client_id: "secretthing"
+client_secret: "secretthing"
+`
+	_ = os.Setenv("PREFIX_REDIRECT_URI", "http://localhost:8080")
+	_ = os.Setenv("PREFIX_ISSUER", "http://localhost:8181")
+
+	c := &OIDCProvider{}
+	// Run the resolver
+	err := config.NewResolver[OIDCProvider]().
+		SetConfigData([]byte(testYamlInput)).
+		SetEnvPrefix("PREFIX").
+		Resolve(c).
+		Verify()
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost:8080", c.RedirectURI.String())
+	assert.Equal(t, "http://localhost:8181", c.Issuer.String())
 }

--- a/pkg/model/api/config/security.go
+++ b/pkg/model/api/config/security.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	"github.com/perses/perses/pkg/model/api/v1/secret"
-	"github.com/prometheus/common/model"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/model/api/v1/common/url.go
+++ b/pkg/model/api/v1/common/url.go
@@ -22,6 +22,10 @@ type URL struct {
 	*url.URL
 }
 
+func (u *URL) IsNilOrEmpty() bool {
+	return u == nil || u.URL == nil || u.URL.String() == ""
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface for URLs.
 func (u *URL) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string

--- a/pkg/model/api/v1/common/url.go
+++ b/pkg/model/api/v1/common/url.go
@@ -19,11 +19,11 @@ import (
 )
 
 type URL struct {
-	*url.URL
+	*url.URL `json:"-" yaml:"-"`
 }
 
 func (u *URL) IsNilOrEmpty() bool {
-	return u == nil || u.URL == nil || u.URL.String() == ""
+	return u.URL == nil || u.URL.String() == ""
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for URLs.

--- a/pkg/model/api/v1/common/url_test.go
+++ b/pkg/model/api/v1/common/url_test.go
@@ -28,7 +28,7 @@ type testURLStruct struct {
 	URL URL `json:"url" yaml:"url"`
 }
 
-func TestSecret_YAML(t *testing.T) {
+func TestURL_YAML(t *testing.T) {
 	c := &testURLStruct{}
 	err := yaml.Unmarshal([]byte(`url: http://localhost:8080`), c)
 	assert.NoError(t, err)
@@ -39,7 +39,7 @@ func TestSecret_YAML(t *testing.T) {
 	assert.Contains(t, string(res), `url: http://localhost:8080`)
 
 }
-func TestSecret_JSON(t *testing.T) {
+func TestURL_JSON(t *testing.T) {
 	c := &testURLStruct{}
 	err := json.Unmarshal([]byte(`{"url": "http://localhost:8080"}`), c)
 	assert.NoError(t, err)
@@ -50,7 +50,7 @@ func TestSecret_JSON(t *testing.T) {
 	assert.Equal(t, string(res), `{"url":"http://localhost:8080"}`)
 }
 
-func TestSecret_ENV(t *testing.T) {
+func TestURL_ENV(t *testing.T) {
 	_ = os.Setenv("PREFIX_URL", "http://localhost:8080")
 	c := &testURLStruct{}
 	err := lamenv.Unmarshal(c, []string{"PREFIX"})


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This PR comes after having tested several external OIDC provider.

So far I tested Azure, Google, Gitlab, Linkedin as OIDC providers. 
This last one seems to not support all the features like the others.

That's why this PR allow more fine grain in configuration:


### ``discovery_url`` config
Set a custom Discovery URL (the famous "/.well-known/openid-configuration" where all the config can be accessed)

With linkedin the problem is that the lib we use expected the discovery url to be {issuer}/.well-known/openid-configuration, which is not the case
```
// 20240102161055
// https://www.linkedin.com/oauth/.well-known/openid-configuration

{
  "issuer": "https://www.linkedin.com",
```

### PKCE check
By default my first implementatio assumed that PKCE verification is supported by all the OIDC providers, which is not the case. 
So we can now disable it through ``disable_pkce`` configuration.

### More efficient user info parsing
In anticipation, I also include in that PR an interface and a service that will have to be implemented to upsert user at login time (see userinfo.go file)

> Important Note: the left part of the email is now used to generate username, and I am planning in a first place to forbid the login with same username and different providers. (this is a best effort solution and will have to be rethink later)
> It is also still subject to change in the following PRs when we'll do the sync. 
> ![image](https://github.com/perses/perses/assets/10258608/9dfcae05-4f04-453b-9967-25b197ba946e)



<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
