### PR TITLE
[BREAKINGCHANGE] PluginEditor takes multiple plugin types as input

### DIFF
--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -53,10 +53,13 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
 
   // Use common plugin editor logic even though we've split the inputs up in this form
   const pluginEditor = usePluginEditor({
-    pluginType: 'Panel',
-    value: { kind: plugin.kind, spec: plugin.spec },
+    pluginTypes: ['Panel'],
+    value: { selection: { kind: plugin.kind, type: 'Panel' }, spec: plugin.spec },
     onChange: (plugin) => {
-      setPlugin(plugin);
+      setPlugin({
+        kind: plugin.selection.kind,
+        spec: plugin.spec,
+      });
     },
     onHideQueryEditorChange: (isHidden) => {
       setQueries(undefined, isHidden);
@@ -73,7 +76,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
       name: initialPanelDef.spec.display.name,
       groupId: initialGroupId,
       description: initialPanelDef.spec.display.description,
-      type: pluginEditor.pendingKind ? pluginEditor.pendingKind : plugin.kind,
+      selection: pluginEditor.pendingSelection ? pluginEditor.pendingSelection : { type: 'Panel', kind: plugin.kind },
     },
   });
 
@@ -197,11 +200,11 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
           </Grid>
           <Grid item xs={4}>
             <Controller
-              name="type"
+              name="selection"
               render={({ field, fieldState }) => (
                 <PluginKindSelect
                   {...field}
-                  pluginType="Panel"
+                  pluginTypes={['Panel']}
                   required
                   fullWidth
                   label="Type"
@@ -210,7 +213,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
                   helperText={pluginEditor.error?.message ?? fieldState.error?.message}
                   onChange={(event) => {
                     field.onChange(event);
-                    pluginEditor.onKindChange(event);
+                    pluginEditor.onSelectionChange(event);
                   }}
                 />
               )}

