### PR TITLE
[ENHANCEMENT] Run ID validation on Metadata.Name in all cases to avoid discrepancies

### DIFF
--- a/cue/model/api/v1/metadata_go_gen.cue
+++ b/cue/model/api/v1/metadata_go_gen.cue
@@ -4,17 +4,16 @@
 
 package v1
 
-import "time"
+#Metadata: _
 
-#Metadata: {
-	name:      string    @go(Name)
-	createdAt: time.Time @go(CreatedAt)
-	updatedAt: time.Time @go(UpdatedAt)
-	version:   uint64    @go(Version)
-}
+// This wrapping struct is required to allow defining a custom unmarshall on Metadata
+// without breaking the Project attribute (the fact Metadata is injected line in
+// ProjectMetadata caused Project string to be ignored when unmarshalling)
+#ProjectAsStruct: _
 
 // ProjectMetadata is the metadata struct for resources that belongs to a project.
 #ProjectMetadata: {
 	#Metadata
-	project: string @go(Project)
+
+	#ProjectAsStruct
 }

--- a/cue/model/api/v1/metadata_go_gen.cue
+++ b/cue/model/api/v1/metadata_go_gen.cue
@@ -9,11 +9,11 @@ package v1
 // This wrapping struct is required to allow defining a custom unmarshall on Metadata
 // without breaking the Project attribute (the fact Metadata is injected line in
 // ProjectMetadata caused Project string to be ignored when unmarshalling)
-#ProjectAsStruct: _
+#ProjectMetadataWrapper: _
 
 // ProjectMetadata is the metadata struct for resources that belongs to a project.
 #ProjectMetadata: {
 	#Metadata
 
-	#ProjectAsStruct
+	#ProjectMetadataWrapper
 }

--- a/cue/model/api/v1/metadata_go_gen.cue
+++ b/cue/model/api/v1/metadata_go_gen.cue
@@ -12,8 +12,4 @@ package v1
 #ProjectMetadataWrapper: _
 
 // ProjectMetadata is the metadata struct for resources that belongs to a project.
-#ProjectMetadata: {
-	#Metadata
-
-	#ProjectMetadataWrapper
-}
+#ProjectMetadata: _

--- a/cue/model/api/v1/metadata_patch.cue
+++ b/cue/model/api/v1/metadata_patch.cue
@@ -13,11 +13,30 @@
 
 package v1
 
-// This definition provides placeholder values for the dashboard metadata,
-// required to pass the CUE evaluation, as those attributes are flagged as
-// mandatory in the (Go) datamodel but populated by the server in the end.
+import (
+	"strings"
+	"time"
+)
+
 #Metadata: {
+	name: string @go(Name)
+	// extra constraints for the name attribute, that reproduces some validation we have on
+	// the Golang side placeholder values for the dashboard metadata,
+	name: strings.MinRunes(1) & strings.MaxRunes(75)
+	name: =~"^[a-zA-Z0-9_.-]+$"
+
+	createdAt: time.Time @go(CreatedAt)
+	updatedAt: time.Time @go(UpdatedAt)
+	version:   uint64    @go(Version)
+	// placeholder values required to pass the CUE evaluation, as those attributes are flagged
+	// as mandatory in the (Go) datamodel but populated by the server in the end.
 	createdAt: "1970-01-01T00:00:00.000000000Z"
 	updatedAt: "1970-01-01T00:00:00.000000000Z"
 	version:   1
+}
+
+// ProjectMetadata is the metadata struct for resources that belongs to a project.
+#ProjectMetadata: {
+	#Metadata
+	project: string @go(Project)
 }

--- a/cue/model/api/v1/metadata_patch.cue
+++ b/cue/model/api/v1/metadata_patch.cue
@@ -18,25 +18,24 @@ import (
 	"time"
 )
 
+// Extra constraints for the name attributes, that reproduce validation we have on the Golang side.
+#metadataName: strings.MinRunes(1) & strings.MaxRunes(75) & =~"^[a-zA-Z0-9_.-]+$"
+
 #Metadata: {
