### PR TITLE
[FEATURE] Add duplicate button for global and project resources

### DIFF
--- a/ui/app/src/components/CRUDButton/CRUDGridActionsCellItem.tsx
+++ b/ui/app/src/components/CRUDButton/CRUDGridActionsCellItem.tsx
@@ -66,5 +66,11 @@ export function CRUDGridActionsCellItem({
     );
   }
 
-  return <GridActionsCellItem icon={icon} label={label} onClick={onClick} />;
+  return (
+    <Tooltip title={label} placement="top">
+      <span>
+        <GridActionsCellItem icon={icon} label={label} onClick={onClick} />
+      </span>
+    </Tooltip>
+  );
 }

--- a/ui/app/src/components/dialogs/CreateDashboardDialog.tsx
+++ b/ui/app/src/components/dialogs/CreateDashboardDialog.tsx
@@ -23,6 +23,7 @@ interface CreateDashboardProps {
   open: boolean;
   projectOptions: string[];
   hideProjectSelect?: boolean;
+  title?: string;
   onClose: DispatchWithoutAction;
   onSuccess?: Dispatch<DashboardSelector>;
 }
@@ -36,7 +37,7 @@ interface CreateDashboardProps {
  * @param props.onSuccess Action to perform when user confirmed.
  */
 export const CreateDashboardDialog = (props: CreateDashboardProps) => {
-  const { open, projectOptions, hideProjectSelect, onClose, onSuccess } = props;
+  const { open, projectOptions, hideProjectSelect, title, onClose, onSuccess } = props;
 
   const schemaValidation = useDashboardValidationSchema();
 
@@ -59,7 +60,7 @@ export const CreateDashboardDialog = (props: CreateDashboardProps) => {
   };
   return (
     <Dialog open={open} onClose={handleClose} aria-labelledby="confirm-dialog" fullWidth={true}>
-      <Dialog.Header>Create Dashboard</Dialog.Header>
+      <Dialog.Header>{title ? title : 'Create Dashboard'}</Dialog.Header>
       <FormProvider {...form}>
         <form onSubmit={form.handleSubmit(processForm)}>
           <Dialog.Content sx={{ width: '100%' }}>

--- a/ui/app/src/components/roles/RoleList.tsx
+++ b/ui/app/src/components/roles/RoleList.tsx
@@ -19,6 +19,7 @@ import { intlFormatDistance } from 'date-fns';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import ContentCopyIcon from 'mdi-material-ui/ContentCopy';
 import { DeleteRoleDialog } from '../dialogs';
 import { useIsReadonly } from '../../context/Config';
 import { GlobalProject } from '../../context/Authorization';
@@ -29,6 +30,7 @@ import { RoleDrawer } from './RoleDrawer';
 export interface RoleListProperties<T extends Role> {
   data: T[];
   hideToolbar?: boolean;
+  onCreate: DispatchWithPromise<T>;
   onUpdate: DispatchWithPromise<T>;
   onDelete: DispatchWithPromise<T>;
   initialState?: GridInitialStateCommunity;
@@ -45,7 +47,7 @@ export interface RoleListProperties<T extends Role> {
  * @param props.isLoading Display a loading circle if enabled
  */
 export function RoleList<T extends Role>(props: RoleListProperties<T>) {
-  const { data, hideToolbar, onUpdate, onDelete, initialState, isLoading } = props;
+  const { data, hideToolbar, onCreate, onUpdate, onDelete, initialState, isLoading } = props;
   const isReadonly = useIsReadonly();
 
   const findRole = useCallback(
@@ -73,18 +75,32 @@ export function RoleList<T extends Role>(props: RoleListProperties<T>) {
   const [isRoleDrawerOpened, setRoleDrawerOpened] = useState<boolean>(false);
   const [isDeleteRoleDialogOpened, setDeleteRoleDialogOpened] = useState<boolean>(false);
 
-  const handleRoleUpdate = useCallback(
+  const handleRoleSave = useCallback(
     async (role: T) => {
-      await onUpdate(role);
+      if (action === 'create') {
+        await onCreate(role);
+      } else if (action === 'update') {
+        await onUpdate(role);
+      }
       setRoleDrawerOpened(false);
     },
-    [onUpdate]
+    [action, onCreate, onUpdate]
   );
 
   const handleRowClick = useCallback(
     (name: string, project?: string) => {
       setTargetedRole(findRole(name, project));
       setAction('read');
+      setRoleDrawerOpened(true);
+    },
+    [findRole]
+  );
+
+  const handleDuplicateButtonClick = useCallback(
+    (name: string, project?: string) => () => {
+      const role = findRole(name, project);
+      setTargetedRole(role);
+      setAction('create');
       setRoleDrawerOpened(true);
     },
     [findRole]
@@ -152,7 +168,7 @@ export function RoleList<T extends Role>(props: RoleListProperties<T>) {
         headerName: 'Actions',
         type: 'actions',
         flex: 0.5,
-        minWidth: 100,
+        minWidth: 150,
         getActions: (params: GridRowParams<Row>) => [
           <CRUDGridActionsCellItem
             key={params.id + '-edit'}
@@ -162,6 +178,15 @@ export function RoleList<T extends Role>(props: RoleListProperties<T>) {
             scope={params.row.project ? 'Role' : 'GlobalRole'}
             project={params.row.project ? params.row.project : GlobalProject}
             onClick={handleEditButtonClick(params.row.name, params.row.project)}
+          />,
+          <CRUDGridActionsCellItem
+            key={params.id + '-duplicate'}
+            icon={<ContentCopyIcon />}
+            label="Duplicate"
+            action="create"
+            scope={params.row.project ? 'Role' : 'GlobalRole'}
+            project={params.row.project ? params.row.project : GlobalProject}
+            onClick={handleDuplicateButtonClick(params.row.name, params.row.project)}
           />,
           <CRUDGridActionsCellItem
             key={params.id + '-delete'}
@@ -175,7 +200,7 @@ export function RoleList<T extends Role>(props: RoleListProperties<T>) {
         ],
       },
     ],
-    [handleEditButtonClick, handleDeleteButtonClick]
+    [handleEditButtonClick, handleDuplicateButtonClick, handleDeleteButtonClick]
   );
 
   return (
@@ -195,8 +220,8 @@ export function RoleList<T extends Role>(props: RoleListProperties<T>) {
             isOpen={isRoleDrawerOpened}
             action={action}
             isReadonly={isReadonly}
-            onSave={(v: T) => handleRoleUpdate(v).then(() => setRoleDrawerOpened(false))}
-            onDelete={onDelete}
+            onSave={handleRoleSave}
+            onDelete={(v) => onDelete(v).then(() => setRoleDrawerOpened(false))}
             onClose={() => setRoleDrawerOpened(false)}
           />
           <DeleteRoleDialog

--- a/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalDatasources.tsx
@@ -17,6 +17,7 @@ import { useSnackbar } from '@perses-dev/components';
 import { useCallback } from 'react';
 import { DatasourceList } from '../../../components/datasource/DatasourceList';
 import {
+  useCreateGlobalDatasourceMutation,
   useDeleteGlobalDatasourceMutation,
   useGlobalDatasourceList,
   useUpdateGlobalDatasourceMutation,
@@ -32,8 +33,30 @@ export function GlobalDatasources(props: GlobalDatasourcesProps) {
   const { data, isLoading } = useGlobalDatasourceList();
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
 
+  const createDatasourceMutation = useCreateGlobalDatasourceMutation();
   const deleteDatasourceMutation = useDeleteGlobalDatasourceMutation();
   const updateDatasourceMutation = useUpdateGlobalDatasourceMutation();
+
+  const handleDatasourceCreate = useCallback(
+    (datasource: GlobalDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        createDatasourceMutation.mutate(datasource, {
+          onSuccess: (createdDatasource: GlobalDatasource) => {
+            successSnackbar(
+              `Global Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
+  );
 
   const handleDatasourceUpdate = useCallback(
     (datasource: GlobalDatasource): Promise<void> => {
@@ -82,6 +105,7 @@ export function GlobalDatasources(props: GlobalDatasourcesProps) {
       <DatasourceList
         data={data || []}
         hideToolbar={hideToolbar}
+        onCreate={handleDatasourceCreate}
         onUpdate={handleDatasourceUpdate}
         onDelete={handleDatasourceDelete}
         isLoading={isLoading}

--- a/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
@@ -17,6 +17,7 @@ import { GlobalRoleBindingResource, RoleBinding } from '@perses-dev/core';
 import { useSnackbar } from '@perses-dev/components';
 import { RoleBindingList } from '../../../components/rolebindings/RoleBindingList';
 import {
+  useCreateGlobalRoleBindingMutation,
   useDeleteGlobalRoleBindingMutation,
   useGlobalRoleBindingList,
   useUpdateGlobalRoleBindingMutation,
@@ -32,8 +33,27 @@ export function GlobalRoleBindings(props: GlobalRoleBindingsProps) {
   const { data, isLoading } = useGlobalRoleBindingList();
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createRoleBindingMutation = useCreateGlobalRoleBindingMutation();
   const updateRoleBindingMutation = useUpdateGlobalRoleBindingMutation();
   const deleteRoleBindingMutation = useDeleteGlobalRoleBindingMutation();
+
+  const handleGlobalRoleBindingCreate = useCallback(
+    (roleBinding: GlobalRoleBindingResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        createRoleBindingMutation.mutate(roleBinding, {
+          onSuccess: (createdRoleBinding: RoleBinding) => {
+            successSnackbar(`GlobalRoleBinding ${createdRoleBinding.metadata.name} has been successfully created`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, createRoleBindingMutation]
+  );
 
   const handleGlobalRoleBindingUpdate = useCallback(
     (roleBinding: GlobalRoleBindingResource): Promise<void> =>
@@ -76,6 +96,7 @@ export function GlobalRoleBindings(props: GlobalRoleBindingsProps) {
       <RoleBindingList
         data={data ?? []}
         isLoading={isLoading}
+        onCreate={handleGlobalRoleBindingCreate}
         onUpdate={handleGlobalRoleBindingUpdate}
         onDelete={handleGlobalRoleBindingDelete}
         initialState={{

--- a/ui/app/src/views/admin/tabs/GlobalRoles.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalRoles.tsx
@@ -17,6 +17,7 @@ import { GlobalRoleResource, Role } from '@perses-dev/core';
 import { useSnackbar } from '@perses-dev/components';
 import { RoleList } from '../../../components/roles/RoleList';
 import {
+  useCreateGlobalRoleMutation,
   useDeleteGlobalRoleMutation,
   useGlobalRoleList,
   useUpdateGlobalRoleMutation,
@@ -32,8 +33,27 @@ export function GlobalRoles(props: GlobalRolesProps) {
   const { data, isLoading } = useGlobalRoleList();
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createRoleMutation = useCreateGlobalRoleMutation();
   const updateRoleMutation = useUpdateGlobalRoleMutation();
   const deleteRoleMutation = useDeleteGlobalRoleMutation();
+
+  const handleGlobalRoleCreate = useCallback(
+    (role: GlobalRoleResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        createRoleMutation.mutate(role, {
+          onSuccess: (createdRole: Role) => {
+            successSnackbar(`GlobalRole ${createdRole.metadata.name} has been successfully created`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, createRoleMutation]
+  );
 
   const handleGlobalRoleUpdate = useCallback(
     (role: GlobalRoleResource): Promise<void> =>
@@ -76,6 +96,7 @@ export function GlobalRoles(props: GlobalRolesProps) {
       <RoleList
         data={data ?? []}
         isLoading={isLoading}
+        onCreate={handleGlobalRoleCreate}
         onUpdate={handleGlobalRoleUpdate}
         onDelete={handleGlobalRoleDelete}
         initialState={{

--- a/ui/app/src/views/admin/tabs/GlobalSecret.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalSecret.tsx
@@ -18,6 +18,7 @@ import { GlobalSecretResource, Secret } from '@perses-dev/core';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasource-api';
 import { SecretList } from '../../../components/secrets/SecretList';
 import {
+  useCreateGlobalSecretMutation,
   useDeleteGlobalSecretMutation,
   useGlobalSecretList,
   useUpdateGlobalSecretMutation,
@@ -38,8 +39,27 @@ export function GlobalSecrets(props: GlobalSecretsProps) {
   const { data, isLoading } = useGlobalSecretList();
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createSecretMutation = useCreateGlobalSecretMutation();
   const updateSecretMutation = useUpdateGlobalSecretMutation();
   const deleteSecretMutation = useDeleteGlobalSecretMutation();
+
+  const handleSecretCreate = useCallback(
+    (secret: GlobalSecretResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        createSecretMutation.mutate(secret, {
+          onSuccess: (createdSecret: Secret) => {
+            successSnackbar(`Global Secret ${createdSecret.metadata.name} has been successfully created`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, createSecretMutation]
+  );
 
   const handleSecretUpdate = useCallback(
     (secret: GlobalSecretResource): Promise<void> =>
@@ -82,6 +102,7 @@ export function GlobalSecrets(props: GlobalSecretsProps) {
       <SecretList
         data={data ?? []}
         isLoading={isLoading}
+        onCreate={handleSecretCreate}
         onUpdate={handleSecretUpdate}
         onDelete={handleSecretDelete}
         initialState={{

--- a/ui/app/src/views/admin/tabs/GlobalVariables.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalVariables.tsx
@@ -18,6 +18,7 @@ import { getVariableExtendedDisplayName, GlobalVariableResource, Variable } from
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasource-api';
 import { VariableList } from '../../../components/variable/VariableList';
 import {
+  useCreateGlobalVariableMutation,
   useDeleteGlobalVariableMutation,
   useGlobalVariableList,
   useUpdateGlobalVariableMutation,
@@ -38,8 +39,29 @@ export function GlobalVariables(props: GlobalVariablesProps) {
   const { data, isLoading } = useGlobalVariableList();
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createVariableMutation = useCreateGlobalVariableMutation();
   const updateVariableMutation = useUpdateGlobalVariableMutation();
   const deleteVariableMutation = useDeleteGlobalVariableMutation();
+
+  const handleVariableCreate = useCallback(
+    (variable: GlobalVariableResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        createVariableMutation.mutate(variable, {
+          onSuccess: (createdVariable: Variable) => {
+            successSnackbar(
+              `Global Variable ${getVariableExtendedDisplayName(createdVariable)} has been successfully created`
+            );
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, createVariableMutation]
+  );
 
   const handleVariableUpdate = useCallback(
     (variable: GlobalVariableResource): Promise<void> =>
@@ -86,6 +108,7 @@ export function GlobalVariables(props: GlobalVariablesProps) {
       <VariableList
         data={data ?? []}
         isLoading={isLoading}
+        onCreate={handleVariableCreate}
         onUpdate={handleVariableUpdate}
         onDelete={handleVariableDelete}
         initialState={{

--- a/ui/app/src/views/home/HomeView.tsx
+++ b/ui/app/src/views/home/HomeView.tsx
@@ -41,7 +41,7 @@ function HomeView() {
 
   const handleAddProjectDialogSubmit = (entity: ProjectResource) => navigate(`/projects/${entity.metadata.name}`);
   const handleAddDashboardDialogSubmit = (dashboardSelector: DashboardSelector) =>
-    navigate(`/projects/${dashboardSelector.project}/dashboard/new`, { state: dashboardSelector.dashboard });
+    navigate(`/projects/${dashboardSelector.project}/dashboard/new`, { state: { name: dashboardSelector.dashboard } });
 
   // Open/Close management for dialogs
   const [isAddProjectDialogOpen, setIsAddProjectDialogOpen] = useState(false);

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -85,7 +85,7 @@ function TabButton({ index, projectName, ...props }: TabButtonProps) {
   const isReadonly = useIsReadonly();
 
   const handleDashboardCreation = (dashboardSelector: DashboardSelector) => {
-    navigate(`/projects/${dashboardSelector.project}/dashboard/new`, { state: dashboardSelector.dashboard });
+    navigate(`/projects/${dashboardSelector.project}/dashboard/new`, { state: { name: dashboardSelector.dashboard } });
   };
 
   const { data } = useRoleList(projectName);

--- a/ui/app/src/views/projects/dashboards/CreateDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/CreateDashboardView.tsx
@@ -18,11 +18,17 @@ import {
   getDashboardExtendedDisplayName,
   DEFAULT_DASHBOARD_DURATION,
   DEFAULT_REFRESH_INTERVAL,
+  DashboardSpec,
 } from '@perses-dev/core';
 import { useCallback } from 'react';
 import { useCreateDashboardMutation } from '../../../model/dashboard-client';
 import { generateMetadataName } from '../../../utils/metadata';
 import { HelperDashboardView } from './HelperDashboardView';
+
+export interface CreateDashboardState {
+  name: string;
+  spec?: DashboardSpec;
+}
 
 /**
  * The View for creating a new Dashboard.
@@ -30,7 +36,8 @@ import { HelperDashboardView } from './HelperDashboardView';
 function CreateDashboardView() {
   const { projectName } = useParams();
   const location = useLocation();
-  const dashboardName = location.state;
+  const state: CreateDashboardState = location.state;
+  const dashboardName = state.name;
 
   if (!projectName || !dashboardName) {
     throw new Error('Unable to get the dashboard or project name');
@@ -47,7 +54,7 @@ function CreateDashboardView() {
       project: projectName,
       version: 0,
     },
-    spec: {
+    spec: state.spec ?? {
       display: {
         name: dashboardName,
       },

--- a/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectDatasources.tsx
@@ -16,6 +16,7 @@ import { useSnackbar } from '@perses-dev/components';
 import { useCallback } from 'react';
 import { getDatasourceDisplayName, ProjectDatasource } from '@perses-dev/core';
 import {
+  useCreateDatasourceMutation,
   useDatasourceList,
   useDeleteDatasourceMutation,
   useUpdateDatasourceMutation,
@@ -34,8 +35,28 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
 
+  const createDatasourceMutation = useCreateDatasourceMutation(projectName);
   const deleteDatasourceMutation = useDeleteDatasourceMutation(projectName);
   const updateDatasourceMutation = useUpdateDatasourceMutation(projectName);
+
+  const handleDatasourceCreate = useCallback(
+    (datasource: ProjectDatasource): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        createDatasourceMutation.mutate(datasource, {
+          onSuccess: (createdDatasource: ProjectDatasource) => {
+            successSnackbar(`Datasource ${getDatasourceDisplayName(createdDatasource)} has been successfully created`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      });
+    },
+    [exceptionSnackbar, successSnackbar, createDatasourceMutation]
+  );
 
   const handleDatasourceUpdate = useCallback(
     (datasource: ProjectDatasource): Promise<void> => {
@@ -80,6 +101,7 @@ export function ProjectDatasources(props: ProjectDatasourcesProps) {
       <DatasourceList
         data={data || []}
         hideToolbar={hideToolbar}
+        onCreate={handleDatasourceCreate}
         onUpdate={handleDatasourceUpdate}
         onDelete={handleDatasourceDelete}
         isLoading={isLoading}

--- a/ui/app/src/views/projects/tabs/ProjectRoleBindings.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectRoleBindings.tsx
@@ -20,6 +20,7 @@ import {
   useDeleteRoleBindingMutation,
   useUpdateRoleBindingMutation,
   useRoleBindingList,
+  useCreateRoleBindingMutation,
 } from '../../../model/rolebinding-client';
 
 interface ProjectRoleBindingsProps {
@@ -33,8 +34,27 @@ export function ProjectRoleBindings(props: ProjectRoleBindingsProps) {
   const { data, isLoading } = useRoleBindingList(projectName);
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createRoleBindingMutation = useCreateRoleBindingMutation(projectName);
   const updateRoleBindingMutation = useUpdateRoleBindingMutation(projectName);
   const deleteRoleBindingMutation = useDeleteRoleBindingMutation(projectName);
+
+  const handleRoleBindingCreate = useCallback(
+    (roleBinding: RoleBindingResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        createRoleBindingMutation.mutate(roleBinding, {
+          onSuccess: (createdRoleBinding: RoleBinding) => {
+            successSnackbar(`RoleBinding ${createdRoleBinding.metadata.name} has been successfully created`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, createRoleBindingMutation]
+  );
 
   const handleRoleBindingUpdate = useCallback(
     (roleBinding: RoleBindingResource): Promise<void> =>
@@ -77,6 +97,7 @@ export function ProjectRoleBindings(props: ProjectRoleBindingsProps) {
       <RoleBindingList
         data={data ?? []}
         isLoading={isLoading}
+        onCreate={handleRoleBindingCreate}
         onUpdate={handleRoleBindingUpdate}
         onDelete={handleRoleBindingDelete}
         initialState={{

--- a/ui/app/src/views/projects/tabs/ProjectRoles.tsx
+++ b/ui/app/src/views/projects/tabs/ProjectRoles.tsx
@@ -16,7 +16,12 @@ import { useCallback } from 'react';
 import { Role, RoleResource } from '@perses-dev/core';
 import { useSnackbar } from '@perses-dev/components';
 import { RoleList } from '../../../components/roles/RoleList';
-import { useDeleteRoleMutation, useUpdateRoleMutation, useRoleList } from '../../../model/role-client';
+import {
+  useDeleteRoleMutation,
+  useUpdateRoleMutation,
+  useRoleList,
+  useCreateRoleMutation,
+} from '../../../model/role-client';
 
 interface ProjectRolesProps {
   projectName: string;
@@ -29,8 +34,27 @@ export function ProjectRoles(props: ProjectRolesProps) {
   const { data, isLoading } = useRoleList(projectName);
 
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
+  const createRoleMutation = useCreateRoleMutation(projectName);
   const updateRoleMutation = useUpdateRoleMutation(projectName);
   const deleteRoleMutation = useDeleteRoleMutation(projectName);
+
+  const handleRoleCreate = useCallback(
+    (role: RoleResource): Promise<void> =>
+      new Promise((resolve, reject) => {
+        createRoleMutation.mutate(role, {
+          onSuccess: (createdRole: Role) => {
+            successSnackbar(`Role ${createdRole.metadata.name} has been successfully created`);
+            resolve();
+          },
+          onError: (err) => {
+            exceptionSnackbar(err);
+            reject();
+            throw err;
+          },
+        });
+      }),
+    [exceptionSnackbar, successSnackbar, createRoleMutation]
+  );
 
   const handleRoleUpdate = useCallback(
     (role: RoleResource): Promise<void> =>
@@ -73,6 +97,7 @@ export function ProjectRoles(props: ProjectRolesProps) {
       <RoleList
         data={data ?? []}
         isLoading={isLoading}
+        onCreate={handleRoleCreate}
         onUpdate={handleRoleUpdate}
         onDelete={handleRoleDelete}
         initialState={{


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Add duplicate button on resource lists for global and project resources. Closes: https://github.com/perses/perses/issues/1383

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/perses/perses/assets/5657041/f58d8bf1-be8d-4573-96f4-3c367117c95d)



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
