### PR TITLE
[IGNORE] Remove Add dashboard button for ephemeral dashboards

### DIFF
--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -28,12 +28,11 @@ import {
   RoleResource,
   RoleBindingResource,
   SecretResource,
-  EphemeralDashboardInfo,
 } from '@perses-dev/core';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSnackbar } from '@perses-dev/components';
 import { CRUDButton, CRUDButtonProps } from '../../components/CRUDButton/CRUDButton';
-import { CreateDashboardDialog, CreateEphemeralDashboardDialog } from '../../components/dialogs';
+import { CreateDashboardDialog } from '../../components/dialogs';
 import { VariableDrawer } from '../../components/variable/VariableDrawer';
 import { DatasourceDrawer } from '../../components/datasource/DatasourceDrawer';
 import { useCreateDatasourceMutation } from '../../model/datasource-client';
@@ -80,7 +79,6 @@ function TabButton({ index, projectName, ...props }: TabButtonProps) {
   const createVariableMutation = useCreateVariableMutation(projectName);
 
   const [isCreateDashboardDialogOpened, setCreateDashboardDialogOpened] = useState(false);
-  const [isCreateEphemeralDashboardDialogOpened, setCreateEphemeralDashboardDialogOpened] = useState(false);
   const [isDatasourceDrawerOpened, setDatasourceDrawerOpened] = useState(false);
   const [isRoleDrawerOpened, setRoleDrawerOpened] = useState(false);
   const [isRoleBindingDrawerOpened, setRoleBindingDrawerOpened] = useState(false);
@@ -91,12 +89,6 @@ function TabButton({ index, projectName, ...props }: TabButtonProps) {
 
   const handleDashboardCreation = (dashboardSelector: DashboardSelector) => {
     navigate(`/projects/${dashboardSelector.project}/dashboard/new`, { state: { name: dashboardSelector.dashboard } });
-  };
-
-  const handleEphemeralDashboardCreation = (dashboardInfo: EphemeralDashboardInfo) => {
-    navigate(`/projects/${dashboardInfo.project}/ephemeraldashboard/new`, {
-      state: { name: dashboardInfo.dashboard, ttl: dashboardInfo.ttl },
-    });
   };
 
   const { data } = useRoleList(projectName);
@@ -204,27 +196,6 @@ function TabButton({ index, projectName, ...props }: TabButtonProps) {
             hideProjectSelect={true}
             onClose={() => setCreateDashboardDialogOpened(false)}
             onSuccess={handleDashboardCreation}
-          />
-        </>
-      );
-    case ephemeralDashboardsTabIndex:
-      return (
-        <>
-          <CRUDButton
-            action="create"
-            scope="EphemeralDashboard"
-            project={projectName}
-            variant="contained"
-            onClick={() => setCreateEphemeralDashboardDialogOpened(true)}
-            {...props}
-          >
-            Add Dashboard
-          </CRUDButton>
-          <CreateEphemeralDashboardDialog
-            open={isCreateEphemeralDashboardDialogOpened}
-            projectOptions={[projectName]}
-            onClose={() => setCreateEphemeralDashboardDialogOpened(false)}
-            onSuccess={handleEphemeralDashboardCreation}
           />
         </>
       );


### PR DESCRIPTION
# Description

Ephemeral dashboards would be created either via DaC or via temporary copy of existing dashboards (https://github.com/perses/perses/pull/1818)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
