### PR TITLE
[ENHANCEMENT] Add grouped variable helper in Go SDK

### DIFF
--- a/go-sdk/dashboard/dashboard.go
+++ b/go-sdk/dashboard/dashboard.go
@@ -43,5 +43,5 @@ func New(name string, options ...Option) (Builder, error) {
 }
 
 type Builder struct {
-	v1.Dashboard
+	Dashboard v1.Dashboard `json:"-" yaml:"-"`
 }

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -110,32 +110,13 @@ func TestDashboardBuilder(t *testing.T) {
 	outputJSONFilePath := filepath.Join("..", "..", "internal", "test", "dac", "expected_output.json")
 	expectedOutput, readErr := os.ReadFile(outputJSONFilePath)
 
-	testSuites := []struct {
-		title          string
-		sdkResult      string
-		expectedResult string
-		expectedError  bool
-	}{
-		{
-			title:          "full dashboard",
-			sdkResult:      string(builderOutput),
-			expectedResult: string(expectedOutput),
-		},
-	}
-	for i := range testSuites {
-		test := testSuites[i]
-		t.Run(test.title, func(t *testing.T) {
-			fmt.Println(string(expectedOutput))
-			fmt.Println(string(builderOutput))
+	t.Run("classic dashboard", func(t *testing.T) {
+		fmt.Println(string(expectedOutput))
+		fmt.Println(string(builderOutput))
 
-			if test.expectedError {
-				assert.NotNil(t, buildErr)
-			} else {
-				assert.NoError(t, buildErr)
-				assert.NoError(t, marshErr)
-				assert.NoError(t, readErr)
-				require.JSONEq(t, test.expectedResult, test.sdkResult)
-			}
-		})
-	}
+		assert.NoError(t, buildErr)
+		assert.NoError(t, marshErr)
+		assert.NoError(t, readErr)
+		require.JSONEq(t, string(expectedOutput), string(builderOutput))
+	})
 }

--- a/go-sdk/group/options.go
+++ b/go-sdk/group/options.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import "github.com/perses/perses/go-sdk/variable"
+
+func AddVariable(name string, options ...variable.Option) Option {
+	return func(builder *Builder) error {
+		options = append([]variable.Option{variable.Filter(builder.FilteringVariables...)}, options...)
+		v, err := variable.New(name, options...)
+		if err != nil {
+			return err
+		}
+
+		builder.FilteringVariables = append(builder.FilteringVariables, v.Variable)
+		builder.Variables = append(builder.Variables, v.Variable)
+		return nil
+	}
+}
+
+// AddIgnoredVariable adds a variable to the group that will not be added in the filter
+// but will still be filtered by the other variables
+func AddIgnoredVariable(name string, options ...variable.Option) Option {
+	return func(builder *Builder) error {
+		options = append([]variable.Option{variable.Filter(builder.FilteringVariables...)}, options...)
+		v, err := variable.New(name, options...)
+		if err != nil {
+			return err
+		}
+
+		builder.Variables = append(builder.Variables, v.Variable)
+		return nil
+	}
+}

