### PR TITLE
[BUGFIX] Fixing variable loading indefinitely

### DIFF
--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -82,7 +82,7 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
             }}
             gap={1}
           >
-            <TemplateVariableList></TemplateVariableList>
+            <TemplateVariableList />
             {props.initialVariableIsSticky && (
               <IconButton style={{ width: 'fit-content', height: 'fit-content' }} onClick={() => setIsPin(!isPin)}>
                 {isPin ? <PinOutline /> : <PinOffOutline />}

--- a/ui/dashboards/src/components/Variables/TemplateVariable.tsx
+++ b/ui/dashboards/src/components/Variables/TemplateVariable.tsx
@@ -74,8 +74,8 @@ export function useListVariableState(
   const allowMultiple = spec?.allowMultiple === true;
   const allowAllValue = spec?.allowAllValue === true;
   const sort = spec?.sort;
-  const loading = useMemo(() => variablesOptionsQuery.isFetching || false, [variablesOptionsQuery]);
-  const options = variablesOptionsQuery.data;
+  const loading = useMemo(() => variablesOptionsQuery.isFetching ?? false, [variablesOptionsQuery.isFetching]);
+  const options = useMemo(() => variablesOptionsQuery.data ?? [], [variablesOptionsQuery.data]);
 
   let value = state?.value;
 

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -180,74 +180,77 @@ function PluginProvider({ children, builtinVariables }: PluginProviderProps) {
     return contextValues;
   }, [originalValues, definitions, externalDefinitions]);
 
-  const allBuiltinVariables: BuiltinVariableDefinition[] = [
-    {
-      kind: 'BuiltinVariable',
-      spec: {
-        name: '__from',
-        value: () => absoluteTimeRange.start.valueOf().toString(),
-        source: 'Dashboard',
-        display: {
+  const allBuiltinVariables: BuiltinVariableDefinition[] = useMemo(() => {
+    const result: BuiltinVariableDefinition[] = [
+      {
+        kind: 'BuiltinVariable',
+        spec: {
           name: '__from',
-          description: 'Start time of the current time range in unix millisecond epoch',
-          hidden: true,
+          value: () => absoluteTimeRange.start.valueOf().toString(),
+          source: 'Dashboard',
+          display: {
+            name: '__from',
+            description: 'Start time of the current time range in unix millisecond epoch',
+            hidden: true,
+          },
         },
       },
-    },
-    {
-      kind: 'BuiltinVariable',
-      spec: {
-        name: '__to',
-        value: () => absoluteTimeRange.end.valueOf().toString(),
-        source: 'Dashboard',
-        display: {
+      {
+        kind: 'BuiltinVariable',
+        spec: {
           name: '__to',
-          description: 'End time of the current time range in unix millisecond epoch',
-          hidden: true,
+          value: () => absoluteTimeRange.end.valueOf().toString(),
+          source: 'Dashboard',
+          display: {
+            name: '__to',
+            description: 'End time of the current time range in unix millisecond epoch',
+            hidden: true,
+          },
         },
       },
-    },
-    {
-      kind: 'BuiltinVariable',
-      spec: {
-        name: '__range',
-        value: () => formatDuration(intervalToPrometheusDuration(absoluteTimeRange)),
-        source: 'Dashboard',
-        display: {
+      {
+        kind: 'BuiltinVariable',
+        spec: {
           name: '__range',
-          description: 'The range for the current dashboard in human readable format',
-          hidden: true,
+          value: () => formatDuration(intervalToPrometheusDuration(absoluteTimeRange)),
+          source: 'Dashboard',
+          display: {
+            name: '__range',
+            description: 'The range for the current dashboard in human readable format',
+            hidden: true,
+          },
         },
       },
-    },
-    {
-      kind: 'BuiltinVariable',
-      spec: {
-        name: '__range_s',
-        value: () => ((absoluteTimeRange.end.valueOf() - absoluteTimeRange.start.valueOf()) / 1000).toString(),
-        source: 'Dashboard',
-        display: {
+      {
+        kind: 'BuiltinVariable',
+        spec: {
           name: '__range_s',
-          description: 'The range for the current dashboard in second',
-          hidden: true,
+          value: () => ((absoluteTimeRange.end.valueOf() - absoluteTimeRange.start.valueOf()) / 1000).toString(),
+          source: 'Dashboard',
+          display: {
+            name: '__range_s',
+            description: 'The range for the current dashboard in second',
+            hidden: true,
+          },
         },
       },
-    },
-    {
-      kind: 'BuiltinVariable',
-      spec: {
-        name: '__range_ms',
-        value: () => (absoluteTimeRange.end.valueOf() - absoluteTimeRange.start.valueOf()).toString(),
-        source: 'Dashboard',
-        display: {
+      {
+        kind: 'BuiltinVariable',
+        spec: {
           name: '__range_ms',
-          description: 'The range for the current dashboard in millisecond',
-          hidden: true,
+          value: () => (absoluteTimeRange.end.valueOf() - absoluteTimeRange.start.valueOf()).toString(),
+          source: 'Dashboard',
+          display: {
+            name: '__range_ms',
+            description: 'The range for the current dashboard in millisecond',
+            hidden: true,
+          },
         },
       },
-    },
-  ];
-  builtinVariables?.forEach((def) => allBuiltinVariables.push(def));
+    ];
+    builtinVariables?.forEach((def) => result.push(def));
+    return result;
+  }, [absoluteTimeRange, builtinVariables]);
 
   return (
     <BuiltinVariableContext.Provider value={{ variables: allBuiltinVariables }}>

--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -73,13 +73,13 @@ export function useListVariablePluginValues(definition: ListVariableDefinition) 
   const variablesValueKey = getVariableValuesKey(variables);
 
   return useQuery(
-    [name, definition, variablesValueKey, timeRange, refreshKey],
+    [definition, variablesValueKey, timeRange, refreshKey],
     async () => {
       const resp = await variablePlugin?.getVariableOptions(spec, { datasourceStore, variables, timeRange });
       if (resp === undefined) {
         return [];
       }
-      if (capturingRegexp === undefined) {
+      if (!capturingRegexp) {
         return resp.data;
       }
       return filterVariableList(resp.data, capturingRegexp);

--- a/ui/plugin-system/src/runtime/template-variables.ts
+++ b/ui/plugin-system/src/runtime/template-variables.ts
@@ -163,7 +163,9 @@ export function useVariableValues(names?: string[]): VariableStateMap {
   const templateVariableValues = useTemplateVariableValues(names);
   const builtinVariableValues = useBuiltinVariableValues(names);
 
-  return Object.assign(templateVariableValues, builtinVariableValues);
+  return useMemo(() => {
+    return { ...templateVariableValues, ...builtinVariableValues } as VariableStateMap;
+  }, [templateVariableValues, builtinVariableValues]);
 }
 
 // Convenience hook for replacing template variables in a string


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixing promql variables loading indefinitely when using builtin variables in the expr. Closes #1552.
The issue come from Object.assign ...
On the way I did small improvements

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
