### PR TITLE
[FEATURE] Add dac preview command

### DIFF
--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -14,6 +14,7 @@
 package build
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -138,7 +139,8 @@ func (o *option) processFile(file string, extension string) error {
 	// Capture the output of the command
 	cmdOutput, err := cmd.Output()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			return fmt.Errorf("failed to build %s: %s", file, string(exitErr.Stderr))
 		}
 		return err

--- a/internal/cli/cmd/dac/dac.go
+++ b/internal/cli/cmd/dac/dac.go
@@ -15,6 +15,7 @@ package dac
 
 import (
 	"github.com/perses/perses/internal/cli/cmd/dac/build"
+	"github.com/perses/perses/internal/cli/cmd/dac/preview"
 	"github.com/perses/perses/internal/cli/cmd/dac/setup"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,7 @@ func NewCMD() *cobra.Command {
 		Short: "Commands related to Dashboard-as-Code",
 	}
 	cmd.AddCommand(build.NewCMD())
+	cmd.AddCommand(preview.NewCMD())
 	cmd.AddCommand(setup.NewCMD())
 
 	return cmd

--- a/internal/cli/cmd/dac/preview/preview.go
+++ b/internal/cli/cmd/dac/preview/preview.go
@@ -1,0 +1,189 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preview
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/perses/perses/internal/api/utils"
+	persesCMD "github.com/perses/perses/internal/cli/cmd"
+	"github.com/perses/perses/internal/cli/config"
+	"github.com/perses/perses/internal/cli/file"
+	"github.com/perses/perses/internal/cli/opt"
+	"github.com/perses/perses/internal/cli/output"
+	"github.com/perses/perses/internal/cli/resource"
+	"github.com/perses/perses/internal/cli/service"
+	"github.com/perses/perses/pkg/client/api"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type previewResponse struct {
+	Project   string `json:"project" yaml:"project"`
+	Dashboard string `json:"dashboard" yaml:"dashboard"`
+	Preview   string `json:"preview" yaml:"preview"`
+}
+
+func newEphemeralDashboard(project string, name string, ttl model.Duration, dashboard *modelV1.Dashboard) *modelV1.EphemeralDashboard {
+	return &modelV1.EphemeralDashboard{
+		Kind: modelV1.KindEphemeralDashboard,
+		Metadata: modelV1.ProjectMetadata{
+			Metadata:               modelV1.Metadata{Name: name},
+			ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{Project: project},
+		},
+		Spec: modelV1.EphemeralDashboardSpec{
+			EphemeralDashboardSpecBase: modelV1.EphemeralDashboardSpecBase{TTL: ttl},
+			DashboardSpec:              dashboard.Spec,
+		},
+	}
+}
+
+type option struct {
+	persesCMD.Option
+	opt.ProjectOption
+	opt.FileOption
+	opt.DirectoryOption
+	opt.OutputOption
+	dashboards   []*modelV1.Dashboard
+	writer       io.Writer
+	apiClient    api.ClientInterface
+	ttl          model.Duration
+	ttlAsAString string
+	prefix       string
+}
+
+func (o *option) Complete(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("no args are supported by the command 'dac preview'")
+	}
+	if len(o.Directory) == 0 && len(o.File) == 0 {
+		o.Directory = config.Global.Dac.OutputFolder
+		if len(o.Directory) == 0 {
+			return fmt.Errorf("you need to set the flag --directory or --file or to set the output folder for the 'dac' command")
+		}
+	}
+	apiClient, err := config.Global.GetAPIClient()
+	if err != nil {
+		return err
+	}
+	o.apiClient = apiClient
+	ttl, err := model.ParseDuration(o.ttlAsAString)
+	if err != nil {
+		return err
+	}
+	o.ttl = ttl
+	return o.setDashboards()
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	var response []previewResponse
+	for _, dashboard := range o.dashboards {
+		project := resource.GetProject(dashboard.GetMetadata(), o.Project)
+		name := o.computeEphemeralDashboardName(dashboard.Metadata.Name)
+		ephemeralDashboard := newEphemeralDashboard(project, name, o.ttl, dashboard)
+		svc, svcErr := service.New(modelV1.KindEphemeralDashboard, project, o.apiClient)
+		if svcErr != nil {
+			return svcErr
+		}
+
+		if upsertError := service.Upsert(svc, name, ephemeralDashboard); upsertError != nil {
+			return upsertError
+		}
+		response = append(response, o.buildPreviewResponse(dashboard, ephemeralDashboard))
+
+		logrus.Infof("ephemeral dashboard %q has been applied in the project %q", name, project)
+	}
+	return output.Handle(o.writer, o.Output, response)
+}
+
+func (o *option) setDashboards() error {
+	var entities []modelAPI.Entity
+	if len(o.File) > 0 {
+		var err error
+		entities, err = file.UnmarshalEntitiesFromFile(o.File)
+		if err != nil {
+			return err
+		}
+	} else if len(o.Directory) > 0 {
+		var errorList []error
+		entities, errorList = file.UnmarshalEntitiesFromDirectory(o.Directory)
+		if len(errorList) > 0 {
+			return errorList[0]
+		}
+	}
+	for _, e := range entities {
+		if e.GetKind() == string(modelV1.KindDashboard) {
+			o.dashboards = append(o.dashboards, e.(*modelV1.Dashboard))
+		}
+	}
+	if len(o.dashboards) == 0 {
+		return fmt.Errorf("no dashboard found to create a preview")
+	}
+	return nil
+}
+
+func (o *option) computeEphemeralDashboardName(dashboardName string) string {
+	var result strings.Builder
+	if len(o.prefix) > 0 {
+		result.WriteString(fmt.Sprintf("%s-", strings.ReplaceAll(strings.ToLower(o.prefix), " ", "-")))
+	}
+	result.WriteString(dashboardName)
+	return result.String()
+}
+
+func (o *option) buildPreviewResponse(dashboard *modelV1.Dashboard, tmpDashboard *modelV1.EphemeralDashboard) previewResponse {
+	finalURL := &url.URL{}
+	*finalURL = *o.apiClient.RESTClient().BaseURL
+	finalURL.Path = fmt.Sprintf("/%s/%s/%s/%s", utils.PathProject, tmpDashboard.Metadata.Project, utils.PathEphemeralDashboard, tmpDashboard.Metadata.Name)
+	return previewResponse{
+		Dashboard: dashboard.Metadata.Name,
+		Project:   tmpDashboard.Metadata.Project,
+		Preview:   finalURL.String()}
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "preview (-f [FILENAME] | -d [DIRECTORY_NAME])",
+		Short: "Preview of dashboards",
+		Long:  "Creates ephemeral dashboard based on dashboard built locally. As a response it gives the list of the URL for each dashboard preview.",
+		Example: `
+percli dac preview -d ./build
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return persesCMD.Run(o, cmd, args)
+		},
+	}
+	opt.AddOutputFlags(cmd, &o.OutputOption)
+	opt.AddProjectFlags(cmd, &o.ProjectOption)
+	opt.AddFileFlags(cmd, &o.FileOption)
+	opt.AddDirectoryFlags(cmd, &o.DirectoryOption)
+	cmd.Flags().StringVar(&o.ttlAsAString, "ttl", "1d", "Time To Live of the dashboard preview")
+	cmd.Flags().StringVar(&o.prefix, "prefix", "", "If provided, it is used to prefix the dashboard preview name")
+	return cmd
+}

--- a/internal/cli/cmd/dac/preview/preview_test.go
+++ b/internal/cli/cmd/dac/preview/preview_test.go
@@ -1,0 +1,153 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preview
+
+import (
+	"testing"
+
+	"github.com/perses/perses/internal/cli/config"
+	cmdTest "github.com/perses/perses/internal/cli/test"
+	fakeapi "github.com/perses/perses/pkg/client/fake/api"
+)
+
+func TestPreviewCMD(t *testing.T) {
+	testSuite := []cmdTest.Suite{
+		{
+			Title:           "empty args",
+			Args:            []string{},
+			IsErrorExpected: true,
+			ExpectedMessage: "you are not connected to any API",
+		},
+		{
+			Title:           "no dashboard",
+			Args:            []string{},
+			APIClient:       fakeapi.New(),
+			Config:          config.Config{Dac: config.Dac{OutputFolder: "./emptybuild"}},
+			IsErrorExpected: true,
+			ExpectedMessage: "no dashboard found to create a preview",
+		},
+		{
+			Title:           "preview with no prefix",
+			Args:            []string{},
+			APIClient:       fakeapi.New(),
+			Config:          config.Config{Dac: config.Dac{OutputFolder: "../../../../../dev/data/9-dashboard.json"}},
+			IsErrorExpected: false,
+			ExpectedMessage: `- project: perses
+  dashboard: Demo
+  preview: http://localhost:8080/projects/perses/ephemeraldashboards/Demo
+- project: perses
+  dashboard: Benchmark
+  preview: http://localhost:8080/projects/perses/ephemeraldashboards/Benchmark
+- project: testing
+  dashboard: PanelGroups
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/PanelGroups
+- project: testing
+  dashboard: Panels
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/Panels
+- project: testing
+  dashboard: Variables
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/Variables
+- project: testing
+  dashboard: MarkdownPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/MarkdownPanel
+- project: testing
+  dashboard: TimeSeriesChartPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartPanel
+- project: testing
+  dashboard: GaugeChartPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/GaugeChartPanel
+- project: testing
+  dashboard: StatChartPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/StatChartPanel
+- project: testing
+  dashboard: DuplicatePanels
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/DuplicatePanels
+- project: testing
+  dashboard: EditJson
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/EditJson
+- project: testing
+  dashboard: Defaults
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/Defaults
+- project: testing
+  dashboard: TimeSeriesChartLegends
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartLegends
+- project: perses
+  dashboard: NodeExporter
+  preview: http://localhost:8080/projects/perses/ephemeraldashboards/NodeExporter
+
+`,
+		},
+		{
+			Title:           "preview with prefix",
+			Args:            []string{"--prefix", "pr-1664"},
+			APIClient:       fakeapi.New(),
+			Config:          config.Config{Dac: config.Dac{OutputFolder: "../../../../../dev/data/9-dashboard.json"}},
+			IsErrorExpected: false,
+			ExpectedMessage: `- project: perses
+  dashboard: Demo
+  preview: http://localhost:8080/projects/perses/ephemeraldashboards/pr-1664-Demo
+- project: perses
+  dashboard: Benchmark
+  preview: http://localhost:8080/projects/perses/ephemeraldashboards/pr-1664-Benchmark
+- project: testing
+  dashboard: PanelGroups
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-PanelGroups
+- project: testing
+  dashboard: Panels
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-Panels
+- project: testing
+  dashboard: Variables
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-Variables
+- project: testing
+  dashboard: MarkdownPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-MarkdownPanel
+- project: testing
+  dashboard: TimeSeriesChartPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-TimeSeriesChartPanel
+- project: testing
+  dashboard: GaugeChartPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-GaugeChartPanel
+- project: testing
+  dashboard: StatChartPanel
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-StatChartPanel
+- project: testing
+  dashboard: DuplicatePanels
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-DuplicatePanels
+- project: testing
+  dashboard: EditJson
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-EditJson
+- project: testing
+  dashboard: Defaults
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-Defaults
+- project: testing
+  dashboard: TimeSeriesChartLegends
+  preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-TimeSeriesChartLegends
+- project: perses
+  dashboard: NodeExporter
+  preview: http://localhost:8080/projects/perses/ephemeraldashboards/pr-1664-NodeExporter
+
+`,
+		},
+		{
+			Title:           "preview in json",
+			Args:            []string{"--output", "json"},
+			APIClient:       fakeapi.New(),
+			Config:          config.Config{Dac: config.Dac{OutputFolder: "../../../../../dev/data/9-dashboard.json"}},
+			IsErrorExpected: false,
+			ExpectedMessage: `[{"project":"perses","dashboard":"Demo","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/Demo"},{"project":"perses","dashboard":"Benchmark","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/Benchmark"},{"project":"testing","dashboard":"PanelGroups","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/PanelGroups"},{"project":"testing","dashboard":"Panels","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Panels"},{"project":"testing","dashboard":"Variables","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Variables"},{"project":"testing","dashboard":"MarkdownPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/MarkdownPanel"},{"project":"testing","dashboard":"TimeSeriesChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartPanel"},{"project":"testing","dashboard":"GaugeChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/GaugeChartPanel"},{"project":"testing","dashboard":"StatChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/StatChartPanel"},{"project":"testing","dashboard":"DuplicatePanels","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/DuplicatePanels"},{"project":"testing","dashboard":"EditJson","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/EditJson"},{"project":"testing","dashboard":"Defaults","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Defaults"},{"project":"testing","dashboard":"TimeSeriesChartLegends","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartLegends"},{"project":"perses","dashboard":"NodeExporter","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/NodeExporter"}]
+`,
+		},
+	}
+	cmdTest.ExecuteSuiteTest(t, NewCMD, testSuite)
+}

--- a/internal/cli/cmd/lint/lint.go
+++ b/internal/cli/cmd/lint/lint.go
@@ -188,7 +188,7 @@ percli lint -f ./resources.json --online
 	cmd.Flags().BoolVar(&o.online, "online", false, "When enable, it can request the API to make additional validation")
 
 	cmd.MarkFlagsRequiredTogether("schemas.charts", "schemas.queries")
-	// when online flag is used, the CLI will call the endpoint /validate that will then use the schema from the server.
+	// When "online" flag is used, the CLI will call the endpoint /validate that will then use the schema from the server.
 	// So no need to use / load the schemas with the CLI.
 	cmd.MarkFlagsMutuallyExclusive("schemas.charts", "online")
 	cmd.MarkFlagsMutuallyExclusive("schemas.queries", "online")

--- a/pkg/client/fake/api/client.go
+++ b/pkg/client/fake/api/client.go
@@ -27,18 +27,24 @@ import (
 
 type client struct {
 	api.ClientInterface
+	restClient *perseshttp.RESTClient
 }
 
 func New() api.ClientInterface {
-	return &client{}
+	restClient, _ := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+		URL: "http://localhost:8080",
+	})
+	return &client{
+		restClient: restClient,
+	}
 }
 
 func (c *client) RESTClient() *perseshttp.RESTClient {
-	return nil
+	return c.restClient
 }
 
 func (c *client) V1() v1.ClientInterface {
-	return fakev1.New()
+	return fakev1.New(c.restClient)
 }
 
 func (c *client) Config() (*apiConfig.Config, error) {

--- a/pkg/client/fake/api/v1/client.go
+++ b/pkg/client/fake/api/v1/client.go
@@ -20,14 +20,19 @@ import (
 
 type client struct {
 	v1.ClientInterface
+	restClient *perseshttp.RESTClient
 }
 
-func New() v1.ClientInterface {
-	return &client{}
+func New(restClient *perseshttp.RESTClient) v1.ClientInterface {
+	return &client{restClient: restClient}
 }
 
 func (c *client) RESTClient() *perseshttp.RESTClient {
-	return nil
+	return c.restClient
+}
+
+func (c *client) EphemeralDashboard(_ string) v1.EphemeralDashboardInterface {
+	return &ephemeralDashboard{}
 }
 
 func (c *client) Folder(project string) v1.FolderInterface {

--- a/pkg/client/fake/api/v1/ephemeraldashboard.go
+++ b/pkg/client/fake/api/v1/ephemeraldashboard.go
@@ -1,0 +1,39 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakev1
+
+import (
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type ephemeralDashboard struct {
+	v1.EphemeralDashboardInterface
+}
+
+func (e *ephemeralDashboard) Create(entity *modelV1.EphemeralDashboard) (*modelV1.EphemeralDashboard, error) {
+	return entity, nil
+}
+func (e *ephemeralDashboard) Update(entity *modelV1.EphemeralDashboard) (*modelV1.EphemeralDashboard, error) {
+	return entity, nil
+}
+func (e *ephemeralDashboard) Delete(_ string) error {
+	return nil
+}
+func (e *ephemeralDashboard) Get(_ string) (*modelV1.EphemeralDashboard, error) {
+	return nil, nil
+}
+func (e *ephemeralDashboard) List(_ string) ([]*modelV1.EphemeralDashboard, error) {
+	return make([]*modelV1.EphemeralDashboard, 0), nil
+}


### PR DESCRIPTION
I'm adding a new command that would help for the preview of the dashboard in the context of the `dashboard as code`.

```bash
percli dac preview -d ./built
```

The command will give a give of URLs for the previews. For example:

```yaml
- project: perses
  dashboard: Demo
  preview: http://localhost:8080/api/v1/projects/perses/ephemeraldashboards/pr-1664-Demo
- project: perses
  dashboard: Benchmark
  preview: http://localhost:8080/api/v1/projects/perses/ephemeraldashboards/pr-1664-Benchmark
```

Today through flags provided by the command, you can add two prefixes: the repository name & the pull request name.

I'm wondering if we should add another flags for generic prefix or it's fine like that.

Note: result can be printed in JSON too