### PR TITLE
[BUGFIX] Tooltip positioning broken in Firefox

### DIFF
--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -123,11 +123,11 @@ export const LineChart = forwardRef<ChartInstance, LineChartProps>(function Line
             // when chart undef, do not clear highlight series
             return;
           }
-          clearHighlightedSeries(chartRef.current, data.timeSeries.length);
+          clearHighlightedSeries(chartRef.current);
         },
       };
     },
-    [data.timeSeries.length]
+    []
   );
 
   const handleEvents: OnEventsType<LineSeriesOption['data'] | unknown> = useMemo(() => {
@@ -276,7 +276,7 @@ export const LineChart = forwardRef<ChartInstance, LineChartProps>(function Line
           setShowTooltip(false);
         }
         if (chartRef.current !== undefined) {
-          clearHighlightedSeries(chartRef.current, data.timeSeries.length);
+          clearHighlightedSeries(chartRef.current);
         }
       }}
       onMouseEnter={() => {

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -151,11 +151,11 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
             // when chart undef, do not clear highlight series
             return;
           }
-          clearHighlightedSeries(chartRef.current, totalSeries);
+          clearHighlightedSeries(chartRef.current);
         },
       };
     },
-    [totalSeries]
+    []
   );
 
   const handleEvents: OnEventsType<LineSeriesOption['data'] | unknown> = useMemo(() => {
@@ -398,7 +398,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
           setShowTooltip(false);
         }
         if (chartRef.current !== undefined) {
-          clearHighlightedSeries(chartRef.current, totalSeries);
+          clearHighlightedSeries(chartRef.current);
         }
       }}
       onMouseEnter={() => {

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -115,7 +115,6 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
   const [isDragging, setIsDragging] = useState(false);
   const [startX, setStartX] = useState(0);
   const { timeZone } = useTimeZone();
-  const totalSeries = data?.length ?? 0;
   let timeScale: TimeScale;
   if (timeScaleProp === undefined) {
     const commonTimeScale = getCommonTimeScale(data);

--- a/ui/components/src/TimeSeriesTooltip/LineChartTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/LineChartTooltip.tsx
@@ -59,7 +59,7 @@ export const LineChartTooltip = memo(function LineChartTooltip({
   const [showAllSeries, setShowAllSeries] = useState(false);
   const mousePos = useMousePosition();
   const { height, width, ref: tooltipRef } = useResizeObserver();
-  const transform = useRef('');
+  const transform = useRef<string | undefined>();
 
   const isTooltipPinned = pinnedPos !== null && enablePinning;
 
@@ -121,6 +121,7 @@ export const LineChartTooltip = memo(function LineChartTooltip({
         })}
         style={{
           transform: transform.current,
+          display: transform.current ? 'block' : 'none',
         }}
       >
         <Stack spacing={0.5}>

--- a/ui/components/src/TimeSeriesTooltip/TimeChartTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TimeChartTooltip.tsx
@@ -51,7 +51,7 @@ export const TimeChartTooltip = memo(function TimeChartTooltip({
   pinnedPos,
 }: TimeChartTooltipProps) {
   const [showAllSeries, setShowAllSeries] = useState(false);
-  const transform = useRef('');
+  const transform = useRef<string | undefined>();
 
   const mousePos = useMousePosition();
   const { height, width, ref: tooltipRef } = useResizeObserver();

--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -53,10 +53,15 @@ export const defaultCursorData = {
   chartWidth: 0,
 };
 
-export const emptyTooltipData = {
-  cursor: defaultCursorData,
-  focusedSeries: null,
-};
+export const EMPTY_TOOLTIP_DATA: NearbySeriesArray = [];
+
+/**
+ * ECharts is built with zrender, zrX and zrY are undefined when not hovering over a chart canvas
+ */
+export interface ZRCoordinate {
+  x?: number;
+  y?: number;
+}
 
 export interface Coordinate {
   x: number;
@@ -66,11 +71,7 @@ export interface Coordinate {
 export interface CursorCoordinates {
   page: Coordinate;
   client: Coordinate;
-  plotCanvas: Coordinate;
-  zrender?: {
-    x?: number;
-    y?: number;
-  };
+  plotCanvas: ZRCoordinate;
   target: EventTarget | null;
 }
 
@@ -109,12 +110,9 @@ export const useMousePosition = (): CursorData['coords'] => {
           y: e.clientY,
         },
         plotCanvas: {
-          x: e.offsetX,
-          y: e.offsetY,
-        },
-        zrender: {
-          // echarts canvas coordinates added automatically by zrender
-          // zrX and zrY are similar to offsetX and offsetY but they return undefined when not hovering over a chart canvas
+          // Always use zrender mousemove coords since they handle browser inconsistencies for us
+          // ex: Firefox and Chrome have slightly different implementations of offsetX and offsetY
+          // more info: https://github.com/ecomfe/zrender/blob/5.5.0/src/core/event.ts#L46-L120
           x: e.zrX,
           y: e.zrY,
         },

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -35,7 +35,7 @@ export function assembleTransform(
   containerElement?: Element | null
 ) {
   if (mousePos === null) {
-    return 'translate3d(0, 0)';
+    return undefined;
   }
 
   const cursorPaddingX = 32;
@@ -44,6 +44,8 @@ export function assembleTransform(
   if (pinnedPos !== null) {
     mousePos = pinnedPos;
   }
+
+  if (mousePos.plotCanvas.x === undefined) return undefined;
 
   // By default, tooltip is located in a Portal attached to the body.
   // Using page coordinates instead of viewport ensures the tooltip is

--- a/ui/components/src/utils/chart-actions.ts
+++ b/ui/components/src/utils/chart-actions.ts
@@ -56,14 +56,17 @@ export function restoreChart(chart: EChartsInstance) {
  * Clear all highlighted series when cursor exits canvas
  * https://echarts.apache.org/en/api.html#action.downplay
  */
-export function clearHighlightedSeries(chart: EChartsInstance, totalSeries: number) {
+export function clearHighlightedSeries(chart: EChartsInstance) {
   if (chart.dispatchAction !== undefined) {
-    for (let i = 0; i < totalSeries; i++) {
-      chart.dispatchAction({
-        type: 'downplay',
-        seriesIndex: i,
-      });
-    }
+    // Clear any selected data points
+    chart.dispatchAction({
+      type: 'unselect',
+    });
+
+    // Clear any highlighted series
+    chart.dispatchAction({
+      type: 'downplay',
+    });
   }
 }
 

--- a/ui/panels-plugin/src/plugins/scatterplot/Scatterplot.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/Scatterplot.tsx
@@ -60,7 +60,9 @@ export function Scatterplot(props: ScatterplotProps) {
       axisPointer: {
         type: 'cross',
       },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       formatter: function (params: any) {
+        // TODO: import type from ECharts instead of using any
         params = params[0];
         return [
           '<b>time</b>: ' + params.data.startTime + '<br/>',


### PR DESCRIPTION
# Description
Fixes #1396

Tooltip is broken in Firefox, fix up the mousemove logic (offsetX and offsetY have subtle differences with Chrome)

zrender is the canvas/svg graphics lib that ECharts is built on, main change is to always use their mousemove coords that [handle browser inconsistencies](https://github.com/ecomfe/zrender/blob/5.5.0/src/core/event.ts#L46-L120) for us

# Screenshots

## Before
https://github.com/perses/perses/assets/9369625/f8d9433e-4147-47fc-bae7-87ccf86242b1

Also see recording in #1396

## After

https://github.com/perses/perses/assets/9369625/a346979d-e143-452f-a3fc-e4f3b065ca57

https://github.com/perses/perses/assets/9369625/8f7ec20a-1d7e-4f13-b99f-31f37f1b4ab3

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
