### PR TITLE
[ENHANCEMENT] Add --force option to allow applying resource despite project config inconsistencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/goreleaser/goreleaser/v2 v2.2.0
 	github.com/gorilla/securecookie v1.1.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/huandu/go-sqlbuilder v1.30.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/labstack/echo-jwt/v4 v4.2.0
@@ -102,6 +103,7 @@ require (
 	github.com/goreleaser/fileglob v1.3.0 // indirect
 	github.com/goreleaser/nfpm/v2 v2.39.0 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cuelang.org/go v0.11.0-alpha.3
 	github.com/brunoga/deep v1.2.4
 	github.com/charmbracelet/huh v0.6.0
+	github.com/efficientgo/core v1.0.0-rc.3
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gavv/httpexpect/v2 v2.16.0
 	github.com/go-jose/go-jose/v4 v4.0.4
@@ -14,7 +15,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/goreleaser/goreleaser/v2 v2.2.0
 	github.com/gorilla/securecookie v1.1.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/huandu/go-sqlbuilder v1.30.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/labstack/echo-jwt/v4 v4.2.0
@@ -103,7 +103,6 @@ require (
 	github.com/goreleaser/fileglob v1.3.0 // indirect
 	github.com/goreleaser/nfpm/v2 v2.39.0 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/efficientgo/core v1.0.0-rc.3 h1:X6CdgycYWDcbYiJr1H1+lQGzx13o7bq3EUkbB9DsSPc=
+github.com/efficientgo/core v1.0.0-rc.3/go.mod h1:FfGdkzWarkuzOlY04VY+bGfb1lWrjaL6x/GLcQ4vJps=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elliotchance/orderedmap/v2 v2.2.0 h1:7/2iwO98kYT4XkOjA9mBEIwvi4KpGB4cyHeOFOnj4Vk=
@@ -201,11 +203,6 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,11 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/internal/cli/cmd/apply/apply.go
+++ b/internal/cli/cmd/apply/apply.go
@@ -72,7 +72,7 @@ func (o *option) validateProjectConsistency() error {
 	for _, entity := range o.entities {
 		kind := modelV1.Kind(entity.GetKind())
 		project := resource.GetProject(entity.GetMetadata(), o.Project)
-		if !o.forceCreate && len(o.Project) != 0 && project != o.Project {
+		if len(o.Project) != 0 && project != o.Project {
 			result.Add(fmt.Errorf("\ninconsistency has been detected for object %q %q: while the metadata suggests the project name %q, the currently selected project indicates %q, \nuse the '--force' flag to bypass consistency check", kind, entity.GetMetadata().GetName(), project, o.Project))
 		}
 	}

--- a/internal/cli/cmd/apply/apply_test.go
+++ b/internal/cli/cmd/apply/apply_test.go
@@ -62,12 +62,24 @@ func TestApplyCMD(t *testing.T) {
 `,
 		},
 		{
-			Title:           "apply multiples different resources",
-			Args:            []string{"-f", "../../test/sample_resources/multiple_resources.json", "--project", "perses"},
+			Title:           "apply multiples different resources without force creation",
+			Args:            []string{"-f", "../../test/sample_resources/multiple_resources.json", "--project", "foo"},
+			APIClient:       fakeapi.New(),
+			IsErrorExpected: true,
+			ExpectedMessage: `2 errors occurred:
+	* inconsistency has been detected for object "Folder" "aoe4": while the metadata suggests the project name "game", the currently selected project indicates "foo",
+	* inconsistency has been detected for object "Folder" "foo": while the metadata suggests the project name "perses", the currently selected project indicates "foo",
+To enforce creation while respecting the metadata, use the '--force' flag
+`,
+		},
+		{
+			Title:           "apply multiples different resources with force creation",
+			Args:            []string{"-f", "../../test/sample_resources/multiple_resources.json", "--project", "perses", "--force"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: false,
 			ExpectedMessage: `object "Folder" "ff15" has been applied in the project "perses"
 object "Folder" "aoe4" has been applied in the project "game"
+object "Folder" "foo" has been applied in the project "perses"
 object "Project" "perses" has been applied
 `,
 		},

--- a/internal/cli/cmd/apply/apply_test.go
+++ b/internal/cli/cmd/apply/apply_test.go
@@ -66,11 +66,11 @@ func TestApplyCMD(t *testing.T) {
 			Args:            []string{"-f", "../../test/sample_resources/multiple_resources.json", "--project", "foo"},
 			APIClient:       fakeapi.New(),
 			IsErrorExpected: true,
-			ExpectedMessage: `2 errors occurred:
-	* inconsistency has been detected for object "Folder" "aoe4": while the metadata suggests the project name "game", the currently selected project indicates "foo",
-	* inconsistency has been detected for object "Folder" "foo": while the metadata suggests the project name "perses", the currently selected project indicates "foo",
-To enforce creation while respecting the metadata, use the '--force' flag
-`,
+			ExpectedMessage: `2 errors: 
+inconsistency has been detected for object "Folder" "aoe4": while the metadata suggests the project name "game", the currently selected project indicates "foo", 
+use the '--force' flag to bypass consistency check; 
+inconsistency has been detected for object "Folder" "foo": while the metadata suggests the project name "perses", the currently selected project indicates "foo", 
+use the '--force' flag to bypass consistency check`,
 		},
 		{
 			Title:           "apply multiples different resources with force creation",

--- a/internal/cli/cmd/remove/remove_test.go
+++ b/internal/cli/cmd/remove/remove_test.go
@@ -81,6 +81,7 @@ object "Project" "perses" has been deleted
 			IsErrorExpected: false,
 			ExpectedMessage: `object "Folder" "aoe4" has been deleted in the project "game"
 object "Folder" "ff15" has been deleted in the project "perses"
+object "Folder" "foo" has been deleted in the project "perses"
 object "Project" "perses" has been deleted
 `,
 		},

--- a/internal/cli/opt/opt.go
+++ b/internal/cli/opt/opt.go
@@ -105,3 +105,11 @@ func (o *ProjectOption) Complete() error {
 func AddProjectFlags(cmd *cobra.Command, o *ProjectOption) {
 	cmd.Flags().StringVarP(&o.Project, "project", "p", o.Project, "If present, the project scope for this CLI request")
 }
+
+type ForceCreateOption struct {
+	ForceCreate bool
+}
+
+func AddForceCreateFlags(cmd *cobra.Command, o *ForceCreateOption) {
+	cmd.Flags().BoolVarP(&o.ForceCreate, "force", "", false, "If present, the command will create the resource even if the projects are not consistent, it prioritize the json file")
+}

--- a/internal/cli/opt/opt.go
+++ b/internal/cli/opt/opt.go
@@ -105,11 +105,3 @@ func (o *ProjectOption) Complete() error {
 func AddProjectFlags(cmd *cobra.Command, o *ProjectOption) {
 	cmd.Flags().StringVarP(&o.Project, "project", "p", o.Project, "If present, the project scope for this CLI request")
 }
-
-type ForceCreateOption struct {
-	ForceCreate bool
-}
-
-func AddForceCreateFlags(cmd *cobra.Command, o *ForceCreateOption) {
-	cmd.Flags().BoolVarP(&o.ForceCreate, "force", "", false, "If present, the command will create the resource even if the projects are not consistent, it prioritize the json file")
-}

--- a/internal/cli/test/sample_resources/multiple_resources.json
+++ b/internal/cli/test/sample_resources/multiple_resources.json
@@ -25,6 +25,19 @@
     ]
   },
   {
+    "kind": "Folder",
+    "metadata": {
+      "name": "foo",
+      "project": "perses"
+    },
+    "spec": [
+      {
+        "kind": "Dashboard",
+        "name": "node_exporter"
+      }
+    ]   
+  },
+  {
     "kind": "Project",
     "metadata": {
       "name": "perses"


### PR DESCRIPTION
[ENHANCEMENT] Add --force option to allow applying resource despite project config inconsistencies

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Fix: https://github.com/perses/perses/issues/1917, take a look at the problem, i am uncertain if this solution aligns with our objectives. The proposed PR addition of a force flag aims to alert users to potential project inconsistencies while still permitting them to create based on input metadata.
<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- na Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- na Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- na Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
