### PR TITLE
[ENHANCEMENT] OAuth/OIDC possibly get redirect_uri from request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -156,7 +156,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true

--- a/.github/workflows/delete-snapshot.yml
+++ b/.github/workflows/delete-snapshot.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -94,18 +94,19 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+          enable_go_cache: false
           enable_npm: false
       - name: generate files
-        run: make generate
+        run: make assets-compress
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.54.2
+          version: v1.55.2
           args: --timeout 5m
   cue-eval:
     name: cue
@@ -113,7 +114,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.2.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true

--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -159,6 +159,7 @@ Generic placeholders are defined as follows:
   [ client_secret: <secret> ]
 
   # The callback URL for authorization code (Have to be <your URL> + /api/auth/providers/oidc/{slug}/callback)
+  # If not set it will get it from the request.
   [ redirect_uri: <string> ]
 
   # scopes the needed scopes to authenticate a user in the provider

--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/labstack/echo/v4"
 	"github.com/perses/perses/internal/api/interface/v1/user"
@@ -27,6 +28,19 @@ import (
 	"github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/config"
 )
+
+func getRedirectURI(r *http.Request, authKind string, slugID string) string {
+	rd := url.URL{}
+	rd.Host = r.Host
+	rd.Scheme = r.URL.Scheme
+	// If there's no scheme in the request, we should still include one
+	if rd.Scheme == "" {
+		rd.Scheme = "http"
+	}
+
+	rd.Path = fmt.Sprintf("%s/%s/%s/%s/callback", utils.APIPrefix, utils.PathAuthProviders, authKind, slugID)
+	return rd.String()
+}
 
 type endpoint struct {
 	endpoints       []route.Endpoint

--- a/internal/api/impl/auth/auth_test.go
+++ b/internal/api/impl/auth/auth_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/perses/perses/internal/api/shared/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRedirectURI(t *testing.T) {
+	assert.Equal(t, "http://localhost:8080/api/auth/providers/oidc/azure/callback", getRedirectURI(&http.Request{
+		URL: &url.URL{
+			Scheme: "http",
+		},
+		Host: "localhost:8080",
+	}, utils.AuthKindOIDC, "azure"))
+}

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -52,9 +52,6 @@ func (p *Provider) Verify() error {
 	if p.ClientSecret == "" {
 		return errors.New("provider's `client_secret` is mandatory")
 	}
-	if p.RedirectURI.IsNilOrEmpty() {
-		return errors.New("provider's `redirect_uri` is mandatory")
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

In some companies you may be under different proxy when you run your perses instance. 
This PR is make it possible to replace the redirect_uri hardly defined in oauth config to something computed dynamically

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
