### PR TITLE
[BUGFIX] Go SDK move some int to float

### DIFF
--- a/go-sdk/common/thresholds.go
+++ b/go-sdk/common/thresholds.go
@@ -21,9 +21,9 @@ const (
 )
 
 type StepOption struct {
-	Value int    `json:"value" yaml:"value"`
-	Color string `json:"color,omitempty" yaml:"color,omitempty"`
-	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	Value float64 `json:"value" yaml:"value"`
+	Color string  `json:"color,omitempty" yaml:"color,omitempty"`
+	Name  string  `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 type Thresholds struct {

--- a/go-sdk/panel/gauge/gauge.go
+++ b/go-sdk/panel/gauge/gauge.go
@@ -22,7 +22,7 @@ type PluginSpec struct {
 	Calculation commonSdk.Calculation `json:"calculation" yaml:"calculation"`
 	Format      *commonSdk.Format     `json:"format,omitempty" yaml:"format,omitempty"`
 	Thresholds  *commonSdk.Thresholds `json:"thresholds,omitempty" yaml:"thresholds,omitempty"`
-	Max         int                   `json:"max,omitempty" yaml:"max,omitempty"`
+	Max         float64               `json:"max,omitempty" yaml:"max,omitempty"`
 }
 
 type Option func(plugin *Builder) error

--- a/go-sdk/panel/gauge/options.go
+++ b/go-sdk/panel/gauge/options.go
@@ -38,7 +38,7 @@ func Thresholds(thresholds common.Thresholds) Option {
 	}
 }
 
-func Max(max int) Option {
+func Max(max float64) Option {
 	return func(builder *Builder) error {
 		builder.Max = max
 		return nil

--- a/go-sdk/panel/stat/stat.go
+++ b/go-sdk/panel/stat/stat.go
@@ -19,8 +19,8 @@ import (
 )
 
 type Sparkline struct {
-	Color string `json:"color,omitempty" yaml:"color,omitempty"`
-	Width int    `json:"width,omitempty" yaml:"width,omitempty"`
+	Color string  `json:"color,omitempty" yaml:"color,omitempty"`
+	Width float64 `json:"width,omitempty" yaml:"width,omitempty"`
 }
 
 type PluginSpec struct {

--- a/go-sdk/panel/time-series/time-series.go
+++ b/go-sdk/panel/time-series/time-series.go
@@ -84,11 +84,11 @@ const (
 
 type Visual struct {
 	Display      VisualDisplay    `json:"display,omitempty" yaml:"display,omitempty"`
-	LineWidth    int              `json:"lineWidth,omitempty" yaml:"lineWidth,omitempty"`
-	AreaOpacity  int              `json:"areaOpacity,omitempty" yaml:"areaOpacity,omitempty"`
+	LineWidth    float64          `json:"lineWidth,omitempty" yaml:"lineWidth,omitempty"`
+	AreaOpacity  float64          `json:"areaOpacity,omitempty" yaml:"areaOpacity,omitempty"`
 	ShowPoints   VisualShowPoints `json:"showPoints,omitempty" yaml:"showPoints,omitempty"`
-	Palette      int              `json:"palette,omitempty" yaml:"palette,omitempty"`
-	PointRadius  int              `json:"pointRadius,omitempty" yaml:"pointRadius,omitempty"`
+	Palette      Palette          `json:"palette,omitempty" yaml:"palette,omitempty"`
+	PointRadius  float64          `json:"pointRadius,omitempty" yaml:"pointRadius,omitempty"`
 	Stack        VisualStack      `json:"stack,omitempty" yaml:"stack,omitempty"`
 	ConnectNulls bool             `json:"connectNulls,omitempty" yaml:"connectNulls,omitempty"`
 }
@@ -97,8 +97,8 @@ type YAxis struct {
 	Show   bool              `json:"show,omitempty" yaml:"show,omitempty"`
 	Label  string            `json:"label,omitempty" yaml:"label,omitempty"`
 	Format *commonSdk.Format `json:"format,omitempty" yaml:"format,omitempty"`
-	Min    int               `json:"min,omitempty" yaml:"min,omitempty"`
-	Max    int               `json:"max,omitempty" yaml:"max,omitempty"`
+	Min    float64           `json:"min,omitempty" yaml:"min,omitempty"`
+	Max    float64           `json:"max,omitempty" yaml:"max,omitempty"`
 }
 
 type PluginSpec struct {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Some `int` in the Go SDK should be `float`

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
