### PR TITLE
[IGNORE] Move provisioning to a dedicated package

### DIFF
--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -23,6 +23,7 @@ import (
 	"github.com/perses/perses/internal/api/core/middleware"
 	"github.com/perses/perses/internal/api/shared/dependency"
 	"github.com/perses/perses/internal/api/shared/migrate"
+	"github.com/perses/perses/internal/api/shared/provisioning"
 	"github.com/perses/perses/internal/api/shared/rbac"
 	"github.com/perses/perses/internal/api/shared/schemas"
 	"github.com/perses/perses/pkg/model/api/config"
@@ -62,7 +63,8 @@ func New(conf config.Config, banner string) (*app.Runner, dependency.Persistence
 	runner.WithTasks(watcher, migrateWatcher)
 	runner.WithCronTasks(time.Duration(conf.Schemas.Interval), reloader, migrateReloader)
 	if len(conf.Provisioning.Folders) > 0 {
-		runner.WithCronTasks(time.Duration(conf.Provisioning.Interval), serviceManager.GetProvisioning())
+		provisioningTask := provisioning.New(serviceManager, conf.Provisioning.Folders)
+		runner.WithCronTasks(time.Duration(conf.Provisioning.Interval), provisioningTask)
 	}
 	if conf.Security.EnableAuth {
 		rbacTask := rbac.NewCronTask(serviceManager.GetRBAC(), persesDAO)

--- a/internal/api/shared/dependency/service_manager.go
+++ b/internal/api/shared/dependency/service_manager.go
@@ -16,7 +16,6 @@
 package dependency
 
 import (
-	"github.com/perses/common/async"
 	dashboardImpl "github.com/perses/perses/internal/api/impl/v1/dashboard"
 	datasourceImpl "github.com/perses/perses/internal/api/impl/v1/datasource"
 	folderImpl "github.com/perses/perses/internal/api/impl/v1/folder"
@@ -68,7 +67,6 @@ type ServiceManager interface {
 	GetJWT() crypto.JWT
 	GetMigration() migrate.Migration
 	GetProject() project.Service
-	GetProvisioning() async.SimpleTask
 	GetSchemas() schemas.Schemas
 	GetRBAC() rbac.RBAC
 	GetRole() role.Service
@@ -93,7 +91,6 @@ type service struct {
 	jwt               crypto.JWT
 	migrate           migrate.Migration
 	project           project.Service
-	provisioning      async.SimpleTask
 	schemas           schemas.Schemas
 	rbac              rbac.RBAC
 	role              role.Service
@@ -158,11 +155,6 @@ func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 		user:              userService,
 		variable:          variableService,
 	}
-	provisioningService := &provisioning{
-		serviceManager: svc,
-		folders:        conf.Provisioning.Folders,
-	}
-	svc.provisioning = provisioningService
 	return svc, nil
 }
 
@@ -216,10 +208,6 @@ func (s *service) GetMigration() migrate.Migration {
 
 func (s *service) GetProject() project.Service {
 	return s.project
-}
-
-func (s *service) GetProvisioning() async.SimpleTask {
-	return s.provisioning
 }
 
 func (s *service) GetSchemas() schemas.Schemas {

--- a/internal/api/shared/provisioning/provisioning.go
+++ b/internal/api/shared/provisioning/provisioning.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package dependency
+package provisioning
 
 import (
 	"context"
@@ -20,6 +20,7 @@ import (
 	"github.com/perses/common/async"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	databaseModel "github.com/perses/perses/internal/api/shared/database/model"
+	"github.com/perses/perses/internal/api/shared/dependency"
 	"github.com/perses/perses/internal/cli/file"
 	"github.com/perses/perses/internal/cli/resource"
 	modelAPI "github.com/perses/perses/pkg/model/api"
@@ -27,9 +28,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func New(serviceManager dependency.ServiceManager, folders []string) async.SimpleTask {
+	return &provisioning{
+		serviceManager: serviceManager,
+		folders:        folders,
+	}
+}
+
 type provisioning struct {
 	async.SimpleTask
-	serviceManager ServiceManager
+	serviceManager dependency.ServiceManager
 	folders        []string
 }
 


### PR DESCRIPTION
I think it makes more sense to have the provisioning to not be included in the `service_manager`. It's not a service but just a cron task, so no reason to let the `service_manager` returning an instance of the provisioning.