### PR TITLE
[BUGFIX] Fix CLI cmd apply that wasn't able to create a resource with no read permission

### DIFF
--- a/internal/cli/cmd/apply/apply.go
+++ b/internal/cli/cmd/apply/apply.go
@@ -94,7 +94,7 @@ func (o *option) applyEntity() error {
 			return svcErr
 		}
 
-		if upsertError := service.Upsert(svc, name, entity); upsertError != nil {
+		if upsertError := service.Upsert(svc, entity); upsertError != nil {
 			return upsertError
 		}
 

--- a/internal/cli/cmd/dac/preview/preview.go
+++ b/internal/cli/cmd/dac/preview/preview.go
@@ -106,7 +106,7 @@ func (o *option) Execute() error {
 			return svcErr
 		}
 
-		if upsertError := service.Upsert(svc, name, ephemeralDashboard); upsertError != nil {
+		if upsertError := service.Upsert(svc, ephemeralDashboard); upsertError != nil {
 			return upsertError
 		}
 		response = append(response, o.buildPreviewResponse(dashboard, ephemeralDashboard))

--- a/pkg/client/perseshttp/request.go
+++ b/pkg/client/perseshttp/request.go
@@ -325,6 +325,7 @@ func (re *RequestError) Unwrap() error {
 var (
 	RequestInternalError = &RequestError{Message: "internal server error", StatusCode: http.StatusInternalServerError}
 	RequestNotFoundError = &RequestError{Message: "document not found", StatusCode: http.StatusNotFound}
+	ConflictError        = &RequestError{Message: "document already exists", StatusCode: http.StatusConflict}
 )
 
 // Response contains the result of calling #Request.Do()
@@ -349,6 +350,9 @@ func (r *Response) Error() error {
 		}
 		if r.statusCode == http.StatusNotFound {
 			return RequestNotFoundError
+		}
+		if r.statusCode == http.StatusConflict {
+			return ConflictError
 		}
 		// check error message contains in the body
 		if r.body != nil {


### PR DESCRIPTION
To fix #1904, I simplify the way the command `apply` is working. Instead of checking if the resource exists which required a read permission on it, I'm trying to create it first. Then based on the HTTP code result, the code will try to update it or stop.

Like that we are also saving one additional request to the database.