### PR TITLE
BUGFIX: Fix setting projects when importing Perses dashboards

### DIFF
--- a/ui/app/src/views/import/PersesFlow.tsx
+++ b/ui/app/src/views/import/PersesFlow.tsx
@@ -37,6 +37,7 @@ function PersesFlow({ dashboard }: PersesFlowProps) {
   });
 
   const importOnClick = () => {
+    dashboard.metadata.project = projectName;
     dashboardMutation.mutate(dashboard);
   };
 


### PR DESCRIPTION
# Description

When importing dashboards we fail to set the project correctly. This causes dashboards to be imported into the project set in the JSON, rather than the project the user has selected.

This fixes this by setting the project in the `PersesFlow` component when the user selects a project.

Solves #1833

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
