### PR TITLE
[ENHANCEMENT] DaC SDKs: allow using different identifiers for name vs label

### DIFF
--- a/cue/dac-utils/prometheus/filter/filter.cue
+++ b/cue/dac-utils/prometheus/filter/filter.cue
@@ -21,11 +21,11 @@ import (
 
 #input: [...varBuilder]
 
-// TODO support label arg if provided like ""\(d.label)=\"$\(d.name)\"""
 filter: strings.Join(
 	[for var in #input {
 		[// switch
-			if var.#pluginKind == _|_ {"\(var.#name)=\"$\(var.#name)\""},
+			if var.#label != _|_ {"\(var.#label)=\"$\(var.#name)\""},
+			if var.#kind == "TextVariable" {"\(var.#name)=\"$\(var.#name)\""},
 			if var.#pluginKind != _|_ if var.#pluginKind != labelNamesVar.kind {"\(var.#name)=\"$\(var.#name)\""},
 		][0]
 	}],

--- a/cue/dac-utils/prometheus/variable/labelnames/labelnames.cue
+++ b/cue/dac-utils/prometheus/variable/labelnames/labelnames.cue
@@ -14,10 +14,10 @@
 package labelnames
 
 import (
-	"strings"
 	labelNamesVar "github.com/perses/perses/cue/schemas/variables/prometheus-label-names:model"
 	listVarBuilder "github.com/perses/perses/cue/dac-utils/variable/list"
 	v1Variable "github.com/perses/perses/cue/model/api/v1/variable"
+	filterBuilder "github.com/perses/perses/cue/dac-utils/prometheus/filter"
 )
 
 _kind=#kind: listVarBuilder.#kind & "ListVariable"
@@ -36,16 +36,7 @@ _sort=#sort?:                       v1Variable.#Sort
 #query:                             string
 #dependencies: [...{...}]
 
-// TODO support label arg if provided like ""\(d.label)=\"$\(d.name)\"""
-filter: strings.Join(
-	[for d in #dependencies {
-		[// switch
-			if d.#pluginKind == _|_ {"\(d.#name)=\"$\(d.#name)\""},
-			if d.#pluginKind != _|_ if d.#pluginKind != labelNamesVar.kind {"\(d.#name)=\"$\(d.#name)\""},
-		][0]
-	}],
-	",",
-	)
+filter: { filterBuilder & { #input: #dependencies } }.filter
 
 queryExpr: [// switch
 		if #query != _|_ {#query},

--- a/cue/dac-utils/prometheus/variable/labelvalues/labelvalues.cue
+++ b/cue/dac-utils/prometheus/variable/labelvalues/labelvalues.cue
@@ -14,11 +14,10 @@
 package labelvalues
 
 import (
-	"strings"
 	labelValuesVar "github.com/perses/perses/cue/schemas/variables/prometheus-label-values:model"
-	labelNamesVar "github.com/perses/perses/cue/schemas/variables/prometheus-label-names:model"
 	listVarBuilder "github.com/perses/perses/cue/dac-utils/variable/list"
 	v1Variable "github.com/perses/perses/cue/model/api/v1/variable"
+	filterBuilder "github.com/perses/perses/cue/dac-utils/prometheus/filter"
 )
 
 _kind=#kind: listVarBuilder.#kind & "ListVariable"
@@ -38,16 +37,7 @@ _sort=#sort?:                       v1Variable.#Sort
 #query:                             string
 #dependencies: [...{...}]
 
-// TODO support label arg if provided like ""\(d.label)=\"$\(d.name)\"""
-filter: strings.Join(
-	[for d in #dependencies {
-		[// switch
-			if d.#pluginKind == _|_ {"\(d.#name)=\"$\(d.#name)\""},
-			if d.#pluginKind != _|_ if d.#pluginKind != labelNamesVar.kind {"\(d.#name)=\"$\(d.#name)\""},
-		][0]
-	}],
-	",",
-	)
+filter: { filterBuilder & { #input: #dependencies } }.filter
 
 queryExpr: [// switch
 		if #query != _|_ {#query},

--- a/cue/dac-utils/prometheus/variable/promql/promql.cue
+++ b/cue/dac-utils/prometheus/variable/promql/promql.cue
@@ -14,11 +14,10 @@
 package promql
 
 import (
-	"strings"
 	promQLVar "github.com/perses/perses/cue/schemas/variables/prometheus-promql:model"
-	labelNamesVar "github.com/perses/perses/cue/schemas/variables/prometheus-label-names:model"
 	listVarBuilder "github.com/perses/perses/cue/dac-utils/variable/list"
 	v1Variable "github.com/perses/perses/cue/model/api/v1/variable"
+	filterBuilder "github.com/perses/perses/cue/dac-utils/prometheus/filter"
 )
 
 _kind=#kind: listVarBuilder.#kind & "ListVariable"
@@ -38,16 +37,7 @@ _sort=#sort?:                       v1Variable.#Sort
 #query:                             string
 #dependencies: [...{...}]
 
-// TODO support label arg if provided like ""\(d.label)=\"$\(d.name)\"""
-filter: strings.Join(
-	[for d in #dependencies {
-		[// switch
-			if d.#pluginKind == _|_ {"\(d.#name)=\"$\(d.#name)\""},
-			if d.#pluginKind != _|_ if d.#pluginKind != labelNamesVar.kind {"\(d.#name)=\"$\(d.#name)\""},
-		][0]
-	}],
-	",",
-	)
+filter: { filterBuilder & { #input: #dependencies } }.filter
 
 queryExpr: [// switch
 		if #query != _|_ {#query},

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -37,14 +37,14 @@ var (
 	memoryPanel = panelgroup.AddPanel("Container memory",
 		timeseries.Chart(),
 		panel.AddQuery(
-			query.PromQL("max by (container) (container_memory_rss{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"),
+			query.PromQL("max by (container) (container_memory_rss{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"),
 		),
 	)
 
 	cpuPanel = panelgroup.AddPanel("Container CPU",
 		timeseries.Chart(),
 		panel.AddQuery(
-			query.PromQL("sum  (container_cpu_usage_seconds{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"),
+			query.PromQL("sum  (container_cpu_usage_seconds{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"),
 		),
 	)
 )
@@ -54,7 +54,7 @@ func TestDashboardBuilder(t *testing.T) {
 		ProjectName("MyProject"),
 
 		// VARIABLES
-		AddVariable("stack",
+		AddVariable("paas",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("stack",
 					labelValuesVar.Matchers("thanos_build_info{}"),
@@ -74,22 +74,22 @@ func TestDashboardBuilder(t *testing.T) {
 			),
 		),
 		AddVariable("namespace", listVar.List(
-			promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
+			promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
 			listVar.AllowMultiple(true),
 		)),
 		AddVariable("namespaceLabels", listVar.List(
 			labelNamesVar.PrometheusLabelNames(
-				labelNamesVar.Matchers("kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"}"),
+				labelNamesVar.Matchers("kube_namespace_labels{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"}"),
 				labelNamesVar.Datasource("promDemo"),
 			),
 		)),
 		AddVariable("pod", listVar.List(
-			promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
+			promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
 			listVar.AllowMultiple(true),
 			listVar.AllowAllValue(true),
 		)),
 		AddVariable("container", listVar.List(
-			promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
+			promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
 			listVar.AllowMultiple(true),
 			listVar.AllowAllValue(true),
 			listVar.CustomAllValue(".*"),
@@ -98,7 +98,7 @@ func TestDashboardBuilder(t *testing.T) {
 			listVar.Description("simply the list of labels for the considered metric"),
 			listVar.Hidden(true),
 			labelNamesVar.PrometheusLabelNames(
-				labelNamesVar.Matchers("kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"}"),
+				labelNamesVar.Matchers("kube_pod_container_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"}"),
 				labelNamesVar.Datasource("promDemo"),
 			),
 			listVar.SortingBy("alphabetical-ci-desc"),
@@ -141,7 +141,7 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 
 		// VARIABLES
 		AddVariableGroup(
-			variablegroup.AddVariable("stack",
+			variablegroup.AddVariable("paas",
 				listVar.List(
 					labelValuesVar.PrometheusLabelValues("stack",
 						labelValuesVar.Matchers("thanos_build_info"),
@@ -161,7 +161,7 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 				),
 			),
 			variablegroup.AddVariable("namespace", listVar.List(
-				promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
+				promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
 				listVar.AllowMultiple(true),
 			)),
 			variablegroup.AddIgnoredVariable("namespaceLabels", listVar.List(
@@ -171,12 +171,12 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 				),
 			)),
 			variablegroup.AddVariable("pod", listVar.List(
-				promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
+				promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
 				listVar.AllowMultiple(true),
 				listVar.AllowAllValue(true),
 			)),
 			variablegroup.AddVariable("container", listVar.List(
-				promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
+				promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
 				listVar.AllowMultiple(true),
 				listVar.AllowAllValue(true),
 				listVar.CustomAllValue(".*"),

--- a/internal/test/dac/dac_test.go
+++ b/internal/test/dac/dac_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestDashboardAsCodeCUESDK(t *testing.T) {
-
 	testSuite := []struct {
 		title                  string
 		inputCUEFile           string

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -12,7 +12,7 @@
       {
         "kind": "ListVariable",
         "spec": {
-          "name": "stack",
+          "name": "paas",
           "display": {
             "name": "PaaS",
             "hidden": false
@@ -68,7 +68,7 @@
                 "kind": "PrometheusDatasource",
                 "name": "promDemo"
               },
-              "expr": "group by (namespace) (kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})",
+              "expr": "group by (namespace) (kube_namespace_labels{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})",
               "labelName": "namespace"
             }
           }
@@ -88,7 +88,7 @@
                 "name": "promDemo"
               },
               "matchers": [
-                "kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"}"
+                "kube_namespace_labels{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"}"
               ]
             }
           }
@@ -107,7 +107,7 @@
                 "kind": "PrometheusDatasource",
                 "name": "promDemo"
               },
-              "expr": "group by (pod) (kube_pod_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})",
+              "expr": "group by (pod) (kube_pod_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})",
               "labelName": "pod"
             }
           }
@@ -127,7 +127,7 @@
                 "kind": "PrometheusDatasource",
                 "name": "promDemo"
               },
-              "expr": "group by (container) (kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})",
+              "expr": "group by (container) (kube_pod_container_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})",
               "labelName": "container"
             }
           }
@@ -152,7 +152,7 @@
                 "name": "promDemo"
               },
               "matchers": [
-                "kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"}"
+                "kube_pod_container_info{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"}"
               ]
             }
           }
@@ -177,7 +177,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "max by (container) (container_memory_rss{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "max by (container) (container_memory_rss{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
                   }
                 }
               }
@@ -202,7 +202,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "sum  (container_cpu_usage_seconds{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "sum  (container_cpu_usage_seconds{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
                   }
                 }
               }
@@ -227,7 +227,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "sum  (container_cpu_usage_seconds{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "sum  (container_cpu_usage_seconds{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
                   }
                 }
               }
@@ -252,7 +252,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "max by (container) (container_memory_rss{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "max by (container) (container_memory_rss{stack=\"$paas\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
                   }
                 }
               }

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -30,7 +30,7 @@ import (
 #myVarsBuilder: varGroupBuilder & {
 	#input: [
 		labelValuesVarBuilder & {
-			#name: "stack"
+			#name: "paas"
 			#display: name: "PaaS"
 			#metric:          "thanos_build_info"
 			#label:           "stack"


### PR DESCRIPTION
# Description

The goal is to allow with both SDKs to use a different identifier/alias between a (prometheus) variable name & label attributes.
Also factorizes some duplicated code on CUE SDK side.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).