### PR TITLE
[ENHANCEMENT] add persistant flag to set the output folder for dac

### DIFF
--- a/cmd/percli/main.go
+++ b/cmd/percli/main.go
@@ -87,7 +87,7 @@ func initializeCLI() {
 }
 
 func main() {
-	cobra.OnInitialize(initializeCLI)
+	cobra.OnInitialize(initializeCLI, dac.Initialize)
 	rootCmd := newRootCommand()
 
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/cli/cmd/dac/dac.go
+++ b/internal/cli/cmd/dac/dac.go
@@ -17,8 +17,15 @@ import (
 	"github.com/perses/perses/internal/cli/cmd/dac/build"
 	"github.com/perses/perses/internal/cli/cmd/dac/preview"
 	"github.com/perses/perses/internal/cli/cmd/dac/setup"
+	"github.com/perses/perses/internal/cli/config"
 	"github.com/spf13/cobra"
 )
+
+var dacOutputFolder string
+
+func Initialize() {
+	config.Global.Dac.OutputFolder = dacOutputFolder
+}
 
 func NewCMD() *cobra.Command {
 	cmd := &cobra.Command{
@@ -28,6 +35,8 @@ func NewCMD() *cobra.Command {
 	cmd.AddCommand(build.NewCMD())
 	cmd.AddCommand(preview.NewCMD())
 	cmd.AddCommand(setup.NewCMD())
+
+	cmd.PersistentFlags().StringVar(&dacOutputFolder, "dac.output_folder", config.DefaultOutputFolder, "Path to the folder where the dac-generated files are stored.")
 
 	return cmd
 }


### PR DESCRIPTION
I'm adding a global flag for all `dac` sub command so we can set the output folder at any moment.