### PR TITLE
[ENHANCEMENT] Tab disabled if user do not have read permission

### DIFF
--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -23,28 +23,28 @@ import { AuthorizationProvider } from './context/Authorization';
 function App() {
   const location = useLocation();
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '100vh',
-        backgroundColor: ({ palette }) => palette.background.default,
-      }}
-    >
-      {location.pathname !== SignInRoute && location.pathname !== SignUpRoute && <Header />}
-
+    <AuthorizationProvider>
       <Box
         sx={{
-          flex: 1,
           display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100vh',
+          backgroundColor: ({ palette }) => palette.background.default,
         }}
       >
-        <AuthorizationProvider>
+        {location.pathname !== SignInRoute && location.pathname !== SignUpRoute && <Header />}
+
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+          }}
+        >
           <Router />
-        </AuthorizationProvider>
+        </Box>
+        <Footer />
       </Box>
-      <Footer />
-    </Box>
+    </AuthorizationProvider>
   );
 }
 

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -27,7 +27,7 @@ import {
   SignUpRoute,
   ExploreRoute,
 } from './model/route';
-import { useIsAuthEnable, useIsSignUpDisable } from './context/Config';
+import { useIsAuthEnabled, useIsSignUpDisable } from './context/Config';
 
 // Other routes are lazy-loaded for code-splitting
 const ImportView = lazy(() => import('./views/import/ImportView'));
@@ -42,15 +42,15 @@ const CreateEphemeralDashboardView = lazy(() => import('./views/projects/dashboa
 const EphemeralDashboardView = lazy(() => import('./views/projects/dashboards/EphemeralDashboardView'));
 
 function Router() {
-  const isAuthEnable = useIsAuthEnable();
+  const isAuthEnabled = useIsAuthEnabled();
   const isSignUpDisable = useIsSignUpDisable();
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
       {/* TODO: What sort of loading fallback do we want? */}
       <Suspense>
         <Routes>
-          {isAuthEnable && <Route path={SignInRoute} element={<SignInView />} />}
-          {isAuthEnable && !isSignUpDisable && <Route path={SignUpRoute} element={<SignUpView />} />}
+          {isAuthEnabled && <Route path={SignInRoute} element={<SignInView />} />}
+          {isAuthEnabled && !isSignUpDisable && <Route path={SignUpRoute} element={<SignUpView />} />}
           <Route path={AdminRoute} element={<AdminView />} />
           <Route path={`${AdminRoute}/:tab`} element={<AdminView />} />
           <Route path={ConfigRoute} element={<ConfigView />} />

--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -48,7 +48,7 @@ export function useIsReadonly() {
   return config.security.readonly;
 }
 
-export function useIsAuthEnable() {
+export function useIsAuthEnabled() {
   const { config } = useConfigContext();
   return config.security.enable_auth;
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Disabling tabs if user do not have enough permission. Hiding is a little more tricky: what do we do if all tab are hidden. 
Bonus: admin menu hidden if user don't have read permission on at least one admin resource.
Related to  #1844 

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/perses/perses/assets/5657041/382fcaa3-6685-4085-8cc7-cca335ed469b)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
