### PR TITLE
[BUGFIX] Grafana migrate: fix issue with inputs containing double quotes

### DIFF
--- a/internal/api/migrate/migrate.go
+++ b/internal/api/migrate/migrate.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -68,8 +69,13 @@ const (
 func ReplaceInputValue(input map[string]string, grafanaDashboard string) string {
 	result := grafanaDashboard
 	for key, value := range input {
-		result = strings.Replace(result, fmt.Sprintf("$%s", key), value, -1)
-		result = strings.Replace(result, fmt.Sprintf("${%s}", key), value, -1)
+		// Escape special characters that may be present in the value
+		escapedValue := strconv.Quote(value)
+		// Remove the extra surrounding quotes added by strconv.Quote
+		escapedValue = escapedValue[1 : len(escapedValue)-1]
+		// Do the replacement (2 syntaxes to support)
+		result = strings.ReplaceAll(result, fmt.Sprintf("$%s", key), escapedValue)
+		result = strings.ReplaceAll(result, fmt.Sprintf("${%s}", key), escapedValue)
 	}
 	return result
 }

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -63,14 +63,6 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps) {
     setGrafanaInput(grafanaInput);
   };
 
-  // Users can provide input values that contain double quotes, we need to escape them before sending them to the backend
-  const escapeDoubleQuotesInInput = () => {
-    for (const [key, value] of Object.entries(grafanaInput)) {
-      grafanaInput[key] = value.replace(/"/g, '\\"');
-    }
-    setGrafanaInput(grafanaInput);
-  };
-
   const importOnClick = () => {
     const dashboard = migrateMutation.data;
     if (dashboard === undefined) {
@@ -109,7 +101,6 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps) {
         disabled={migrateMutation.isLoading}
         startIcon={<AutoFix />}
         onClick={() => {
-          escapeDoubleQuotesInInput();
           migrateMutation.mutate({ input: grafanaInput, grafanaDashboard: dashboard ?? {} });
         }}
       >


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

- [BUGFIX] Grafana migrate: fix issue with inputs containing double quotes
- [ENHANCEMENT] Grafana migrate: set current input value as default suggestion

# Screenshots

For the enhancement part:

Before, current values of constants were lost in the process:
![image](https://github.com/perses/perses/assets/7058693/e48b0c87-2574-4c24-8b34-cf45422c8f9b)

Now, current values are provided as default values. You can always change them.
![image](https://github.com/perses/perses/assets/7058693/29296832-4ff6-4b32-9235-93bd1d31874c)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
