### PR TITLE
[BUGFIX] Fix dashboard list with empty project on home page

### DIFF
--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -58,7 +58,7 @@ export function useDashboard(project: string, name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDashboardList(project?: string) {
-  return useQuery<DashboardResource[], Error>([resource, project], () => {
+  return useQuery<DashboardResource[] | null, Error>([resource, project], () => {
     return getDashboards(project);
   });
 }
@@ -182,7 +182,7 @@ export function getDashboard(project: string, name: string) {
 
 export function getDashboards(project?: string) {
   const url = buildURL({ resource: resource, project: project });
-  return fetchJson<DashboardResource[]>(url, {
+  return fetchJson<DashboardResource[] | null>(url, {
     method: HTTPMethodGET,
     headers: HTTPHeader,
   });

--- a/ui/app/src/model/project-client.ts
+++ b/ui/app/src/model/project-client.ts
@@ -185,7 +185,7 @@ async function getProjectsWithDashboard(): Promise<ProjectWithDashboards[]> {
   const projects = await getProjects();
   const result: ProjectWithDashboards[] = [];
   for (const project of projects ?? []) {
-    const dashboards = await getDashboards(project.metadata.name);
+    const dashboards = (await getDashboards(project.metadata.name)) ?? [];
     result.push({ project: project, dashboards: dashboards });
   }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
With PR #1900, empty projects are now listed on the home page. However if a project is empty, it will raise an error when opening the accordion as the API returns `null`. Idea for later: maybe returns an empty list? 😄 

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
