### PR TITLE
[FEATURE] Backend work for usage tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/perses/common v0.23.1
 	github.com/prometheus/client_golang v1.19.0
+	github.com/prometheus/client_model v0.6.0
 	github.com/prometheus/common v0.52.3
 	github.com/prometheus/common/assets v0.2.0
 	github.com/prometheus/promu v0.16.0
@@ -96,7 +97,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -73,7 +73,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		secret.NewEndpoint(serviceManager.GetSecret(), serviceManager.GetRBAC(), readonly, caseSensitive),
 		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetRBAC(), cfg.Security.Authentication.DisableSignUp, readonly, caseSensitive),
 		variable.NewEndpoint(serviceManager.GetVariable(), serviceManager.GetRBAC(), readonly, caseSensitive),
-		view.NewEndpoint(serviceManager.GetView(), serviceManager.GetRBAC()),
+		view.NewEndpoint(serviceManager.GetView(), serviceManager.GetRBAC(), serviceManager.GetDashboard()),
 	}
 
 	authEndpoint, err := authendpoint.New(

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -37,6 +37,7 @@ import (
 	"github.com/perses/perses/internal/api/impl/v1/secret"
 	"github.com/perses/perses/internal/api/impl/v1/user"
 	"github.com/perses/perses/internal/api/impl/v1/variable"
+	"github.com/perses/perses/internal/api/impl/v1/view"
 	validateendpoint "github.com/perses/perses/internal/api/impl/validate"
 	"github.com/perses/perses/internal/api/route"
 	"github.com/perses/perses/internal/api/utils"
@@ -72,6 +73,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		secret.NewEndpoint(serviceManager.GetSecret(), serviceManager.GetRBAC(), readonly, caseSensitive),
 		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetRBAC(), cfg.Security.Authentication.DisableSignUp, readonly, caseSensitive),
 		variable.NewEndpoint(serviceManager.GetVariable(), serviceManager.GetRBAC(), readonly, caseSensitive),
+		view.NewEndpoint(serviceManager.GetView()),
 	}
 
 	authEndpoint, err := authendpoint.New(

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -73,7 +73,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		secret.NewEndpoint(serviceManager.GetSecret(), serviceManager.GetRBAC(), readonly, caseSensitive),
 		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetRBAC(), cfg.Security.Authentication.DisableSignUp, readonly, caseSensitive),
 		variable.NewEndpoint(serviceManager.GetVariable(), serviceManager.GetRBAC(), readonly, caseSensitive),
