### PR TITLE
[BUGFIX] Fix auto refresh

### DIFF
--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -44,7 +44,6 @@ export interface TimeSeriesQueryContext {
   variableState: VariableStateMap;
   datasourceStore: DatasourceStore;
   refreshKey: string;
-  refreshIntervalInMs: number;
 }
 
 export type TimeSeriesDataQuery = Query<TimeSeriesData, unknown, TimeSeriesData, QueryKey>;

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
@@ -90,6 +90,17 @@ export function TimeRangeProvider(props: TimeRangeProviderProps) {
     setRefreshCounter((counter) => counter + 1);
   }, [setRefreshCounter]);
 
+  const refreshIntervalInMs = getRefreshIntervalInMs(localRefreshInterval);
+  useEffect(() => {
+    if (refreshIntervalInMs > 0) {
+      const interval = setInterval(() => {
+        refresh();
+      }, refreshIntervalInMs);
+
+      return () => clearInterval(interval);
+    }
+  }, [refresh, refreshIntervalInMs]);
+
   const ctx = useMemo(() => {
     const absoluteTimeRange = isRelativeTimeRange(localTimeRange)
       ? toAbsoluteTimeRange(localTimeRange)
@@ -101,10 +112,18 @@ export function TimeRangeProvider(props: TimeRangeProviderProps) {
       refresh,
       refreshKey: `${absoluteTimeRange.start}:${absoluteTimeRange.end}:${localRefreshInterval}:${refreshCounter}`,
       refreshInterval: localRefreshInterval,
-      refreshIntervalInMs: getRefreshIntervalInMs(localRefreshInterval),
+      refreshIntervalInMs: refreshIntervalInMs,
       setRefreshInterval: setRefreshInterval ?? setLocalRefreshInterval,
     };
-  }, [localTimeRange, setTimeRange, refresh, refreshCounter, localRefreshInterval, setRefreshInterval]);
+  }, [
+    localTimeRange,
+    setTimeRange,
+    refresh,
+    localRefreshInterval,
+    refreshCounter,
+    refreshIntervalInMs,
+    setRefreshInterval,
+  ]);
 
   return <TimeRangeContext.Provider value={ctx}>{children}</TimeRangeContext.Provider>;
 }

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -97,7 +97,6 @@ export const useTimeSeriesQuery = (
   return useQuery({
     enabled: (queryOptions?.enabled ?? true) || queryEnabled,
     queryKey: queryKey,
-    refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : false,
     queryFn: () => {
       // The 'enabled' option should prevent this from happening, but make TypeScript happy by checking
       if (plugin === undefined) {
@@ -133,7 +132,6 @@ export function useTimeSeriesQueries(
       return {
         enabled: (queryOptions?.enabled ?? true) && queryEnabled,
         queryKey: queryKey,
-        refetchInterval: context.refreshIntervalInMs > 0 ? context.refreshIntervalInMs : undefined,
         queryFn: async () => {
           // Keep options out of query key so we don't re-run queries because suggested step changes
           const ctx: TimeSeriesQueryContext = { ...context, suggestedStepMs: options?.suggestedStepMs };
@@ -150,7 +148,7 @@ export function useTimeSeriesQueries(
  * Build the time series query context object from data available at runtime
  */
 function useTimeSeriesQueryContext(): TimeSeriesQueryContext {
-  const { absoluteTimeRange, refreshKey, refreshIntervalInMs } = useTimeRange();
+  const { absoluteTimeRange, refreshKey } = useTimeRange();
   const variableState = useVariableValues();
   const datasourceStore = useDatasourceStore();
 
@@ -159,7 +157,6 @@ function useTimeSeriesQueryContext(): TimeSeriesQueryContext {
     variableState,
     datasourceStore,
     refreshKey,
-    refreshIntervalInMs: refreshIntervalInMs,
   };
 }
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -74,7 +74,6 @@ const createStubContext = () => {
       setSavedDatasources: jest.fn(),
     },
     refreshKey: 'test',
-    refreshIntervalInMs: 0,
     timeRange: {
       end: new Date('01-01-2023'),
       start: new Date('01-02-2023'),


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Improving auto refresh. The actual auto refresh was only working with timeseries query. Now it will refresh all dashboard components (panels / variables /...).

We still need to improve refresh display => it's removing data, show loader and put it again, it should keep previous data  visible and only replace it when it's ready

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
