### PR TITLE
[DOC] Fix wrong usage of `dac build` command in user guide

### DIFF
--- a/docs/user-guides/dashboard-as-code.md
+++ b/docs/user-guides/dashboard-as-code.md
@@ -170,8 +170,8 @@ func main() {
 Anytime you want to build the final dashboard definition (i.e: Perses dashboard in JSON or YAML format) corresponding to your as-code definition, you can use the `dac build` command, as the following:
 
 ```
-percli dac build main.go -ojson
-percli dac build my_dashboard.cue -ojson
+percli dac build -f main.go -ojson
+percli dac build -f my_dashboard.cue -ojson
 ```
 
 If the build is successful, the result can be found in the generated `built` folder.


### PR DESCRIPTION
# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).