### PR TITLE
[FEATURE] Client Credentials authentication flow

### DIFF
--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -211,6 +211,18 @@ Generic placeholders are defined as follows:
     [ client_id: <secret> ]
     # Allow to use a different Client Secret for the device code flow
     [ client_secret: <secret> ]
+    # Allow to use different Scopes for the device code flow
+    scopes:
+      - [ <string> ]
+
+  client_credentials:
+    # Allow to use a different Client ID for the client credentials flow
+    [ client_id: <secret> ]
+    # Allow to use a different Client Secret for the client credentials flow
+    [ client_secret: <secret> ]
+    # Allow to use different Scopes for the client credentials flow
+    scopes:
+      - [ <string> ]
 
   # The callback URL for authorization code (Have to be <your URL> + /api/auth/providers/oidc/{slug}/callback)
   [ redirect_uri: <string> ]

--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -27,32 +27,12 @@ import (
 	"github.com/perses/perses/internal/api/utils"
 	"github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/config"
-	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
 const (
 	xForwardedProto = "X-Forwarded-Proto"
 	xForwardedHost  = "X-Forwarded-Host"
 )
-
-// grantType is a subset of the OAuth 2.0 grant types.
-// In our case, we will explicitly need them only in the /token endpoint, that we are using
-// only in the context of device code flow and client credentials flow.
-type grantType oidc.GrantType
-
-const (
-	GrantTypeDeviceCode        = grantType(oidc.GrantTypeDeviceCode)
-	GrantTypeClientCredentials = grantType(oidc.GrantTypeClientCredentials)
-)
-
-// tokenRequestBody represents the body of a /token endpoint request.
-// DeviceCode or ClientID, ClientSecret will be necessary based on the grant type.
-type tokenRequestBody struct {
-	GrantType    grantType `json:"grant_type"`
-	DeviceCode   string    `json:"device_code"`
-	ClientID     string    `json:"client_id"`
-	ClientSecret string    `json:"client_secret"`
-}
 
 func getRedirectURI(r *http.Request, authKind string, slugID string) string {
 	rd := url.URL{}

--- a/internal/api/impl/auth/service.go
+++ b/internal/api/impl/auth/service.go
@@ -88,6 +88,10 @@ func (s *service) getOrPrepareUserEntity(login string) (*v1.User, bool, error) {
 }
 
 func (s *service) syncUser(uInfo externalUserInfo) (*v1.User, error) {
+	login := uInfo.GetLogin()
+	if len(login) == 0 {
+		return nil, errors.New("the user login cannot be empty")
+	}
 	entity, isNew, err := s.getOrPrepareUserEntity(uInfo.GetLogin())
 	if err != nil {
 		return nil, err

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -39,12 +39,18 @@ const (
 	externalAuthKindOIDC  externalAuthKind = utils.AuthKindOIDC
 )
 
+const (
+	nativeProvider = "native"
+)
+
 type option struct {
 	persesCMD.Option
 	writer               io.Writer
 	url                  string
 	username             string
 	password             string
+	clientID             string
+	clientSecret         string
 	externalAuthKind     externalAuthKind
 	externalAuthProvider string
 	accessToken          string
@@ -117,6 +123,7 @@ func (o *option) SetWriter(writer io.Writer) {
 }
 
 func (o *option) authAndSetToken() error {
+	// If the user has provided username and password, we use the native provider
 	if len(o.username) > 0 && len(o.password) > 0 {
 		token, err := o.apiClient.Auth().Login(o.username, o.password)
 		if err != nil {
@@ -127,7 +134,18 @@ func (o *option) authAndSetToken() error {
 		return nil
 	}
 
-	// Start the device code flow
+	// If the user has provided clientID and clientSecret, we use the robotic access
+	if len(o.clientID) > 0 && len(o.clientSecret) > 0 {
+		token, err := o.apiClient.Auth().ClientCredentialsToken(string(o.externalAuthKind), o.externalAuthProvider, o.clientID, o.clientSecret)
+		if err != nil {
+			return err
+		}
+		o.accessToken = token.AccessToken
+		o.refreshToken = token.RefreshToken
+		return nil
+	}
+
+	// Otherwise, we start the device code flow
 	deviceCodeResponse, err := o.apiClient.Auth().DeviceCode(string(o.externalAuthKind), o.externalAuthProvider)
 	if err != nil {
 		return err
@@ -192,26 +210,60 @@ func (o *option) readAndSetLoginInputNative() error {
 	return nil
 }
 
-func (o *option) readAndSetLoginInputExternal(providers backendConfig.AuthProviders, slugID string) error {
+func (o *option) readAndSetClientCredentials() error {
+	if len(o.clientID) == 0 {
+		input := huh.NewInput().Title("Client ID").Value(&o.clientID)
+		if err := input.Run(); err != nil {
+			return err
+		}
+		if err := output.HandleString(o.writer, input.View()); err != nil {
+			return err
+		}
+	}
+	if len(o.clientSecret) == 0 {
+		input := huh.NewInput().Title("Client Secret").EchoMode(huh.EchoModeNone).Value(&o.clientSecret)
+		if err := input.Run(); err != nil {
+			return err
+		}
+		if err := output.HandleString(o.writer, input.View()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// trySetLoginInputExternal will try to set the external auth provider based on the slugID.
+// If the slugID does not exist, it will return an error.
+func (o *option) trySetLoginInputExternal(providers backendConfig.AuthProviders, slugID string) error {
 	for _, prov := range providers.OIDC {
 		if prov.SlugID == slugID {
-			return o.setLoginInputExternal(externalAuthKindOIDC, slugID)()
+			return o.setLoginInputExternal(externalAuthKindOIDC, slugID)
 		}
 	}
 	for _, prov := range providers.OAuth {
 		if prov.SlugID == slugID {
-			return o.setLoginInputExternal(externalAuthKindOAuth, slugID)()
+			return o.setLoginInputExternal(externalAuthKindOAuth, slugID)
 		}
 	}
 	return fmt.Errorf("provider %q does not exist", slugID)
 }
 
-func (o *option) setLoginInputExternal(kind externalAuthKind, slugID string) func() error {
+func (o *option) newLoginInputExternalModifier(kind externalAuthKind, slugID string) func() error {
 	return func() error {
-		o.externalAuthKind = kind
-		o.externalAuthProvider = slugID
-		return nil
+		return o.setLoginInputExternal(kind, slugID)
 	}
+}
+
+func (o *option) setLoginInputExternal(kind externalAuthKind, slugID string) error {
+	o.externalAuthKind = kind
+	o.externalAuthProvider = slugID
+
+	// In case the user is trying to set client id / secret, we do set
+	if len(o.clientID) > 0 || len(o.clientSecret) > 0 {
+		return o.readAndSetClientCredentials()
+	}
+	return nil
+
 }
 
 func (o *option) promptProvider(options []huh.Option[string]) (string, error) {
@@ -235,16 +287,25 @@ func (o *option) readAndSetLoginInput(providers backendConfig.AuthProviders) err
 		return errors.New("username/password input is forbidden as backend does not support native auth provider")
 	}
 
-	// In case the user is trying to set user / password, we don´t make selection
+	// In case the user is trying to set user / password, we don´t make selection. We know it's native provider.
 	if len(o.username) > 0 || len(o.password) > 0 {
 		return o.readAndSetLoginInputNative()
 	}
 
-	// In case the user set the provider as argument, we don´t make selection, but validate its input
-	if len(o.externalAuthProvider) > 0 {
-		return o.readAndSetLoginInputExternal(providers, o.externalAuthProvider)
+	// Otherwise it's considered that it wants to use an external provider
+	if err := o.readAndSetExternalProvider(providers); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+// readAndSetExternalProvider will prompt the user to select the external provider to use.
+func (o *option) readAndSetExternalProvider(providers backendConfig.AuthProviders) error {
+	if len(o.externalAuthProvider) > 0 {
+		// The user gave an external auth provider, we try to set it.
+		return o.trySetLoginInputExternal(providers, o.externalAuthProvider)
+	}
 	// The first step is to collect the different providers and store it into items + modifiers.
 	// items will be the selection items to display to users.
 	// modifiers will be the action to save the different user input into option struct.
@@ -252,10 +313,10 @@ func (o *option) readAndSetLoginInput(providers backendConfig.AuthProviders) err
 
 	var options []huh.Option[string]
 
-	// Saving Native item if supported
+	// We still give the possibility to the user to choose the native provider if it's supported by the backend
 	if providers.EnableNative {
 		optKey := "Native (username/password)"
-		optValue := "native"
+		optValue := nativeProvider
 		options = append(options, huh.NewOption(optKey, optValue))
 		modifiers[optValue] = o.readAndSetLoginInputNative
 
@@ -265,20 +326,20 @@ func (o *option) readAndSetLoginInput(providers backendConfig.AuthProviders) err
 		}
 	}
 
-	// Saving OIDC item(s) if supported
+	// Saving OIDC item(s)
 	for _, prov := range providers.OIDC {
 		optKey := fmt.Sprintf("OIDC (%s)", prov.Name)
 		optValue := prov.SlugID
 		options = append(options, huh.NewOption(optKey, optValue))
-		modifiers[optValue] = o.setLoginInputExternal(externalAuthKindOIDC, prov.SlugID)
+		modifiers[optValue] = o.newLoginInputExternalModifier(externalAuthKindOIDC, prov.SlugID)
 	}
 
-	// Saving OAuth 2.0 item(s) if supported
+	// Saving OAuth 2.0 item(s)
 	for _, prov := range providers.OAuth {
 		optKey := fmt.Sprintf("OAuth 2.0 (%s)", prov.Name)
 		optValue := prov.SlugID
 		options = append(options, huh.NewOption(optKey, optValue))
-		modifiers[optValue] = o.setLoginInputExternal(externalAuthKindOAuth, prov.SlugID)
+		modifiers[optValue] = o.newLoginInputExternalModifier(externalAuthKindOAuth, prov.SlugID)
 	}
 
 	// In case there is only one item available, prompt selection is not necessary
@@ -311,6 +372,8 @@ percli login https://perses.dev
 	cmd.Flags().BoolVar(&o.insecureTLS, "insecure-skip-tls-verify", o.insecureTLS, "If true the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
 	cmd.Flags().StringVarP(&o.username, "username", "u", "", "Username used for the authentication.")
 	cmd.Flags().StringVarP(&o.password, "password", "p", "", "Password used for the authentication.")
+	cmd.Flags().StringVar(&o.clientID, "client-id", "", "Client ID used for robotic access when using external authentication provider.")
+	cmd.Flags().StringVar(&o.clientSecret, "client-secret", "", "Client Secret used for robotic access when using external authentication provider.")
 	cmd.Flags().StringVar(&o.accessToken, "token", "", "Bearer token for authentication to the API server")
 	cmd.Flags().StringVar(&o.externalAuthProvider, "provider", "", "External authentication provider identifier. (slug_id)")
 	return cmd

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -28,9 +28,10 @@ const (
 	DefaultRefreshTokenTTL = time.Hour * 24
 )
 
-type DeviceCode struct {
+type OAuthOverride struct {
 	ClientID     secret.Hidden `json:"client_id" yaml:"client_id"`
 	ClientSecret secret.Hidden `json:"client_secret" yaml:"client_secret"`
+	Scopes       []string      `json:"scopes" yaml:"scopes"`
 }
 
 // appendIfMissing will append the value in the slice, only if not already present.
@@ -45,14 +46,15 @@ func appendIfMissing[T comparable](slice []T, value T) ([]T, bool) {
 }
 
 type Provider struct {
-	SlugID       string        `json:"slug_id" yaml:"slug_id"`
-	Name         string        `json:"name" yaml:"name"`
-	ClientID     secret.Hidden `json:"client_id" yaml:"client_id"`
-	ClientSecret secret.Hidden `json:"client_secret" yaml:"client_secret"`
-	DeviceCode   DeviceCode    `json:"device_code,omitempty" yaml:"device_code,omitempty"`
-	RedirectURI  common.URL    `json:"redirect_uri" yaml:"redirect_uri"`
-	Scopes       []string      `json:"scopes" yaml:"scopes"`
-	DisablePKCE  bool          `json:"disable_pkce" yaml:"disable_pkce"`
+	SlugID            string         `json:"slug_id" yaml:"slug_id"`
+	Name              string         `json:"name" yaml:"name"`
+	ClientID          secret.Hidden  `json:"client_id" yaml:"client_id"`
+	ClientSecret      secret.Hidden  `json:"client_secret" yaml:"client_secret"`
+	DeviceCode        *OAuthOverride `json:"device_code,omitempty" yaml:"device_code,omitempty"`
+	ClientCredentials *OAuthOverride `json:"client_credentials,omitempty" yaml:"client_credentials,omitempty"`
+	RedirectURI       common.URL     `json:"redirect_uri" yaml:"redirect_uri"`
+	Scopes            []string       `json:"scopes" yaml:"scopes"`
+	DisablePKCE       bool           `json:"disable_pkce" yaml:"disable_pkce"`
 }
 
 func (p *Provider) Verify() error {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Implement the client credentials flow. It will allow to authenticate in Perses through CLI or API using a robotic access like it would be needed in scripted pipeline for example. 

A specification documentation with a sequence diagram is coming, but the logic is the same as the auth code/device code flow, we send a query to /providers/{oidc|oauth}/{slug_id}/token, it asks a token to the provider and generate a Perses access token from it. 

It performs also a user synchronization to save a user using a ``metadata.name`` as good as we can. The decision of what to take as ``metadata.name`` is not easy but the ``GetLogin`` of both oauth and oidc are well encapsulated and quite explicit. We can improve but for now it is good enough in my opinion.

![image](https://github.com/perses/perses/assets/10258608/51ea14bb-03c8-4d54-8ca5-f2b2d61eaf15)


<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
