### PR TITLE
[FEATURE] Ephemeral dashboards are automatically removed once expiration delay has passed

### DIFF
--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -43,3 +43,5 @@ important_dashboards:
 information: |-
   # Hello World
   ## File Database setup
+
+ephemeral_dashboards_cleanup_interval: "1h"

--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -82,6 +82,9 @@ Generic placeholders are defined as follows:
   # If provided, Perses server will look to the different folders configured and populate the database based on what it is found
   # The data coming from the provisioning folder will totally override what exists in the database.
   [ provisioning: <provisioning_spec> ]
+
+  # The interval at which to trigger the cleanup of ephemeral dashboards, based on their TTLs.
+  [ ephemeral_dashboards_cleanup_interval: <provisioning_spec> ]
 ```
 
 ### `<security_config>`

--- a/internal/api/shared/dashboard/cleaner.go
+++ b/internal/api/shared/dashboard/cleaner.go
@@ -1,0 +1,69 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard
+
+import (
+	"context"
+	"time"
+
+	"github.com/perses/common/async"
+	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
+	"github.com/sirupsen/logrus"
+)
+
+func NewEphemeralDashboardCleaner(dao ephemeraldashboard.DAO) (async.SimpleTask, error) {
+	return &Cleaner{
+		dao: dao,
+	}, nil
+}
+
+type Cleaner struct {
+	async.Task
+	dao ephemeraldashboard.DAO
+}
+
+func (c *Cleaner) String() string {
+	return "ephemeral dashboards cleaner"
+}
+
+func (c *Cleaner) Initialize() error {
+	return nil
+}
+
+func (c *Cleaner) Execute(_ context.Context, _ context.CancelFunc) error {
+	// Get the full list of ephemeral dashboards
+	dashboards, err := c.dao.List(&ephemeraldashboard.Query{})
+	if err != nil {
+		return err
+	}
+
+	// Delete any dashboard	for which the TTL has passed
+	// /!\ the comparison is done using the updatedAt field, not createdAt
+	currentTime := time.Now()
+	for _, dashboard := range dashboards {
+		if dashboard.Metadata.UpdatedAt.Add(time.Duration(dashboard.Spec.TTL)).Before(currentTime) {
+			err := c.dao.Delete(dashboard.Metadata.Project, dashboard.Metadata.Name)
+			if err != nil {
+				return err
+			}
+			logrus.Debugf("ephemeral dashboard '%s' has been deleted", dashboard.Metadata.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c *Cleaner) Finalize() error {
+	return nil
+}

--- a/internal/api/shared/dashboard/cleaner_test.go
+++ b/internal/api/shared/dashboard/cleaner_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDAO struct {
+	dashboards []*v1.EphemeralDashboard
+}
+
+func (d *mockDAO) List(_ databaseModel.Query) ([]*v1.EphemeralDashboard, error) {
+	return d.dashboards, nil
+}
+
+func (d *mockDAO) Delete(project string, name string) error {
+	for ed := range d.dashboards {
+		if d.dashboards[ed].Metadata.Project == project && d.dashboards[ed].Metadata.Name == name {
+			d.dashboards = append(d.dashboards[:ed], d.dashboards[ed+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+// unused but required by interface contract
+func (d *mockDAO) Create(_ *v1.EphemeralDashboard) error {
+	return nil
+}
+
+// unused but required by interface contract
+func (d *mockDAO) Update(_ *v1.EphemeralDashboard) error {
+	return nil
+}
+
+// unused but required by interface contract
+func (d *mockDAO) DeleteAll(_ string) error {
+	return nil
+}
+
+// unused but required by interface contract
+func (d *mockDAO) Get(_ string, _ string) (*v1.EphemeralDashboard, error) {
+	return nil, nil
+}
+
+func TestCleaner_Execute(t *testing.T) {
+	var ephemeralDashboardsInit = []*v1.EphemeralDashboard{
+		{
+			Metadata: v1.ProjectMetadata{
+				Metadata: v1.Metadata{
+					UpdatedAt: time.Now().Add(-time.Hour), // TTL has passed
+				},
+			},
+			Spec: v1.EphemeralDashboardSpec{
+				EphemeralDashboardSpecBase: v1.EphemeralDashboardSpecBase{
+					TTL: model.Duration(30 * time.Minute),
+				},
+			},
+		},
+		{
+			Metadata: v1.ProjectMetadata{
+				Metadata: v1.Metadata{
+					UpdatedAt: time.Now(), // TTL still valid
+				},
+			},
+			Spec: v1.EphemeralDashboardSpec{
+				EphemeralDashboardSpecBase: v1.EphemeralDashboardSpecBase{
+					TTL: model.Duration(time.Hour),
+				},
+			},
+		},
+	}
+
+	var ephemeralDashboardsExpected = []*v1.EphemeralDashboard{
+		ephemeralDashboardsInit[1],
+	}
+
+	mockDAO := &mockDAO{
+		dashboards: ephemeralDashboardsInit,
+	}
+
+	cleaner := &Cleaner{
+		dao: mockDAO,
+	}
+
+	err := cleaner.Execute(context.Background(), func() {})
+	assert.NoError(t, err)
+	assert.Equal(t, mockDAO.dashboards, ephemeralDashboardsExpected)
+}

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -14,7 +14,14 @@
 package config
 
 import (
+	"time"
+
 	"github.com/perses/common/config"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	defaultEphemeralDashboardsCleanupInterval = 168 * time.Hour // 1 week
 )
 
 type dashboardSelector struct {
@@ -35,9 +42,14 @@ type Config struct {
 	// Information contains markdown content to be display on the home page
 	Information  string             `json:"information,omitempty" yaml:"information,omitempty"`
 	Provisioning ProvisioningConfig `json:"provisioning,omitempty" yaml:"provisioning,omitempty"`
+	// EphemeralDashboardsCleanupInterval is the interval at which the ephemeral dashboards are cleaned up
+	EphemeralDashboardsCleanupInterval model.Duration `json:"ephemeral_dashboards_cleanup_interval,omitempty" yaml:"ephemeral_dashboards_cleanup_interval,omitempty"`
 }
 
 func (c *Config) Verify() error {
+	if c.EphemeralDashboardsCleanupInterval <= 0 {
+		c.EphemeralDashboardsCleanupInterval = model.Duration(defaultEphemeralDashboardsCleanupInterval)
+	}
 	return nil
 }
 

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultEphemeralDashboardsCleanupInterval = 168 * time.Hour // 1 week
+	defaultEphemeralDashboardsCleanupInterval = 24 * time.Hour
 )
 
 type dashboardSelector struct {

--- a/pkg/model/api/config/config_test.go
+++ b/pkg/model/api/config/config_test.go
@@ -31,7 +31,7 @@ func defaultConfig() Config {
 	return cfg
 }
 
-func TestJSONMarshallConfig(t *testing.T) {
+func TestJSONMarshalConfig(t *testing.T) {
 	testSuite := []struct {
 		title string
 		cfg   Config
@@ -93,7 +93,7 @@ func TestJSONMarshallConfig(t *testing.T) {
   "provisioning": {
     "interval": "1h"
   },
-  "ephemeral_dashboards_cleanup_interval": "1w"
+  "ephemeral_dashboards_cleanup_interval": "1d"
 }`,
 		},
 	}
