### PR TITLE
[ENHANCE] Plugin Editor / Queries support multiple type of queries

### DIFF
--- a/ui/panels-plugin/src/plugins/bar-chart/BarChart.ts
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChart.ts
@@ -27,5 +27,6 @@ export const BarChart: PanelPlugin<BarChartOptions> = {
       content: BarChartOptionsEditorSettings,
     },
   ],
+  supportedQueryInterfaces: ['TimeSeriesQuery', 'TraceQuery'],
   createInitialOptions: createInitialBarChartOptions,
 };

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChart.ts
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChart.ts
@@ -22,5 +22,6 @@ export const ScatterChart: PanelPlugin<ScatterChartOptions> = {
   PanelComponent: ScatterChartPanel,
   // TODO: add a chart options editor plugin, for example:
   // panelOptionsEditorComponents: [{ label: 'Settings', content: ScatterChartOptionsEditorSettings }],
+  supportedQueryInterfaces: ['TraceQuery'],
   createInitialOptions: createInitialScatterChartOptions,
 };

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChart.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChart.ts
@@ -22,5 +22,6 @@ import { TimeSeriesChartPanel } from './TimeSeriesChartPanel';
 export const TimeSeriesChart: PanelPlugin<TimeSeriesChartOptions> = {
   PanelComponent: TimeSeriesChartPanel,
   panelOptionsEditorComponents: [{ label: 'Settings', content: TimeSeriesChartOptionsEditorSettings }],
+  supportedQueryInterfaces: ['TimeSeriesQuery'],
   createInitialOptions: createInitialTimeSeriesChartOptions,
 };

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -263,7 +263,7 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
           width="100%"
           pluginType="Datasource"
           pluginKindLabel="Source"
