### PR TITLE
[ignore] refactor the way different provider are managed in the login 

### DIFF
--- a/internal/cli/cmd/login/device_code.go
+++ b/internal/cli/cmd/login/device_code.go
@@ -1,0 +1,100 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/perses/perses/internal/cli/output"
+	"github.com/perses/perses/pkg/client/api"
+	"github.com/perses/perses/pkg/client/perseshttp"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+)
+
+type deviceCodeLogin struct {
+	writer               io.Writer
+	externalAuthKind     externalAuthKind
+	externalAuthProvider string
+	apiClient            api.ClientInterface
+}
+
+func (l *deviceCodeLogin) Login() (*modelAPI.AuthResponse, error) {
+	deviceCodeResponse, err := l.apiClient.Auth().DeviceCode(string(l.externalAuthKind), l.externalAuthProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	// Display the user code and verification URL
+	if outErr := output.HandleString(l.writer, fmt.Sprintf("Go to %s and enter this user code: %s\nWaiting for user to authorize the application...", deviceCodeResponse.VerificationURI, deviceCodeResponse.UserCode)); err != nil {
+		return nil, outErr
+	}
+
+	// Compute the expiry and interval from the response
+	ctx := context.Background()
+	if !deviceCodeResponse.Expiry.IsZero() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deviceCodeResponse.Expiry)
+		defer cancel()
+	}
+	interval := deviceCodeResponse.Interval
+	if interval == 0 {
+		interval = 5
+	}
+
+	// Poll for an access token
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			tokenResponse, tokenErr := l.apiClient.Auth().DeviceAccessToken(string(l.externalAuthKind), l.externalAuthProvider, deviceCodeResponse.DeviceCode)
+			if tokenErr == nil {
+				// Handle the access token
+				return tokenResponse, nil
+			}
+
+			reqErr := &perseshttp.RequestError{}
+			if errors.As(tokenErr, &reqErr) && reqErr.Err != nil {
+				oauthErr := &modelAPI.OAuthError{}
+				if errors.As(reqErr.Err, &oauthErr) {
+					switch oauthErr.ErrorCode {
+					case errSlowDown:
+						// https://datatracker.ietf.org/doc/html/rfc8628#section-3.5
+						// "the interval MUST be increased by 5 seconds for this and all subsequent requests"
+						interval += 5
+						ticker.Reset(time.Duration(interval) * time.Second)
+						continue
+					case errAuthorizationPending:
+						// Do nothing.
+						continue
+					default:
+						return nil, oauthErr
+					}
+				}
+				return nil, reqErr.Err
+			}
+			return nil, tokenErr
+		}
+	}
+}
+
+func (l *deviceCodeLogin) SetMissingInput() error {
+	return nil
+}

--- a/internal/cli/cmd/login/login_test.go
+++ b/internal/cli/cmd/login/login_test.go
@@ -28,6 +28,24 @@ func TestLoginCMD(t *testing.T) {
 			ExpectedMessage: "no URL has been provided neither found in the previous configuration",
 		},
 		{
+			Title:           "native login flag and provider flag cannot be set at the same time (1)",
+			Args:            []string{"--username", "foo", "--provider", "google", "https://demo.perses.dev"},
+			IsErrorExpected: true,
+			ExpectedMessage: "you can not set --username or --token at the same time than --client-id or --client-secret or --provider",
+		},
+		{
+			Title:           "native login flag and provider flag cannot be set at the same time (2)",
+			Args:            []string{"--username", "foo", "--client-id", "bar", "https://demo.perses.dev"},
+			IsErrorExpected: true,
+			ExpectedMessage: "you can not set --username or --token at the same time than --client-id or --client-secret or --provider",
+		},
+		{
+			Title:           "provider not known",
+			Args:            []string{"--provider", "bar", "https://demo.perses.dev"},
+			IsErrorExpected: true,
+			ExpectedMessage: "provider \"bar\" does not exist",
+		},
+		{
 			Title:           "token flag used",
 			Args:            []string{"--token", "foo.bar.jwt", "https://demo.perses.dev"},
 			IsErrorExpected: false,

--- a/internal/cli/cmd/login/native.go
+++ b/internal/cli/cmd/login/native.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package login
+
+import (
+	"io"
+
+	"github.com/charmbracelet/huh"
+	"github.com/perses/perses/internal/cli/output"
+	"github.com/perses/perses/pkg/client/api"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+)
+
+type nativeLogin struct {
+	writer    io.Writer
+	username  string
+	password  string
+	apiClient api.ClientInterface
+}
+
+func (l *nativeLogin) Login() (*modelAPI.AuthResponse, error) {
+	return l.apiClient.Auth().Login(l.username, l.password)
+}
+
+func (l *nativeLogin) SetMissingInput() error {
+	if len(l.username) == 0 {
+		input := huh.NewInput().Title("Username").Value(&l.username)
+		if err := input.Run(); err != nil {
+			return err
+		}
+		if err := output.HandleString(l.writer, input.View()); err != nil {
+			return err
+		}
+	}
+	if len(l.password) == 0 {
+		input := huh.NewInput().Title("Password").EchoMode(huh.EchoModeNone).Value(&l.password)
+		if err := input.Run(); err != nil {
+			return err
+		}
+		if err := output.HandleString(l.writer, input.View()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cli/cmd/login/robotic.go
+++ b/internal/cli/cmd/login/robotic.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package login
+
+import (
+	"io"
+
+	"github.com/charmbracelet/huh"
+	"github.com/perses/perses/internal/cli/output"
+	"github.com/perses/perses/pkg/client/api"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+)
+
+type roboticLogin struct {
+	writer               io.Writer
+	externalAuthKind     externalAuthKind
+	externalAuthProvider string
+	clientID             string
+	clientSecret         string
+	apiClient            api.ClientInterface
+}
+
+func (l *roboticLogin) Login() (*modelAPI.AuthResponse, error) {
+	return l.apiClient.Auth().ClientCredentialsToken(string(l.externalAuthKind), l.externalAuthProvider, l.clientID, l.clientSecret)
+}
+
+func (l *roboticLogin) SetMissingInput() error {
+	if len(l.clientID) == 0 {
+		input := huh.NewInput().Title("Client ID").Value(&l.clientID)
+		if err := input.Run(); err != nil {
+			return err
+		}
+		if err := output.HandleString(l.writer, input.View()); err != nil {
+			return err
+		}
+	}
+	if len(l.clientSecret) == 0 {
+		input := huh.NewInput().Title("Client Secret").EchoMode(huh.EchoModeNone).Value(&l.clientSecret)
+		if err := input.Run(); err != nil {
+			return err
+		}
+		if err := output.HandleString(l.writer, input.View()); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is refactoring the way we are managing the different provider in the CLI cmd `login`.

Like that each login flows are isolated from each other and we cannot execute a default flow if nothing is entered.