-		view.NewEndpoint(serviceManager.GetView()),
+		view.NewEndpoint(serviceManager.GetView(), serviceManager.GetRBAC()),
 	}
 
 	authEndpoint, err := authendpoint.New(

--- a/internal/api/dependency/service_manager.go
+++ b/internal/api/dependency/service_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,6 +33,7 @@ import (
 	secretImpl "github.com/perses/perses/internal/api/impl/v1/secret"
 	userImpl "github.com/perses/perses/internal/api/impl/v1/user"
 	variableImpl "github.com/perses/perses/internal/api/impl/v1/variable"
+	viewImpl "github.com/perses/perses/internal/api/impl/v1/view"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
@@ -49,6 +50,7 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/secret"
 	"github.com/perses/perses/internal/api/interface/v1/user"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
+	"github.com/perses/perses/internal/api/interface/v1/view"
 	"github.com/perses/perses/internal/api/migrate"
 	"github.com/perses/perses/internal/api/rbac"
 	"github.com/perses/perses/internal/api/schemas"
@@ -77,6 +79,7 @@ type ServiceManager interface {
 	GetSecret() secret.Service
 	GetUser() user.Service
 	GetVariable() variable.Service
+	GetView() view.Service
 }
 
 type service struct {
@@ -102,6 +105,7 @@ type service struct {
 	secret             secret.Service
 	user               user.Service
 	variable           variable.Service
+	view               view.Service
 }
 
 func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManager, error) {
@@ -137,6 +141,7 @@ func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 	roleBindingService := roleBindingImpl.NewService(dao.GetRoleBinding(), dao.GetRole(), dao.GetUser(), rbacService, schemasService)
 	secretService := secretImpl.NewService(dao.GetSecret(), cryptoService)
 	userService := userImpl.NewService(dao.GetUser())
+	viewService := viewImpl.NewMetricsViewService()
 
 	svc := &service{
 		crypto:             cryptoService,
@@ -160,6 +165,7 @@ func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 		secret:             secretService,
 		user:               userService,
 		variable:           variableService,
+		view:               viewService,
 	}
 	return svc, nil
 }
@@ -246,4 +252,8 @@ func (s *service) GetUser() user.Service {
 
 func (s *service) GetVariable() variable.Service {
 	return s.variable
+}
+
+func (s *service) GetView() view.Service {
+	return s.view
 }

--- a/internal/api/impl/v1/view/endpoint.go
+++ b/internal/api/impl/v1/view/endpoint.go
@@ -1,0 +1,52 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package view
+
+import (
+	"fmt"
+
+	"github.com/labstack/echo/v4"
+	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/internal/api/interface/v1/view"
+	"github.com/perses/perses/internal/api/route"
+	"github.com/perses/perses/internal/api/utils"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type endpoint struct {
+	service view.Service
+}
+
+func NewEndpoint(service view.Service) route.Endpoint {
+	return &endpoint{
+		service: service,
+	}
+}
+
+func (e *endpoint) CollectRoutes(g *route.Group) {
+	g.POST(fmt.Sprintf("/%s", utils.PathView), e.View, false)
+}
+
+func (e *endpoint) View(ctx echo.Context) error {
+	view := v1.View{}
+	if err := ctx.Bind(&view); err != nil {
+		return apiInterface.HandleBadRequestError(err.Error())
+	}
+
+	if err := view.Validate(); err != nil {
+		return apiInterface.HandleBadRequestError(err.Error())
+	}
+
+	return e.service.View(&view)
+}

--- a/internal/api/impl/v1/view/endpoint_test.go
+++ b/internal/api/impl/v1/view/endpoint_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package view
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoint(t *testing.T) {
+	endpoint := NewEndpoint(NewMetricsViewService()).(*endpoint)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/view", strings.NewReader(`{"project":"project","dashboard":"dashboard", "render_errors":2, "render_time_secs":1.7}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := endpoint.View(ctx)
+	require.NoError(t, err)
+
+	metric := io_prometheus_client.Metric{}
+	count, err := dashboardViewCounter.GetMetricWithLabelValues("project", "dashboard")
+	require.NoError(t, err)
+	require.NoError(t, count.Write(&metric))
+	require.Equal(t, 1.0, *metric.Counter.Value)
+
+	count, err = dashboardRenderErrorCounter.GetMetricWithLabelValues("project", "dashboard")
+	require.NoError(t, err)
+	require.NoError(t, count.Write(&metric))
+	require.Equal(t, 2.0, *metric.Counter.Value)
+}

--- a/internal/api/impl/v1/view/endpoint_test.go
+++ b/internal/api/impl/v1/view/endpoint_test.go
@@ -19,31 +19,79 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
-	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/perses/perses/internal/api/crypto"
+	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/internal/api/rbac"
+	"github.com/perses/perses/pkg/model/api/v1/role"
+	promclient "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+var _ = rbac.RBAC(&testRBAC{})
+
+type testRBAC struct {
+	allow bool
+}
+
+func (t *testRBAC) GetPermissions(_ string) map[string][]*role.Permission {
+	return map[string][]*role.Permission{}
+}
+
+func (t *testRBAC) HasPermission(_ string, _ role.Action, _ string, _ role.Scope) bool {
+	return t.allow
+}
+
+func (t *testRBAC) IsEnabled() bool {
+	return true
+}
+
+func (t *testRBAC) Refresh() error {
+	panic("unimplemented")
+}
+
 func TestEndpoint(t *testing.T) {
-	endpoint := NewEndpoint(NewMetricsViewService()).(*endpoint)
+	endpoint := NewEndpoint(NewMetricsViewService(), &testRBAC{true}).(*endpoint)
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/view", strings.NewReader(`{"project":"project","dashboard":"dashboard", "render_errors":2, "render_time_secs":1.7}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
+	ctx.Set("user", &jwt.Token{
+		Claims: &crypto.JWTCustomClaims{},
+	})
 
 	err := endpoint.View(ctx)
 	require.NoError(t, err)
 
-	metric := io_prometheus_client.Metric{}
+	metric := promclient.Metric{}
 	count, err := dashboardViewCounter.GetMetricWithLabelValues("project", "dashboard")
 	require.NoError(t, err)
 	require.NoError(t, count.Write(&metric))
-	require.Equal(t, 1.0, *metric.Counter.Value)
+	assert.Equal(t, 1.0, *metric.Counter.Value)
 
 	count, err = dashboardRenderErrorCounter.GetMetricWithLabelValues("project", "dashboard")
 	require.NoError(t, err)
 	require.NoError(t, count.Write(&metric))
-	require.Equal(t, 2.0, *metric.Counter.Value)
+	assert.Equal(t, 2.0, *metric.Counter.Value)
+}
+
+func TestNotAllowed(t *testing.T) {
+	endpoint := NewEndpoint(NewMetricsViewService(), &testRBAC{false}).(*endpoint)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/view", strings.NewReader(`{"project":"project","dashboard":"dashboard", "render_errors":2, "render_time_secs":1.7}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.Set("user", &jwt.Token{
+		Claims: &crypto.JWTCustomClaims{},
+	})
+
+	err := endpoint.View(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, apiInterface.UnauthorizedError)
 }

--- a/internal/api/impl/v1/view/service.go
+++ b/internal/api/impl/v1/view/service.go
@@ -14,6 +14,7 @@
 package view
 
 import (
+	"github.com/perses/perses/internal/api/interface/v1/view"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -48,7 +49,7 @@ func init() {
 type metricsViewService struct {
 }
 
-func NewMetricsViewService() *metricsViewService {
+func NewMetricsViewService() view.Service {
 	return &metricsViewService{}
 }
 

--- a/internal/api/impl/v1/view/service.go
+++ b/internal/api/impl/v1/view/service.go
@@ -19,24 +19,33 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	namespace = "perses"
+)
+
+var labelNames = []string{"project", "dashboard"}
+
 // A counter for the total number of views of a dashboard.
 var dashboardViewCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Name: "perses_dashboard_view_total",
-	Help: "The total number of views of a dashboard",
-}, []string{"project", "dashboard"})
+	Namespace: namespace,
+	Name:      "dashboard_views_total",
+	Help:      "The total number of views of a dashboard",
+}, labelNames)
 
 // A counter for the total number of render errors of a dashboard.
 var dashboardRenderErrorCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Name: "perses_dashboard_render_error_total",