-	name: string @go(Name)
-	// extra constraints for the name attribute, that reproduces some validation we have on
-	// the Golang side placeholder values for the dashboard metadata,
-	name: strings.MinRunes(1) & strings.MaxRunes(75)
-	name: =~"^[a-zA-Z0-9_.-]+$"
+	name: #metadataName @go(Name)
 
 	createdAt: time.Time @go(CreatedAt)
 	updatedAt: time.Time @go(UpdatedAt)
 	version:   uint64    @go(Version)
-	// placeholder values required to pass the CUE evaluation, as those attributes are flagged
-	// as mandatory in the (Go) datamodel but populated by the server in the end.
+	// Placeholder values required to pass the CUE evaluation, as those
+	// attributes are flagged as mandatory in the (Go) datamodel but
+	// populated by the server in the end.
 	createdAt: "1970-01-01T00:00:00.000000000Z"
 	updatedAt: "1970-01-01T00:00:00.000000000Z"
 	version:   1
 }
 
 // ProjectMetadata is the metadata struct for resources that belongs to a project.
-#ProjectMetadata: {
-	#Metadata
-	project: string @go(Project)
+#ProjectMetadataWrapper: {
+	project: #metadataName @go(Project)
 }

--- a/cue/model/api/v1/metadata_patch.cue
+++ b/cue/model/api/v1/metadata_patch.cue
@@ -35,7 +35,12 @@ import (
 	version:   1
 }
 
-// ProjectMetadata is the metadata struct for resources that belongs to a project.
 #ProjectMetadataWrapper: {
 	project: #metadataName @go(Project)
+}
+
+#ProjectMetadata: {
+	#Metadata
+
+	#ProjectMetadataWrapper
 }

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -173,7 +173,7 @@ func newProjectMetadata(projectName string, name string) v1.ProjectMetadata {
 		Metadata: v1.Metadata{
 			Name: name,
 		},
-		ProjectAsStruct: v1.ProjectAsStruct{
+		ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 			Project: projectName,
 		},
 	}

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -173,7 +173,9 @@ func newProjectMetadata(projectName string, name string) v1.ProjectMetadata {
 		Metadata: v1.Metadata{
 			Name: name,
 		},
-		Project: projectName,
+		ProjectAsStruct: v1.ProjectAsStruct{
+			Project: projectName,
+		},
 	}
 }
 

--- a/internal/api/shared/schemas/schemas_test.go
+++ b/internal/api/shared/schemas/schemas_test.go
@@ -75,7 +75,7 @@ func TestValidatePanels(t *testing.T) {
 		Metadata: v1.Metadata{
 			Name: "SimpleDashboard",
 		},
-		ProjectAsStruct: v1.ProjectAsStruct{
+		ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 			Project: "perses",
 		},
 	}
@@ -233,7 +233,7 @@ func TestValidateDashboardVariables(t *testing.T) {
 		Metadata: v1.Metadata{
 			Name: "SimpleDashboard",
 		},
-		ProjectAsStruct: v1.ProjectAsStruct{
+		ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 			Project: "perses",
 		},
 	}

