### PR TITLE
[ENHANCEMENT] Make default datasources more visible

### DIFF
--- a/ui/app/src/components/datasource/DatasourceDataGrid.tsx
+++ b/ui/app/src/components/datasource/DatasourceDataGrid.tsx
@@ -42,9 +42,12 @@ const MemoizedRow = memo(GridRow);
 const MemoizedColumnHeaders = memo(GridColumnHeaders);
 
 export interface Row {
+  default: boolean;
   project?: string;
   name: string;
   displayName: string;
+  description: string;
+  type: string;
   version: number;
   createdAt: string;
   updatedAt: string;

--- a/ui/app/src/components/datasource/DatasourceList.tsx
+++ b/ui/app/src/components/datasource/DatasourceList.tsx
@@ -67,6 +67,7 @@ export function DatasourceList<T extends Datasource>(props: DatasourceListProper
     return data.map(
       (datasource) =>
         ({
+          default: datasource.spec.default,
           project: getMetadataProject(datasource.metadata),
           name: datasource.metadata.name,
           displayName: getDatasourceDisplayName(datasource),
@@ -121,6 +122,12 @@ export function DatasourceList<T extends Datasource>(props: DatasourceListProper
 
   const columns = useMemo<Array<GridColDef<Row>>>(
     () => [
+      {
+        field: 'default',
+        headerName: 'Default',
+        type: 'boolean',
+        minWidth: 100,
+      },
       { field: 'project', headerName: 'Project', type: 'string', flex: 2, minWidth: 150 },
       { field: 'displayName', headerName: 'Display Name', type: 'string', flex: 3, minWidth: 150 },
       {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Add a column for displaying if a datasource is a default datasource or not

# Screenshots

<!-- If there are UI changes -->
Before:
![image](https://github.com/perses/perses/assets/5657041/81d1521d-e72c-4908-86bd-c0b996d9b2eb)

After:
![image](https://github.com/perses/perses/assets/5657041/1dfb0628-370b-4a78-b99b-e32e57789345)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