--- a/ui/dashboards/src/context/DatasourceStoreProvider.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.tsx
@@ -150,7 +150,7 @@ export function DatasourceStoreProvider(props: DatasourceStoreProviderProps) {
   const listDatasourceSelectItems = useEvent(
     async (datasourcePluginKind: string): Promise<DatasourceSelectItemGroup[]> => {
       const [pluginMetadata, datasources, globalDatasources] = await Promise.all([
-        listPluginMetadata('Datasource'),
+        listPluginMetadata(['Datasource']),
         project ? datasourceApi.listDatasources(project, datasourcePluginKind) : [],
         datasourceApi.listGlobalDatasources(datasourcePluginKind),
       ]);

--- a/ui/dashboards/src/validation/panel.ts
+++ b/ui/dashboards/src/validation/panel.ts
@@ -17,7 +17,10 @@ export const panelEditorValidationSchema = z.object({
   name: z.string().nonempty('Required'),
   groupId: z.number(),
   description: z.string().optional(),
-  type: z.string().nonempty('Required'),
+  selection: z.object({
+    type: z.string(),
+    kind: z.string(),
+  }),
 });
 
 export type PanelEditorValidationType = z.infer<typeof panelEditorValidationSchema>;

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -261,13 +261,20 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
         </Typography>
         <PluginEditor
           width="100%"
-          pluginType="Datasource"
+          pluginTypes={['Datasource']}
           pluginKindLabel="Source"
-          value={state.spec.plugin}
+          value={{
+            selection: {
+              kind: state.spec.plugin.kind,
+              type: 'Datasource',
+            },
+            spec: state.spec.plugin.spec,
+          }}
           isReadonly={action === 'read'}
           onChange={(v) => {
             setState((draft) => {
-              draft.spec.plugin = v;
+              draft.spec.plugin.kind = v.selection.kind;
+              draft.spec.plugin.spec = v.spec;
             });
           }}
         />

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.test.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.test.tsx
@@ -20,15 +20,18 @@ import { PluginEditor } from './PluginEditor';
 import { PluginEditorProps } from './plugin-editor-api';
 
 type RenderComponentOptions = {
-  pluginType?: PluginEditorProps['pluginType'];
+  pluginTypes?: PluginEditorProps['pluginTypes'];
   defaultPluginKinds?: DefaultPluginKinds;
   value?: PluginEditorProps['value'];
 };
 
 describe('PluginEditor', () => {
-  const renderComponent = ({ pluginType = 'Variable', defaultPluginKinds, value }: RenderComponentOptions = {}) => {
+  const renderComponent = ({ pluginTypes = ['Variable'], defaultPluginKinds, value }: RenderComponentOptions = {}) => {
     const testValue: PluginEditorProps['value'] = value || {
-      kind: 'ErnieVariable1',
+      selection: {
+        type: 'Variable',
+        kind: 'ErnieVariable1',
+      },
       spec: { variableOption: 'Option1Value' },
     };
 
@@ -38,7 +41,9 @@ describe('PluginEditor', () => {
       const [value, setValue] = useState(testValue);
       onChange = jest.fn((v) => setValue(v));
 
-      return <PluginEditor pluginType={pluginType} pluginKindLabel="Variable Type" value={value} onChange={onChange} />;
+      return (
+        <PluginEditor pluginTypes={pluginTypes} pluginKindLabel="Variable Type" value={value} onChange={onChange} />
+      );
     }
 
     renderWithContext(<TestHelperForm />, undefined, { defaultPluginKinds });
@@ -77,7 +82,10 @@ describe('PluginEditor', () => {
 
     // Make sure onChange was only called once (i.e. initializes both kind and spec at the same time
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({ kind: 'ErnieVariable2', spec: { variableOption2: '' } });
+    expect(onChange).toHaveBeenCalledWith({
+      selection: { type: 'Variable', kind: 'ErnieVariable2' },
+      spec: { variableOption2: '' },
+    });
   });
 
   it('remembers previous spec values', async () => {
@@ -108,12 +116,12 @@ describe('PluginEditor', () => {
   describe('when defaultPluginKinds specified in plugin registry', () => {
     it('uses default kind when one is not provided', async () => {
       renderComponent({
-        pluginType: 'Variable',
+        pluginTypes: ['Variable'],
         defaultPluginKinds: {
           TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
           Variable: 'ErnieVariable1',
         },
-        value: { kind: '', spec: {} },
+        value: { selection: { type: 'Variable', kind: '' }, spec: {} },
       });
 
       // Wait for default panel kind to load.
@@ -123,9 +131,9 @@ describe('PluginEditor', () => {
 
     it('does not use default when kind is provided', async () => {
       renderComponent({
-        pluginType: 'Variable',
+        pluginTypes: ['Variable'],
         defaultPluginKinds: { Variable: 'ErnieVariable1', TimeSeriesQuery: 'PrometheusTimeSeriesQuery' },
-        value: { kind: 'ErnieVariable2', spec: {} },
+        value: { selection: { type: 'Variable', kind: 'ErnieVariable2' }, spec: {} },
       });
 
       // Wait for specified panel kind to load.

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -26,8 +26,8 @@ import { PluginEditorProps, usePluginEditor } from './plugin-editor-api';
  */
 export function PluginEditor(props: PluginEditorProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { value, pluginType, pluginKindLabel, onChange: _, isReadonly, ...others } = props;
-  const { pendingKind, isLoading, error, onKindChange, onSpecChange } = usePluginEditor(props);
+  const { value, pluginTypes, pluginKindLabel, onChange: _, isReadonly, ...others } = props;
+  const { pendingSelection, isLoading, error, onSelectionChange, onSpecChange } = usePluginEditor(props);
   return (
     <Box {...others}>
       <PluginKindSelect
@@ -35,17 +35,16 @@ export function PluginEditor(props: PluginEditorProps) {
         sx={{ mb: 1, minWidth: 120 }}
         margin="dense"
         label={pluginKindLabel}
-        pluginType={pluginType}
+        pluginTypes={pluginTypes}
         disabled={isLoading}
-        value={pendingKind !== '' ? pendingKind : value.kind}
+        value={pendingSelection ? pendingSelection : value.selection}
         InputProps={{ readOnly: isReadonly }}
         error={!!error}
         helperText={error?.message}
-        onChange={onKindChange}
+        onChange={onSelectionChange}
       />
       <PluginSpecEditor
-        pluginType={pluginType}
-        pluginKind={value.kind}
+        pluginSelection={value.selection}
         value={value.spec}
         onChange={onSpecChange}
         isReadonly={isReadonly}

--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.test.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.test.tsx
@@ -31,8 +31,8 @@ describe('PluginKindSelect', () => {
 
   it('displays the list of plugins for a plugin type', async () => {
     renderComponent({
-      pluginType: 'Panel',
-      value: '',
+      pluginTypes: ['Panel'],
+      value: undefined,
     });
 
     // Open the select and verify the list of options from the test plugin data
@@ -47,8 +47,8 @@ describe('PluginKindSelect', () => {
 
   it('shows the correct selected value', async () => {
     renderComponent({
-      pluginType: 'Variable',
-      value: 'ErnieVariable1',
+      pluginTypes: ['Variable'],
+      value: { type: 'Variable', kind: 'ErnieVariable1' },
     });
 
     // Use findByRole to wait for loading to finish and selected value to appear
@@ -58,12 +58,12 @@ describe('PluginKindSelect', () => {
 
   it('can select new value', async () => {
     let onChangeValue: string | undefined = undefined;
-    const onChange = jest.fn((e) => {
-      onChangeValue = e.target.value;
+    const onChange = jest.fn((value) => {
+      onChangeValue = value;
     });
     renderComponent({
-      pluginType: 'Variable',
-      value: 'ErnieVariable1',
+      pluginTypes: ['Variable'],
+      value: { type: 'Variable', kind: 'ErnieVariable1' },
       onChange,
     });
 
@@ -72,6 +72,6 @@ describe('PluginKindSelect', () => {
     userEvent.click(newOption);
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChangeValue).toBe('BertVariable');
+    expect(onChangeValue).toStrictEqual({ type: 'Variable', kind: 'BertVariable' });
   });
 });

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.test.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.test.tsx
@@ -82,7 +82,7 @@ const PluginConsumer = (props: { pluginType: PluginType; kind: string }) => {
 
 // A helper component for testing the PluginRegistry metadata APIs by calling useListPluginMetadata
 const MetadataConsumer = (props: { pluginType: PluginType }) => {
-  const { data: pluginMetadata, isLoading, error } = useListPluginMetadata(props.pluginType);
+  const { data: pluginMetadata, isLoading, error } = useListPluginMetadata([props.pluginType]);
   if (error) {
     return <div>Error: {(error as Error).message}</div>;
   }

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -89,9 +89,9 @@ export function PluginRegistry(props: PluginRegistryProps) {
   );
 
   const listPluginMetadata = useCallback(
-    async (pluginType: PluginType) => {
+    async (pluginTypes: PluginType[]) => {
       const pluginIndexes = await getPluginIndexes();
-      return pluginIndexes.pluginMetadataByType.get(pluginType) ?? [];
+      return pluginTypes.flatMap((type) => pluginIndexes.pluginMetadataByType.get(type) ?? []);
     },
     [getPluginIndexes]
   );

--- a/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.test.tsx
+++ b/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.test.tsx
@@ -22,7 +22,7 @@ describe('PluginSpecEditor', () => {
   };
 
   it('shows the options editor component for a plugin', async () => {
-    renderComponent({ pluginType: 'Variable', pluginKind: 'ErnieVariable1', value: {}, onChange: jest.fn() });
+    renderComponent({ pluginSelection: { type: 'Variable', kind: 'ErnieVariable1' }, value: {}, onChange: jest.fn() });
     const editor = await screen.findByLabelText('ErnieVariable editor');
     expect(editor).toBeInTheDocument();
   });
@@ -30,8 +30,7 @@ describe('PluginSpecEditor', () => {
   it('propagates value changes', async () => {
     const onChange = jest.fn();
     renderComponent({
-      pluginType: 'Variable',
-      pluginKind: 'ErnieVariable1',
+      pluginSelection: { type: 'Variable', kind: 'ErnieVariable1' },
       value: { variableOption: 'Option1Value' },
       onChange,
     });
@@ -43,14 +42,14 @@ describe('PluginSpecEditor', () => {
   });
 
   it('shows an error if plugin fails to load', async () => {
-    renderComponent({ pluginType: 'Variable', pluginKind: 'DoesNotExist', value: {}, onChange: jest.fn() });
+    renderComponent({ pluginSelection: { type: 'Variable', kind: 'DoesNotExist' }, value: {}, onChange: jest.fn() });
     const errorAlert = await screen.findByRole('alert');
     expect(errorAlert).toHaveTextContent(/doesnotexist/i);
   });
 
   it('should throw an error if panel type is used', () => {
     try {
-      renderComponent({ pluginType: 'Panel', pluginKind: 'TimeSeriesChart', value: {}, onChange: jest.fn() });
+      renderComponent({ pluginSelection: { type: 'Panel', kind: 'TimeSeriesChart' }, value: {}, onChange: jest.fn() });
     } catch (e) {
       expect(e).toBe('This editor should not be used for panel type. Please use Panel Spec Editor instead.');
     }

--- a/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.tsx
@@ -13,17 +13,20 @@
 
 import { ErrorAlert } from '@perses-dev/components';
 import { UnknownSpec } from '@perses-dev/core';
-import { OptionsEditorProps, PluginType } from '../../model';
+import { OptionsEditorProps } from '../../model';
 import { usePlugin } from '../../runtime';
+import { PluginEditorSelection } from '../PluginEditor';
 
 export interface PluginSpecEditorProps extends OptionsEditorProps<UnknownSpec> {
-  pluginType: PluginType;
-  pluginKind: string;
+  pluginSelection: PluginEditorSelection;
   isEditor?: boolean;
 }
 
 export function PluginSpecEditor(props: PluginSpecEditorProps) {
-  const { pluginType, pluginKind, ...others } = props;
+  const {
+    pluginSelection: { type: pluginType, kind: pluginKind },
+    ...others
+  } = props;
   const { data: plugin, isLoading, error } = usePlugin(pluginType, pluginKind);
 
   if (error) {

--- a/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
+++ b/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryEditor.tsx
@@ -28,7 +28,7 @@ export function TimeSeriesQueryEditor({ queries = [], onChange }: TimeSeriesQuer
   // Build the default query plugin
   // Use as default the plugin kind explicitly set as default or the first in the list
   const { defaultPluginKinds } = usePluginRegistry();
-  const { data: timeSeriesPlugins } = useListPluginMetadata(TIME_SERIES_QUERY_KEY);
+  const { data: timeSeriesPlugins } = useListPluginMetadata([TIME_SERIES_QUERY_KEY]);
   const defaultTimeSeriesQueryKind = defaultPluginKinds?.[TIME_SERIES_QUERY_KEY] ?? timeSeriesPlugins?.[0]?.kind ?? '';
   const { data: defaultQueryPlugin } = usePlugin(TIME_SERIES_QUERY_KEY, defaultTimeSeriesQueryKind, {
     useErrorBoundary: true,

--- a/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryInput.tsx
+++ b/ui/plugin-system/src/components/TimeSeriesQueryEditor/TimeSeriesQueryInput.tsx
@@ -80,7 +80,8 @@ function QueryEditor(props: QueryEditorProps) {
   const handlePluginChange: PluginEditorProps['onChange'] = (next) => {
     onChange(
       produce(value, (draft) => {
-        draft.spec.plugin = next;
+        draft.spec.plugin.kind = next.selection.kind;
+        draft.spec.plugin.spec = next.spec;
       })
     );
   };
@@ -89,9 +90,15 @@ function QueryEditor(props: QueryEditorProps) {
     <Box {...others}>
       {/* If TimeSeriesQuery plugins ever have common props on the definition, the inputs could go here */}
       <PluginEditor
-        pluginType="TimeSeriesQuery"
+        pluginTypes={['TimeSeriesQuery']}
         pluginKindLabel="Query Type"
-        value={plugin}
+        value={{
+          selection: {
+            kind: plugin.kind,
+            type: value.kind,
+          },
+          spec: plugin.spec,
+        }}
         onChange={handlePluginChange}
       />
     </Box>

--- a/ui/plugin-system/src/components/TraceQueryEditor/TraceQueryInput.tsx
+++ b/ui/plugin-system/src/components/TraceQueryEditor/TraceQueryInput.tsx
@@ -80,14 +80,26 @@ function QueryEditor(props: QueryEditorProps) {
   const handlePluginChange: PluginEditorProps['onChange'] = (next) => {
     onChange(
       produce(value, (draft) => {
-        draft.spec.plugin = next;
+        draft.spec.plugin.kind = next.selection.kind;
+        draft.spec.plugin.spec = next.spec;
       })
     );
   };
 
   return (
     <Box {...others}>
-      <PluginEditor pluginType="TraceQuery" pluginKindLabel="Query Type" value={plugin} onChange={handlePluginChange} />
+      <PluginEditor
+        pluginTypes={['TraceQuery']}
+        pluginKindLabel="Query Type"
+        value={{
+          selection: {
+            kind: plugin.kind,
+            type: value.kind,
+          },
+          spec: plugin.spec,
+        }}
+        onChange={handlePluginChange}
+      />
     </Box>
   );
 }

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -357,14 +357,24 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
                   render={({ field }) => (
                     <PluginEditor
                       width="100%"
-                      pluginType="Variable"
+                      pluginTypes={['Variable']}
                       pluginKindLabel="Source"
                       isReadonly={action === 'read'}
-                      value={state.listVariableFields.plugin}
+                      value={{
+                        selection: {
+                          kind: state.listVariableFields.plugin.kind,
+                          type: 'Variable',
+                        },
+                        spec: state.listVariableFields.plugin.spec,
+                      }}
                       onChange={(val) => {
-                        field.onChange(val);
+                        field.onChange({
+                          spec: val.spec,
+                          kind: val.selection.kind,
+                        });
                         setState((draft) => {
-                          draft.listVariableFields.plugin = val;
+                          draft.listVariableFields.plugin.kind = val.selection.kind;
+                          draft.listVariableFields.plugin.spec = val.spec;
                         });
                       }}
                     />

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -59,9 +59,10 @@ export function transformQueryResults(results: UseQueryResult[], definitions: Qu
 }
 
 export function useQueryType(): (pluginKind: string) => string | undefined {
-  const { data: timeSeriesQueryPlugins, isLoading: isTimeSeriesQueryLoading } =
-    useListPluginMetadata('TimeSeriesQuery');
-  const { data: traceQueryPlugins, isLoading: isTraceQueryPluginLoading } = useListPluginMetadata('TraceQuery');
+  const { data: timeSeriesQueryPlugins, isLoading: isTimeSeriesQueryLoading } = useListPluginMetadata([
+    'TimeSeriesQuery',
+  ]);
+  const { data: traceQueryPlugins, isLoading: isTraceQueryPluginLoading } = useListPluginMetadata(['TraceQuery']);
 
   // For example, `map: {"TimeSeriesQuery":["PrometheusTimeSeriesQuery"],"TraceQuery":["TempoTraceQuery"]}`
   const queryTypeMap = useMemo(() => {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
linked with #1303 

First step of a set of PR with end goal of being able to associate with a panel several type of queries.

This is only touching the ``PluginEditor`` for now so functionally nothing happen differently than before as we always give a list of one plugin type.

The idea would be then to call the ``PluginEditor`` giving several ``PluginType``. 
e.g: Would help for a future Table Panel that would support giving `TimeSeriesQuery` and `TraceQuery` result.

Example of screenshot tweaking a bit the ``BarChart`` Panel to support ``TraceQuery`` and ``TimeSeriesQuery`` (not included in that PR that concern only the ``PluginEditor``)
![image](https://github.com/perses/perses/assets/10258608/26bc4bc5-8650-4e42-a83c-ec1fe1956af9)


> [!IMPORTANT]
> Depending on the output of the plugin improvements discussion #1543, the  three `TimeSeriesQuery`, `TraceQuery`, `LogQuery` plugin types could end up dying, but nothing is decided yet. 

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
