### PR TITLE
[ignore] use generic for every api services and the toolbox struct

### DIFF
--- a/internal/api/dashboard/cleaner_test.go
+++ b/internal/api/dashboard/cleaner_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	databaseModel "github.com/perses/perses/internal/api/database/model"
+	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ type mockDAO struct {
 	dashboards []*v1.EphemeralDashboard
 }
 
-func (d *mockDAO) List(_ databaseModel.Query) ([]*v1.EphemeralDashboard, error) {
+func (d *mockDAO) List(_ *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, error) {
 	return d.dashboards, nil
 }
 

--- a/internal/api/impl/v1/dashboard/endpoint.go
+++ b/internal/api/impl/v1/dashboard/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.Dashboard, *dashboard.Query]
 	readonly bool
 }
 
 func NewEndpoint(service dashboard.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindDashboard, caseSensitive),
+		toolbox:  toolbox.New[*v1.Dashboard, *v1.Dashboard, *dashboard.Query](service, rbacService, v1.KindDashboard, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/dashboard/persistence.go
+++ b/internal/api/impl/v1/dashboard/persistence.go
@@ -53,7 +53,7 @@ func (d *dao) Get(project string, name string) (*v1.Dashboard, error) {
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.Dashboard, error) {
+func (d *dao) List(q *dashboard.Query) ([]*v1.Dashboard, error) {
 	var result []*v1.Dashboard
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/dashboard/service.go
+++ b/internal/api/impl/v1/dashboard/service.go
@@ -14,16 +14,12 @@
 package dashboard
 
 import (
-	"fmt"
-
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/internal/api/schemas"
 	"github.com/perses/perses/internal/api/validate"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -45,14 +41,7 @@ func NewService(dao dashboard.DAO, globalVarDAO globalvariable.DAO, projectVarDA
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.Dashboard); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting dashboard format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.Dashboard) (*v1.Dashboard, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.Dashboard) (*v1.Dashboard, error) {
 	// verify this new dashboard passes the validation
 	if err := s.Validate(entity); err != nil {
 		return nil, err
@@ -66,14 +55,7 @@ func (s *service) create(entity *v1.Dashboard) (*v1.Dashboard, error) {
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.Dashboard); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting dashboard format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.Dashboard, parameters apiInterface.Parameters) (*v1.Dashboard, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.Dashboard, parameters apiInterface.Parameters) (*v1.Dashboard, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in dashboard %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -107,11 +89,11 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Project, parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.Dashboard, error) {
 	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *dashboard.Query, _ apiInterface.Parameters) ([]*v1.Dashboard, error) {
 	return s.dao.List(q)
 }
 

--- a/internal/api/impl/v1/datasource/endpoint.go
+++ b/internal/api/impl/v1/datasource/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.Datasource, *datasource.Query]
 	readonly bool
 }
 
 func NewEndpoint(service datasource.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindDatasource, caseSensitive),
+		toolbox:  toolbox.New[*v1.Datasource, *v1.Datasource, *datasource.Query](service, rbacService, v1.KindDatasource, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/datasource/persistence.go
+++ b/internal/api/impl/v1/datasource/persistence.go
@@ -53,7 +53,7 @@ func (d *dao) Get(project string, name string) (*v1.Datasource, error) {
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.Datasource, error) {
+func (d *dao) List(q *datasource.Query) ([]*v1.Datasource, error) {
 	var result []*v1.Datasource
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/datasource/service.go
+++ b/internal/api/impl/v1/datasource/service.go
@@ -14,15 +14,10 @@
 package datasource
 
 import (
-	"fmt"
-
 	apiInterface "github.com/perses/perses/internal/api/interface"
-
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/schemas"
 	"github.com/perses/perses/internal/api/validate"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -40,14 +35,7 @@ func NewService(dao datasource.DAO, sch schemas.Schemas) datasource.Service {
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.Datasource); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Datasource format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.Datasource) (*v1.Datasource, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.Datasource) (*v1.Datasource, error) {
 	if err := s.validate(entity); err != nil {
 		return nil, apiInterface.HandleBadRequestError(err.Error())
 	}
@@ -59,14 +47,7 @@ func (s *service) create(entity *v1.Datasource) (*v1.Datasource, error) {
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.Datasource); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Datasource format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.Datasource, parameters apiInterface.Parameters) (*v1.Datasource, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.Datasource, parameters apiInterface.Parameters) (*v1.Datasource, error) {
 	if err := s.validate(entity); err != nil {
 		return nil, apiInterface.HandleBadRequestError(err.Error())
 	}
@@ -97,17 +78,16 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Project, parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.Datasource, error) {
 	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *datasource.Query, _ apiInterface.Parameters) ([]*v1.Datasource, error) {
 	dtsList, err := s.dao.List(q)
 	if err != nil {
 		return nil, err
 	}
-	dtsQuery := q.(*datasource.Query)
-	return v1.FilterDatasource(dtsQuery.Kind, dtsQuery.Default, dtsList), nil
+	return v1.FilterDatasource(q.Kind, q.Default, dtsList), nil
 }
 
 func (s *service) validate(entity *v1.Datasource) error {

--- a/internal/api/impl/v1/ephemeraldashboard/endpoint.go
+++ b/internal/api/impl/v1/ephemeraldashboard/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.EphemeralDashboard, *ephemeraldashboard.Query]
 	readonly bool
 }
 
 func NewEndpoint(service ephemeraldashboard.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindEphemeralDashboard, caseSensitive),
+		toolbox:  toolbox.New[*v1.EphemeralDashboard, *v1.EphemeralDashboard, *ephemeraldashboard.Query](service, rbacService, v1.KindEphemeralDashboard, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/ephemeraldashboard/persistence.go
+++ b/internal/api/impl/v1/ephemeraldashboard/persistence.go
@@ -53,7 +53,7 @@ func (d *dao) Get(project string, name string) (*v1.EphemeralDashboard, error) {
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.EphemeralDashboard, error) {
+func (d *dao) List(q *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, error) {
 	var result []*v1.EphemeralDashboard
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/ephemeraldashboard/service.go
+++ b/internal/api/impl/v1/ephemeraldashboard/service.go
@@ -14,16 +14,12 @@
 package ephemeraldashboard
 
 import (
-	"fmt"
-
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
 	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/internal/api/schemas"
 	"github.com/perses/perses/internal/api/validate"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -45,14 +41,7 @@ func NewService(dao ephemeraldashboard.DAO, globalVarDAO globalvariable.DAO, pro
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.EphemeralDashboard); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting ephemeral dashboard format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.EphemeralDashboard) (*v1.EphemeralDashboard, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.EphemeralDashboard) (*v1.EphemeralDashboard, error) {
 	// verify this new dashboard passes the validation
 	if err := s.Validate(entity); err != nil {
 		return nil, err
@@ -66,14 +55,7 @@ func (s *service) create(entity *v1.EphemeralDashboard) (*v1.EphemeralDashboard,
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.EphemeralDashboard); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting ephemeral dashboard format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.EphemeralDashboard, parameters apiInterface.Parameters) (*v1.EphemeralDashboard, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.EphemeralDashboard, parameters apiInterface.Parameters) (*v1.EphemeralDashboard, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in ephemeral dashboard %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -107,11 +89,11 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Project, parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.EphemeralDashboard, error) {
 	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, _ apiInterface.Parameters) ([]*v1.EphemeralDashboard, error) {
 	return s.dao.List(q)
 }
 

--- a/internal/api/impl/v1/folder/endpoint.go
+++ b/internal/api/impl/v1/folder/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.Folder, *folder.Query]
 	readonly bool
 }
 
 func NewEndpoint(service folder.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindFolder, caseSensitive),
+		toolbox:  toolbox.New[*v1.Folder, *v1.Folder, *folder.Query](service, rbacService, v1.KindFolder, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/folder/persistence.go
+++ b/internal/api/impl/v1/folder/persistence.go
@@ -53,7 +53,7 @@ func (d *dao) Get(project string, name string) (*v1.Folder, error) {
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.Folder, error) {
+func (d *dao) List(q *folder.Query) ([]*v1.Folder, error) {
 	var result []*v1.Folder
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/folder/service.go
+++ b/internal/api/impl/v1/folder/service.go
@@ -14,12 +14,8 @@
 package folder
 
 import (
-	"fmt"
-
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -35,14 +31,7 @@ func NewService(dao folder.DAO) folder.Service {
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.Folder); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Folder format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.Folder) (*v1.Folder, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.Folder) (*v1.Folder, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.dao.Create(entity); err != nil {
@@ -51,14 +40,7 @@ func (s *service) create(entity *v1.Folder) (*v1.Folder, error) {
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.Folder); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Folder format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.Folder, parameters apiInterface.Parameters) (*v1.Folder, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.Folder, parameters apiInterface.Parameters) (*v1.Folder, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Folder %q and name from the http request: %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -86,10 +68,10 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Project, parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.Folder, error) {
 	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *folder.Query, _ apiInterface.Parameters) ([]*v1.Folder, error) {
 	return s.dao.List(q)
 }

--- a/internal/api/impl/v1/globaldatasource/endpoint.go
+++ b/internal/api/impl/v1/globaldatasource/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.GlobalDatasource, *globaldatasource.Query]
 	readonly bool
 }
 
 func NewEndpoint(service globaldatasource.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindGlobalDatasource, caseSensitive),
+		toolbox:  toolbox.New[*v1.GlobalDatasource, *v1.GlobalDatasource, *globaldatasource.Query](service, rbacService, v1.KindGlobalDatasource, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/globaldatasource/persistence.go
+++ b/internal/api/impl/v1/globaldatasource/persistence.go
@@ -49,7 +49,7 @@ func (d *dao) Get(name string) (*v1.GlobalDatasource, error) {
 	return entity, d.client.Get(d.kind, v1.NewMetadata(name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.GlobalDatasource, error) {
+func (d *dao) List(q *globaldatasource.Query) ([]*v1.GlobalDatasource, error) {
 	var result []*v1.GlobalDatasource
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/globaldatasource/service.go
+++ b/internal/api/impl/v1/globaldatasource/service.go
@@ -14,14 +14,10 @@
 package globaldatasource
 
 import (
-	"fmt"
-
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
 	"github.com/perses/perses/internal/api/schemas"
 	"github.com/perses/perses/internal/api/validate"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -39,14 +35,7 @@ func NewService(dao globaldatasource.DAO, sch schemas.Schemas) globaldatasource.
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalDatasource); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting GlobalDatasource format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.GlobalDatasource) (*v1.GlobalDatasource, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.GlobalDatasource) (*v1.GlobalDatasource, error) {
 	if err := s.validate(entity); err != nil {
 		return nil, apiInterface.HandleBadRequestError(err.Error())
 	}
@@ -58,14 +47,7 @@ func (s *service) create(entity *v1.GlobalDatasource) (*v1.GlobalDatasource, err
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalDatasource); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting GlobalDatasource format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.GlobalDatasource, parameters apiInterface.Parameters) (*v1.GlobalDatasource, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.GlobalDatasource, parameters apiInterface.Parameters) (*v1.GlobalDatasource, error) {
 	if err := s.validate(entity); err != nil {
 		return nil, apiInterface.HandleBadRequestError(err.Error())
 	}
@@ -90,17 +72,16 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.GlobalDatasource, error) {
 	return s.dao.Get(parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *globaldatasource.Query, _ apiInterface.Parameters) ([]*v1.GlobalDatasource, error) {
 	dtsList, err := s.dao.List(q)
 	if err != nil {
 		return nil, err
 	}
-	dtsQuery := q.(*globaldatasource.Query)
-	return v1.FilterDatasource(dtsQuery.Kind, dtsQuery.Default, dtsList), nil
+	return v1.FilterDatasource(q.Kind, q.Default, dtsList), nil
 }
 
 func (s *service) validate(entity *v1.GlobalDatasource) error {

--- a/internal/api/impl/v1/globalrole/endpoint.go
+++ b/internal/api/impl/v1/globalrole/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.GlobalRole, *globalrole.Query]
 	readonly bool
 }
 
 func NewEndpoint(service globalrole.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindGlobalRole, caseSensitive),
+		toolbox:  toolbox.New[*v1.GlobalRole, *v1.GlobalRole, *globalrole.Query](service, rbacService, v1.KindGlobalRole, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/globalrole/persistence.go
+++ b/internal/api/impl/v1/globalrole/persistence.go
@@ -49,7 +49,7 @@ func (d *dao) Get(name string) (*v1.GlobalRole, error) {
 	return entity, d.client.Get(d.kind, v1.NewMetadata(name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.GlobalRole, error) {
+func (d *dao) List(q *globalrole.Query) ([]*v1.GlobalRole, error) {
 	var result []*v1.GlobalRole
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/globalrole/service.go
+++ b/internal/api/impl/v1/globalrole/service.go
@@ -14,14 +14,10 @@
 package globalrole
 
 import (
-	"fmt"
-
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/globalrole"
 	"github.com/perses/perses/internal/api/rbac"
 	"github.com/perses/perses/internal/api/schemas"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -41,14 +37,7 @@ func NewService(dao globalrole.DAO, rbac rbac.RBAC, sch schemas.Schemas) globalr
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalRole); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Globalrole format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.GlobalRole) (*v1.GlobalRole, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.GlobalRole) (*v1.GlobalRole, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.dao.Create(entity); err != nil {
@@ -61,14 +50,7 @@ func (s *service) create(entity *v1.GlobalRole) (*v1.GlobalRole, error) {
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalRole); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Globalrole format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.GlobalRole, parameters apiInterface.Parameters) (*v1.GlobalRole, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.GlobalRole, parameters apiInterface.Parameters) (*v1.GlobalRole, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Datasource %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -102,10 +84,10 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return nil
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.GlobalRole, error) {
 	return s.dao.Get(parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([]*v1.GlobalRole, error) {
 	return s.dao.List(q)
 }

--- a/internal/api/impl/v1/globalrolebinding/endpoint.go
+++ b/internal/api/impl/v1/globalrolebinding/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.GlobalRoleBinding, *globalrolebinding.Query]
 	readonly bool
 }
 
 func NewEndpoint(service globalrolebinding.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindGlobalRoleBinding, caseSensitive),
+		toolbox:  toolbox.New[*v1.GlobalRoleBinding, *v1.GlobalRoleBinding, *globalrolebinding.Query](service, rbacService, v1.KindGlobalRoleBinding, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/globalrolebinding/persistence.go
+++ b/internal/api/impl/v1/globalrolebinding/persistence.go
@@ -49,7 +49,7 @@ func (d *dao) Get(name string) (*v1.GlobalRoleBinding, error) {
 	return entity, d.client.Get(d.kind, v1.NewMetadata(name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.GlobalRoleBinding, error) {
+func (d *dao) List(q *globalrolebinding.Query) ([]*v1.GlobalRoleBinding, error) {
 	var result []*v1.GlobalRoleBinding
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/globalrolebinding/service.go
+++ b/internal/api/impl/v1/globalrolebinding/service.go
@@ -23,7 +23,6 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/user"
 	"github.com/perses/perses/internal/api/rbac"
 	"github.com/perses/perses/internal/api/schemas"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -47,14 +46,7 @@ func NewService(dao globalrolebinding.DAO, globalRoleDAO globalrole.DAO, userDAO
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalRoleBinding); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting GlobalroleBinding format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.GlobalRoleBinding) (*v1.GlobalRoleBinding, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.GlobalRoleBinding) (*v1.GlobalRoleBinding, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.validateGlobalRoleBinding(entity); err != nil {
@@ -70,14 +62,7 @@ func (s *service) create(entity *v1.GlobalRoleBinding) (*v1.GlobalRoleBinding, e
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalRoleBinding); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting GlobalroleBinding format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.GlobalRoleBinding, parameters apiInterface.Parameters) (*v1.GlobalRoleBinding, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.GlobalRoleBinding, parameters apiInterface.Parameters) (*v1.GlobalRoleBinding, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Datasource %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -123,11 +108,11 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return nil
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.GlobalRoleBinding, error) {
 	return s.dao.Get(parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([]*v1.GlobalRoleBinding, error) {
 	return s.dao.List(q)
 }
 

--- a/internal/api/impl/v1/globalsecret/endpoint.go
+++ b/internal/api/impl/v1/globalsecret/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.GlobalSecret, *globalsecret.Query]
 	readonly bool
 }
 
 func NewEndpoint(service globalsecret.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindGlobalSecret, caseSensitive),
+		toolbox:  toolbox.New[*v1.GlobalSecret, *v1.PublicGlobalSecret, *globalsecret.Query](service, rbacService, v1.KindGlobalSecret, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/globalsecret/persistence.go
+++ b/internal/api/impl/v1/globalsecret/persistence.go
@@ -52,7 +52,7 @@ func (d *dao) Get(name string) (*v1.GlobalSecret, error) {
 	return entity, d.client.Get(d.kind, v1.NewMetadata(name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.GlobalSecret, error) {
+func (d *dao) List(q *globalsecret.Query) ([]*v1.GlobalSecret, error) {
 	var result []*v1.GlobalSecret
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/globalvariable/endpoint.go
+++ b/internal/api/impl/v1/globalvariable/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.GlobalVariable, *globalvariable.Query]
 	readonly bool
 }
 
 func NewEndpoint(service globalvariable.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindGlobalVariable, caseSensitive),
+		toolbox:  toolbox.New[*v1.GlobalVariable, *v1.GlobalVariable, *globalvariable.Query](service, rbacService, v1.KindGlobalVariable, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/globalvariable/persistence.go
+++ b/internal/api/impl/v1/globalvariable/persistence.go
@@ -49,7 +49,7 @@ func (d *dao) Get(name string) (*v1.GlobalVariable, error) {
 	return entity, d.client.Get(d.kind, v1.NewMetadata(name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.GlobalVariable, error) {
+func (d *dao) List(q *globalvariable.Query) ([]*v1.GlobalVariable, error) {
 	var result []*v1.GlobalVariable
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/globalvariable/service.go
+++ b/internal/api/impl/v1/globalvariable/service.go
@@ -14,14 +14,10 @@
 package globalvariable
 
 import (
-	"fmt"
-
 	apiInterface "github.com/perses/perses/internal/api/interface"
 
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/schemas"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -39,14 +35,7 @@ func NewService(dao globalvariable.DAO, sch schemas.Schemas) globalvariable.Serv
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalVariable); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Globalvariable format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.GlobalVariable) (*v1.GlobalVariable, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.GlobalVariable) (*v1.GlobalVariable, error) {
 	if err := s.sch.ValidateGlobalVariable(entity.Spec); err != nil {
 		return nil, apiInterface.HandleBadRequestError(err.Error())
 	}
@@ -59,14 +48,7 @@ func (s *service) create(entity *v1.GlobalVariable) (*v1.GlobalVariable, error) 
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.GlobalVariable); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Globalvariable format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.GlobalVariable, parameters apiInterface.Parameters) (*v1.GlobalVariable, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.GlobalVariable, parameters apiInterface.Parameters) (*v1.GlobalVariable, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Datasource %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -91,10 +73,10 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.GlobalVariable, error) {
 	return s.dao.Get(parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([]*v1.GlobalVariable, error) {
 	return s.dao.List(q)
 }

--- a/internal/api/impl/v1/project/endpoint.go
+++ b/internal/api/impl/v1/project/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.Project, *project.Query]
 	readonly bool
 }
 
 func NewEndpoint(service project.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindProject, caseSensitive),
+		toolbox:  toolbox.New[*v1.Project, *v1.Project, *project.Query](service, rbacService, v1.KindProject, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/project/persistence.go
+++ b/internal/api/impl/v1/project/persistence.go
@@ -49,7 +49,7 @@ func (d *dao) Delete(name string) error {
 	return d.client.Delete(d.kind, v1.NewMetadata(name))
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.Project, error) {
+func (d *dao) List(q *project.Query) ([]*v1.Project, error) {
 	var result []*v1.Project
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/role/endpoint.go
+++ b/internal/api/impl/v1/role/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.Role, *role.Query]
 	readonly bool
 }
 
 func NewEndpoint(service role.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindRole, caseSensitive),
+		toolbox:  toolbox.New[*v1.Role, *v1.Role, *role.Query](service, rbacService, v1.KindRole, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/role/persistence.go
+++ b/internal/api/impl/v1/role/persistence.go
@@ -53,7 +53,7 @@ func (d *dao) Get(project string, name string) (*v1.Role, error) {
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.Role, error) {
+func (d *dao) List(q *role.Query) ([]*v1.Role, error) {
 	var result []*v1.Role
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/role/service.go
+++ b/internal/api/impl/v1/role/service.go
@@ -14,15 +14,11 @@
 package role
 
 import (
-	"fmt"
-
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/rbac"
 
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/role"
 	"github.com/perses/perses/internal/api/schemas"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -42,14 +38,7 @@ func NewService(dao role.DAO, rbac rbac.RBAC, sch schemas.Schemas) role.Service 
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.Role); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting role format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.Role) (*v1.Role, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.Role) (*v1.Role, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.dao.Create(entity); err != nil {
@@ -62,14 +51,7 @@ func (s *service) create(entity *v1.Role) (*v1.Role, error) {
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.Role); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting role format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.Role, parameters apiInterface.Parameters) (*v1.Role, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.Role, parameters apiInterface.Parameters) (*v1.Role, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in role %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -109,10 +91,10 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return nil
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.Role, error) {
 	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *role.Query, _ apiInterface.Parameters) ([]*v1.Role, error) {
 	return s.dao.List(q)
 }

--- a/internal/api/impl/v1/rolebinding/endpoint.go
+++ b/internal/api/impl/v1/rolebinding/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.RoleBinding, *rolebinding.Query]
 	readonly bool
 }
 
 func NewEndpoint(service rolebinding.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindRoleBinding, caseSensitive),
+		toolbox:  toolbox.New[*v1.RoleBinding, *v1.RoleBinding, *rolebinding.Query](service, rbacService, v1.KindRoleBinding, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/rolebinding/persistence.go
+++ b/internal/api/impl/v1/rolebinding/persistence.go
@@ -53,7 +53,7 @@ func (d *dao) Get(project string, name string) (*v1.RoleBinding, error) {
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.RoleBinding, error) {
+func (d *dao) List(q *rolebinding.Query) ([]*v1.RoleBinding, error) {
 	var result []*v1.RoleBinding
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/rolebinding/service.go
+++ b/internal/api/impl/v1/rolebinding/service.go
@@ -24,7 +24,6 @@ import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/rolebinding"
 	"github.com/perses/perses/internal/api/schemas"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -48,14 +47,7 @@ func NewService(dao rolebinding.DAO, roleDAO role.DAO, userDAO user.DAO, rbac rb
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.RoleBinding); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting roleBinding format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.RoleBinding) (*v1.RoleBinding, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.RoleBinding) (*v1.RoleBinding, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	if err := s.validateRoleBinding(entity); err != nil {
@@ -71,14 +63,7 @@ func (s *service) create(entity *v1.RoleBinding) (*v1.RoleBinding, error) {
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.RoleBinding); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting roleBinding format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.RoleBinding, parameters apiInterface.Parameters) (*v1.RoleBinding, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.RoleBinding, parameters apiInterface.Parameters) (*v1.RoleBinding, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in roleBinding %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -129,11 +114,11 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return nil
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.RoleBinding, error) {
 	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *rolebinding.Query, _ apiInterface.Parameters) ([]*v1.RoleBinding, error) {
 	return s.dao.List(q)
 }
 

--- a/internal/api/impl/v1/secret/endpoint.go
+++ b/internal/api/impl/v1/secret/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.Secret, *secret.Query]
 	readonly bool
 }
 
 func NewEndpoint(service secret.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindSecret, caseSensitive),
+		toolbox:  toolbox.New[*v1.Secret, *v1.PublicSecret, *secret.Query](service, rbacService, v1.KindSecret, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/secret/persistence.go
+++ b/internal/api/impl/v1/secret/persistence.go
@@ -56,7 +56,7 @@ func (d *dao) Get(project string, name string) (*v1.Secret, error) {
 
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.Secret, error) {
+func (d *dao) List(q *secret.Query) ([]*v1.Secret, error) {
 	var result []*v1.Secret
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/user/endpoint.go
+++ b/internal/api/impl/v1/user/endpoint.go
@@ -31,7 +31,7 @@ import (
 )
 
 type endpoint struct {
-	toolbox       toolbox.Toolbox
+	toolbox       toolbox.Toolbox[*v1.User, *user.Query]
 	rbac          rbac.RBAC
 	readonly      bool
 	disableSignUp bool
@@ -40,7 +40,7 @@ type endpoint struct {
 
 func NewEndpoint(service user.Service, rbacService rbac.RBAC, disableSignUp bool, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:       toolbox.New(service, rbacService, v1.KindUser, caseSensitive),
+		toolbox:       toolbox.New[*v1.User, *v1.PublicUser, *user.Query](service, rbacService, v1.KindUser, caseSensitive),
 		rbac:          rbacService,
 		readonly:      readonly,
 		disableSignUp: disableSignUp,

--- a/internal/api/impl/v1/user/persistence.go
+++ b/internal/api/impl/v1/user/persistence.go
@@ -52,7 +52,7 @@ func (d *dao) Get(name string) (*v1.User, error) {
 	return entity, d.client.Get(d.kind, v1.NewMetadata(name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.User, error) {
+func (d *dao) List(q *user.Query) ([]*v1.User, error) {
 	var result []*v1.User
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -19,9 +19,7 @@ import (
 	apiInterface "github.com/perses/perses/internal/api/interface"
 
 	"github.com/perses/perses/internal/api/crypto"
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/user"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -37,14 +35,7 @@ func NewService(dao user.DAO) user.Service {
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.User); ok {
-		return s.create(object)
-	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting user format, received '%T'", apiInterface.BadRequestError, entity)
-}
-
-func (s *service) create(entity *v1.User) (*v1.PublicUser, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.User) (*v1.PublicUser, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	// check that the password is correctly filled
@@ -64,14 +55,7 @@ func (s *service) create(entity *v1.User) (*v1.PublicUser, error) {
 	return v1.NewPublicUser(entity), nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if userObject, ok := entity.(*v1.User); ok {
-		return s.update(userObject, parameters)
-	}
-	return nil, fmt.Errorf("%w: wrong entity format, attempting user format, received '%T'", apiInterface.BadRequestError, entity)
-}
-
-func (s *service) update(entity *v1.User, parameters apiInterface.Parameters) (*v1.PublicUser, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.User, parameters apiInterface.Parameters) (*v1.PublicUser, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in user '%s' and coming from the http request: '%s' doesn't match", entity.Metadata.Name, parameters.Name)
 		return nil, fmt.Errorf("%w: metadata.name and the name in the http path request doesn't match", apiInterface.BadRequestError)
@@ -111,7 +95,7 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.PublicUser, error) {
 	usr, err := s.dao.Get(parameters.Name)
 	if err != nil {
 		return nil, err
@@ -119,7 +103,7 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 	return v1.NewPublicUser(usr), nil
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *user.Query, _ apiInterface.Parameters) ([]*v1.PublicUser, error) {
 	l, err := s.dao.List(q)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/variable/endpoint.go
+++ b/internal/api/impl/v1/variable/endpoint.go
@@ -28,13 +28,13 @@ import (
 )
 
 type endpoint struct {
-	toolbox  toolbox.Toolbox
+	toolbox  toolbox.Toolbox[*v1.Variable, *variable.Query]
 	readonly bool
 }
 
 func NewEndpoint(service variable.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool) route.Endpoint {
 	return &endpoint{
-		toolbox:  toolbox.New(service, rbacService, v1.KindVariable, caseSensitive),
+		toolbox:  toolbox.New[*v1.Variable, *v1.Variable, *variable.Query](service, rbacService, v1.KindVariable, caseSensitive),
 		readonly: readonly,
 	}
 }

--- a/internal/api/impl/v1/variable/persistence.go
+++ b/internal/api/impl/v1/variable/persistence.go
@@ -53,7 +53,7 @@ func (d *dao) Get(project string, name string) (*v1.Variable, error) {
 	return entity, d.client.Get(d.kind, v1.NewProjectMetadata(project, name), entity)
 }
 
-func (d *dao) List(q databaseModel.Query) ([]*v1.Variable, error) {
+func (d *dao) List(q *variable.Query) ([]*v1.Variable, error) {
 	var result []*v1.Variable
 	err := d.client.Query(q, &result)
 	return result, err

--- a/internal/api/impl/v1/variable/service.go
+++ b/internal/api/impl/v1/variable/service.go
@@ -14,15 +14,11 @@
 package variable
 
 import (
-	"fmt"
-
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/validate"
 
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/internal/api/schemas"
-	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -40,14 +36,7 @@ func NewService(dao variable.DAO, sch schemas.Schemas) variable.Service {
 	}
 }
 
-func (s *service) Create(_ apiInterface.PersesContext, entity api.Entity) (interface{}, error) {
-	if object, ok := entity.(*v1.Variable); ok {
-		return s.create(object)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Variable format, received '%T'", entity))
-}
-
-func (s *service) create(entity *v1.Variable) (*v1.Variable, error) {
+func (s *service) Create(_ apiInterface.PersesContext, entity *v1.Variable) (*v1.Variable, error) {
 	if err := validate.Variable(entity, s.sch); err != nil {
 		return nil, apiInterface.HandleBadRequestError(err.Error())
 	}
@@ -59,14 +48,7 @@ func (s *service) create(entity *v1.Variable) (*v1.Variable, error) {
 	return entity, nil
 }
 
-func (s *service) Update(_ apiInterface.PersesContext, entity api.Entity, parameters apiInterface.Parameters) (interface{}, error) {
-	if object, ok := entity.(*v1.Variable); ok {
-		return s.update(object, parameters)
-	}
-	return nil, apiInterface.HandleBadRequestError(fmt.Sprintf("wrong entity format, attempting Variable format, received '%T'", entity))
-}
-
-func (s *service) update(entity *v1.Variable, parameters apiInterface.Parameters) (*v1.Variable, error) {
+func (s *service) Update(_ apiInterface.PersesContext, entity *v1.Variable, parameters apiInterface.Parameters) (*v1.Variable, error) {
 	if entity.Metadata.Name != parameters.Name {
 		logrus.Debugf("name in Variable %q and name from the http request %q don't match", entity.Metadata.Name, parameters.Name)
 		return nil, apiInterface.HandleBadRequestError("metadata.name and the name in the http path request don't match")
@@ -99,10 +81,10 @@ func (s *service) Delete(_ apiInterface.PersesContext, parameters apiInterface.P
 	return s.dao.Delete(parameters.Project, parameters.Name)
 }
 
-func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (interface{}, error) {
+func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Parameters) (*v1.Variable, error) {
 	return s.dao.Get(parameters.Project, parameters.Name)
 }
 
-func (s *service) List(_ apiInterface.PersesContext, q databaseModel.Query, _ apiInterface.Parameters) (interface{}, error) {
+func (s *service) List(_ apiInterface.PersesContext, q *variable.Query, _ apiInterface.Parameters) ([]*v1.Variable, error) {
 	return s.dao.List(q)
 }

--- a/internal/api/interface/service.go
+++ b/internal/api/interface/service.go
@@ -55,10 +55,10 @@ type Parameters struct {
 	Name    string
 }
 
-type Service interface {
-	Create(ctx PersesContext, entity api.Entity) (interface{}, error)
-	Update(ctx PersesContext, entity api.Entity, parameters Parameters) (interface{}, error)
+type Service[T api.Entity, K api.Entity, V databaseModel.Query] interface {
+	Create(ctx PersesContext, entity T) (K, error)
+	Update(ctx PersesContext, entity T, parameters Parameters) (K, error)
 	Delete(ctx PersesContext, parameters Parameters) error
-	Get(ctx PersesContext, parameters Parameters) (interface{}, error)
-	List(ctx PersesContext, q databaseModel.Query, parameters Parameters) (interface{}, error)
+	Get(ctx PersesContext, parameters Parameters) (K, error)
+	List(ctx PersesContext, q V, parameters Parameters) ([]K, error)
 }

--- a/internal/api/interface/v1/dashboard/interface.go
+++ b/internal/api/interface/v1/dashboard/interface.go
@@ -35,10 +35,10 @@ type DAO interface {
 	Delete(project string, name string) error
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Dashboard, error)
-	List(q databaseModel.Query) ([]*v1.Dashboard, error)
+	List(q *Query) ([]*v1.Dashboard, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.Dashboard, *v1.Dashboard, *Query]
 	Validate(entity *v1.Dashboard) error
 }

--- a/internal/api/interface/v1/datasource/interface.go
+++ b/internal/api/interface/v1/datasource/interface.go
@@ -39,9 +39,9 @@ type DAO interface {
 	Delete(project string, name string) error
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Datasource, error)
-	List(q databaseModel.Query) ([]*v1.Datasource, error)
+	List(q *Query) ([]*v1.Datasource, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.Datasource, *v1.Datasource, *Query]
 }

--- a/internal/api/interface/v1/ephemeraldashboard/interface.go
+++ b/internal/api/interface/v1/ephemeraldashboard/interface.go
@@ -35,10 +35,10 @@ type DAO interface {
 	Delete(project string, name string) error
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.EphemeralDashboard, error)
-	List(q databaseModel.Query) ([]*v1.EphemeralDashboard, error)
+	List(q *Query) ([]*v1.EphemeralDashboard, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.EphemeralDashboard, *v1.EphemeralDashboard, *Query]
 	Validate(entity *v1.EphemeralDashboard) error
 }

--- a/internal/api/interface/v1/folder/interface.go
+++ b/internal/api/interface/v1/folder/interface.go
@@ -35,9 +35,9 @@ type DAO interface {
 	Delete(project string, name string) error
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Folder, error)
-	List(q databaseModel.Query) ([]*v1.Folder, error)
+	List(q *Query) ([]*v1.Folder, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.Folder, *v1.Folder, *Query]
 }

--- a/internal/api/interface/v1/globaldatasource/interface.go
+++ b/internal/api/interface/v1/globaldatasource/interface.go
@@ -35,9 +35,9 @@ type DAO interface {
 	Update(entity *v1.GlobalDatasource) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalDatasource, error)
-	List(q databaseModel.Query) ([]*v1.GlobalDatasource, error)
+	List(q *Query) ([]*v1.GlobalDatasource, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.GlobalDatasource, *v1.GlobalDatasource, *Query]
 }

--- a/internal/api/interface/v1/globalrole/interface.go
+++ b/internal/api/interface/v1/globalrole/interface.go
@@ -31,9 +31,9 @@ type DAO interface {
 	Update(entity *v1.GlobalRole) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRole, error)
-	List(q databaseModel.Query) ([]*v1.GlobalRole, error)
+	List(q *Query) ([]*v1.GlobalRole, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.GlobalRole, *v1.GlobalRole, *Query]
 }

--- a/internal/api/interface/v1/globalrolebinding/interface.go
+++ b/internal/api/interface/v1/globalrolebinding/interface.go
@@ -31,9 +31,9 @@ type DAO interface {
 	Update(entity *v1.GlobalRoleBinding) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRoleBinding, error)
-	List(q databaseModel.Query) ([]*v1.GlobalRoleBinding, error)
+	List(q *Query) ([]*v1.GlobalRoleBinding, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.GlobalRoleBinding, *v1.GlobalRoleBinding, *Query]
 }

--- a/internal/api/interface/v1/globalsecret/interface.go
+++ b/internal/api/interface/v1/globalsecret/interface.go
@@ -31,9 +31,9 @@ type DAO interface {
 	Update(entity *v1.GlobalSecret) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalSecret, error)
-	List(q databaseModel.Query) ([]*v1.GlobalSecret, error)
+	List(q *Query) ([]*v1.GlobalSecret, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.GlobalSecret, *v1.PublicGlobalSecret, *Query]
 }

--- a/internal/api/interface/v1/globalvariable/interface.go
+++ b/internal/api/interface/v1/globalvariable/interface.go
@@ -31,9 +31,9 @@ type DAO interface {
 	Update(entity *v1.GlobalVariable) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalVariable, error)
-	List(q databaseModel.Query) ([]*v1.GlobalVariable, error)
+	List(q *Query) ([]*v1.GlobalVariable, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.GlobalVariable, *v1.GlobalVariable, *Query]
 }

--- a/internal/api/interface/v1/project/interface.go
+++ b/internal/api/interface/v1/project/interface.go
@@ -31,9 +31,9 @@ type DAO interface {
 	Update(entity *v1.Project) error
 	Delete(name string) error
 	Get(name string) (*v1.Project, error)
-	List(q databaseModel.Query) ([]*v1.Project, error)
+	List(q *Query) ([]*v1.Project, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.Project, *v1.Project, *Query]
 }

--- a/internal/api/interface/v1/role/interface.go
+++ b/internal/api/interface/v1/role/interface.go
@@ -35,9 +35,9 @@ type DAO interface {
 	Delete(project string, name string) error
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Role, error)
-	List(q databaseModel.Query) ([]*v1.Role, error)
+	List(q *Query) ([]*v1.Role, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.Role, *v1.Role, *Query]
 }

--- a/internal/api/interface/v1/rolebinding/interface.go
+++ b/internal/api/interface/v1/rolebinding/interface.go
@@ -35,9 +35,9 @@ type DAO interface {
 	Delete(project string, name string) error
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.RoleBinding, error)
-	List(q databaseModel.Query) ([]*v1.RoleBinding, error)
+	List(q *Query) ([]*v1.RoleBinding, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.RoleBinding, *v1.RoleBinding, *Query]
 }

--- a/internal/api/interface/v1/secret/interface.go
+++ b/internal/api/interface/v1/secret/interface.go
@@ -36,9 +36,9 @@ type DAO interface {
 
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Secret, error)
-	List(q databaseModel.Query) ([]*v1.Secret, error)
+	List(q *Query) ([]*v1.Secret, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.Secret, *v1.PublicSecret, *Query]
 }

--- a/internal/api/interface/v1/user/interface.go
+++ b/internal/api/interface/v1/user/interface.go
@@ -31,9 +31,9 @@ type DAO interface {
 	Update(entity *v1.User) error
 	Delete(name string) error
 	Get(name string) (*v1.User, error)
-	List(q databaseModel.Query) ([]*v1.User, error)
+	List(q *Query) ([]*v1.User, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.User, *v1.PublicUser, *Query]
 }

--- a/internal/api/interface/v1/variable/interface.go
+++ b/internal/api/interface/v1/variable/interface.go
@@ -34,9 +34,9 @@ type DAO interface {
 	Delete(project string, name string) error
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Variable, error)
-	List(q databaseModel.Query) ([]*v1.Variable, error)
+	List(q *Query) ([]*v1.Variable, error)
 }
 
 type Service interface {
-	apiInterface.Service
+	apiInterface.Service[*v1.Variable, *v1.Variable, *Query]
 }


### PR DESCRIPTION
This PR is updating every services / endpoints to use generics.

It removes unnecessary cast / type check. Using direct type in the API services will be helpful for the issue #1907 (specially for the `List` method as we will be able to modify the query struct directly with the data coming from the parameter) 