### PR TITLE
[BUGFIX] Don't reset token data when expired

### DIFF
--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -82,7 +82,7 @@ function ThemeSwitch(props: { isAuthEnabled: boolean }) {
 }
 
 function AccountMenu() {
-  const token = useAuthToken();
+  const { data: decodedToken } = useAuthToken();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleMenu = (event: MouseEvent<HTMLElement>) => {
@@ -117,7 +117,7 @@ function AccountMenu() {
           <ListItemIcon>
             <AccountCircle />
           </ListItemIcon>
-          {token.decodedToken?.sub}
+          {decodedToken?.sub}
         </MenuItem>
         <Divider />
         <ThemeSwitch isAuthEnabled />

--- a/ui/app/src/context/Authorization.tsx
+++ b/ui/app/src/context/Authorization.tsx
@@ -32,7 +32,7 @@ const AuthorizationContext = createContext<AuthorizationContext | undefined>(und
 // Provide RBAC helpers for checking current user permissions
 export function AuthorizationProvider(props: { children: ReactNode }) {
   const enabled = useIsAuthEnabled();
-  const { decodedToken } = useAuthToken();
+  const { data: decodedToken } = useAuthToken();
   const username = decodedToken?.sub || '';
   const { data } = useUserPermissions(username);
   const userPermissions = useMemo(() => {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Authorization Provider data is reset when token expire, this PR keep the data even if the TTL is passed.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