@@ -107,7 +107,7 @@ func TestJSONMarshallConfig(t *testing.T) {
 	}
 }
 
-func TestUnMarshallJSONConfig(t *testing.T) {
+func TestUnmarshalJSONConfig(t *testing.T) {
 	testSuite := []struct {
 		title  string
 		jason  string
@@ -175,7 +175,8 @@ func TestUnMarshallJSONConfig(t *testing.T) {
       "dev/data"
     ],
     "interval": "1h"
-  }
+  },
+  "ephemeral_dashboards_cleanup_interval": "2h"
 }`,
 			result: Config{
 				Security: Security{
@@ -237,6 +238,7 @@ func TestUnMarshallJSONConfig(t *testing.T) {
 					},
 					Interval: model.Duration(defaultInterval),
 				},
+				EphemeralDashboardsCleanupInterval: model.Duration(2 * time.Hour),
 			},
 		},
 	}
@@ -304,7 +306,7 @@ information: |-
   # Hello World
   ## File Database setup
 
-ephemeral_dashboards_cleanup_interval: "1h"
+ephemeral_dashboards_cleanup_interval: "2h"
 `,
 			result: Config{
 				Security: Security{
@@ -375,7 +377,7 @@ ephemeral_dashboards_cleanup_interval: "1h"
 					},
 					Interval: model.Duration(defaultInterval),
 				},
-				EphemeralDashboardsCleanupInterval: model.Duration(1 * time.Hour),
+				EphemeralDashboardsCleanupInterval: model.Duration(2 * time.Hour),
 			},
 		},
 	}

--- a/pkg/model/api/config/config_test.go
+++ b/pkg/model/api/config/config_test.go
@@ -92,7 +92,8 @@ func TestJSONMarshallConfig(t *testing.T) {
   },
   "provisioning": {
     "interval": "1h"
-  }
+  },
+  "ephemeral_dashboards_cleanup_interval": "1w"
 }`,
 		},
 	}
@@ -302,6 +303,8 @@ important_dashboards:
 information: |-
   # Hello World
   ## File Database setup
+
+ephemeral_dashboards_cleanup_interval: "1h"
 `,
 			result: Config{
 				Security: Security{
@@ -372,6 +375,7 @@ information: |-
 					},
 					Interval: model.Duration(defaultInterval),
 				},
+				EphemeralDashboardsCleanupInterval: model.Duration(1 * time.Hour),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Ephemeral dashboards are automatically removed once expiration delay has passed.
New config param added to tune the interval.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).