### PR TITLE
[ENHANCEMENT] Grafana migrate: avoid error when variable defines a "ghost" All value

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -110,7 +110,7 @@ spec: {
                 }
                 allowAllValue: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
                 allowMultiple: *grafanaVar.multi | false      // the default value tackles the case of variables of type `interval` that don't have such field
-                if grafanaVar.allValue != _|_ {
+                if allowAllValue if grafanaVar.allValue != _|_ {
                     customAllValue: grafanaVar.allValue
                 }
                 if grafanaVar.regex != _|_ {


### PR DESCRIPTION
# Description

A Grafana variable can have a custom All value defined even if the "include All" option is not ticked. On our side we have backend validation that forbids this, thus this PR patches the migration logic to avoid migrating the custom All value if "include All" is not ticked.

# Screenshots

This avoids the migration to fail with this error: 
![image](https://github.com/perses/perses/assets/7058693/17e2c35e-000b-4a6b-ae76-70387714a066)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).