### PR TITLE
[BUGFIX] Fix datasource query copy

### DIFF
--- a/internal/api/impl/v1/datasource/service.go
+++ b/internal/api/impl/v1/datasource/service.go
@@ -86,9 +86,10 @@ func (s *service) List(_ apiInterface.PersesContext, q *datasource.Query, params
 	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
 
 	query := &datasource.Query{
-		Query:      q.Query,
 		NamePrefix: q.NamePrefix,
 		Project:    q.Project,
+		Kind:       q.Kind,
+		Default:    q.Default,
 	}
 	if len(query.Project) == 0 {
 		query.Project = params.Project


### PR DESCRIPTION
Suddenly the datasources query from the frontend didn't return the accurate datasource (specially when we want to get the default datasource).

This is a regression introduced in https://github.com/perses/perses/pull/1932