### PR TITLE
[BREAKINGCHANGE] Deactivate cron task that reloads the cue schemas

### DIFF
--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -14,7 +14,6 @@
 package core
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -55,12 +54,12 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 	// enable hot reload of CUE schemas for dashboard validation:
 	// - watch for changes on the schemas folders
 	// - register a cron task to reload all the schemas every <interval>
-	watcher, reloader, err := schemas.NewHotReloaders(serviceManager.GetSchemas().GetLoaders())
+	watcher, _, err := schemas.NewHotReloaders(serviceManager.GetSchemas().GetLoaders())
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to instantiate the tasks for hot reload of schemas: %w", err)
 	}
 	// enable hot reload of the migration schemas
-	migrateWatcher, migrateReloader, err := migrate.NewHotReloaders(serviceManager.GetMigration())
+	migrateWatcher, _, err := migrate.NewHotReloaders(serviceManager.GetMigration())
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to instantiate the tasks for hot reload of migration schema: %w", err)
 	}
@@ -73,18 +72,21 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 	// There is a memory leak in the package Cuelang we are using: https://github.com/cue-lang/cue/issues/2121.
 	// A way to mitigate the issue is to deactivate the cron that is calling the method that leaks.
 	// For the moment, it's ok to deactivate it since it's not possible to load a plugin from outside (missing the JS loading).
