### PR TITLE
[REFACTOR] Free TimeRangeControls from dashboard dep

### DIFF
--- a/ui/app/src/views/projects/explore/ExploreView.tsx
+++ b/ui/app/src/views/projects/explore/ExploreView.tsx
@@ -11,37 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DashboardResource, DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL } from '@perses-dev/core';
 import Compass from 'mdi-material-ui/Compass';
-import { generateMetadataName } from '../../../utils/metadata';
 import AppBreadcrumbs from '../../../components/breadcrumbs/AppBreadcrumbs';
 import ProjectExploreView from './ProjectExploreView';
 
-const DEFAULT_DASHBOARD_NAME = 'Explore Page';
-
 function ExploreView() {
-  const dashboardResource: DashboardResource = {
-    kind: 'Dashboard',
-    metadata: {
-      name: generateMetadataName(DEFAULT_DASHBOARD_NAME),
-      project: '',
-      version: 0,
-    },
-    spec: {
-      display: {
-        name: DEFAULT_DASHBOARD_NAME,
-      },
-      duration: DEFAULT_DASHBOARD_DURATION,
-      refreshInterval: DEFAULT_REFRESH_INTERVAL,
-      variables: [],
-      layouts: [],
-      panels: {},
-    },
-  };
-
   return (
     <ProjectExploreView
-      dashboardResource={dashboardResource}
       exploreTitleComponent={<AppBreadcrumbs rootPageName="Explore" icon={<Compass fontSize={'large'} />} />}
     />
   );

--- a/ui/app/src/views/projects/explore/ProjectExploreView.tsx
+++ b/ui/app/src/views/projects/explore/ProjectExploreView.tsx
@@ -13,9 +13,8 @@
 
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { PluginRegistry, ProjectStoreProvider, useProjectStore } from '@perses-dev/plugin-system';
-import { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ExternalVariableDefinition } from '@perses-dev/dashboards';
-import { DashboardResource } from '@perses-dev/core';
 import { ViewExplore } from '@perses-dev/explore';
 import { CircularProgress, Stack } from '@mui/material';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasource-api';
@@ -25,8 +24,7 @@ import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '.
 import { bundledPluginLoader } from '../../../model/bundled-plugins';
 
 export interface ProjectExploreViewProps {
-  dashboardResource: DashboardResource;
-  exploreTitleComponent?: JSX.Element;
+  exploreTitleComponent?: React.ReactNode;
 }
 
 function ProjectExploreView(props: ProjectExploreViewProps) {
@@ -38,15 +36,11 @@ function ProjectExploreView(props: ProjectExploreViewProps) {
 }
 
 function HelperExploreView(props: ProjectExploreViewProps) {
-  const { dashboardResource, exploreTitleComponent } = props;
+  const { exploreTitleComponent } = props;
   const { project } = useProjectStore();
   const projectName = project?.metadata.name == 'none' ? '' : project?.metadata.name;
 
   const [datasourceApi] = useState(() => new CachedDatasourceAPI(new HTTPDatasourceAPI()));
-
-  const dashResource = useMemo(() => {
-    return { ...dashboardResource, metadata: { ...dashboardResource.metadata, project: projectName } };
-  }, [projectName, dashboardResource]);
 
   useEffect(() => {
     // warm up the caching of the datasources
@@ -81,7 +75,6 @@ function HelperExploreView(props: ProjectExploreViewProps) {
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <ViewExplore
             datasourceApi={datasourceApi}
-            dashboardResource={dashResource}
             externalVariableDefinitions={externalVariableDefinitions}
             exploreTitleComponent={exploreTitleComponent}
           />

--- a/ui/dashboards/src/constants/user-interface-text.ts
+++ b/ui/dashboards/src/constants/user-interface-text.ts
@@ -19,8 +19,6 @@ export const TOOLTIP_TEXT = {
   editDatasources: 'Edit datasources',
   editJson: 'Edit JSON',
   editVariables: 'Edit variables',
-  refreshDashboard: 'Refresh dashboard',
-  refreshDashboardInterval: 'Auto refresh interval',
   viewJson: 'View JSON',
   // Group buttons
   addPanelToGroup: 'Add panel to group',

--- a/ui/e2e/src/tests/saveDefaults.spec.ts
+++ b/ui/e2e/src/tests/saveDefaults.spec.ts
@@ -60,7 +60,7 @@ test.describe('Dashboard: Defaults', () => {
     await page.evaluate(() => {
       window.location.search = '';
     });
-    await page.getByRole('button', { name: 'Refresh dashboard' }).click();
+    await page.getByRole('button', { name: 'Refresh', exact: true }).click();
     await expect(page.url()).toContain('start=6h');
     await expect(dashboardPage.timePicker).toContainText('Last 6 hours');
     await expect(dashboardPage.getTemplateVariable('interval')).toHaveValue('5m');

--- a/ui/explore/src/views/ViewExplore/ViewExplore.tsx
+++ b/ui/explore/src/views/ViewExplore/ViewExplore.tsx
@@ -17,58 +17,55 @@ import {
   useInitialRefreshInterval,
   useInitialTimeRange,
 } from '@perses-dev/plugin-system';
-import { DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL, DashboardResource } from '@perses-dev/core';
+import { DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL } from '@perses-dev/core';
 import { ErrorAlert, ErrorBoundary, combineSx } from '@perses-dev/components';
 import {
   DatasourceStoreProviderProps,
   TemplateVariableProviderProps,
   DatasourceStoreProvider,
-  DashboardProvider,
   TemplateVariableProvider,
 } from '@perses-dev/dashboards';
+import React from 'react';
 import { ViewExploreApp } from './ViewExploreApp';
 
 export interface ViewExploreProps extends Omit<BoxProps, 'children'> {
-  dashboardResource: DashboardResource;
   datasourceApi: DatasourceStoreProviderProps['datasourceApi'];
   externalVariableDefinitions?: TemplateVariableProviderProps['externalVariableDefinitions'];
-  exploreTitleComponent?: JSX.Element;
+  exploreTitleComponent?: React.ReactNode;
 }
 
 export function ViewExplore(props: ViewExploreProps) {
-  const { dashboardResource, datasourceApi, externalVariableDefinitions, sx, exploreTitleComponent, ...others } = props;
+  const { datasourceApi, externalVariableDefinitions, sx, exploreTitleComponent, ...others } = props;
 
   const initialTimeRange = useInitialTimeRange(DEFAULT_DASHBOARD_DURATION);
   const initialRefreshInterval = useInitialRefreshInterval(DEFAULT_REFRESH_INTERVAL);
 
   return (
-    <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>
-      <DashboardProvider initialState={{ dashboardResource, isEditMode: true }}>
-        <TimeRangeProviderWithQueryParams
-          initialTimeRange={initialTimeRange}
-          initialRefreshInterval={initialRefreshInterval}
-        >
-          <TemplateVariableProvider externalVariableDefinitions={externalVariableDefinitions}>
-            <Box
-              sx={combineSx(
-                {
-                  display: 'flex',
-                  width: '100%',
-                  height: '100%',
-                  position: 'relative',
-                  overflow: 'hidden',
-                },
-                sx
-              )}
-              {...others}
-            >
-              <ErrorBoundary FallbackComponent={ErrorAlert}>
-                <ViewExploreApp exploreTitleComponent={exploreTitleComponent} />
-              </ErrorBoundary>
-            </Box>
-          </TemplateVariableProvider>
-        </TimeRangeProviderWithQueryParams>
-      </DashboardProvider>
+    <DatasourceStoreProvider datasourceApi={datasourceApi}>
+      <TimeRangeProviderWithQueryParams
+        initialTimeRange={initialTimeRange}
+        initialRefreshInterval={initialRefreshInterval}
+      >
+        <TemplateVariableProvider externalVariableDefinitions={externalVariableDefinitions}>
+          <Box
+            sx={combineSx(
+              {
+                display: 'flex',
+                width: '100%',
+                height: '100%',
+                position: 'relative',
+                overflow: 'hidden',
+              },
+              sx
+            )}
+            {...others}
+          >
+            <ErrorBoundary FallbackComponent={ErrorAlert}>
+              <ViewExploreApp exploreTitleComponent={exploreTitleComponent} />
+            </ErrorBoundary>
+          </Box>
+        </TemplateVariableProvider>
+      </TimeRangeProviderWithQueryParams>
     </DatasourceStoreProvider>
   );
 }

--- a/ui/explore/src/views/ViewExplore/ViewExploreApp.tsx
+++ b/ui/explore/src/views/ViewExplore/ViewExploreApp.tsx
@@ -14,10 +14,11 @@
 import { Box } from '@mui/material';
 import { ChartsProvider, useChartsTheme } from '@perses-dev/components';
 import { PanelEditorValues } from '@perses-dev/dashboards';
+import React from 'react';
 import { PanelEditorForm } from '../../components/PanelEditor/PanelEditorForm';
 
 export interface ViewAppProps {
-  exploreTitleComponent?: JSX.Element;
+  exploreTitleComponent?: React.ReactNode;
 }
 
 export function ViewExploreApp(props: ViewAppProps) {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This PR aims to eliminate the dependency of ``TimeRangeControl`` on dashboard package.
It remains in dashboard package to make the move inanother PR.

The only dependency remaining is the ToolbarIconButton, but this component is isolated as well, so it can be also moved.
Now the next question will be: **where do we put them?** Knowing that ``TimeRangeControls`` have now dep on ``components``, ``core``, and ``plugin-system``. :question: :question: :question: 

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
