### PR TITLE
[BUGFIX] Fix the refresh token client in the CLI

### DIFF
--- a/pkg/client/api/auth.go
+++ b/pkg/client/api/auth.go
@@ -20,7 +20,7 @@ import (
 	"github.com/perses/perses/pkg/model/api"
 )
 
-const authResource = "auth/providers/native/login"
+const authResource = "auth"
 
 // AuthInterface has methods to work with Auth resource
 type AuthInterface interface {
@@ -47,7 +47,7 @@ func (c *auth) Login(user string, password string) (*api.AuthResponse, error) {
 
 	return result, c.client.Post().
 		APIVersion("").
-		Resource(authResource).
+		Resource(fmt.Sprintf("%s/%s", authResource, "providers/native/login")).
 		Body(body).
 		Do().
 		Object(result)


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

I think I broke the refresh when I implemented the external auth 

Here is where it was broken 

![image](https://github.com/perses/perses/assets/10258608/2a90ce32-8557-4a4a-8e83-531f2c85baad)


Refresh was calling the /auth/providers/native/login/refresh endpoint instead of /auth/refresh
<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
