### PR TITLE
[ENHANCEMENT] Reduce panel group header height

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridTitle.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridTitle.tsx
@@ -55,7 +55,6 @@ export function GridTitle(props: GridTitleProps) {
         display: 'flex',
         justifyContent: 'start',
         alignItems: 'center',
-        padding: (theme) => theme.spacing(1),
         cursor: collapse ? 'pointer' : 'auto',
         backgroundColor: ({ palette }) => palette.background.paper,
       }}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
In the optic to keep more place for useful data (panels), I propose to reduce panel group header height. Thanks for the idea @lalooose 😄 

# Screenshots

<!-- If there are UI changes -->

Before:
![image](https://github.com/perses/perses/assets/5657041/c788ab6c-4a9a-4da1-80aa-32e6ad271e2d)

After:
![image](https://github.com/perses/perses/assets/5657041/8da20c71-9cbf-4a7a-9038-e6d3854feb69)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
