### PR TITLE
[ENHANCEMENT] DaC CUE SDK: support passing datasources in dashboard builder

### DIFF
--- a/cue/dac-utils/dashboard/dashboard.cue
+++ b/cue/dac-utils/dashboard/dashboard.cue
@@ -26,11 +26,12 @@ import (
 #name:     string
 #display?: v1Common.#Display
 #project:  string
-#variables: [...v1Dashboard.#Variable]
+#variables?: [...v1Dashboard.#Variable]
 #panelGroups: [string]: {
 	layout: v1Dashboard.#Layout
 	panels: [string]: v1.#Panel
 }
+#datasources?: [string]: v1.#DatasourceSpec
 
 // output: the dashboard in the format expected by Perses 
 v1.#Dashboard & {
@@ -42,7 +43,12 @@ v1.#Dashboard & {
 		if #display != _|_ {
 			display: #display
 		}
-		variables: #variables
+		if #datasources != _|_ {
+			datasources: #datasources
+		}
+		if #variables != _|_ {
+			variables: #variables
+		}
 		panels: {for group in #panelGroups {group.panels}}
 		layouts: [for group in #panelGroups {group.layout}]
 	}

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -19,9 +19,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/perses/perses/go-sdk/datasource"
 	"github.com/perses/perses/go-sdk/panel"
 	panelgroup "github.com/perses/perses/go-sdk/panel-group"
 	timeseries "github.com/perses/perses/go-sdk/panel/time-series"
+	promDs "github.com/perses/perses/go-sdk/prometheus/datasource"
 	"github.com/perses/perses/go-sdk/prometheus/query"
 	labelNamesVar "github.com/perses/perses/go-sdk/prometheus/variable/label-names"
 	labelValuesVar "github.com/perses/perses/go-sdk/prometheus/variable/label-values"
@@ -121,6 +123,14 @@ func TestDashboardBuilder(t *testing.T) {
 			cpuPanel,
 			memoryPanel,
 		),
+
+		// DATASOURCES
+		AddDatasource("myPromDemo",
+			datasource.Default(true),
+			promDs.Prometheus(
+				promDs.DirectURL("http://localhost:9090"),
+			),
+		),
 	)
 
 	builderOutput, marshErr := json.Marshal(builder.Dashboard)
@@ -209,6 +219,14 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 			// PANELS
 			cpuPanel,
 			memoryPanel,
+		),
+
+		// DATASOURCES
+		AddDatasource("myPromDemo",
+			datasource.Default(true),
+			promDs.Prometheus(
+				promDs.DirectURL("http://localhost:9090"),
+			),
 		),
 	)
 

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -322,6 +322,17 @@
         }
       }
     ],
-    "duration": "1h"
+    "duration": "1h",
+    "datasources": {
+      "myPromDemo": {
+        "default": true,
+        "plugin": {
+          "kind": "PrometheusDatasource",
+          "spec": {
+            "directUrl": "http://localhost:9090"
+          }
+        }
+      }
+    }
   }
 }

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -25,6 +25,7 @@ import (
 	promFilterBuilder "github.com/perses/perses/cue/dac-utils/prometheus/filter"
 	timeseriesChart "github.com/perses/perses/cue/schemas/panels/time-series:model"
 	promQuery "github.com/perses/perses/cue/schemas/queries/prometheus:model"
+	prometheusDs "github.com/perses/perses/cue/schemas/datasources/prometheus:model"
 )
 
 #myVarsBuilder: varGroupBuilder & {
@@ -148,4 +149,10 @@ dashboardBuilder & {
 			},
 		]
 	}
+	#datasources: {myPromDemo: {
+		default: true
+		plugin: prometheusDs & {spec: {
+			directUrl: "http://localhost:9090"
+		}}
+	}}
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

(Also fixes a small issue where variables field was mandatory for the builder while it's optional for the final dashboard).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).