### PR TITLE
[ENHANCEMENT] New type for URL and Secret suitable for configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/huandu/go-sqlbuilder v1.25.0
 	github.com/labstack/echo-jwt/v4 v4.2.0
 	github.com/labstack/echo/v4 v4.11.4
+	github.com/nexucis/lamenv v0.5.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/perses/common v0.22.0
 	github.com/prometheus/client_golang v1.18.0
@@ -78,7 +79,6 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
-	github.com/nexucis/lamenv v0.5.0 // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/onsi/gomega v1.23.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -30,8 +30,8 @@ import (
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	apiConfig "github.com/perses/perses/pkg/model/api/config"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/prometheus/client_golang/prometheus"
-	promConfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 )
 
@@ -48,7 +48,7 @@ func DefaultConfig() apiConfig.Config {
 				AccessTokenTTL:  model.Duration(apiConfig.DefaultAccessTokenTTL),
 				RefreshTokenTTL: model.Duration(apiConfig.DefaultRefreshTokenTTL),
 			},
-			EncryptionKey: promConfig.Secret(hex.EncodeToString([]byte("=tW$56zytgB&3jN2E%7-+qrGZE?v6LCc"))),
+			EncryptionKey: secret.Hidden(hex.EncodeToString([]byte("=tW$56zytgB&3jN2E%7-+qrGZE?v6LCc"))),
 		},
 		Schemas: apiConfig.Schemas{
 			PanelsPath:      filepath.Join(projectPath, apiConfig.DefaultPanelsPath),

--- a/pkg/model/api/config/config_test.go
+++ b/pkg/model/api/config/config_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/perses/common/config"
 	"github.com/perses/perses/pkg/model/api/v1/role"
-	promConfig "github.com/prometheus/common/config"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -297,7 +297,7 @@ information: |-
 			result: Config{
 				Security: Security{
 					Readonly:      false,
-					EncryptionKey: promConfig.Secret(hex.EncodeToString([]byte("=tW$56zytgB&3jN2E%7-+qrGZE?v6LCc"))),
+					EncryptionKey: secret.Hidden(hex.EncodeToString([]byte("=tW$56zytgB&3jN2E%7-+qrGZE?v6LCc"))),
 					EnableAuth:    true,
 					Authorization: AuthorizationConfig{
 						CheckLatestUpdateInterval: model.Duration(defaultCacheInterval),

--- a/pkg/model/api/config/database.go
+++ b/pkg/model/api/config/database.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/sirupsen/logrus"
@@ -51,15 +52,15 @@ type SQL struct {
 	// TLS configuration
 	TLSConfig *config.TLSConfig `json:"tls_config,omitempty" yaml:"tls_config,omitempty"`
 	// Username
-	User config.Secret `json:"user,omitempty" yaml:"user,omitempty"`
+	User secret.Hidden `json:"user,omitempty" yaml:"user,omitempty"`
 	// Password (requires User)
-	Password config.Secret `json:"password,omitempty" yaml:"password,omitempty"`
+	Password secret.Hidden `json:"password,omitempty" yaml:"password,omitempty"`
 	// PasswordFile is a path to a file that contains a password
 	PasswordFile string `json:"password_file,omitempty" yaml:"password_file,omitempty"`
 	// Network type
 	Net string `json:"net,omitempty" yaml:"net,omitempty"`
 	// Network address (requires Net)
-	Addr config.Secret `json:"addr,omitempty" yaml:"addr,omitempty"`
+	Addr secret.Hidden `json:"addr,omitempty" yaml:"addr,omitempty"`
 	// Database name
 	DBName string `json:"db_name" yaml:"db_name"`
 	// Connection collation
@@ -118,7 +119,7 @@ func (s *SQL) Verify() error {
 		if err != nil {
 			return err
 		}
-		s.Password = config.Secret(data)
+		s.Password = secret.Hidden(data)
 	}
 	return nil
 }

--- a/pkg/model/api/config/security.go
+++ b/pkg/model/api/config/security.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"time"
 
-	promConfig "github.com/prometheus/common/config"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/prometheus/common/model"
 	"github.com/sirupsen/logrus"
 )
@@ -61,7 +61,7 @@ type Security struct {
 	// When Perses is used in a multi instance mode, you should provide the key.
 	// Otherwise, each instance will have a different key and therefore won't be able to decrypt what the other is encrypting.
 	// Also note the key must be at least 32 bytes long.
-	EncryptionKey promConfig.Secret `json:"encryption_key,omitempty" yaml:"encryption_key,omitempty"`
+	EncryptionKey secret.Hidden `json:"encryption_key,omitempty" yaml:"encryption_key,omitempty"`
 	// EncryptionKeyFile is the path to file containing the secret key
 	EncryptionKeyFile string `json:"encryption_key_file,omitempty" yaml:"encryption_key_file,omitempty"`
 	// When it is true, the authentication and authorization config are considered.
@@ -87,11 +87,11 @@ func (s *Security) Verify() error {
 		if err != nil {
 			return err
 		}
-		s.EncryptionKey = promConfig.Secret(data)
+		s.EncryptionKey = secret.Hidden(data)
 	}
 	if len(s.EncryptionKey) < 32 {
 		return fmt.Errorf("encryption_key must be longer than 32 bytes")
 	}
-	s.EncryptionKey = promConfig.Secret(hex.EncodeToString([]byte(s.EncryptionKey)))
+	s.EncryptionKey = secret.Hidden(hex.EncodeToString([]byte(s.EncryptionKey)))
 	return nil
 }

--- a/pkg/model/api/v1/common/url.go
+++ b/pkg/model/api/v1/common/url.go
@@ -1,0 +1,83 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+type URL struct {
+	*url.URL
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for URLs.
+func (u *URL) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+
+	urlp, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+	u.URL = urlp
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface for URLs.
+func (u URL) MarshalYAML() (interface{}, error) {
+	if u.URL != nil {
+		return u.String(), nil
+	}
+	return nil, nil
+}
+
+// UnmarshalJSON implements the json.Marshaler interface for URL.
+func (u *URL) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	urlp, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+	u.URL = urlp
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for URL.
+func (u URL) MarshalJSON() ([]byte, error) {
+	if u.URL != nil {
+		return json.Marshal(u.URL.String())
+	}
+	return []byte("null"), nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (u *URL) MarshalText() ([]byte, error) {
+	return []byte(u.URL.String()), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (u *URL) UnmarshalText(text []byte) error {
+	urlp, err := url.Parse(string(text))
+	if err != nil {
+		return err
+	}
+	u.URL = urlp
+	return nil
+}

--- a/pkg/model/api/v1/common/url_test.go
+++ b/pkg/model/api/v1/common/url_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/nexucis/lamenv"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+type testURLStruct struct {
+	URL URL `json:"url" yaml:"url"`
+}
+
+func TestSecret_YAML(t *testing.T) {
+	c := &testURLStruct{}
+	err := yaml.Unmarshal([]byte(`url: http://localhost:8080`), c)
+	assert.NoError(t, err)
+	u, _ := url.Parse("http://localhost:8080")
+	assert.Equal(t, c, &testURLStruct{URL: URL{URL: u}})
+	res, err := yaml.Marshal(c)
+	assert.NoError(t, err)
+	assert.Contains(t, string(res), `url: http://localhost:8080`)
+
+}
+func TestSecret_JSON(t *testing.T) {
+	c := &testURLStruct{}
+	err := json.Unmarshal([]byte(`{"url": "http://localhost:8080"}`), c)
+	assert.NoError(t, err)
+	u, _ := url.Parse("http://localhost:8080")
+	assert.Equal(t, c, &testURLStruct{URL: URL{URL: u}})
+	res, err := json.Marshal(c)
+	assert.NoError(t, err)
+	assert.Equal(t, string(res), `{"url":"http://localhost:8080"}`)
+}
+
+func TestSecret_ENV(t *testing.T) {
+	_ = os.Setenv("PREFIX_URL", "http://localhost:8080")
+	c := &testURLStruct{}
+	err := lamenv.Unmarshal(c, []string{"PREFIX"})
+	assert.NoError(t, err)
+	u, _ := url.Parse("http://localhost:8080")
+	assert.Equal(t, c, &testURLStruct{URL: URL{URL: u}})
+	err = lamenv.Marshal(c, []string{"PREFIX"})
+	assert.NoError(t, err)
+	assert.Equal(t, os.Getenv("PREFIX_URL"), `http://localhost:8080`)
+	_ = os.Unsetenv("PREFIX_URL")
+}

--- a/pkg/model/api/v1/secret/secret.go
+++ b/pkg/model/api/v1/secret/secret.go
@@ -34,10 +34,18 @@ func (h *Hidden) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(h))
 }
 
-// MarshalJSON implements the json.Marshaler interface for Secret.
+// MarshalJSON implements the json.Marshaler interface for Hidden.
 func (h Hidden) MarshalJSON() ([]byte, error) {
 	if len(h) == 0 {
 		return json.Marshal("")
 	}
 	return json.Marshal(secretToken)
+}
+
+// MarshalText implements the encoding.TextMarshaler interface for Hidden.
+func (h Hidden) MarshalText() ([]byte, error) {
+	if len(h) == 0 {
+		return []byte{}, nil
+	}
+	return []byte(secretToken), nil
 }

--- a/pkg/model/api/v1/secret/secret_test.go
+++ b/pkg/model/api/v1/secret/secret_test.go
@@ -1,0 +1,60 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/nexucis/lamenv"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+type testSecretStruct struct {
+	Secret Hidden `json:"secret" yaml:"secret"`
+}
+
+func TestSecret_YAML(t *testing.T) {
+	c := &testSecretStruct{}
+	err := yaml.Unmarshal([]byte(`secret: something`), c)
+	assert.NoError(t, err)
+	assert.Equal(t, c, &testSecretStruct{Secret: "something"})
+	res, err := yaml.Marshal(c)
+	assert.NoError(t, err)
+	assert.Contains(t, string(res), `secret: <secret>`)
+
+}
+func TestSecret_JSON(t *testing.T) {
+	c := &testSecretStruct{}
+	err := json.Unmarshal([]byte(`{"secret": "something"}`), c)
+	assert.NoError(t, err)
+	assert.Equal(t, c, &testSecretStruct{Secret: "something"})
+	res, err := json.Marshal(c)
+	assert.NoError(t, err)
+	assert.Equal(t, string(res), `{"secret":"\u003csecret\u003e"}`)
+}
+
+func TestSecret_ENV(t *testing.T) {
+	_ = os.Setenv("PREFIX_SECRET", "something")
+	c := &testSecretStruct{}
+	err := lamenv.Unmarshal(c, []string{"PREFIX"})
+	assert.NoError(t, err)
+	assert.Equal(t, c, &testSecretStruct{Secret: "something"})
+	err = lamenv.Marshal(c, []string{"PREFIX"})
+	assert.NoError(t, err)
+	assert.Equal(t, os.Getenv("PREFIX_SECRET"), `<secret>`)
+	_ = os.Unsetenv("PREFIX_SECRET")
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

- One new URL type supporting any deserialization/serialization.
- Hidden type augmented to support MarshalText

These two types will be designed to be used in configuration, to simplify some url treatment and secure sensitive strings.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
