### PR TITLE
[ENHANCEMENT] DaC CUE SDK: support time fields in dashboard builder

### DIFF
--- a/cue/dac-utils/dashboard/dashboard.cue
+++ b/cue/dac-utils/dashboard/dashboard.cue
@@ -32,6 +32,8 @@ import (
 	panels: [string]: v1.#Panel
 }
 #datasources?: [string]: v1.#DatasourceSpec
+#duration?:        string
+#refreshInterval?: string
 
 // output: the dashboard in the format expected by Perses 
 v1.#Dashboard & {
@@ -51,5 +53,11 @@ v1.#Dashboard & {
 		}
 		panels: {for group in #panelGroups {group.panels}}
 		layouts: [for group in #panelGroups {group.layout}]
+		if #duration != _|_ {
+			duration: #duration
+		}
+		if #refreshInterval != _|_ {
+			refreshInterval: #refreshInterval
+		}
 	}
 }

--- a/cue/dac-utils/dashboard/dashboard.cue
+++ b/cue/dac-utils/dashboard/dashboard.cue
@@ -26,11 +26,12 @@ import (
 #name:     string
 #display?: v1Common.#Display
 #project:  string
-#variables: [...v1Dashboard.#Variable]
+#variables?: [...v1Dashboard.#Variable]
 #panelGroups: [string]: {
 	layout: v1Dashboard.#Layout
 	panels: [string]: v1.#Panel
 }
+#datasources?: [string]: v1.#DatasourceSpec
 
 // output: the dashboard in the format expected by Perses 
 v1.#Dashboard & {
@@ -42,7 +43,12 @@ v1.#Dashboard & {
 		if #display != _|_ {
 			display: #display
 		}
-		variables: #variables
+		if #datasources != _|_ {
+			datasources: #datasources
+		}
+		if #variables != _|_ {
+			variables: #variables
+		}
 		panels: {for group in #panelGroups {group.panels}}
 		layouts: [for group in #panelGroups {group.layout}]
 	}

--- a/cue/model/api/v1/dashboard_patch.cue
+++ b/cue/model/api/v1/dashboard_patch.cue
@@ -45,8 +45,8 @@ import (
 		[string]: #Panel @go(Panels)
 	}
 	layouts: [...dashboard.#Layout] @go(Layouts,[]Layout)
-	duration:         _ | *"1h" @go(Duration)        // TODO def should come from github.com/prometheus/common/model 
-	refreshInterval?: _         @go(RefreshInterval) // TODO def should come from github.com/prometheus/common/model
+	duration:         string | *"1h" @go(Duration)        // TODO instead of string the def should come from github.com/prometheus/common/model 
+	refreshInterval?: string         @go(RefreshInterval) // TODO instead of string the def should come from github.com/prometheus/common/model
 }
 
 #Dashboard: {

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/perses/perses/go-sdk/datasource"
 	"github.com/perses/perses/go-sdk/panel"
@@ -131,6 +132,10 @@ func TestDashboardBuilder(t *testing.T) {
 				promDs.DirectURL("http://localhost:9090"),
 			),
 		),
+
+		// TIME
+		Duration(3*time.Hour),
+		RefreshInterval(30*time.Second),
 	)
 
 	builderOutput, marshErr := json.Marshal(builder.Dashboard)
@@ -228,6 +233,10 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 				promDs.DirectURL("http://localhost:9090"),
 			),
 		),
+
+		// TIME
+		Duration(3*time.Hour),
+		RefreshInterval(30*time.Second),
 	)
 
 	builderOutput, marshErr := json.Marshal(builder.Dashboard)

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -19,9 +19,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/perses/perses/go-sdk/datasource"
 	"github.com/perses/perses/go-sdk/panel"
 	panelgroup "github.com/perses/perses/go-sdk/panel-group"
 	timeseries "github.com/perses/perses/go-sdk/panel/time-series"
+	promDs "github.com/perses/perses/go-sdk/prometheus/datasource"
 	"github.com/perses/perses/go-sdk/prometheus/query"
 	labelNamesVar "github.com/perses/perses/go-sdk/prometheus/variable/label-names"
 	labelValuesVar "github.com/perses/perses/go-sdk/prometheus/variable/label-values"
@@ -121,6 +123,14 @@ func TestDashboardBuilder(t *testing.T) {
 			cpuPanel,
 			memoryPanel,
 		),
+
+		// DATASOURCES
+		AddDatasource("myPromDemo",
+			datasource.Default(true),
+			promDs.Prometheus(
+				promDs.DirectURL("http://localhost:9090"),
+			),
+		),
 	)
 
 	builderOutput, marshErr := json.Marshal(builder.Dashboard)
@@ -209,6 +219,14 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 			// PANELS
 			cpuPanel,
 			memoryPanel,
+		),
+
+		// DATASOURCES
+		AddDatasource("myPromDemo",
+			datasource.Default(true),
+			promDs.Prometheus(
+				promDs.DirectURL("http://localhost:9090"),
+			),
 		),
 	)
 

--- a/internal/test/dac/dac_cue_test.go
+++ b/internal/test/dac/dac_cue_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestDashboardAsCodeCUESDK(t *testing.T) {
-
 	testSuite := []struct {
 		title                  string
 		inputCUEFile           string

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -322,7 +322,6 @@
         }
       }
     ],
-    "duration": "1h",
     "datasources": {
       "myPromDemo": {
         "default": true,
@@ -333,6 +332,8 @@
           }
         }
       }
-    }
+    },
+    "duration": "3h",
+    "refreshInterval": "30s"
   }
 }

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -322,6 +322,17 @@
         }
       }
     ],
-    "duration": "1h"
+    "duration": "1h",
+    "datasources": {
+      "myPromDemo": {
+        "default": true,
+        "plugin": {
+          "kind": "PrometheusDatasource",
+          "spec": {
+            "directUrl": "http://localhost:9090"
+          }
+        }
+      }
+    }
   }
 }

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -25,6 +25,7 @@ import (
 	promFilterBuilder "github.com/perses/perses/cue/dac-utils/prometheus/filter"
 	timeseriesChart "github.com/perses/perses/cue/schemas/panels/time-series:model"
 	promQuery "github.com/perses/perses/cue/schemas/queries/prometheus:model"
+	prometheusDs "github.com/perses/perses/cue/schemas/datasources/prometheus:model"
 )
 
 #myVarsBuilder: varGroupBuilder & {
@@ -148,4 +149,10 @@ dashboardBuilder & {
 			},
 		]
 	}
+	#datasources: {myPromDemo: {
+		default: true
+		plugin: prometheusDs & {spec: {
+			directUrl: "http://localhost:9090"
+		}}
+	}}
 }

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -155,4 +155,6 @@ dashboardBuilder & {
 			directUrl: "http://localhost:9090"
 		}}
 	}}
+	#duration:        "3h"
+	#refreshInterval: "30s"
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Before you could already pass values to these fields via the base datamodel like the following:
```cue
dashboardBuilder & {
	#name: "ContainersMonitoring"
	#display: name: "Containers monitoring"
	// ...
} & {spec: {
	duration:        "3h"
	refreshInterval: "30s"
}}
```

But it's a bit easier & aligns the UX with the other fields to just support these in the dashboard builder, so that you can do:
```cue
dashboardBuilder & {
	#name: "ContainersMonitoring"
	#display: name: "Containers monitoring"
	// ...
	#duration:        "3h"
	#refreshInterval: "30s"
}
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).