### PR TITLE
[BUGFIX] Fix HTTP error returned when access permission is missing

### DIFF
--- a/internal/api/e2e/api/rbac_test.go
+++ b/internal/api/e2e/api/rbac_test.go
@@ -140,7 +140,7 @@ func TestUnauthorizedEndpoints(t *testing.T) {
 		token := authResponse.JSON().Object().Value("accessToken").String().Raw()
 
 		glRole := e2eframework.NewGlobalRole("test")
-		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathGlobalRole)).WithJSON(glRole).WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).Expect().Status(http.StatusUnauthorized)
+		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathGlobalRole)).WithJSON(glRole).WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).Expect().Status(http.StatusForbidden)
 
 		project2Entity := e2eframework.NewProject("mysuperproject2")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathProject)).WithJSON(project2Entity).WithHeader("Authorization", "Bearer <bad token>").Expect().Status(http.StatusUnauthorized)

--- a/internal/api/impl/v1/user/endpoint.go
+++ b/internal/api/impl/v1/user/endpoint.go
@@ -93,7 +93,7 @@ func (e *endpoint) GetPermissions(ctx echo.Context) error {
 		return apiinterface.HandleUnauthorizedError("you need to be connected to retrieve your permissions")
 	}
 	if claims.Subject != parameters.Name {
-		return apiinterface.HandleUnauthorizedError("you can only retrieve your permissions")
+		return apiinterface.HandleForbiddenError("you can only retrieve your permissions")
 	}
 	permissions := e.rbac.GetPermissions(claims.Subject)
 	return ctx.JSON(http.StatusOK, permissions)

--- a/internal/api/toolbox/toolbox.go
+++ b/internal/api/toolbox/toolbox.go
@@ -83,7 +83,7 @@ func (t *toolbox[T, K, V]) checkPermission(ctx echo.Context, entity api.Entity, 
 	}
 	if role.IsGlobalScope(*scope) {
 		if ok := t.rbac.HasPermission(claims.Subject, action, rbac.GlobalProject, *scope); !ok {
-			return apiInterface.HandleUnauthorizedError(fmt.Sprintf("missing '%s' global permission for '%s' kind", action, *scope))
+			return apiInterface.HandleForbiddenError(fmt.Sprintf("missing '%s' global permission for '%s' kind", action, *scope))
 		}
 		return nil
 	}
@@ -93,7 +93,7 @@ func (t *toolbox[T, K, V]) checkPermission(ctx echo.Context, entity api.Entity, 
 		// Create is still a "Global" only permission
 		if action == role.CreateAction {
 			if ok := t.rbac.HasPermission(claims.Subject, action, rbac.GlobalProject, *scope); !ok {
-				return apiInterface.HandleUnauthorizedError(fmt.Sprintf("missing '%s' global permission for '%s' kind", action, *scope))
+				return apiInterface.HandleForbiddenError(fmt.Sprintf("missing '%s' global permission for '%s' kind", action, *scope))
 			}
 			return nil
 		}
@@ -105,7 +105,7 @@ func (t *toolbox[T, K, V]) checkPermission(ctx echo.Context, entity api.Entity, 
 		projectName = utils.GetMetadataProject(entity.GetMetadata())
 	}
 	if ok := t.rbac.HasPermission(claims.Subject, action, projectName, *scope); !ok {
-		return apiInterface.HandleUnauthorizedError(fmt.Sprintf("missing '%s' permission in '%s' project for '%s' kind", action, projectName, *scope))
+		return apiInterface.HandleForbiddenError(fmt.Sprintf("missing '%s' permission in '%s' project for '%s' kind", action, projectName, *scope))
 
 	}
 	return nil


### PR DESCRIPTION
Move from the HTTP error 401 to 403 when user doesn't have enough permission to make the request.