### PR TITLE
[BUGFIX] Update relative timerange value when refreshing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dev/local_db
 .goreleaser.yaml
 
 /.github/perses-ci/
+
+*.ignore.*

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
@@ -64,16 +64,16 @@ export function TimeRangeProvider(props: TimeRangeProviderProps) {
   const { timeRange, refreshInterval, children, setTimeRange, setRefreshInterval } = props;
 
   const [localTimeRange, setLocalTimeRange] = useState<TimeRangeValue>(timeRange);
-  const [localRefreshInterval, setLocalefreshInterval] = useState<DurationString | undefined>(refreshInterval);
+  const [localRefreshInterval, setLocalRefreshInterval] = useState<DurationString | undefined>(refreshInterval);
 
   const [refreshCounter, setRefreshCounter] = useState(0);
 
   useEffect(() => {
     setLocalTimeRange(timeRange);
-  }, [timeRange]);
+  }, [timeRange, refreshCounter]);
 
   useEffect(() => {
-    setLocalefreshInterval(refreshInterval);
+    setLocalRefreshInterval(refreshInterval);
   }, [refreshInterval]);
 
   const refresh = useCallback(() => {
@@ -92,7 +92,7 @@ export function TimeRangeProvider(props: TimeRangeProviderProps) {
       refreshKey: `${absoluteTimeRange.start}:${absoluteTimeRange.end}:${localRefreshInterval}:${refreshCounter}`,
       refreshInterval: localRefreshInterval,
       refreshIntervalInMs: getRefreshIntervalInMs(localRefreshInterval),
-      setRefreshInterval: setRefreshInterval ?? setLocalefreshInterval,
+      setRefreshInterval: setRefreshInterval ?? setLocalRefreshInterval,
     };
   }, [localTimeRange, setTimeRange, refresh, refreshCounter, localRefreshInterval, setRefreshInterval]);
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
When using embedded dashboard on our app, we saw that the refreshing button in timerange control was not updating the "relative" time range and queries/panels were not updated. It's fixed with this new dependency on the useEffect.
 
And added a pattern for easily ignoring files 😄 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).