-          value={state.spec.plugin}
+          value={{ ...state.spec.plugin }}
           isReadonly={action === 'read'}
           onChange={(v) => {
             setState((draft) => {

--- a/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
@@ -44,31 +44,21 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
     throw new Error(`Missing implementation for panel plugin with kind '${kind}'`);
   }
 
-  const getQueryType = (): string => {
+  const getQueryTypes = (): string[] => {
+    if (plugin.supportedQueryInterfaces && plugin.supportedQueryInterfaces.length > 0) {
+      return plugin.supportedQueryInterfaces;
+    }
     const queriesList = panelDefinition?.spec?.queries;
     if (queriesList === undefined) {
-      return '';
+      return [''];
     }
     const queryType: string = queriesList[0]?.kind;
-    return queryType;
+    return [queryType];
   };
 
   // Get the corresponding queryEditor depending on the queryType
   const getQueryEditorComponent = () => {
-    const queryType = getQueryType();
-    // default case handles cause where there is no queryType yet (e.g. UI > 'editing' mode > 'Add Panel')
-    switch (queryType) {
-      case 'TimeSeriesQuery':
-        return <TimeSeriesQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
-      case 'TraceQuery':
-        return <TraceQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
-      default:
-        // ScatterChart only handles trace queries for now
-        if (kind === 'ScatterChart') {
-          return <TraceQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
-        }
-        return <TimeSeriesQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
-    }
+    return <TimeSeriesQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
   };
 
   const { panelOptionsEditorComponents, hideQueryEditor } = plugin as PanelPlugin;

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -44,7 +44,7 @@ export function PluginEditor(props: PluginEditorProps) {
         onChange={onKindChange}
       />
       <PluginSpecEditor
-        pluginType={pluginType}
+        pluginType={value.pluginType!}
         pluginKind={value.kind}
         value={value.spec}
         onChange={onSpecChange}

--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
@@ -17,7 +17,7 @@ import { PluginType } from '../../model';
 import { useListPluginMetadata } from '../../runtime';
 
 export interface PluginKindSelectProps extends Omit<TextFieldProps, 'children'> {
-  pluginType: PluginType;
+  pluginType: PluginType | PluginType[];
 }
 
 /**

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -89,9 +89,16 @@ export function PluginRegistry(props: PluginRegistryProps) {
   );
 
   const listPluginMetadata = useCallback(
-    async (pluginType: PluginType) => {
+    async (pluginType: PluginType | PluginType[]) => {
+      if (!Array.isArray(pluginType)) {
+        pluginType = [pluginType];
+      }
       const pluginIndexes = await getPluginIndexes();
-      return pluginIndexes.pluginMetadataByType.get(pluginType) ?? [];
+      const result = [];
+      for (const type of pluginType) {
+        result.push(...(pluginIndexes.pluginMetadataByType.get(type) ?? []));
+      }
+      return result;
     },
     [getPluginIndexes]
   );

--- a/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.tsx
@@ -24,6 +24,7 @@ export interface PluginSpecEditorProps extends OptionsEditorProps<UnknownSpec> {
 
 export function PluginSpecEditor(props: PluginSpecEditorProps) {
   const { pluginType, pluginKind, ...others } = props;
+  console.log(pluginType, pluginKind);
   const { data: plugin, isLoading, error } = usePlugin(pluginType, pluginKind);
 
   if (error) {

--- a/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
+++ b/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
@@ -28,7 +28,7 @@ export function TimeSeriesQueryEditor({ queries = [], onChange }: TimeSeriesQuer
   // Build the default query plugin
   // Use as default the plugin kind explicitly set as default or the first in the list
   const { defaultPluginKinds } = usePluginRegistry();
-  const { data: timeSeriesPlugins } = useListPluginMetadata(TIME_SERIES_QUERY_KEY);
+  const { data: timeSeriesPlugins } = useListPluginMetadata([TIME_SERIES_QUERY_KEY, 'TraceQuery']);
   const defaultTimeSeriesQueryKind = defaultPluginKinds?.[TIME_SERIES_QUERY_KEY] ?? timeSeriesPlugins?.[0]?.kind ?? '';
   const { data: defaultQueryPlugin } = usePlugin(TIME_SERIES_QUERY_KEY, defaultTimeSeriesQueryKind, {
     useErrorBoundary: true,

--- a/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryInput.tsx
+++ b/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryInput.tsx
@@ -89,9 +89,9 @@ function QueryEditor(props: QueryEditorProps) {
     <Box {...others}>
       {/* If TimeSeriesQuery plugins ever have common props on the definition, the inputs could go here */}
       <PluginEditor
-        pluginType="TimeSeriesQuery"
+        pluginType={['TimeSeriesQuery', 'TraceQuery']}
         pluginKindLabel="Query Type"
-        value={plugin}
+        value={{ ...plugin }}
         onChange={handlePluginChange}
       />
     </Box>

--- a/ui/plugin-system/src/components/TraceQueryEditor/TraceQueryInput.tsx
+++ b/ui/plugin-system/src/components/TraceQueryEditor/TraceQueryInput.tsx
@@ -87,7 +87,12 @@ function QueryEditor(props: QueryEditorProps) {
 
   return (
     <Box {...others}>
-      <PluginEditor pluginType="TraceQuery" pluginKindLabel="Query Type" value={plugin} onChange={handlePluginChange} />
+      <PluginEditor
+        pluginType="TraceQuery"
+        pluginKindLabel="Query Type"
+        value={{ ...plugin }}
+        onChange={handlePluginChange}
+      />
     </Box>
   );
 }

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -360,7 +360,7 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                       pluginType="Variable"
                       pluginKindLabel="Source"
                       isReadonly={action === 'read'}
-                      value={state.listVariableFields.plugin}
+                      value={{ ...state.listVariableFields.plugin }}
                       onChange={(val) => {
                         field.onChange(val);
                         setState((draft) => {

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -29,6 +29,13 @@ export interface PanelPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
    */
   panelOptionsEditorComponents?: Array<PanelOptionsEditorComponent<Spec>>;
   /**
+   * Explicitly specify which query interfaces the panel supports.
+   * Allows panel to support several query interfaces.
+   * If not provided, the panel will guess which interface to use based on the queries
+   * given in parameters.
+   */
+  supportedQueryInterfaces?: Array<'TimeSeriesQuery' | 'LogQuery' | 'TraceQuery'>;
+  /**
    * If true, query editor will be hidden for panel plugin
    * @default false
    */

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -18,7 +18,7 @@ import { DefaultPluginKinds, PluginImplementation, PluginMetadata, PluginType } 
 
 export interface PluginRegistryContextType {
   getPlugin<T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>>;
-  listPluginMetadata(pluginType: PluginType): Promise<PluginMetadata[]>;
+  listPluginMetadata(pluginTypes: PluginType | PluginType[]): Promise<PluginMetadata[]>;
   defaultPluginKinds?: DefaultPluginKinds;
 }
 
@@ -72,16 +72,16 @@ export function usePlugins<T extends PluginType>(pluginType: T, plugins: Array<{
 
 // Allow consumers to pass useQuery options from react-query when listing metadata
 type UseListPluginMetadataOptions = Omit<
-  UseQueryOptions<PluginMetadata[], Error, PluginMetadata[], [string, PluginType]>,
+  UseQueryOptions<PluginMetadata[], Error, PluginMetadata[], [string, PluginType | PluginType[]]>,
   'queryKey' | 'queryFn'
 >;
 
 /**
  * Gets a list of plugin metadata for the specified plugin type and returns it, along with loading/error state.
  */
-export function useListPluginMetadata(pluginType: PluginType, options?: UseListPluginMetadataOptions) {
+export function useListPluginMetadata(pluginTypes: PluginType | PluginType[], options?: UseListPluginMetadataOptions) {
   const { listPluginMetadata } = usePluginRegistry();
-  return useQuery(['listPluginMetadata', pluginType], () => listPluginMetadata(pluginType), options);
+  return useQuery(['listPluginMetadata', pluginTypes], () => listPluginMetadata(pluginTypes), options);
 }
 
 export function usePluginBuiltinVariableDefinitions() {

--- a/ui/tempo-plugin/src/plugins/tempo-trace-query/DashboardTempoTraceQueryEditor.tsx
+++ b/ui/tempo-plugin/src/plugins/tempo-trace-query/DashboardTempoTraceQueryEditor.tsx
@@ -45,7 +45,7 @@ export function DashboardTempoTraceQueryEditor(props: DashboardTempoTraceQueryEd
         />
       </FormControl>
       <TraceQLEditor
-        completeConfig={{ remote: { url: datasourceURL } }}
+        // completeConfig={{ remote: { url: datasourceURL } }}
         value={query}
         onChange={handleQueryChange}
         onBlur={handleQueryBlur}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

> [!CAUTION]
> Closed as splitted in 3 : #1887 #1898 #1899

After one day of experimentation, here is the kind of result I have to address the issue #1303 

The code is not mergeable as a lot of little shortcuts needs to be fixed before, but I ended up building a BarChart panel that can take Prometheus time series and Tempo Traces as input. 

To do so I think I applied the suggestions from you @eunicorn and @sjcobb. But also a big hack on the TimeSeriesQuery editor has been done, transforming it into a component that can manage TimeSeriesQuery and TraceQuery. 
I'm not sure I went into the right direction so I would like, before going further that one of you review it carefully please.

![image](https://github.com/perses/perses/assets/10258608/e61d30fb-b272-4f8f-bdf7-995c6ff17653)


<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
