### PR TITLE
[BUGFIX] Fix grafana migration failing for "custom" template variables

### DIFF
--- a/cue/schemas/variables/static-list/migrate.cue
+++ b/cue/schemas/variables/static-list/migrate.cue
@@ -1,8 +1,16 @@
 if #var.type == "custom" || #var.type == "interval" {
 	kind: "StaticListVariable"
 	spec: {
-		values: [ for _, option in #var.options if option.value !~ "^\\$__.*$" { // the if filters out the grafana global vars that'd be causing validation issues later (e.g "__auto_interval_sampling is used but not defined")
-			option.value
+		_valuesArray: strings.Split(#var.query, ",")
+		_aliasedValueRegexp: "^(.*) : (.*)$"
+		values: [ for val in _valuesArray {
+			[// switch
+				if val =~ _aliasedValueRegexp {
+					label: strings.TrimSpace(regexp.FindSubmatch(_aliasedValueRegexp, val)[1])
+					value: strings.TrimSpace(regexp.FindSubmatch(_aliasedValueRegexp, val)[2])
+				},
+				strings.TrimSpace(val),
+			][0]
 		}]
 	}
 },

--- a/cue/schemas/variables/static-list/static-list.json
+++ b/cue/schemas/variables/static-list/static-list.json
@@ -2,13 +2,12 @@
   "kind": "StaticListVariable",
   "spec": {
     "values": [
-      {
-        "value": "1m"
-      },
+      "1m",
       {
         "value": "5m"
       },
       {
+        "label": "Ten minutes",
         "value": "10m"
       }
     ]

--- a/docs/plugin/cue.md
+++ b/docs/plugin/cue.md
@@ -87,9 +87,7 @@ A variable migration file looks like the following:
 if #var.type == "custom" || #var.type == "interval" {
     kind: "StaticListVariable"
     spec: {
-        values: [ for _, option in #var.options if option.value !~ "^\\$__.*$" { // the if filters out the grafana global vars that'd be causing validation issues later (e.g "__auto_interval_sampling is used but not defined")
-            option.value
-        }]
+        values: strings.Split(#var.query, ",")
     }
 },
 ```

--- a/internal/api/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/simple_grafana_dashboard.json
@@ -500,7 +500,7 @@
             "value": "three"
           }
         ],
-        "query": "one,two,three",
+        "query": "one,  two  ,three : 3  ",
         "skipUrlSync": false,
         "type": "custom"
       },

--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -28,7 +28,10 @@
               "values": [
                 "one",
                 "two",
-                "three"
+                {
+                  "label": "three",
+                  "value": "3"
+                }
               ]
             }
           },


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Rework the migration logic of StaticListVariable to avoid migration failure: relying on the `options` field was causing the following error when migrating dashboards retrieved directly from the Grafana database (not from UI):

```
error="something wrong happened with the request to the API.  Message: bad request: unable to convert to Perses dashboard: spec.variables.0.spec.plugin.spec.values: undefined field: options (and 1 more errors) StatusCode: 400"
```

This was happening because the `options` field is actually made-up by the frontend from the `query` field, it doesn't get saved in db.

Also I took advantage of this fix to enhance the StaticListVariable migration logic, to no longer lose the "key" when the `key : value` syntax is used.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).