--- a/go-sdk/group/variable.go
+++ b/go-sdk/group/variable.go
@@ -11,29 +11,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package promql
+package group
 
 import (
-	promDatasource "github.com/perses/perses/go-sdk/prometheus/datasource"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
-func Expr(expr string) Option {
-	return func(builder *Builder) error {
-		builder.PluginSpec.Expr = expr
-		return nil
-	}
+type Option func(group *Builder) error
+
+type Builder struct {
+	Variables          []v1.Variable
+	FilteringVariables []v1.Variable
 }
 
-func LabelName(labelName string) Option {
-	return func(builder *Builder) error {
-		builder.PluginSpec.LabelName = labelName
-		return nil
-	}
-}
+func New(options ...Option) (Builder, error) {
+	builder := &Builder{}
 
-func Datasource(datasourceName string) Option {
-	return func(builder *Builder) error {
-		builder.PluginSpec.Datasource = promDatasource.Selector(datasourceName)
-		return nil
+	var defaults []Option
+
+	for _, opt := range append(defaults, options...) {
+		if err := opt(builder); err != nil {
+			return *builder, err
+		}
 	}
+
+	return *builder, nil
 }

--- a/go-sdk/prometheus/variable/label-names/label-names.go
+++ b/go-sdk/prometheus/variable/label-names/label-names.go
@@ -50,7 +50,6 @@ func New(options ...Option) (Builder, error) {
 func PrometheusLabelNames(options ...Option) list_variable.Option {
 	return func(builder *list_variable.Builder) error {
 		options = append([]Option{Filter(builder.Filters...)}, options...)
-		//options = append(options, Filter(builder.Filters...))
 		t, err := New(options...)
 		if err != nil {
 			return err

--- a/go-sdk/prometheus/variable/label-names/options.go
+++ b/go-sdk/prometheus/variable/label-names/options.go
@@ -15,25 +15,33 @@ package labelnames
 
 import (
 	promDatasource "github.com/perses/perses/go-sdk/prometheus/datasource"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 func Datasource(datasourceName string) Option {
 	return func(builder *Builder) error {
-		builder.Datasource = promDatasource.Selector(datasourceName)
+		builder.PluginSpec.Datasource = promDatasource.Selector(datasourceName)
 		return nil
 	}
 }
 
 func Matchers(matchers ...string) Option {
 	return func(builder *Builder) error {
-		builder.Matchers = matchers
+		builder.PluginSpec.Matchers = matchers
 		return nil
 	}
 }
 
 func AddMatchers(matcher string) Option {
 	return func(builder *Builder) error {
-		builder.Matchers = append(builder.Matchers, matcher)
+		builder.PluginSpec.Matchers = append(builder.PluginSpec.Matchers, matcher)
+		return nil
+	}
+}
+
+func Filter(variables ...v1.Variable) Option {
+	return func(builder *Builder) error {
+		builder.Filters = variables
 		return nil
 	}
 }

--- a/go-sdk/prometheus/variable/label-values/options.go
+++ b/go-sdk/prometheus/variable/label-values/options.go
@@ -15,39 +15,47 @@ package labelvalues
 
 import (
 	promDatasource "github.com/perses/perses/go-sdk/prometheus/datasource"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 func LabelName(labelName string) Option {
 	return func(builder *Builder) error {
-		builder.LabelName = labelName
+		builder.PluginSpec.LabelName = labelName
 		return nil
 	}
 }
 
 func DefaultDatasource() Option {
 	return func(builder *Builder) error {
-		builder.Datasource = promDatasource.Selector("")
+		builder.PluginSpec.Datasource = promDatasource.Selector("")
 		return nil
 	}
 }
 
 func Datasource(datasourceName string) Option {
 	return func(builder *Builder) error {
-		builder.Datasource = promDatasource.Selector(datasourceName)
+		builder.PluginSpec.Datasource = promDatasource.Selector(datasourceName)
 		return nil
 	}
 }
 
 func Matchers(matchers ...string) Option {
 	return func(builder *Builder) error {
-		builder.Matchers = matchers
+		builder.PluginSpec.Matchers = matchers
 		return nil
 	}
 }
 
 func AddMatchers(matcher string) Option {
 	return func(builder *Builder) error {
-		builder.Matchers = append(builder.Matchers, matcher)
+		builder.PluginSpec.Matchers = append(builder.PluginSpec.Matchers, matcher)
+		return nil
+	}
+}
+
+func Filter(variables ...v1.Variable) Option {
+	return func(builder *Builder) error {
+		builder.Filters = variables
 		return nil
 	}
 }

--- a/go-sdk/prometheus/variable/promql/promql.go
+++ b/go-sdk/prometheus/variable/promql/promql.go
@@ -26,10 +26,6 @@ type PluginSpec struct {
 
 type Option func(plugin *Builder) error
 
-type Builder struct {
-	PluginSpec
-}
-
 func New(expr string, labelName string, options ...Option) (Builder, error) {
 	var builder = &Builder{
 		PluginSpec: PluginSpec{},
@@ -55,8 +51,12 @@ func PrometheusPromQL(expr string, labelName string, options ...Option) list_var
 		if err != nil {
 			return err
 		}
-		builder.Plugin.Kind = "PrometheusPromQLVariable"
-		builder.Plugin.Spec = t
+		builder.ListVariableSpec.Plugin.Kind = "PrometheusPromQLVariable"
+		builder.ListVariableSpec.Plugin.Spec = t
 		return nil
 	}
+}
+
+type Builder struct {
+	PluginSpec `json:",inline" yaml:",inline"`
 }

--- a/go-sdk/variable/list-variable/list-variable.go
+++ b/go-sdk/variable/list-variable/list-variable.go
@@ -15,6 +15,7 @@ package listvariable
 
 import (
 	"github.com/perses/perses/go-sdk/variable"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
 	variable2 "github.com/perses/perses/pkg/model/api/v1/variable"
 )
@@ -22,7 +23,8 @@ import (
 type Option func(listVariableSpec *Builder) error
 
 type Builder struct {
-	dashboard.ListVariableSpec
+	ListVariableSpec dashboard.ListVariableSpec `json:",inline" yaml:",inline"`
+	Filters          []v1.Variable              `json:"-" yaml:"-"`
 }
 
 func New(options ...Option) (Builder, error) {
@@ -47,12 +49,13 @@ func New(options ...Option) (Builder, error) {
 
 func List(options ...Option) variable.Option {
 	return func(builder *variable.Builder) error {
+		options = append([]Option{Filter(builder.Filters...)}, options...)
 		t, err := New(options...)
 		if err != nil {
 			return err
 		}
-		builder.Spec.Kind = "ListVariable"
-		builder.Spec.Spec = t.ListVariableSpec
+		builder.Variable.Spec.Kind = "ListVariable"
+		builder.Variable.Spec.Spec = t.ListVariableSpec
 		return nil
 	}
 }

--- a/go-sdk/variable/list-variable/options.go
+++ b/go-sdk/variable/list-variable/options.go
@@ -14,13 +14,13 @@
 package listvariable
 
 import (
-	"github.com/perses/perses/pkg/model/api/v1/common"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/variable"
 )
 
 func DefaultValue(value string) Option {
 	return func(builder *Builder) error {
-		builder.DefaultValue = &variable.DefaultValue{
+		builder.ListVariableSpec.DefaultValue = &variable.DefaultValue{
 			SingleValue: value,
 		}
 		return nil
@@ -29,7 +29,7 @@ func DefaultValue(value string) Option {
 
 func DefaultValues(values ...string) Option {
 	return func(builder *Builder) error {
-		builder.DefaultValue = &variable.DefaultValue{
+		builder.ListVariableSpec.DefaultValue = &variable.DefaultValue{
 			SliceValues: values,
 		}
 		return nil
@@ -38,72 +38,72 @@ func DefaultValues(values ...string) Option {
 
 func AllowAllValues(isAllValueAllowed bool) Option {
 	return func(builder *Builder) error {
-		builder.AllowAllValue = isAllValueAllowed
+		builder.ListVariableSpec.AllowAllValue = isAllValueAllowed
 		return nil
 	}
 }
 
 func AllowMultiple(isMultipleValuesAllowed bool) Option {
 	return func(builder *Builder) error {
-		builder.AllowMultiple = isMultipleValuesAllowed
+		builder.ListVariableSpec.AllowMultiple = isMultipleValuesAllowed
 		return nil
 	}
 }
 
 func CustomAllValue(value string) Option {
 	return func(builder *Builder) error {
-		builder.CustomAllValue = value
+		builder.ListVariableSpec.CustomAllValue = value
 		return nil
 	}
 }
 
 func CapturingRegexp(regexp string) Option {
 	return func(builder *Builder) error {
-		builder.CapturingRegexp = regexp
+		builder.ListVariableSpec.CapturingRegexp = regexp
 		return nil
 	}
 }
 
 func SortingBy(sort variable.Sort) Option {
 	return func(builder *Builder) error {
-		builder.Sort = &sort
-		return nil
-	}
-}
-
-func Plugin(plugin common.Plugin) Option {
-	return func(builder *Builder) error {
-		builder.Plugin = plugin
+		builder.ListVariableSpec.Sort = &sort
 		return nil
 	}
 }
 
 func Description(description string) Option {
 	return func(builder *Builder) error {
-		if builder.Display == nil {
-			builder.Display = &variable.Display{}
+		if builder.ListVariableSpec.Display == nil {
+			builder.ListVariableSpec.Display = &variable.Display{}
 		}
-		builder.Display.Description = description
+		builder.ListVariableSpec.Display.Description = description
 		return nil
 	}
 }
 
 func DisplayName(displayName string) Option {
 	return func(builder *Builder) error {
-		if builder.Display == nil {
-			builder.Display = &variable.Display{}
+		if builder.ListVariableSpec.Display == nil {
+			builder.ListVariableSpec.Display = &variable.Display{}
 		}
-		builder.Display.Name = displayName
+		builder.ListVariableSpec.Display.Name = displayName
 		return nil
 	}
 }
 
 func Hidden(isHidden bool) Option {
 	return func(builder *Builder) error {
-		if builder.Display == nil {
-			builder.Display = &variable.Display{}
+		if builder.ListVariableSpec.Display == nil {
+			builder.ListVariableSpec.Display = &variable.Display{}
 		}
-		builder.Display.Hidden = isHidden
+		builder.ListVariableSpec.Display.Hidden = isHidden
+		return nil
+	}
+}
+
+func Filter(variables ...v1.Variable) Option {
+	return func(builder *Builder) error {
+		builder.Filters = variables
 		return nil
 	}
 }

--- a/go-sdk/variable/options.go
+++ b/go-sdk/variable/options.go
@@ -14,6 +14,7 @@
 package variable
 
 import (
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 )
 
@@ -22,7 +23,14 @@ func Name(name string) Option {
 		if err := common.ValidateID(name); err != nil {
 			return err // TODO: error ctx
 		}
-		builder.Metadata.Name = name
+		builder.Variable.Metadata.Name = name
+		return nil
+	}
+}
+
+func Filter(variables ...v1.Variable) Option {
+	return func(builder *Builder) error {
+		builder.Filters = variables
 		return nil
 	}
 }

--- a/go-sdk/variable/plugin/static-list/static-list.go
+++ b/go-sdk/variable/plugin/static-list/static-list.go
@@ -32,7 +32,7 @@ func New(options ...Option) (Builder, error) {
 		PluginSpec: PluginSpec{},
 	}
 
-	defaults := []Option{}
+	var defaults []Option
 
 	for _, opt := range append(defaults, options...) {
 		if err := opt(builder); err != nil {
@@ -49,8 +49,8 @@ func StaticList(options ...Option) list_variable.Option {
 		if err != nil {
 			return err
 		}
-		builder.Plugin.Kind = "StaticListVariable"
-		builder.Plugin.Spec = t
+		builder.ListVariableSpec.Plugin.Kind = "StaticListVariable"
+		builder.ListVariableSpec.Plugin.Spec = t
 		return nil
 	}
 }

--- a/go-sdk/variable/text-variable/options.go
+++ b/go-sdk/variable/text-variable/options.go
@@ -14,49 +14,57 @@
 package textvariable
 
 import (
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/variable"
 )
 
 func Value(value string) Option {
 	return func(builder *Builder) error {
-		builder.Value = value
+		builder.TextVariableSpec.Value = value
 		return nil
 	}
 }
 
 func Constant(isConstant bool) Option {
 	return func(builder *Builder) error {
-		builder.Constant = isConstant
+		builder.TextVariableSpec.Constant = isConstant
 		return nil
 	}
 }
 
 func Description(description string) Option {
 	return func(builder *Builder) error {
-		if builder.Display == nil {
-			builder.Display = &variable.Display{}
+		if builder.TextVariableSpec.Display == nil {
+			builder.TextVariableSpec.Display = &variable.Display{}
 		}
-		builder.Display.Description = description
+		builder.TextVariableSpec.Display.Description = description
 		return nil
 	}
 }
 
 func DisplayName(displayName string) Option {
 	return func(builder *Builder) error {
-		if builder.Display == nil {
-			builder.Display = &variable.Display{}
+		if builder.TextVariableSpec.Display == nil {
+			builder.TextVariableSpec.Display = &variable.Display{}
 		}
-		builder.Display.Name = displayName
+		builder.TextVariableSpec.Display.Name = displayName
 		return nil
 	}
 }
 
 func Hidden(isHidden bool) Option {
 	return func(builder *Builder) error {
-		if builder.Display == nil {
-			builder.Display = &variable.Display{}
+		if builder.TextVariableSpec.Display == nil {
+			builder.TextVariableSpec.Display = &variable.Display{}
 		}
-		builder.Display.Hidden = isHidden
+		builder.TextVariableSpec.Display.Hidden = isHidden
+		return nil
+	}
+}
+
+func Filter(variables ...v1.Variable) Option {
+	return func(builder *Builder) error {
+		builder.Filters = variables
 		return nil
 	}
 }

--- a/go-sdk/variable/text-variable/text-variable.go
+++ b/go-sdk/variable/text-variable/text-variable.go
@@ -15,13 +15,15 @@ package textvariable
 
 import (
 	"github.com/perses/perses/go-sdk/variable"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
 )
 
 type Option func(textVariableSpec *Builder) error
 
 type Builder struct {
-	dashboard.TextVariableSpec
+	TextVariableSpec dashboard.TextVariableSpec `json:",inline" yaml:",inline"`
+	Filters          []v1.Variable              `json:"-" yaml:"-"`
 }
 
 func New(value string, options ...Option) (Builder, error) {
@@ -45,12 +47,13 @@ func New(value string, options ...Option) (Builder, error) {
 
 func Text(value string, options ...Option) variable.Option {
 	return func(builder *variable.Builder) error {
+		options = append([]Option{Filter(builder.Filters...)}, options...)
 		t, err := New(value, options...)
 		if err != nil {
 			return err
 		}
-		builder.Spec.Kind = "TextVariable"
-		builder.Spec.Spec = t.TextVariableSpec
+		builder.Variable.Spec.Kind = "TextVariable"
+		builder.Variable.Spec.Spec = t.TextVariableSpec
 		return nil
 	}
 }

--- a/go-sdk/variable/variable.go
+++ b/go-sdk/variable/variable.go
@@ -20,7 +20,8 @@ import (
 type Option func(variable *Builder) error
 
 type Builder struct {
-	v1.Variable
+	Variable v1.Variable   `json:",inline" yaml:",inline"`
+	Filters  []v1.Variable `json:"-" yaml:"-"`
 }
 
 func New(name string, options ...Option) (Builder, error) {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Align Go SDK with Cue feature, you can create grouped variables. Grouped variables will be filtered by their parent variables. For now, it only applied automatically to label values and label names variables matchers.

Prev:
```golang
	dashboard.AddVariable("stack",
		listVar.List(
			labelValuesVar.PrometheusLabelValues("stack",
				labelValuesVar.Matchers("thanos_build_info{}"),
				labelValuesVar.Datasource("promDemo"),
			),
			listVar.DisplayName("PaaS"),
		),
	),
	dashboard.AddVariable("namespace", listVar.List(
		labelValuesVar.PrometheusLabelValues("namespace",
			labelValuesVar.Matchers("kube_namespace_labels{\"stack\"=\"$stack\"}"),
			labelValuesVar.Datasource("promDemo"),
		),
	)),
	dashboard.AddVariable("namespaceLabels", listVar.List(
		labelNamesVar.PrometheusLabelNames(
			labelNamesVar.Matchers("kube_namespace_labels{\"stack\"=\"$stack\", \"namespace\"=\"$namespace\"}"),
			labelNamesVar.Datasource("promDemo"),
		),
	)),
	dashboard.AddVariable("pod", listVar.List(
		labelValuesVar.PrometheusLabelValues("pod",
			labelValuesVar.Matchers("kube_namespace_labels{\"stack\"=\"$stack\", \"namespace\"=\"$namespace\"}"),
			labelValuesVar.Datasource("promDemo"),
		),
	)),
```

New:
```golang
dashboard.AddVariableGroup(
	group.AddVariable("stack",
		listVar.List(
			labelValuesVar.PrometheusLabelValues("stack",
				labelValuesVar.Matchers("thanos_build_info"),
				labelValuesVar.Datasource("promDemo"),
			),
			listVar.DisplayName("PaaS"),
		),
	),
	group.AddVariable("namespace", listVar.List(
		labelValuesVar.PrometheusLabelValues("namespace",
			labelValuesVar.Matchers("kube_namespace_labels"),
			labelValuesVar.Datasource("promDemo"),
		),
	)),
	group.AddIgnoredVariable("namespaceLabels", listVar.List(
		labelNamesVar.PrometheusLabelNames(
			labelNamesVar.Matchers("kube_namespace_labels"),
			labelNamesVar.Datasource("promDemo"),
		),
	)),
	group.AddVariable("pod", listVar.List(
		labelValuesVar.PrometheusLabelValues("pod",
			labelValuesVar.Matchers("kube_namespace_labels"),
			labelValuesVar.Datasource("promDemo"),
		),
	)),
),
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
