### PR TITLE
[FEATURE] CLI: add cmd whoami

### DIFF
--- a/cmd/percli/main.go
+++ b/cmd/percli/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/perses/perses/internal/cli/cmd/refresh"
 	"github.com/perses/perses/internal/cli/cmd/remove"
 	"github.com/perses/perses/internal/cli/cmd/version"
+	"github.com/perses/perses/internal/cli/cmd/whoami"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -57,6 +58,7 @@ func newRootCommand() *cobra.Command {
 	cmd.AddCommand(refresh.NewCMD())
 	cmd.AddCommand(remove.NewCMD())
 	cmd.AddCommand(version.NewCMD())
+	cmd.AddCommand(whoami.NewCMD())
 
 	// the list of supported global flags
 	cmd.PersistentFlags().StringVar(&configPath, "percliconfig", config.GetDefaultPath(), "Path to the percliconfig file to use for CLI requests.")

--- a/docs/tooling/cli.md
+++ b/docs/tooling/cli.md
@@ -23,6 +23,7 @@ Usage:
 Available Commands:
   apply       Create or update resources through a file. JSON or YAML format supported
   completion  Generate the autocompletion script for the specified shell
+  config      display local or remote config
   dac         Commands related to Dashboard-as-Code
   delete      Delete resources
   describe    Show details of a specific resource
@@ -34,6 +35,7 @@ Available Commands:
   project     Select the project used by default.
   refresh     refresh the access token when it expires
   version     Display client version.
+  whoami      Display current user used
 
 Flags:
   -h, --help                  help for percli

--- a/internal/cli/cmd/whoami/whoami.go
+++ b/internal/cli/cmd/whoami/whoami.go
@@ -1,0 +1,92 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package whoami
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/perses/perses/internal/api/crypto"
+	persesCMD "github.com/perses/perses/internal/cli/cmd"
+	"github.com/perses/perses/internal/cli/config"
+	"github.com/perses/perses/internal/cli/output"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	persesCMD.Option
+	writer        io.Writer
+	showToken     bool
+	showURL       bool
+	authorization *secret.Authorization
+}
+
+func (o *option) Complete(_ []string) error {
+	o.authorization = config.Global.RestClientConfig.Authorization
+	return nil
+}
+
+func (o *option) Validate() error {
+	if o.authorization == nil {
+		return fmt.Errorf("you are not connected to any Perses server")
+	}
+	return nil
+}
+
+func (o *option) Execute() error {
+	if o.showToken {
+		if err := output.HandleString(o.writer, fmt.Sprintf("Token used: %s", o.authorization.Credentials)); err != nil {
+			return err
+		}
+	}
+	if o.showURL {
+		if err := output.HandleString(o.writer, fmt.Sprintf("Authenticated to the server: %s", config.Global.RestClientConfig.URL)); err != nil {
+			return err
+		}
+	}
+	login, err := o.extractLogin()
+	if err != nil {
+		return err
+	}
+	return output.HandleString(o.writer, fmt.Sprintf("User used: %s", login))
+}
+
+func (o *option) extractLogin() (string, error) {
+	claims := &crypto.JWTCustomClaims{}
+	token, _, err := jwt.NewParser().ParseUnverified(o.authorization.Credentials, claims)
+	if err != nil {
+		return "", err
+	}
+	return token.Claims.(*crypto.JWTCustomClaims).Subject, nil
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Display current user used",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return persesCMD.Run(o, cmd, args)
+		},
+	}
+	cmd.Flags().BoolVar(&o.showToken, "show-token", o.showToken, "Print the token the current session is using.")
+	cmd.Flags().BoolVar(&o.showURL, "show-url", o.showURL, "If true, print the current server's REST API URL.")
+	return cmd
+}

--- a/internal/cli/cmd/whoami/whoami.go
+++ b/internal/cli/cmd/whoami/whoami.go
@@ -87,6 +87,6 @@ func NewCMD() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&o.showToken, "show-token", o.showToken, "Print the token the current session is using.")
-	cmd.Flags().BoolVar(&o.showURL, "show-url", o.showURL, "If true, print the current server's REST API URL.")
+	cmd.Flags().BoolVar(&o.showURL, "show-url", o.showURL, "Print the current server's REST API URL.")
 	return cmd
 }


### PR DESCRIPTION
can be used as follow:

```bash
./bin/percli whoami --show-token --show-url
Token used: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTcxMzI3OTg3MiwibmJmIjoxNzEzMjc4OTcyfQ.mecrHuc4FVMLLNcOfc_2IEPlZ85BZJrtO8FAWFKieZV4rg_b32iiLLcfcOEv36h6QL5EVizSg7XLA5UxCk-m2Q
Authenticated to the server: http://localhost:8080
User used: admin
```