--- a/internal/api/shared/schemas/schemas_test.go
+++ b/internal/api/shared/schemas/schemas_test.go
@@ -75,7 +75,9 @@ func TestValidatePanels(t *testing.T) {
 		Metadata: v1.Metadata{
 			Name: "SimpleDashboard",
 		},
-		Project: "perses",
+		ProjectAsStruct: v1.ProjectAsStruct{
+			Project: "perses",
+		},
 	}
 
 	testSuite := []struct {
@@ -231,7 +233,9 @@ func TestValidateDashboardVariables(t *testing.T) {
 		Metadata: v1.Metadata{
 			Name: "SimpleDashboard",
 		},
-		Project: "perses",
+		ProjectAsStruct: v1.ProjectAsStruct{
+			Project: "perses",
+		},
 	}
 
 	testSuite := []struct {

--- a/internal/api/shared/utils/utils.go
+++ b/internal/api/shared/utils/utils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
-	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/sirupsen/logrus"
 )
 
@@ -89,9 +88,6 @@ func validateMetadataVersusParameter(ctx echo.Context, paramName string, metadat
 }
 
 func ValidateMetadata(ctx echo.Context, metadata api.Metadata) error {
-	if err := common.ValidateID(metadata.GetName()); err != nil {
-		return err
-	}
 	switch met := metadata.(type) {
 	case *v1.ProjectMetadata:
 		if err := validateMetadataVersusParameter(ctx, ParamProject, &met.Project); err != nil {

--- a/internal/cli/cmd/dac/build/testdata/invalid_dac.cue
+++ b/internal/cli/cmd/dac/build/testdata/invalid_dac.cue
@@ -39,8 +39,8 @@ import (
 
 v1.#Dashboard & {
 	metadata: {
-		name:    "Containers monitoring"
-		project: "My project"
+		name:    "ContainersMonitoring"
+		project: "MyProject"
 	}
 	spec: {
 		panels: #myPanels

--- a/internal/cli/cmd/dac/build/testdata/working_dac.cue
+++ b/internal/cli/cmd/dac/build/testdata/working_dac.cue
@@ -43,8 +43,8 @@ import (
 
 v1.#Dashboard & {
 	metadata: {
-		name:    "Containers monitoring"
-		project: "My project"
+		name:    "ContainersMonitoring"
+		project: "MyProject"
 	}
 	spec: {
 		panels: #myPanels

--- a/internal/cli/cmd/describe/describe_test.go
+++ b/internal/cli/cmd/describe/describe_test.go
@@ -92,7 +92,7 @@ func TestDescribeCMD(t *testing.T) {
 					Metadata: modelV1.Metadata{
 						Name: "myFolder",
 					},
-					ProjectAsStruct: modelV1.ProjectAsStruct{
+					ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 						Project: "perses",
 					},
 				},
@@ -110,7 +110,7 @@ func TestDescribeCMD(t *testing.T) {
 					Metadata: modelV1.Metadata{
 						Name: "myFolder",
 					},
-					ProjectAsStruct: modelV1.ProjectAsStruct{
+					ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 						Project: "perses",
 					},
 				},

--- a/internal/cli/cmd/describe/describe_test.go
+++ b/internal/cli/cmd/describe/describe_test.go
@@ -92,7 +92,9 @@ func TestDescribeCMD(t *testing.T) {
 					Metadata: modelV1.Metadata{
 						Name: "myFolder",
 					},
-					Project: "perses",
+					ProjectAsStruct: modelV1.ProjectAsStruct{
+						Project: "perses",
+					},
 				},
 			})) + "\n",
 		},
@@ -108,7 +110,9 @@ func TestDescribeCMD(t *testing.T) {
 					Metadata: modelV1.Metadata{
 						Name: "myFolder",
 					},
-					Project: "perses",
+					ProjectAsStruct: modelV1.ProjectAsStruct{
+						Project: "perses",
+					},
 				},
 			})) + "\n",
 		},

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -1,10 +1,10 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Containers monitoring",
+    "name": "ContainersMonitoring",
     "createdAt": "1970-01-01T00:00:00.000000000Z",
     "updatedAt": "1970-01-01T00:00:00.000000000Z",
-    "project": "My project",
+    "project": "MyProject",
     "version": 1
   },
   "spec": {

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -110,8 +110,8 @@ import (
 
 v1.#Dashboard & {
 	metadata: {
-		name:    "Containers monitoring"
-		project: "My project"
+		name:    "ContainersMonitoring"
+		project: "MyProject"
 	}
 	spec: {
 		panels:    #myPanels

--- a/pkg/client/fake/api/v1/folder.go
+++ b/pkg/client/fake/api/v1/folder.go
@@ -28,7 +28,9 @@ func FolderList(project string, prefix string) []*modelV1.Folder {
 				Metadata: modelV1.Metadata{
 					Name: "FF15",
 				},
-				Project: "perses",
+				ProjectAsStruct: modelV1.ProjectAsStruct{
+					Project: "perses",
+				},
 			},
 		},
 		{
@@ -37,7 +39,9 @@ func FolderList(project string, prefix string) []*modelV1.Folder {
 				Metadata: modelV1.Metadata{
 					Name: "AnotherFolder",
 				},
-				Project: "AnotherProject",
+				ProjectAsStruct: modelV1.ProjectAsStruct{
+					Project: "AnotherProject",
+				},
 			},
 		},
 	}
@@ -75,7 +79,9 @@ func (c *folder) Get(name string) (*modelV1.Folder, error) {
 			Metadata: modelV1.Metadata{
 				Name: name,
 			},
-			Project: c.project,
+			ProjectAsStruct: modelV1.ProjectAsStruct{
+				Project: c.project,
+			},
 		},
 	}, nil
 }

