### PR TITLE
[BREAKING CHANGE] Sync external user with database at login time

### DIFF
--- a/dev/data/user.json
+++ b/dev/data/user.json
@@ -5,7 +5,9 @@
       "name": "admin"
     },
     "spec": {
-      "password": "password"
+      "nativeProvider": {
+        "password": "password"
+      }
     }
   },
   {
@@ -14,7 +16,9 @@
       "name": "guest"
     },
     "spec": {
-      "password": "password"
+      "nativeProvider": {
+        "password": "password"
+      }
     }
   }
 ]

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -14,9 +14,28 @@ spec:
   [ lastName: <string> ]
 
   # Password when provided is hashed and salted before going to the database
-  # Password is optional because depending on the Perses configuration, you might not be able to create a user.
+  # Password is optional because depending on the Perses configuration, you might be able to login with external
+  # authentication provider or not be able to create a user at all.
   # It can happen when the Perses server relies on a ldap database for authentication.
-  [ password: <string> ]
+  [ nativeProvider: [ password: <string>]] 
+
+  # Save the context of the oauth provider used if the user has been created from an external OIDC or OAuth
+  # authentication provider.
+  oauthProviders:  
+  - [ <oauthProvider> ]
+```
+
+### `<oauthProvider>`
+
+```yaml
+  # Identifying the provider
+  issuer: <string>
+
+  # Email of the user in the provider
+  email: <string>
+
+  # Identifying the user in the provider
+  subject: <string>
 ```
 
 ## API definition

--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -37,13 +37,34 @@ func TestAuth(t *testing.T) {
 
 		authEntity := modelAPI.Auth{
 			Login:    usrEntity.GetMetadata().GetName(),
-			Password: usrEntity.Spec.Password,
+			Password: usrEntity.Spec.NativeProvider.Password,
 		}
 
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindNative, utils.PathLogin)).
 			WithJSON(authEntity).
 			Expect().
 			Status(http.StatusOK)
+		return []modelAPI.Entity{usrEntity}
+	})
+}
+
+func TestAuth_EmptyPassword(t *testing.T) {
+	e2eframework.WithServerConfig(t, serverAuthConfig(), func(expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+		usrEntity := e2eframework.NewUser("foo")
+		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
+			WithJSON(usrEntity).
+			Expect().
+			Status(http.StatusOK)
+
+		authEntity := modelAPI.Auth{
+			Login:    usrEntity.GetMetadata().GetName(),
+			Password: "",
+		}
+
+		expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindNative, utils.PathLogin)).
+			WithJSON(authEntity).
+			Expect().
+			Status(http.StatusBadRequest)
 		return []modelAPI.Entity{usrEntity}
 	})
 }

--- a/internal/api/e2e/api/rbac_test.go
+++ b/internal/api/e2e/api/rbac_test.go
@@ -58,7 +58,7 @@ func TestNewProjectEndpoints(t *testing.T) {
 
 		authEntity := modelAPI.Auth{
 			Login:    usrEntity.GetMetadata().GetName(),
-			Password: usrEntity.Spec.Password,
+			Password: usrEntity.Spec.NativeProvider.Password,
 		}
 		authResponse := expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindNative, utils.PathLogin)).
 			WithJSON(authEntity).
@@ -99,7 +99,7 @@ func TestAnonymousEndpoints(t *testing.T) {
 
 		authEntity := modelAPI.Auth{
 			Login:    usrEntity.GetMetadata().GetName(),
-			Password: usrEntity.Spec.Password,
+			Password: usrEntity.Spec.NativeProvider.Password,
 		}
 		authResponse := expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindNative, utils.PathLogin)).
 			WithJSON(authEntity).
@@ -129,7 +129,7 @@ func TestUnauthorizedEndpoints(t *testing.T) {
 
 		authEntity := modelAPI.Auth{
 			Login:    usrEntity.GetMetadata().GetName(),
-			Password: usrEntity.Spec.Password,
+			Password: usrEntity.Spec.NativeProvider.Password,
 		}
 		authResponse := expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindNative, utils.PathLogin)).
 			WithJSON(authEntity).

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -463,7 +463,9 @@ func NewUser(name string) *v1.User {
 		Kind:     v1.KindUser,
 		Metadata: newMetadata(name),
 		Spec: v1.UserSpec{
-			Password: "password",
+			NativeProvider: v1.NativeProvider{
+				Password: "password",
+			},
 		},
 	}
 	entity.Metadata.CreateNow()
@@ -475,7 +477,7 @@ func NewPublicUser(name string) *v1.PublicUser {
 		Kind:     v1.KindUser,
 		Metadata: newMetadata(name),
 		Spec: v1.PublicUserSpec{
-			Password: "<secret>",
+			NativeProvider: v1.PublicNativeProvider{Password: "<secret>"},
 		},
 	}
 	entity.Metadata.CreateNow()

--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -49,7 +49,7 @@ func New(dao user.DAO, jwt crypto.JWT, providers config.AuthProviders, isAuthEna
 
 	// Register the OIDC providers if any
 	for _, provider := range providers.OIDC {
-		oidcEp, err := newOIDCEndpoint(provider, jwt)
+		oidcEp, err := newOIDCEndpoint(provider, jwt, dao)
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +58,7 @@ func New(dao user.DAO, jwt crypto.JWT, providers config.AuthProviders, isAuthEna
 
 	// Register the OAuth providers if any
 	for _, provider := range providers.OAuth {
-		ep.endpoints = append(ep.endpoints, newOAuthEndpoint(provider, jwt))
+		ep.endpoints = append(ep.endpoints, newOAuthEndpoint(provider, jwt, dao))
 	}
 	return ep, nil
 }

--- a/internal/api/impl/auth/native.go
+++ b/internal/api/impl/auth/native.go
@@ -58,7 +58,7 @@ func (e *nativeEndpoint) auth(ctx echo.Context) error {
 		return shared.InternalError
 	}
 
-	if !crypto.ComparePasswords(usr.Spec.Password, body.Password) {
+	if !crypto.ComparePasswords(usr.Spec.NativeProvider.Password, body.Password) {
 		return shared.HandleBadRequestError("wrong login or password ")
 	}
 	login := body.Login

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -24,11 +24,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/securecookie"
 	"github.com/labstack/echo/v4"
+	"github.com/perses/perses/internal/api/interface/v1/user"
 	"github.com/perses/perses/internal/api/shared"
 	"github.com/perses/perses/internal/api/shared/crypto"
 	"github.com/perses/perses/internal/api/shared/route"
 	"github.com/perses/perses/internal/api/shared/utils"
 	"github.com/perses/perses/pkg/model/api/config"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
@@ -68,10 +70,14 @@ func (u *oauthUserInfo) GetProfile() externalUserInfoProfile {
 	return u.externalUserInfoProfile
 }
 
-// GetIssuer implements [externalUserInfo]
-// As there's no particular issuer in oauth2 generic, we recreate a fake issuer from authURL
-func (u *oauthUserInfo) GetIssuer() string {
-	return u.authURL.Hostname()
+// GetProviderContext implements [externalUserInfo]
+func (u *oauthUserInfo) GetProviderContext() v1.OAuthProvider {
+	return v1.OAuthProvider{
+		// As there's no particular issuer in oauth2 generic, we recreate a fake issuer from authURL
+		Issuer:  u.authURL.Hostname(),
+		Email:   u.Email,
+		Subject: u.GetLogin(),
+	}
 }
 
 type oAuthEndpoint struct {
@@ -86,7 +92,7 @@ type oAuthEndpoint struct {
 	loginProps      []string
 }
 
-func newOAuthEndpoint(params config.OAuthProvider, jwt crypto.JWT) route.Endpoint {
+func newOAuthEndpoint(params config.OAuthProvider, jwt crypto.JWT, dao user.DAO) route.Endpoint {
 	// URLS are validated as non nil from the config (see config.OauthProvider.Verify)
 	authURL := *params.AuthURL.URL
 	tokenURL := params.TokenURL.String()
@@ -121,7 +127,7 @@ func newOAuthEndpoint(params config.OAuthProvider, jwt crypto.JWT) route.Endpoin
 		slugID:          params.SlugID,
 		userInfoURL:     userInfosURL,
 		authURL:         authURL,
-		svc:             service{},
+		svc:             service{dao: dao},
 		loginProps:      loginProps,
 	}
 }
@@ -273,13 +279,13 @@ func (e *oAuthEndpoint) codeExchangeHandler(ctx echo.Context) error {
 	}
 
 	// Save the user in database
-	user, err := e.svc.SyncUser(uInfo)
+	entity, err := e.svc.syncUser(uInfo)
 	if err != nil {
 		e.logWithError(err).Error("Failed to sync user in database.")
 		return shared.InternalError
 	}
 
-	username := user.GetMetadata().GetName()
+	username := entity.GetMetadata().GetName()
 	_, err = e.tokenManagement.accessToken(username, ctx.SetCookie)
 	if err != nil {
 		e.logWithError(err).Error("Failed to generate and save access token.")

--- a/internal/api/impl/auth/service.go
+++ b/internal/api/impl/auth/service.go
@@ -1,0 +1,117 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"errors"
+
+	"github.com/perses/perses/internal/api/interface/v1/user"
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+// useNewIfPresent decides if we take the old or new string.
+// Return a boolean saying if the result is different from old value.
+func useNewIfPresent(old, new string) (string, bool) {
+	if len(new) > 0 {
+		return new, old != new
+	}
+	return old, false
+}
+
+// saveProfileInfo build a user spec merging the old spec with a given user profile
+// Return a boolean saying if the result is different from old value.
+func saveProfileInfo(old v1.UserSpec, uInfoProfile externalUserInfoProfile) (v1.UserSpec, bool) {
+	firstChanged := false
+	lastChanged := false
+	old.FirstName, firstChanged = useNewIfPresent(old.FirstName, uInfoProfile.GivenName)
+	old.LastName, lastChanged = useNewIfPresent(old.LastName, uInfoProfile.FamilyName)
+	return old, firstChanged || lastChanged
+}
+
+// saveProviderInfo takes provider context of external user info and control that there is not already a different
+// provider registered for that user.
+// Return a boolean saying if the result is different from old value.
+// If it is a case then an error is returned.
+// NB: Currently done like this for sake of simplicity. This is the most straightforward way to ensure that we can't
+// impersonate another user.
+func saveProviderInfo(old v1.UserSpec, uInfoProvider v1.OAuthProvider) (v1.UserSpec, bool, error) {
+	if len(old.NativeProvider.Password) > 0 {
+		return old, false, errors.New("this user is already registered with the native provider")
+	}
+	foundPerfectMatch := false
+	for _, provider := range old.OauthProviders {
+		if provider != uInfoProvider {
+			return old, false, errors.New("this user is already registered with a different oauth provider context")
+		}
+		foundPerfectMatch = true
+	}
+	if !foundPerfectMatch {
+		// No Native provider, no different oauth provider, no matching oauth provider,
+		// it probably means that oauth providers is empty and the old spec is actually a new user that we want to create
+		old.OauthProviders = append(old.OauthProviders, uInfoProvider)
+	}
+	return old, !foundPerfectMatch, nil
+}
+
+func newSpecIfChanged(old v1.UserSpec, uInfo externalUserInfo) (v1.UserSpec, bool, error) {
+	specWithProfile, profileChanged := saveProfileInfo(old, uInfo.GetProfile())
+	newSpec, providerChanged, err := saveProviderInfo(specWithProfile, uInfo.GetProviderContext())
+	return newSpec, profileChanged || providerChanged, err
+}
+
+type service struct {
+	dao user.DAO
+}
+
+func (s *service) getOrPrepareUserEntity(login string) (*v1.User, bool, error) {
+	result, err := s.dao.Get(login)
+	if err != nil {
+		if databaseModel.IsKeyNotFound(err) {
+			result = &v1.User{Kind: v1.KindUser, Metadata: v1.Metadata{Name: login}}
+			return result, true, nil
+		}
+		return nil, false, err
+	}
+	return result, false, nil
+}
+
+func (s *service) syncUser(uInfo externalUserInfo) (*v1.User, error) {
+	entity, isNew, err := s.getOrPrepareUserEntity(uInfo.GetLogin())
+	if err != nil {
+		return nil, err
+	}
+
+	var specHasChanged bool
+	entity.Spec, specHasChanged, err = newSpecIfChanged(entity.Spec, uInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	if isNew {
+		entity.Metadata.CreateNow()
+		err = s.dao.Create(entity)
+		if err != nil {
+			return nil, err
+		}
+	} else if specHasChanged {
+		entity.Metadata.Update(entity.Metadata)
+		err = s.dao.Update(entity)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return entity, nil
+
+}

--- a/internal/api/impl/auth/service_test.go
+++ b/internal/api/impl/auth/service_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"testing"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSaveProviderInfo(t *testing.T) {
+	uInfoA := oidcUserInfo{
+		externalUserInfoProfile: externalUserInfoProfile{
+			Email: "email",
+		},
+		Subject: "subject",
+		issuer:  "issuer",
+	}
+
+	uInfoB := oidcUserInfo{
+		externalUserInfoProfile: externalUserInfoProfile{
+			Email: "differentEmail",
+		},
+		Subject: "subject",
+		issuer:  "issuer",
+	}
+
+	initialSpec := v1.UserSpec{
+		FirstName:      "",
+		LastName:       "",
+		NativeProvider: v1.NativeProvider{},
+		OauthProviders: nil,
+	}
+
+	// Save a first time the provider (has changed, no error expected)
+	result1, changed1, err1 := saveProviderInfo(initialSpec, uInfoA.GetProviderContext())
+	assert.Equal(t, []v1.OAuthProvider{uInfoA.GetProviderContext()}, result1.OauthProviders)
+	assert.True(t, changed1)
+	assert.NoError(t, err1)
+
+	// Save a second time the same provider (has not changed, no error expected)
+	result2, changed2, err2 := saveProviderInfo(result1, uInfoA.GetProviderContext())
+	assert.Equal(t, []v1.OAuthProvider{uInfoA.GetProviderContext()}, result2.OauthProviders)
+	assert.False(t, changed2)
+	assert.NoError(t, err2)
+
+	// Save a different provider (has not changed, error expected)
+	result3, changed3, err3 := saveProviderInfo(result2, uInfoB.GetProviderContext())
+	assert.Equal(t, []v1.OAuthProvider{uInfoA.GetProviderContext()}, result3.OauthProviders)
+	assert.False(t, changed3)
+	assert.Error(t, err3)
+}

--- a/internal/api/impl/auth/userinfo.go
+++ b/internal/api/impl/auth/userinfo.go
@@ -38,27 +38,11 @@ type externalUserInfo interface {
 	GetLogin() string
 	// GetProfile returns various user information that may be set in the ``specs`` of the user entity.
 	GetProfile() externalUserInfoProfile
-	// GetIssuer returns the provider issuer. It identifies the external provider used to collect this user information.
-	GetIssuer() string
+	// GetProviderContext returns the provider context. It identifies the external provider used to collect this user
+	// information, as well as the identity of the user in that context.
+	GetProviderContext() v1.OAuthProvider
 }
 
 func buildLoginFromEmail(email string) string {
 	return strings.Split(email, "@")[0]
-}
-
-type service struct {
-}
-
-func (s *service) SyncUser(uInfo externalUserInfo) (v1.User, error) {
-	//TODO(cegarcia): to be implemented
-	return v1.User{
-		Kind: v1.KindUser,
-		Metadata: v1.Metadata{
-			Name: uInfo.GetLogin(),
-		},
-		Spec: v1.UserSpec{
-			FirstName: uInfo.GetProfile().GivenName,
-			LastName:  uInfo.GetProfile().FamilyName,
-		},
-	}, nil
 }

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -49,16 +49,16 @@ func (s *service) create(entity *v1.User) (*v1.PublicUser, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	// check that the password is correctly filled
-	if len(entity.Spec.Password) == 0 {
+	if len(entity.Spec.NativeProvider.Password) == 0 {
 		return nil, fmt.Errorf("%w: password cannot be empty", shared.BadRequestError)
 	}
-	hash, err := crypto.HashAndSalt([]byte(entity.Spec.Password))
+	hash, err := crypto.HashAndSalt([]byte(entity.Spec.NativeProvider.Password))
 	if err != nil {
 		logrus.WithError(err).Errorf("unable to generate the hash for the password of the user %s", entity.Metadata.Name)
 		return nil, shared.InternalError
 	}
 	// save the hash in the password field
-	entity.Spec.Password = string(hash)
+	entity.Spec.NativeProvider.Password = string(hash)
 	if createErr := s.dao.Create(entity); createErr != nil {
 		return nil, createErr
 	}
@@ -84,15 +84,15 @@ func (s *service) update(entity *v1.User, parameters apiInterface.Parameters) (*
 	}
 	entity.Metadata.Update(oldEntity.Metadata)
 	// in case the user updated his password, then we should hash it again, otherwise the old password should be kept
-	if len(entity.Spec.Password) > 0 {
-		hash, hashErr := crypto.HashAndSalt([]byte(entity.Spec.Password))
+	if len(entity.Spec.NativeProvider.Password) > 0 {
+		hash, hashErr := crypto.HashAndSalt([]byte(entity.Spec.NativeProvider.Password))
 		if hashErr != nil {
 			logrus.WithError(hashErr).Errorf("unable to generate the hash for the password of the user %q", entity.Metadata.Name)
 			return nil, hashErr
 		}
-		entity.Spec.Password = string(hash)
+		entity.Spec.NativeProvider.Password = string(hash)
 	} else {
-		entity.Spec.Password = oldEntity.Spec.Password
+		entity.Spec.NativeProvider.Password = oldEntity.Spec.NativeProvider.Password
 	}
 	// in case the user is updating the firstname / lastname, then it should be updated, otherwise the old one should be kept
 	if len(entity.Spec.FirstName) == 0 {

--- a/pkg/model/api/v1/public_user.go
+++ b/pkg/model/api/v1/public_user.go
@@ -18,17 +18,25 @@ import (
 	"github.com/perses/perses/pkg/model/api/v1/secret"
 )
 
+type PublicNativeProvider struct {
+	Password secret.Hidden `json:"password,omitempty" yaml:"password,omitempty"`
+}
+
 type PublicUserSpec struct {
-	FirstName string        `json:"firstName,omitempty" yaml:"firstName,omitempty"`
-	LastName  string        `json:"lastName,omitempty" yaml:"lastName,omitempty"`
-	Password  secret.Hidden `json:"password,omitempty" yaml:"password,omitempty"`
+	FirstName      string               `json:"firstName,omitempty" yaml:"firstName,omitempty"`
+	LastName       string               `json:"lastName,omitempty" yaml:"lastName,omitempty"`
+	NativeProvider PublicNativeProvider `json:"nativeProvider,omitempty" yaml:"nativeProvider,omitempty"`
+	OauthProviders []OAuthProvider      `json:"oauthProviders,omitempty" yaml:"oauthProviders,omitempty"`
 }
 
 func NewPublicUserSpec(u UserSpec) PublicUserSpec {
 	return PublicUserSpec{
 		FirstName: u.FirstName,
 		LastName:  u.LastName,
-		Password:  secret.Hidden(u.Password),
+		NativeProvider: PublicNativeProvider{
+			Password: secret.Hidden(u.NativeProvider.Password),
+		},
+		OauthProviders: u.OauthProviders,
 	}
 }
 

--- a/pkg/model/api/v1/user.go
+++ b/pkg/model/api/v1/user.go
@@ -20,10 +20,21 @@ import (
 	modelAPI "github.com/perses/perses/pkg/model/api"
 )
 
+type NativeProvider struct {
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+}
+
+type OAuthProvider struct {
+	Issuer  string `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	Email   string `json:"email,omitempty" yaml:"email,omitempty"`
+	Subject string `json:"subject,omitempty" yaml:"subject,omitempty"`
+}
+
 type UserSpec struct {
-	FirstName string `json:"firstName,omitempty" yaml:"firstName,omitempty"`
-	LastName  string `json:"lastName,omitempty" yaml:"lastName,omitempty"`
-	Password  string `json:"password,omitempty" yaml:"password,omitempty"`
+	FirstName      string          `json:"firstName,omitempty" yaml:"firstName,omitempty"`
+	LastName       string          `json:"lastName,omitempty" yaml:"lastName,omitempty"`
+	NativeProvider NativeProvider  `json:"nativeProvider,omitempty" yaml:"nativeProvider,omitempty"`
+	OauthProviders []OAuthProvider `json:"oauthProviders,omitempty" yaml:"oauthProviders,omitempty"`
 }
 
 type User struct {

--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -76,7 +76,7 @@ export function useNativeAuthMutation() {
 }
 
 export function nativeAuth(body: NativeAuthBody) {
-  const url = buildURL({ resource: `${authResource}/native/login`, apiPrefix: '/api' });
+  const url = buildURL({ resource: `${authResource}/providers/native/login`, apiPrefix: '/api' });
   return fetchJson<NativeAuthResponse>(url, {
     method: HTTPMethodPOST,
     headers: HTTPHeader,

--- a/ui/app/src/model/user-client.ts
+++ b/ui/app/src/model/user-client.ts
@@ -27,7 +27,9 @@ export interface UserResource {
   spec: {
     firstName?: string;
     lastName?: string;
-    password: string;
+    nativeProvider: {
+      password: string;
+    };
   };
 }
 

--- a/ui/app/src/views/auth/SignUpView.tsx
+++ b/ui/app/src/views/auth/SignUpView.tsx
@@ -33,7 +33,7 @@ function SignUpView() {
       {
         kind: 'User',
         metadata: { name: login },
-        spec: { firstName: firstname, lastName: lastname, password: password },
+        spec: { firstName: firstname, lastName: lastname, nativeProvider: { password: password } },
       },
       {
         onSuccess: () => {

--- a/ui/app/src/views/auth/SignWrapper.tsx
+++ b/ui/app/src/views/auth/SignWrapper.tsx
@@ -35,11 +35,6 @@ export function SignWrapper(props: { children: ReactNode }) {
   const socialProviders = [...oidcProviders, ...oauthProviders];
   const nativeProviderIsEnabled = config.config?.security?.authentication?.providers?.enable_native;
 
-  // If there is only one social provider, we automatically redirect to its login page
-  // TODO(cegarcia): Discuss that with other mates as it gives some weird behavior with automatic re-login when we logout
-  if (!nativeProviderIsEnabled && socialProviders.length == 1 && socialProviders[0]) {
-    location.href = `/api/auth/providers/${socialProviders[0].path}/login`;
-  }
   return (
     <Stack
       width="100%"


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This PR add the last important missing brick which consist in saving the user once logged in. 
It allows then to add some permissions to that user. 

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
