### PR TITLE
[ENHANCEMENT] Make defaultPluginKinds of PluginRegistry provider optionnal

### DIFF
--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -49,14 +49,7 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <PluginRegistry
-          pluginLoader={bundledPluginLoader}
-          // TODO this required field is useless here
-          defaultPluginKinds={{
-            Panel: 'TimeSeriesChart',
-            TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
-          }}
-        >
+        <PluginRegistry pluginLoader={bundledPluginLoader}>
           {isOpen && (
             <DatasourceEditorForm
               initialName={datasource.metadata.name}

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -72,13 +72,7 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="variable-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <PluginRegistry
-          pluginLoader={bundledPluginLoader}
-          defaultPluginKinds={{
-            Panel: 'TimeSeriesChart',
-            TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
-          }}
-        >
+        <PluginRegistry pluginLoader={bundledPluginLoader}>
           <DatasourceStoreProvider datasourceApi={datasourceApi} projectName={projectName}>
             <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>
               <TemplateVariableProviderWithQueryParams initialVariableDefinitions={[]}>

--- a/ui/app/src/views/projects/explore/ProjectExploreView.tsx
+++ b/ui/app/src/views/projects/explore/ProjectExploreView.tsx
@@ -77,13 +77,7 @@ function HelperExploreView(props: ProjectExploreViewProps) {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
-      <PluginRegistry
-        pluginLoader={bundledPluginLoader}
-        defaultPluginKinds={{
-          Panel: 'TimeSeriesChart',
-          TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
-        }}
-      >
+      <PluginRegistry pluginLoader={bundledPluginLoader}>
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <ViewExplore
             datasourceApi={datasourceApi}

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { UnknownSpec, useEvent } from '@perses-dev/core';
-import { useRef, useCallback, useMemo } from 'react';
+import { useRef, useCallback, useMemo, ReactNode } from 'react';
 import {
   PluginModuleResource,
   PluginType,
@@ -26,8 +26,8 @@ import { usePluginIndexes, getTypeAndKindKey } from './plugin-indexes';
 
 export interface PluginRegistryProps {
   pluginLoader: PluginLoader;
-  defaultPluginKinds: DefaultPluginKinds;
-  children?: React.ReactNode;
+  defaultPluginKinds?: DefaultPluginKinds;
+  children?: ReactNode;
 }
 
 /**

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -19,7 +19,7 @@ import { DefaultPluginKinds, PluginImplementation, PluginMetadata, PluginType } 
 export interface PluginRegistryContextType {
   getPlugin<T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>>;
   listPluginMetadata(pluginType: PluginType): Promise<PluginMetadata[]>;
-  defaultPluginKinds: DefaultPluginKinds;
+  defaultPluginKinds?: DefaultPluginKinds;
 }
 
 export const PluginRegistryContext = createContext<PluginRegistryContextType | undefined>(undefined);


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
PluginRegistry no longer need a default plugin kind. Remove some unnecessary code and dep on prometheus plugin.


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