--- a/pkg/client/fake/api/v1/folder.go
+++ b/pkg/client/fake/api/v1/folder.go
@@ -28,7 +28,7 @@ func FolderList(project string, prefix string) []*modelV1.Folder {
 				Metadata: modelV1.Metadata{
 					Name: "FF15",
 				},
-				ProjectAsStruct: modelV1.ProjectAsStruct{
+				ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 					Project: "perses",
 				},
 			},
@@ -39,7 +39,7 @@ func FolderList(project string, prefix string) []*modelV1.Folder {
 				Metadata: modelV1.Metadata{
 					Name: "AnotherFolder",
 				},
-				ProjectAsStruct: modelV1.ProjectAsStruct{
+				ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 					Project: "AnotherProject",
 				},
 			},
@@ -79,7 +79,7 @@ func (c *folder) Get(name string) (*modelV1.Folder, error) {
 			Metadata: modelV1.Metadata{
 				Name: name,
 			},
-			ProjectAsStruct: modelV1.ProjectAsStruct{
+			ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 				Project: c.project,
 			},
 		},

--- a/pkg/client/fake/api/v1/folder_test.go
+++ b/pkg/client/fake/api/v1/folder_test.go
@@ -36,7 +36,7 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "FF15",
 						},
-						ProjectAsStruct: modelV1.ProjectAsStruct{
+						ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 							Project: "perses",
 						},
 					},
@@ -47,7 +47,7 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "AnotherFolder",
 						},
-						ProjectAsStruct: modelV1.ProjectAsStruct{
+						ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 							Project: "AnotherProject",
 						},
 					},
@@ -64,7 +64,7 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "FF15",
 						},
-						ProjectAsStruct: modelV1.ProjectAsStruct{
+						ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 							Project: "perses",
 						},
 					},
@@ -81,7 +81,7 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "AnotherFolder",
 						},
-						ProjectAsStruct: modelV1.ProjectAsStruct{
+						ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 							Project: "AnotherProject",
 						},
 					},
@@ -99,7 +99,7 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "AnotherFolder",
 						},
-						ProjectAsStruct: modelV1.ProjectAsStruct{
+						ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
 							Project: "AnotherProject",
 						},
 					},

--- a/pkg/client/fake/api/v1/folder_test.go
+++ b/pkg/client/fake/api/v1/folder_test.go
@@ -36,7 +36,9 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "FF15",
 						},
-						Project: "perses",
+						ProjectAsStruct: modelV1.ProjectAsStruct{
+							Project: "perses",
+						},
 					},
 				},
 				{
@@ -45,7 +47,9 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "AnotherFolder",
 						},
-						Project: "AnotherProject",
+						ProjectAsStruct: modelV1.ProjectAsStruct{
+							Project: "AnotherProject",
+						},
 					},
 				},
 			},
@@ -60,7 +64,9 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "FF15",
 						},
-						Project: "perses",
+						ProjectAsStruct: modelV1.ProjectAsStruct{
+							Project: "perses",
+						},
 					},
 				},
 			},
@@ -75,7 +81,9 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "AnotherFolder",
 						},
-						Project: "AnotherProject",
+						ProjectAsStruct: modelV1.ProjectAsStruct{
+							Project: "AnotherProject",
+						},
 					},
 				},
 			},
