### PR TITLE
[ENHANCEMENT] Support referencing variables in 'Min step' field

### DIFF
--- a/schemas/queries/prometheus/query.cue
+++ b/schemas/queries/prometheus/query.cue
@@ -24,6 +24,6 @@ spec: close({
 	}
 	query:             string
 	seriesNameFormat?: string
-	minStep?:          =~"^(?:(\\d+)y)?(?:(\\d+)w)?(?:(\\d+)d)?(?:(\\d+)h)?(?:(\\d+)m)?(?:(\\d+)s)?(?:(\\d+)ms)?$"
+	minStep?:          =~"^(?:(\\d+)y)?(?:(\\d+)w)?(?:(\\d+)d)?(?:(\\d+)h)?(?:(\\d+)m)?(?:(\\d+)s)?(?:(\\d+)ms)?(?:\\$\\w+)?$"
 	resolution?:       number
 })

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -53,6 +53,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   const minStep =
     getDurationStringSeconds(
       // resolve any variable that may have been provided
+      // TODO add a validation check to make sure the variable is a DurationString, to avoid the back & forth cast here
       replaceTemplateVariables(spec.minStep as string, context.variableState) as DurationString
     ) ?? datasourceScrapeInterval;
   const timeRange = getPrometheusTimeRange(context.timeRange);

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -13,6 +13,7 @@
 
 import {
   DatasourceSpec,
+  DurationString,
   formatDuration,
   msToPrometheusDuration,
   Notice,
@@ -49,7 +50,11 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
     milliseconds(parseDurationString(datasource.plugin.spec.scrapeInterval ?? DEFAULT_SCRAPE_INTERVAL)) / 1000
   );
 
-  const minStep = getDurationStringSeconds(spec.minStep) ?? datasourceScrapeInterval;
+  const minStep =
+    getDurationStringSeconds(
+      // resolve any variable that may have been provided
+      replaceTemplateVariables(spec.minStep as string, context.variableState) as DurationString
+    ) ?? datasourceScrapeInterval;
   const timeRange = getPrometheusTimeRange(context.timeRange);
   const step = getRangeStep(timeRange, minStep, undefined, context.suggestedStepMs); // TODO: resolution
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Closes https://github.com/perses/perses/issues/1724.

# Screenshots

![image](https://github.com/perses/perses/assets/7058693/ac9a2f0e-b341-425c-94c7-6d3b73c8b540)
![2024-01-23_22h44_21](https://github.com/perses/perses/assets/7058693/a87f0565-a9e9-4da9-b3fc-4702d9d8e815)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
