### PR TITLE
[ENHANCEMENT] add kubebuilder annotations to runtime types

### DIFF
--- a/pkg/model/api/v1/common/plugin.go
+++ b/pkg/model/api/v1/common/plugin.go
@@ -19,7 +19,9 @@ import (
 )
 
 type Plugin struct {
-	Kind string      `json:"kind" yaml:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Spec interface{} `json:"spec" yaml:"spec"`
 }
 

--- a/pkg/model/api/v1/dashboard/layout.go
+++ b/pkg/model/api/v1/dashboard/layout.go
@@ -99,6 +99,8 @@ type tmpDashboardLayout struct {
 
 type Layout struct {
 	Kind LayoutKind `json:"kind" yaml:"kind"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Spec LayoutSpec `json:"spec" yaml:"spec"`
 }
 

--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -29,6 +29,8 @@ type variableSpec interface {
 }
 
 type TextVariableSpec struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	variableSpec      `json:"-" yaml:"-"`
 	variable.TextSpec `json:",inline" yaml:",inline"`
 	Name              string `json:"name" yaml:"name"`
@@ -75,6 +77,8 @@ func (v *TextVariableSpec) validate() error {
 }
 
 type ListVariableSpec struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	variableSpec      `json:"-" yaml:"-"`
 	variable.ListSpec `json:",inline" yaml:",inline"`
 	Name              string `json:"name" yaml:"name"`
@@ -120,7 +124,9 @@ func (v *ListVariableSpec) validate() error {
 type Variable struct {
 	// Kind is the type of the variable. Depending on the value of Kind, it will change the content of Spec.
 	Kind variable.Kind `json:"kind" yaml:"kind"`
-	Spec variableSpec  `json:"spec" yaml:"spec"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	Spec variableSpec `json:"spec" yaml:"spec"`
 }
 
 type tmpVariable struct {


### PR DESCRIPTION
# Description

This PR adds kubebuilder annotations to interface types that are resolved at runtime, this allows that the CRD schema can store these dynamic fields

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

no UI changes