-	Help: "The total number of render errors of a dashboard",
-}, []string{"project", "dashboard"})
+	Namespace: namespace,
+	Name:      "dashboard_render_errors_total",
+	Help:      "The total number of render errors of a dashboard",
+}, labelNames)
 
 // A histogram for the render time of a dashboard.
 var dashboardRenderTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "perses_dashboard_render_time_seconds",
-	Help:    "The render time of a dashboard",
-	Buckets: prometheus.DefBuckets,
-}, []string{"project", "dashboard"})
+	Namespace: namespace,
+	Name:      "dashboard_render_time_seconds",
+	Help:      "The render time of a dashboard",
+	Buckets:   prometheus.DefBuckets,
+}, labelNames)
 
 func init() {
 	prometheus.MustRegister(dashboardViewCounter)

--- a/internal/api/interface/v1/view/interface.go
+++ b/internal/api/interface/v1/view/interface.go
@@ -1,0 +1,20 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package view
+
+import v1 "github.com/perses/perses/pkg/model/api/v1"
+
+type Service interface {
+	View(*v1.View) error
+}

--- a/internal/api/utils/utils.go
+++ b/internal/api/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -52,6 +52,7 @@ const (
 	PathUnsaved            = "unsaved"
 	PathUser               = "users"
 	PathVariable           = "variables"
+	PathView               = "view"
 )
 
 // ProjectResourcePathList is containing the list of the resource path that is part of a project.

--- a/pkg/model/api/v1/view.go
+++ b/pkg/model/api/v1/view.go
@@ -1,0 +1,46 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "fmt"
+
+type View struct {
+	// The resource being viewed.
+	Project   string `json:"project" yaml:"project"`
+	Dashboard string `json:"dashboard" yaml:"dashboard"`
+
+	// Stats about the view.
+	RenderTimeSecs float64 `json:"render_time" yaml:"render_time"`
+	RenderErrors   int     `json:"render_errors" yaml:"render_errors"`
+}
+
+func (v *View) Validate() error {
+	if v.Project == "" {
+		return fmt.Errorf("project cannot be empty")
+	}
+
+	if v.Dashboard == "" {
+		return fmt.Errorf("dashboard cannot be empty")
+	}
+
+	if v.RenderErrors < 0 {
+		return fmt.Errorf("render_errors cannot be negative")
+	}
+
+	if v.RenderTimeSecs < 0 {
+		return fmt.Errorf("render_time cannot be negative")
+	}
+
+	return nil
+}

--- a/pkg/model/api/v1/view.go
+++ b/pkg/model/api/v1/view.go
@@ -13,7 +13,10 @@
 
 package v1
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type View struct {
 	// The resource being viewed.
@@ -25,7 +28,37 @@ type View struct {
 	RenderErrors   int     `json:"render_errors" yaml:"render_errors"`
 }
 
-func (v *View) Validate() error {
+func (v *View) UnmarshalJSON(data []byte) error {
+	var tmp View
+	type plain View
+
+	if err := json.Unmarshal(data, (*plain)(&tmp)); err != nil {
+		return err
+	}
+
+	if err := tmp.validate(); err != nil {
+		return err
+	}
+	*v = tmp
+	return nil
+}
+
+func (v *View) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp View
+	type plain View
+
+	if err := unmarshal((*plain)(&tmp)); err != nil {
+		return err
+	}
+
+	if err := tmp.validate(); err != nil {
+		return err
+	}
+	*v = tmp
+	return nil
+}
+
+func (v *View) validate() error {
 	if v.Project == "" {
 		return fmt.Errorf("project cannot be empty")
 	}


### PR DESCRIPTION
# Description

Linked with #1170

Here we add the backend side of usage tracking. We introduce a new view service that will be used to
track the usage of the API, bound to the /api/v1/view endpoint.

We then add a new implementation of that service
that tracks views in Prometheus metrics, with the
flexibility to swap out the implementation later.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
