### PR TITLE
[FEATURE] Add `supportedQueryTypes` to the panel plugins definition

### DIFF
--- a/ui/panels-plugin/src/plugins/bar-chart/BarChart.ts
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChart.ts
@@ -27,5 +27,6 @@ export const BarChart: PanelPlugin<BarChartOptions> = {
       content: BarChartOptionsEditorSettings,
     },
   ],
+  supportedQueryTypes: ['TimeSeriesQuery'],
   createInitialOptions: createInitialBarChartOptions,
 };

--- a/ui/panels-plugin/src/plugins/gauge-chart/GaugeChart.ts
+++ b/ui/panels-plugin/src/plugins/gauge-chart/GaugeChart.ts
@@ -21,6 +21,7 @@ import { GaugeChartPanel } from './GaugeChartPanel';
  */
 export const GaugeChart: PanelPlugin<GaugeChartOptions> = {
   PanelComponent: GaugeChartPanel,
+  supportedQueryTypes: ['TimeSeriesQuery'],
   panelOptionsEditorComponents: [
     {
       label: 'Settings',

--- a/ui/panels-plugin/src/plugins/markdown/Markdown.ts
+++ b/ui/panels-plugin/src/plugins/markdown/Markdown.ts
@@ -21,6 +21,7 @@ import { MarkdownPanelOptionsEditor } from './MarkdownPanelOptionsEditor';
  */
 export const Markdown: PanelPlugin<MarkdownPanelOptions> = {
   PanelComponent: MarkdownPanel,
+  supportedQueryTypes: [],
   panelOptionsEditorComponents: [
     {
       label: 'Markdown',

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChart.ts
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChart.ts
@@ -22,5 +22,6 @@ export const ScatterChart: PanelPlugin<ScatterChartOptions> = {
   PanelComponent: ScatterChartPanel,
   // TODO: add a chart options editor plugin, for example:
   // panelOptionsEditorComponents: [{ label: 'Settings', content: ScatterChartOptionsEditorSettings }],
+  supportedQueryTypes: ['TraceQuery'],
   createInitialOptions: createInitialScatterChartOptions,
 };

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChart.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChart.ts
@@ -21,6 +21,7 @@ import { StatChartPanel } from './StatChartPanel';
  */
 export const StatChart: PanelPlugin<StatChartOptions> = {
   PanelComponent: StatChartPanel,
+  supportedQueryTypes: ['TimeSeriesQuery'],
   panelOptionsEditorComponents: [
     {
       label: 'Settings',

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChart.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChart.ts
@@ -21,6 +21,7 @@ import { TimeSeriesChartPanel } from './TimeSeriesChartPanel';
  */
 export const TimeSeriesChart: PanelPlugin<TimeSeriesChartOptions> = {
   PanelComponent: TimeSeriesChartPanel,
+  supportedQueryTypes: ['TimeSeriesQuery'],
   panelOptionsEditorComponents: [{ label: 'Settings', content: TimeSeriesChartOptionsEditorSettings }],
   createInitialOptions: createInitialTimeSeriesChartOptions,
 };

--- a/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
@@ -12,13 +12,7 @@
 // limitations under the License.
 
 import { ErrorAlert, JSONEditor } from '@perses-dev/components';
-import {
-  PanelDefinition,
-  QueryDefinition,
-  UnknownSpec,
-  isValidQueryPluginType,
-  QueryPluginType,
-} from '@perses-dev/core';
+import { PanelDefinition, QueryDefinition, UnknownSpec } from '@perses-dev/core';
 import { usePlugin } from '../../runtime';
 import { PanelPlugin } from '../../model';
 import { OptionsEditorTabsProps, OptionsEditorTabs } from '../OptionsEditorTabs';
@@ -49,21 +43,6 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
     throw new Error(`Missing implementation for panel plugin with kind '${kind}'`);
   }
 
-  // TODO: Every panel plugin should define which query type they support in their definition
-  const getQueryTypes = (): QueryPluginType[] => {
-    const firstQueryType = panelDefinition?.spec?.queries?.[0]?.kind;
-    if (!firstQueryType || firstQueryType === '' || !isValidQueryPluginType(firstQueryType)) {
-      // this case handles cause where there is no queryType yet (e.g. UI > 'editing' mode > 'Add Panel')
-      // ScatterChart only handles trace queries for now
-      // (this is needed as, otherwise, no way to know that ScatterChart support TraceQuery and not the default TimeSeriesQuery)
-      if (kind === 'ScatterChart') {
-        return ['TraceQuery'];
-      }
-      return ['TimeSeriesQuery'];
-    }
-    return [firstQueryType];
-  };
-
   const { panelOptionsEditorComponents, hideQueryEditor } = plugin as PanelPlugin;
   let tabs: OptionsEditorTabsProps['tabs'] = [];
 
@@ -72,7 +51,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
       label: 'Query',
       content: (
         <MultiQueryEditor
-          queryTypes={getQueryTypes()}
+          queryTypes={plugin.supportedQueryTypes ?? []}
           queries={panelDefinition.spec.queries ?? []}
           onChange={onQueriesChange}
         />

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -12,15 +12,16 @@
 // limitations under the License.
 
 import React from 'react';
-import { UnknownSpec, PanelDefinition } from '@perses-dev/core';
+import { UnknownSpec, PanelDefinition, QueryPluginType } from '@perses-dev/core';
 import { OptionsEditorTab } from '../components';
 import { OptionsEditorProps, Plugin } from './plugin-base';
 
 export type PanelOptionsEditorComponent<T> = Pick<OptionsEditorTab, 'label'> & {
   content: React.ComponentType<OptionsEditorProps<T>>;
 };
+
 /**
- * Plugin the provides custom visualizations inside of a Panel.
+ * Plugin the provides custom visualizations inside a Panel.
  */
 export interface PanelPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
   PanelComponent: React.ComponentType<PanelProps<Spec>>;
@@ -28,6 +29,11 @@ export interface PanelPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
    * React components for custom tabs
    */
   panelOptionsEditorComponents?: Array<PanelOptionsEditorComponent<Spec>>;
+  /**
+   * List of query types supported by this panel.
+   * @default [] (no query types supported) only relevant if hideQueryEditor is true
+   */
+  supportedQueryTypes?: QueryPluginType[];
   /**
    * If true, query editor will be hidden for panel plugin
    * @default false


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
fixes #1303 

> [!NOTE]
Depends on new multi query editor https://github.com/perses/perses/pull/1898
(If you want to review this PR only, check only the latest commit diff)

Last implementation of this thread ^^' 
Thanks to this PR, a panel have to declare the query types that it supports.

### Value
- clarify the contract between a panel and the queries that it can support. Nothing is guessed or under the hood. 
- fully ready to create panel supporting multiple query types

=> **this PR is clearly an enabler for the ``Table`` panel implementation.**

### Additional unexpected benefit: remove hard ScatterChart mention!
Before that, the ``PanelSpecEditor`` had to guess the query type taking the first of the existing queries. 
As you can see, at creation, when queries was empty this was leading to some problem (`default:` case, the `ScatterChart` is hardly mentioned whereas it's a plugin!). 
 ```ts
    // Get the corresponding queryEditor depending on the queryType
  const getQueryEditorComponent = () => {
    const queryType = getQueryType();
    // default case handles cause where there is no queryType yet (e.g. UI > 'editing' mode > 'Add Panel')
    switch (queryType) {
      case 'TimeSeriesQuery':
        return <TimeSeriesQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
      case 'TraceQuery':
        return <TraceQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
      default:
        // ScatterChart only handles trace queries for now
        if (kind === 'ScatterChart') {
          return <TraceQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
        }
        return <TimeSeriesQueryEditor queries={panelDefinition.spec.queries ?? []} onChange={onQueriesChange} />;
    }
 ```
=> This is old story, now the query editor component is always ``MultiQueryEditor`` and takes directly the ``supportedQueryTypes``!



<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