@@ -91,7 +99,9 @@ func TestFolderList(t *testing.T) {
 						Metadata: modelV1.Metadata{
 							Name: "AnotherFolder",
 						},
-						Project: "AnotherProject",
+						ProjectAsStruct: modelV1.ProjectAsStruct{
+							Project: "AnotherProject",
+						},
 					},
 				},
 			},

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -46,7 +46,9 @@ func TestMarshalDashboard(t *testing.T) {
 					Metadata: Metadata{
 						Name: "SimpleDashboard",
 					},
-					Project: "perses",
+					ProjectAsStruct: ProjectAsStruct{
+						Project: "perses",
+					},
 				},
 				Spec: DashboardSpec{
 					Variables: nil,
@@ -150,7 +152,9 @@ func TestMarshalDashboard(t *testing.T) {
 					Metadata: Metadata{
 						Name: "SimpleDashboard",
 					},
-					Project: "perses",
+					ProjectAsStruct: ProjectAsStruct{
+						Project: "perses",
+					},
 				},
 				Spec: DashboardSpec{
 					Variables: []dashboard.Variable{
@@ -431,7 +435,9 @@ func TestUnmarshallDashboard(t *testing.T) {
 			Metadata: Metadata{
 				Name: "SimpleDashboard",
 			},
-			Project: "perses",
+			ProjectAsStruct: ProjectAsStruct{
+				Project: "perses",
+			},
 		},
 		Spec: DashboardSpec{
 			Variables: []dashboard.Variable{

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -46,7 +46,7 @@ func TestMarshalDashboard(t *testing.T) {
 					Metadata: Metadata{
 						Name: "SimpleDashboard",
 					},
-					ProjectAsStruct: ProjectAsStruct{
+					ProjectMetadataWrapper: ProjectMetadataWrapper{
 						Project: "perses",
 					},
 				},
@@ -152,7 +152,7 @@ func TestMarshalDashboard(t *testing.T) {
 					Metadata: Metadata{
 						Name: "SimpleDashboard",
 					},
-					ProjectAsStruct: ProjectAsStruct{
+					ProjectMetadataWrapper: ProjectMetadataWrapper{
 						Project: "perses",
 					},
 				},
@@ -435,7 +435,7 @@ func TestUnmarshallDashboard(t *testing.T) {
 			Metadata: Metadata{
 				Name: "SimpleDashboard",
 			},
-			ProjectAsStruct: ProjectAsStruct{
+			ProjectMetadataWrapper: ProjectMetadataWrapper{
 				Project: "perses",
 			},
 		},

--- a/pkg/model/api/v1/metadata.go
+++ b/pkg/model/api/v1/metadata.go
@@ -126,10 +126,48 @@ type ProjectMetadata struct {
 	ProjectMetadataWrapper `json:",inline" yaml:",inline"`
 }
 
-func (m *ProjectMetadata) GetName() string {
-	return m.Name
+// This method is needed in the case of JSON otherwise parts of the fields are missed when unmarshalling
+func (pm *ProjectMetadata) UnmarshalJSON(data []byte) error {
+	// Call UnmarshalJSON methods of the embedded structs
+	var metadataTmp Metadata
+	if err := metadataTmp.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	var projectMetadataWrapperTmp ProjectMetadataWrapper
+	if err := projectMetadataWrapperTmp.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	pm.Metadata = metadataTmp
+	pm.ProjectMetadataWrapper = projectMetadataWrapperTmp
+
+	return nil
 }
 
-func (m *ProjectMetadata) Update(previous ProjectMetadata) {
-	m.Metadata.Update(previous.Metadata)
+// This method is needed in the case of YAML otherwise the validation part is not triggered when unmarshalling
+func (pm *ProjectMetadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Call UnmarshalYAML methods of the embedded structs
+	var metadataTmp Metadata
+	if err := metadataTmp.UnmarshalYAML(unmarshal); err != nil {
+		return err
+	}
+
+	var projectMetadataWrapperTmp ProjectMetadataWrapper
+	if err := projectMetadataWrapperTmp.UnmarshalYAML(unmarshal); err != nil {
+		return err
+	}
+
+	pm.Metadata = metadataTmp
+	pm.ProjectMetadataWrapper = projectMetadataWrapperTmp
+
+	return nil
+}
+
+func (pm *ProjectMetadata) GetName() string {
+	return pm.Name
+}
+
+func (pm *ProjectMetadata) Update(previous ProjectMetadata) {
+	pm.Metadata.Update(previous.Metadata)
 }

--- a/pkg/model/api/v1/metadata.go
+++ b/pkg/model/api/v1/metadata.go
@@ -57,7 +57,7 @@ func NewProjectMetadata(project string, name string) *ProjectMetadata {
 		Metadata: Metadata{
 			Name: name,
 		},
-		ProjectAsStruct: ProjectAsStruct{
+		ProjectMetadataWrapper: ProjectMetadataWrapper{
 			Project: project,
 		},
 	}
@@ -96,13 +96,13 @@ func (m *Metadata) validate() error {
 // This wrapping struct is required to allow defining a custom unmarshall on Metadata
 // without breaking the Project attribute (the fact Metadata is injected line in
 // ProjectMetadata caused Project string to be ignored when unmarshalling)
-type ProjectAsStruct struct {
+type ProjectMetadataWrapper struct {
 	Project string `json:"project" yaml:"project"`
 }
 
-func (p *ProjectAsStruct) UnmarshalJSON(data []byte) error {
-	var tmp ProjectAsStruct
-	type plain ProjectAsStruct
+func (p *ProjectMetadataWrapper) UnmarshalJSON(data []byte) error {
+	var tmp ProjectMetadataWrapper
+	type plain ProjectMetadataWrapper
 	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
 		return err
 	}
@@ -110,9 +110,9 @@ func (p *ProjectAsStruct) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *ProjectAsStruct) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var tmp ProjectAsStruct
-	type plain ProjectAsStruct
+func (p *ProjectMetadataWrapper) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp ProjectMetadataWrapper
+	type plain ProjectMetadataWrapper
 	if err := unmarshal((*plain)(&tmp)); err != nil {
 		return err
 	}
@@ -122,8 +122,8 @@ func (p *ProjectAsStruct) UnmarshalYAML(unmarshal func(interface{}) error) error
 
 // ProjectMetadata is the metadata struct for resources that belongs to a project.
 type ProjectMetadata struct {
-	Metadata        `json:",inline" yaml:",inline"`
-	ProjectAsStruct `json:",inline" yaml:",inline"`
+	Metadata               `json:",inline" yaml:",inline"`
+	ProjectMetadataWrapper `json:",inline" yaml:",inline"`
 }
 
 func (m *ProjectMetadata) GetName() string {

--- a/pkg/model/api/v1/metadata_test.go
+++ b/pkg/model/api/v1/metadata_test.go
@@ -76,7 +76,9 @@ func TestProjectMetadata_UpdateVersion(t *testing.T) {
 			UpdatedAt: time.Now(),
 			Version:   0,
 		},
-		Project: "Perses",
+		ProjectAsStruct: ProjectAsStruct{
+			Project: "Perses",
+		},
 	}
 	// The idea here is to verify if we update multiple times a ProjectMetadata based on a previous version of the struct,
 	// we will have the correct version number.

--- a/pkg/model/api/v1/metadata_test.go
+++ b/pkg/model/api/v1/metadata_test.go
@@ -76,7 +76,7 @@ func TestProjectMetadata_UpdateVersion(t *testing.T) {
 			UpdatedAt: time.Now(),
 			Version:   0,
 		},
-		ProjectAsStruct: ProjectAsStruct{
+		ProjectMetadataWrapper: ProjectMetadataWrapper{
 			Project: "Perses",
 		},
 	}

--- a/pkg/model/api/v1/metadata_test.go
+++ b/pkg/model/api/v1/metadata_test.go
@@ -113,7 +113,7 @@ func TestUnmarshalMetadata(t *testing.T) {
 		result Metadata
 	}{
 		{
-			title: "simple Prometheus datasource",
+			title: "nominal case",
 			jason: `
 {
   "name": "foo",
@@ -202,7 +202,7 @@ func TestUnmarshalProjectMetadata(t *testing.T) {
 		result ProjectMetadata
 	}{
 		{
-			title: "simple Prometheus datasource",
+			title: "nominal case",
 			jason: `
 {
   "name": "foo",

--- a/pkg/model/api/v1/utils/default.go
+++ b/pkg/model/api/v1/utils/default.go
@@ -36,7 +36,7 @@ func DefaultOwnerRole(projectName string) *v1.Role {
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
-			ProjectAsStruct: v1.ProjectAsStruct{
+			ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 				Project: projectName,
 			},
 		},
@@ -61,7 +61,7 @@ func DefaultEditorRole(projectName string) *v1.Role {
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
-			ProjectAsStruct: v1.ProjectAsStruct{
+			ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 				Project: projectName,
 			},
 		},
@@ -90,7 +90,7 @@ func DefaultViewerRole(projectName string) *v1.Role {
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
-			ProjectAsStruct: v1.ProjectAsStruct{
+			ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 				Project: projectName,
 			},
 		},
@@ -112,7 +112,7 @@ func DefaultOwnerRoleBinding(projectName string, username string) *v1.RoleBindin
 			Metadata: v1.Metadata{
 				Name: owner,
 			},
-			ProjectAsStruct: v1.ProjectAsStruct{
+			ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 				Project: projectName,
 			},
 		},

--- a/pkg/model/api/v1/utils/default.go
+++ b/pkg/model/api/v1/utils/default.go
@@ -36,7 +36,9 @@ func DefaultOwnerRole(projectName string) *v1.Role {
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
-			Project: projectName,
+			ProjectAsStruct: v1.ProjectAsStruct{
+				Project: projectName,
+			},
 		},
 		Spec: v1.RoleSpec{
 			Permissions: []role.Permission{
@@ -59,7 +61,9 @@ func DefaultEditorRole(projectName string) *v1.Role {
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
-			Project: projectName,
+			ProjectAsStruct: v1.ProjectAsStruct{
+				Project: projectName,
+			},
 		},
 		Spec: v1.RoleSpec{
 			Permissions: []role.Permission{
@@ -86,7 +90,9 @@ func DefaultViewerRole(projectName string) *v1.Role {
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
-			Project: projectName,
+			ProjectAsStruct: v1.ProjectAsStruct{
+				Project: projectName,
+			},
 		},
 		Spec: v1.RoleSpec{
 			Permissions: []role.Permission{
@@ -106,7 +112,9 @@ func DefaultOwnerRoleBinding(projectName string, username string) *v1.RoleBindin
 			Metadata: v1.Metadata{
 				Name: owner,
 			},
-			Project: projectName,
+			ProjectAsStruct: v1.ProjectAsStruct{
+				Project: projectName,
+			},
 		},
 		Spec: v1.RoleBindingSpec{
 			Role: owner,

--- a/pkg/model/api/v1/utils/variable_build_order_test.go
+++ b/pkg/model/api/v1/utils/variable_build_order_test.go
@@ -131,7 +131,9 @@ func TestBuildVariableDependencies(t *testing.T) {
 						Metadata: v1.Metadata{
 							Name: "bar",
 						},
-						Project: "myProject",
+						ProjectAsStruct: v1.ProjectAsStruct{
+							Project: "myProject",
+						},
 					},
 					Spec: v1.VariableSpec{
 						Kind: variable.KindList,
@@ -152,7 +154,9 @@ func TestBuildVariableDependencies(t *testing.T) {
 						Metadata: v1.Metadata{
 							Name: "myVariable",
 						},
-						Project: "myProject",
+						ProjectAsStruct: v1.ProjectAsStruct{
+							Project: "myProject",
+						},
 					},
 					Spec: v1.VariableSpec{
 						Kind: variable.KindList,

--- a/pkg/model/api/v1/utils/variable_build_order_test.go
+++ b/pkg/model/api/v1/utils/variable_build_order_test.go
@@ -131,7 +131,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						Metadata: v1.Metadata{
 							Name: "bar",
 						},
-						ProjectAsStruct: v1.ProjectAsStruct{
+						ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 							Project: "myProject",
 						},
 					},
@@ -154,7 +154,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						Metadata: v1.Metadata{
 							Name: "myVariable",
 						},
-						ProjectAsStruct: v1.ProjectAsStruct{
+						ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
 							Project: "myProject",
 						},
 					},


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Run `ValidateID()` as part of the v1.Metadata unmarshalling, so the constraints apply consistently for any kind of resource having metadata.
This solves some validation discrepancies (e.g DaC unit tests, unmarshalling was working but trying to apply the dashboard to a Perses server was failing).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).