### PR TITLE
[IGNORE] DaC CUE SDK documentation: bring back link to Cuetorials

### DIFF
--- a/docs/user-guides/dashboard-as-code.md
+++ b/docs/user-guides/dashboard-as-code.md
@@ -59,7 +59,9 @@ You can omit the version flag if you are connected to a Perses server (it will r
 
 You are now fully ready to start developping dashboards as code!
 
-It's first strongly recommended to ramp up on CUE if you are not familiar with this technology. Please take a look at their [official website](https://cuelang.org/)
+It's first strongly recommended to ramp up on CUE if you are not familiar with this technology. For this have a look at:
+- The [official website](https://cuelang.org/) of Cuelang.
+- [Cuetorials](https://cuetorials.com/), a 3rd party source of information that is a very good complement.
 
 You should then have a look at the [CUE SDK documentation](../dac/cue/) to better understand how to use the framework.
 


### PR DESCRIPTION
# Description

Website is back online https://cuetorials.com.
Partial revert of https://github.com/perses/perses/pull/1862.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
