### PR TITLE
[IGNORE] change provisionning failure log from error to warning

### DIFF
--- a/internal/api/provisioning/provisioning.go
+++ b/internal/api/provisioning/provisioning.go
@@ -75,7 +75,7 @@ func (p *provisioning) applyEntity(entities []modelAPI.Entity) {
 		project := resource.GetProject(entity.GetMetadata(), "")
 		svc, svcErr := p.getService(kind)
 		if svcErr != nil {
-			logrus.WithError(svcErr).Errorf("unable to retrieve the service associated to %q", kind)
+			logrus.WithError(svcErr).Warningf("unable to retrieve the service associated to %q", kind)
 			continue
 		}
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This is mainly to stop considering `unable to retrieve the service associated to \"EphemeralDashboard\"" error="resource \"EphemeralDashboard\" not supported by the provisioning service` as an error, as it's an acknowledged decision to not support ephemeral dasboards via provisioning.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
