### PR TITLE
[ENHANCEMENT] Allow empty value for non-constant TextVariables (= textbox use case)

### DIFF
--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -513,11 +513,13 @@ func TestUnmarshalVariableError(t *testing.T) {
 {
   "kind": "TextVariable",
   "spec": {
-    "name": "hogwarts"
+    "name": "hogwarts",
+    "value": "",
+    "constant": true
   }
 }
 `,
-			err: fmt.Errorf(`value for the text variable cannot be empty`),
+			err: fmt.Errorf(`value for a constant text variable cannot be empty`),
 		},
 		{
 			title: "ListVariable with no name",

--- a/pkg/model/api/v1/variable/text.go
+++ b/pkg/model/api/v1/variable/text.go
@@ -24,8 +24,8 @@ type TextSpec struct {
 }
 
 func (v *TextSpec) Validate() error {
-	if len(v.Value) == 0 {
-		return fmt.Errorf("value for the text variable cannot be empty")
+	if len(v.Value) == 0 && v.Constant {
+		return fmt.Errorf("value for a constant text variable cannot be empty")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Allow empty value for non-constant TextVariables. This is especially useful for the Grafana migrate use case, for which the non-empty value constraint is currently preventing to migrate dashboards that define Textbox variables without default value. 
The constraint is kept for constants, as empty constants don't really make sense.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).