### PR TITLE
[bugfix] remove check on the number of panels in dashboard spec

### DIFF
--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -128,9 +128,6 @@ func (d *DashboardSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (d *DashboardSpec) validate() error {
-	if len(d.Panels) == 0 {
-		return nil
-	}
 	variables := make(map[string]bool, len(d.Variables))
 	for i, variable := range d.Variables {
 		name := variable.Spec.GetName()


### PR DESCRIPTION
in #1536 we removed the error saying a dashboard cannot contain any panel but we kept the check on how many panels we have.

So currently if there is no panel, but we are defining variable, the variables are not verified.