### PR TITLE
[BUGFIX] Grafana migration: best-effort solution to not migrate irrelevant regexps

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -113,9 +113,19 @@ spec: {
                 if allowAllValue if grafanaVar.allValue != _|_ {
                     customAllValue: grafanaVar.allValue
                 }
-                if grafanaVar.regex != _|_ {
-                    capturingRegexp: grafanaVar.regex
-                }
+                // TODO: enable (back) capturing regexp migration
+                capturingRegexp?: _|_
+                // Currently we don't migrate the regex field since (for the moment) one of the most used plugin,
+                // PromQL Variable, works differently in Perses than in Grafana: We are getting the values
+                // corresponding to the provided labelName, thus capturingRegexp applies on label values, while in
+                // Grafana the regexp applies on the full PromQL expression, thus migrating it as-is just makes the
+                // Perses variable return nothing - manual patching is required. We can't add logic here to decide
+                // whether the regexp should be migrated or not, because at this step we have no idea about the
+                // plugin used by the considered variable.
+                //
+                // if grafanaVar.regex != _|_ {
+                //     capturingRegexp: grafanaVar.regex
+                // }
                 if grafanaVar.sort != _|_ if #mapping.sort[grafanaVar.sort] != _|_ {
                     sort: #mapping.sort[grafanaVar.sort]
                 }

--- a/internal/api/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -21,7 +21,6 @@
           },
           "allowAllValue": false,
           "allowMultiple": false,
-          "capturingRegexp": "/^argos-.+/",
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {

--- a/internal/api/migrate/testdata/old_grafana_query_perses_dashboard.json
+++ b/internal/api/migrate/testdata/old_grafana_query_perses_dashboard.json
@@ -17,7 +17,6 @@
         "spec": {
           "allowAllValue": false,
           "allowMultiple": false,
-          "capturingRegexp": "argos-world",
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
@@ -41,7 +40,6 @@
           },
           "allowAllValue": false,
           "allowMultiple": true,
-          "capturingRegexp": ".*stack=\"([^\"]*)\".*",
           "sort": "alphabetical-asc",
           "plugin": {
             "kind": "PrometheusPromQLVariable",

--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -221,7 +221,6 @@
           },
           "allowAllValue": false,
           "allowMultiple": false,
-          "capturingRegexp": ".*type=\\\"(.*)\\\".*",
           "sort": "alphabetical-ci-asc",
           "plugin": {
             "kind": "PrometheusPromQLVariable",
@@ -264,7 +263,6 @@
           },
           "allowAllValue": false,
           "allowMultiple": false,
-          "capturingRegexp": "^.*job=\"([a-z-]+)\".*$",
           "sort": "none",
           "plugin": {
             "kind": "PrometheusPromQLVariable",


### PR DESCRIPTION
# Description

See comment.
Basically undoes https://github.com/perses/perses/pull/1848.
This is related to https://github.com/perses/perses/issues/1930: if ever we decide `labelName` is optional, then `capturingRegexp` should apply to the full query result, thus we'd be able to undo this PR.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).