-	// As we still need to load the schemas, we just need to execute the cron once.
-	ctx, cancel := context.WithCancel(context.Background())
-	runner.WithTasks(watcher, migrateWatcher)
-	if reloaderErr := reloader.Execute(ctx, cancel); reloaderErr != nil {
-		return nil, nil, fmt.Errorf("unable to reload the tasks: %w", reloaderErr)
+	// We still need to load the schemas.
+	for _, loader := range serviceManager.GetSchemas().GetLoaders() {
+		if loaderErr := loader.Load(); loaderErr != nil {
+			return nil, nil, fmt.Errorf("unable to load the schemas: %w", loaderErr)
+		}
 	}
-	if reloaderErr := migrateReloader.Execute(ctx, cancel); reloaderErr != nil {
-		return nil, nil, fmt.Errorf("unable to reload the tasks: %w", reloaderErr)
+	for _, loader := range serviceManager.GetMigration().GetLoaders() {
+		if loaderErr := loader.Load(); loaderErr != nil {
+			return nil, nil, fmt.Errorf("unable to load the migration schemas: %w", loaderErr)
+		}
 	}
 	// Once the memory leak is fixed, then we can uncomment this line.
 	// runner.WithTimerTasks(time.Duration(conf.Schemas.Interval), reloader, migrateReloader)
-
+	runner.WithTasks(watcher, migrateWatcher)
+	
 	if len(conf.Provisioning.Folders) > 0 {
 		provisioningTask := provisioning.New(serviceManager, conf.Provisioning.Folders, persesDAO.IsCaseSensitive())
 		runner.WithTimerTasks(time.Duration(conf.Provisioning.Interval), provisioningTask)

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -23,10 +23,8 @@ import (
 	"github.com/perses/perses/internal/api/core/middleware"
 	"github.com/perses/perses/internal/api/dashboard"
 	"github.com/perses/perses/internal/api/dependency"
-	"github.com/perses/perses/internal/api/migrate"
 	"github.com/perses/perses/internal/api/provisioning"
 	"github.com/perses/perses/internal/api/rbac"
-	"github.com/perses/perses/internal/api/schemas"
 	"github.com/perses/perses/internal/api/utils"
 	"github.com/perses/perses/pkg/model/api/config"
 	"github.com/perses/perses/ui"
@@ -50,19 +48,6 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 	persesAPI := NewPersesAPI(serviceManager, persistenceManager, conf)
 	persesFrontend := ui.NewPersesFrontend()
 	runner := app.NewRunner().WithDefaultHTTPServerAndPrometheusRegisterer(utils.MetricNamespace, registry, registry).SetBanner(banner)
-
-	// enable hot reload of CUE schemas for dashboard validation:
-	// - watch for changes on the schemas folders
-	// - register a cron task to reload all the schemas every <interval>
-	watcher, _, err := schemas.NewHotReloaders(serviceManager.GetSchemas().GetLoaders())
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to instantiate the tasks for hot reload of schemas: %w", err)
-	}
-	// enable hot reload of the migration schemas
-	migrateWatcher, _, err := migrate.NewHotReloaders(serviceManager.GetMigration())
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to instantiate the tasks for hot reload of migration schema: %w", err)
-	}
 	// enable cleanup of the ephemeral dashboards once their ttl is reached
 	ephemeralDashboardsCleaner, err := dashboard.NewEphemeralDashboardCleaner(persistenceManager.GetEphemeralDashboard())
 	if err != nil {
@@ -83,10 +68,10 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 			return nil, nil, fmt.Errorf("unable to load the migration schemas: %w", loaderErr)
 		}
 	}
-	// Once the memory leak is fixed, then we can uncomment this line.
+	// Once the memory leak is fixed, then we can uncomment these lines.
 	// runner.WithTimerTasks(time.Duration(conf.Schemas.Interval), reloader, migrateReloader)
-	runner.WithTasks(watcher, migrateWatcher)
-	
+	// runner.WithTasks(watcher, migrateWatcher)
+
 	if len(conf.Provisioning.Folders) > 0 {
 		provisioningTask := provisioning.New(serviceManager, conf.Provisioning.Folders, persesDAO.IsCaseSensitive())
 		runner.WithTimerTasks(time.Duration(conf.Provisioning.Interval), provisioningTask)

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -57,17 +57,6 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 	// There is a memory leak in the package Cuelang we are using: https://github.com/cue-lang/cue/issues/2121.
 	// A way to mitigate the issue is to deactivate the cron that is calling the method that leaks.
 	// For the moment, it's ok to deactivate it since it's not possible to load a plugin from outside (missing the JS loading).
-	// We still need to load the schemas.
-	for _, loader := range serviceManager.GetSchemas().GetLoaders() {
-		if loaderErr := loader.Load(); loaderErr != nil {
-			return nil, nil, fmt.Errorf("unable to load the schemas: %w", loaderErr)
-		}
-	}
-	for _, loader := range serviceManager.GetMigration().GetLoaders() {
-		if loaderErr := loader.Load(); loaderErr != nil {
-			return nil, nil, fmt.Errorf("unable to load the migration schemas: %w", loaderErr)
-		}
-	}
 	// Once the memory leak is fixed, then we can uncomment these lines.
 	// runner.WithTimerTasks(time.Duration(conf.Schemas.Interval), reloader, migrateReloader)
 	// runner.WithTasks(watcher, migrateWatcher)

--- a/internal/api/schemas/schemas_test.go
+++ b/internal/api/schemas/schemas_test.go
@@ -49,7 +49,7 @@ func loadQueries(testDataPath string, t *testing.T) []v1.Query {
 		t.Fatal(readErr)
 	}
 
-	queries := []v1.Query{}
+	var queries []v1.Query
 	unmarshallErr := json.Unmarshal(data, &queries)
 	if unmarshallErr != nil {
 		t.Fatal(unmarshallErr)


### PR DESCRIPTION
Following the issue #1923 regarding the memory leaks we have when calling frequently the package cuelang to reload the schemas, I'm proposing to deactivate these cron.

As it's not possible to add at runtime a new plugin, likely we won't need to change the schemas at runtime as well. So there is no need to frequently reloading the schemas for the moment.

Besides we still have a file watching on the schema folder. So the functionality is partially degraded.

Once we have a proper plugin flow, these crons will be reactivated.

Monitoring is showing the memory leak is mitigated with this PR:

(for the same range of time (30min))
Before:

<img width="1492" alt="image" src="https://github.com/perses/perses/assets/4548045/3a31b0e8-2b9b-4d48-83b9-d899a2088176">


After:

<img width="1491" alt="image" src="https://github.com/perses/perses/assets/4548045/2f4147f2-c331-4ecf-aa3c-1c218dd0a99e">
