### PR TITLE
[IGNORE] Revert PR #1928

### DIFF
--- a/internal/api/e2e/api/dashboard_test.go
+++ b/internal/api/e2e/api/dashboard_test.go
@@ -134,10 +134,29 @@ func TestAuthListDashboardInProject(t *testing.T) {
 		firstProject := e2eframework.NewProject("first")
 		secondProject := e2eframework.NewProject("second")
 		thirdProject := e2eframework.NewProject("third")
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, firstProject, secondProject, thirdProject)
+		expect.GET(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathDashboard)).
+			WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array().
+			Length().
+			IsEqual(0)
+
+		expect.GET(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, firstProject.GetMetadata().GetName(), utils.PathDashboard)).
+			WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array().
+			Length().
+			IsEqual(0)
+
 		firstDashboard := e2eframework.NewDashboard(t, firstProject.Metadata.Name, "Demo-1")
 		secondDashboard := e2eframework.NewDashboard(t, secondProject.Metadata.Name, "Demo-2")
 		thirdDashboard := e2eframework.NewDashboard(t, thirdProject.Metadata.Name, "Demo-3")
-		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, firstProject, secondProject, thirdProject, firstDashboard, secondDashboard, thirdDashboard)
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, firstDashboard, secondDashboard, thirdDashboard)
 
 		expect.GET(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathDashboard)).
 			WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).

--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -58,7 +58,7 @@ export function useDashboard(project: string, name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDashboardList(project?: string) {
-  return useQuery<DashboardResource[] | null, Error>([resource, project], () => {
+  return useQuery<DashboardResource[], Error>([resource, project], () => {
     return getDashboards(project);
   });
 }
@@ -81,8 +81,8 @@ export function useRecentDashboardList(project?: string, maxSize?: number) {
     const result: DatedDashboards[] = [];
 
     // Iterating with history first to keep history order in the result
-    (history || []).forEach((historyItem) => {
-      const dashboard = (data || []).find(
+    (history ?? []).forEach((historyItem) => {
+      const dashboard = (data ?? []).find(
         (dashboard) =>
           historyItem.project === dashboard.metadata.project && historyItem.name === dashboard.metadata.name
       );
@@ -112,7 +112,7 @@ export function useImportantDashboardList(project?: string) {
   const importantDashboards = useMemo(() => {
     const result: DashboardResource[] = [];
     importantDashboardSelectors.forEach((selector) => {
-      const dashboard = (dashboards || []).find(
+      const dashboard = (dashboards ?? []).find(
         (dashboard) => selector.project === dashboard.metadata.project && selector.dashboard === dashboard.metadata.name
       );
       if (dashboard) {
@@ -182,7 +182,7 @@ export function getDashboard(project: string, name: string) {
 
 export function getDashboards(project?: string) {
   const url = buildURL({ resource: resource, project: project });
-  return fetchJson<DashboardResource[] | null>(url, {
+  return fetchJson<DashboardResource[]>(url, {
     method: HTTPMethodGET,
     headers: HTTPHeader,
   });

--- a/ui/app/src/model/project-client.ts
+++ b/ui/app/src/model/project-client.ts
@@ -185,7 +185,7 @@ async function getProjectsWithDashboard(): Promise<ProjectWithDashboards[]> {
   const projects = await getProjects();
   const result: ProjectWithDashboards[] = [];
   for (const project of projects ?? []) {
-    const dashboards = (await getDashboards(project.metadata.name)) ?? [];
+    const dashboards = await getDashboards(project.metadata.name);
     result.push({ project: project, dashboards: dashboards });
   }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Reverting changes of PR #1928, the API should have returned empty list. The issue was a side effect of #1932 issue.
Tests added for checking empty project with auth 😄 


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
