### PR TITLE
[BREAKINGCHANGE] Introduce a dedicated config for the frontend

### DIFF
--- a/dev/config-mariadb.yaml
+++ b/dev/config-mariadb.yaml
@@ -35,20 +35,23 @@ schemas:
   variables_path: "cue/schemas/variables"
   interval: "5m"
 
-important_dashboards:
-  - project: "perses"
-    dashboard: "Demo"
-  - project: "perses"
-    dashboard: "NodeExporter"
-  - project: "perses"
-    dashboard: "Benchmark"
-  - project: "testing"
-    dashboard: "Defaults"
-  - project: "testing"
-    dashboard: "StatChartPanel"
-  - project: "testing"
-    dashboard: "MarkdownPanel"
+ephemeral_dashboards_cleanup_interval: "1h"
 
-information: |-
-  # Hello World
-  ## MariaDB Database setup
+frontend:
+  important_dashboards:
+    - project: "perses"
+      dashboard: "Demo"
+    - project: "perses"
+      dashboard: "NodeExporter"
+    - project: "perses"
+      dashboard: "Benchmark"
+    - project: "testing"
+      dashboard: "Defaults"
+    - project: "testing"
+      dashboard: "StatChartPanel"
+    - project: "testing"
+      dashboard: "MarkdownPanel"
+
+  information: |-
+    # Hello World
+    ## File Database setup

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -33,22 +33,23 @@ schemas:
   variables_path: "cue/schemas/variables"
   interval: "5m"
 
-important_dashboards:
-  - project: "perses"
-    dashboard: "Demo"
-  - project: "perses"
-    dashboard: "NodeExporter"
-  - project: "perses"
-    dashboard: "Benchmark"
-  - project: "testing"
-    dashboard: "Defaults"
-  - project: "testing"
-    dashboard: "StatChartPanel"
-  - project: "testing"
-    dashboard: "MarkdownPanel"
-
-information: |-
-  # Hello World
-  ## File Database setup
-
 ephemeral_dashboards_cleanup_interval: "1h"
+
+frontend:
+  important_dashboards:
+    - project: "perses"
+      dashboard: "Demo"
+    - project: "perses"
+      dashboard: "NodeExporter"
+    - project: "perses"
+      dashboard: "Benchmark"
+    - project: "testing"
+      dashboard: "Defaults"
+    - project: "testing"
+      dashboard: "StatChartPanel"
+    - project: "testing"
+      dashboard: "MarkdownPanel"
+
+  information: |-
+    # Hello World
+    ## File Database setup

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -96,7 +96,7 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 		}).
 		Middleware(middleware.HandleError()).
 		Middleware(middleware.CheckProject(serviceManager.GetProject()))
-	if !conf.DeactivateFront {
+	if !conf.Frontend.Deactivate {
 		runner.HTTPServerBuilder().APIRegistration(persesFrontend)
 	}
 	return runner, persistenceManager, nil

--- a/internal/cli/cmd/conf/conf_test.go
+++ b/internal/cli/cmd/conf/conf_test.go
@@ -45,7 +45,6 @@ func TestConfigCMD(t *testing.T) {
 			ExpectedMessage: `security:
     readonly: false
     enable_auth: true
-deactivate_front: false
 
 `,
 		},

--- a/pkg/client/fake/api/client.go
+++ b/pkg/client/fake/api/client.go
@@ -56,5 +56,6 @@ func (c *client) Config() (*apiConfig.Config, error) {
 		Database:     apiConfig.Database{},
 		Schemas:      apiConfig.Schemas{},
 		Provisioning: apiConfig.ProvisioningConfig{},
+		Frontend:     apiConfig.Frontend{},
 	}, nil
 }

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -37,16 +37,12 @@ type Config struct {
 	Database Database `json:"database,omitempty" yaml:"database,omitempty"`
 	// Schemas contain the configuration to get access to the CUE schemas
 	Schemas Schemas `json:"schemas,omitempty" yaml:"schemas,omitempty"`
-	// ImportantDashboards contains important dashboard selectors
-	ImportantDashboards []dashboardSelector `json:"important_dashboards,omitempty" yaml:"important_dashboards,omitempty"`
-	// Information contains markdown content to be display on the home page
-	Information string `json:"information,omitempty" yaml:"information,omitempty"`
 	// Provisioning contains the provisioning config that can be used if you want to provide default resources.
 	Provisioning ProvisioningConfig `json:"provisioning,omitempty" yaml:"provisioning,omitempty"`
-	// When it is true, Perses won't serve the frontend anymore.
-	DeactivateFront bool `json:"deactivate_front" yaml:"deactivate_front"`
 	// EphemeralDashboardsCleanupInterval is the interval at which the ephemeral dashboards are cleaned up
 	EphemeralDashboardsCleanupInterval model.Duration `json:"ephemeral_dashboards_cleanup_interval,omitempty" yaml:"ephemeral_dashboards_cleanup_interval,omitempty"`
+	// Frontend contains any config that will be used by the frontend itself.
+	Frontend Frontend `json:"frontend,omitempty" yaml:"frontend,omitempty"`
 }
 
 func (c *Config) Verify() error {

--- a/pkg/model/api/config/config_test.go
+++ b/pkg/model/api/config/config_test.go
@@ -56,7 +56,9 @@ func TestJSONMarshalConfig(t *testing.T) {
   "database": {},
   "schemas": {},
   "provisioning": {},
-  "deactivate_front": false
+  "frontend": {
+    "deactivate": false
+  }
 }`,
 		},
 		{
@@ -96,8 +98,10 @@ func TestJSONMarshalConfig(t *testing.T) {
   "provisioning": {
     "interval": "1h"
   },
-  "deactivate_front": false,
-  "ephemeral_dashboards_cleanup_interval": "1d"
+  "ephemeral_dashboards_cleanup_interval": "1d",
+  "frontend": {
+    "deactivate": false
+  }
 }`,
 		},
 	}
@@ -159,21 +163,23 @@ func TestUnmarshalJSONConfig(t *testing.T) {
     "variables_path": "cue/schemas/variables",
     "interval": "5m"
   },
-  "important_dashboards": [
-    {
-      "project": "perses",
-      "dashboard": "Demo"
-    },
-    {
-      "project": "testing",
-      "dashboard": "DuplicatePanels"
-    },
-    {
-      "project": "Unknown",
-      "dashboard": "Dashboard"
-    }
-  ],
-  "information": "# Hello World\n## File Database setup",
+  "frontend": {
+    "important_dashboards": [
+      {
+        "project": "perses",
+        "dashboard": "Demo"
+      },
+      {
+        "project": "testing",
+        "dashboard": "DuplicatePanels"
+      },
+      {
+        "project": "Unknown",
+        "dashboard": "Dashboard"
+      }
+    ],
+    "information": "# Hello World\n## File Database setup"
+  },
   "provisioning": {
     "folders": [
       "dev/data"
@@ -221,21 +227,23 @@ func TestUnmarshalJSONConfig(t *testing.T) {
 					VariablesPath:   path.Join("cue", DefaultVariablesPath),
 					Interval:        model.Duration(5 * time.Minute),
 				},
-				ImportantDashboards: []dashboardSelector{
-					{
-						Project:   "perses",
-						Dashboard: "Demo",
+				Frontend: Frontend{
+					ImportantDashboards: []dashboardSelector{
+						{
+							Project:   "perses",
+							Dashboard: "Demo",
+						},
+						{
+							Project:   "testing",
+							Dashboard: "DuplicatePanels",
+						},
+						{
+							Project:   "Unknown",
+							Dashboard: "Dashboard",
+						},
 					},
-					{
-						Project:   "testing",
-						Dashboard: "DuplicatePanels",
-					},
-					{
-						Project:   "Unknown",
-						Dashboard: "Dashboard",
-					},
+					Information: "# Hello World\n## File Database setup",
 				},
-				Information: "# Hello World\n## File Database setup",
 				Provisioning: ProvisioningConfig{
 					Folders: []string{
 						"dev/data",
@@ -298,17 +306,18 @@ schemas:
   variables_path: "cue/schemas/variables"
   interval: "5m"
 
-important_dashboards:
-  - project: "perses"
-    dashboard: "Demo"
-  - project: "testing"
-    dashboard: "DuplicatePanels"
-  - project: "Unknown"
-    dashboard: "Dashboard"
-
-information: |-
-  # Hello World
-  ## File Database setup
+frontend:
+  important_dashboards:
+    - project: "perses"
+      dashboard: "Demo"
+    - project: "testing"
+      dashboard: "DuplicatePanels"
+    - project: "Unknown"
+      dashboard: "Dashboard"
+  
+  information: |-
+    # Hello World
+    ## File Database setup
 
 ephemeral_dashboards_cleanup_interval: "2h"
 `,
@@ -360,21 +369,23 @@ ephemeral_dashboards_cleanup_interval: "2h"
 					VariablesPath:   path.Join("cue", DefaultVariablesPath),
 					Interval:        model.Duration(5 * time.Minute),
 				},
-				ImportantDashboards: []dashboardSelector{
-					{
-						Project:   "perses",
-						Dashboard: "Demo",
+				Frontend: Frontend{
+					ImportantDashboards: []dashboardSelector{
+						{
+							Project:   "perses",
+							Dashboard: "Demo",
+						},
+						{
+							Project:   "testing",
+							Dashboard: "DuplicatePanels",
+						},
+						{
+							Project:   "Unknown",
+							Dashboard: "Dashboard",
+						},
 					},
-					{
-						Project:   "testing",
-						Dashboard: "DuplicatePanels",
-					},
-					{
-						Project:   "Unknown",
-						Dashboard: "Dashboard",
-					},
+					Information: "# Hello World\n## File Database setup",
 				},
-				Information: "# Hello World\n## File Database setup",
 				Provisioning: ProvisioningConfig{
 					Folders: []string{
 						"dev/data",

--- a/pkg/model/api/config/frontend.go
+++ b/pkg/model/api/config/frontend.go
@@ -1,0 +1,23 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+type Frontend struct {
+	// When it is true, Perses won't serve the frontend anymore, and any other config set here will be ignored
+	Deactivate bool `json:"deactivate" yaml:"deactivate"`
+	// Information contains markdown content to be display on the home page
+	Information string `json:"information,omitempty" yaml:"information,omitempty"`
+	// ImportantDashboards contains important dashboard selectors
+	ImportantDashboards []dashboardSelector `json:"important_dashboards,omitempty" yaml:"important_dashboards,omitempty"`
+}

--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -63,20 +63,23 @@ export function useImportantDashboardSelectors(): DashboardSelector[] {
   const { config } = useConfigContext();
   return useMemo(() => {
     if (!config.database.file?.case_sensitive || !config.database.sql?.case_sensitive) {
-      return (config.important_dashboards ?? []).map((selector) => {
+      return (config.frontend.important_dashboards ?? []).map((selector) => {
         return {
           project: selector.project.toLowerCase(),
           dashboard: selector.dashboard.toLowerCase(),
         };
       });
     }
-    return config.important_dashboards ?? [];
-  }, [config.database.file?.case_sensitive, config.database.sql?.case_sensitive, config.important_dashboards]);
+    return config.frontend.important_dashboards ?? [];
+  }, [config.database.file?.case_sensitive, config.database.sql?.case_sensitive, config.frontend.important_dashboards]);
 }
 
 export function useInformation(): string {
   const { config } = useConfigContext();
 
-  const html = useMemo(() => marked.parse(config.information ?? '', { gfm: true }), [config.information]);
+  const html = useMemo(
+    () => marked.parse(config.frontend.information ?? '', { gfm: true }),
+    [config.frontend.information]
+  );
   return useMemo(() => DOMPurify.sanitize(html), [html]);
 }

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -130,13 +130,17 @@ export interface SecurityConfig {
   authentication: AuthenticationConfig;
 }
 
+export interface FrontendConfig {
+  important_dashboards?: DashboardSelector[];
+  information?: string;
+}
+
 export interface ConfigModel {
   security: SecurityConfig;
   database: Database;
   schemas: ConfigSchemasModel;
-  important_dashboards?: DashboardSelector[];
-  information?: string;
   provisioning?: ProvisioningConfig;
+  frontend: FrontendConfig;
 }
 
 type ConfigOptions = Omit<UseQueryOptions<ConfigModel, Error>, 'queryKey' | 'queryFn'>;

--- a/ui/app/src/views/home/ImportantDashboards.tsx
+++ b/ui/app/src/views/home/ImportantDashboards.tsx
@@ -50,7 +50,7 @@ export function ImportantDashboards() {
   const { data: dashboards, isLoading } = useImportantDashboardList();
 
   // If no important dashboard defined, hide the section
-  if (!config?.important_dashboards?.length || dashboards.length === 0) {
+  if (!config?.frontend.important_dashboards?.length || dashboards.length === 0) {
     return <></>;
   }
 


### PR DESCRIPTION
I'm introducing a dedicated config for the frontend.

Later it will be interesting as we want to provide a way to configure the au-refresh period value.

It's a breaking change as the config `info` and `important_dashboard` are moving under the new field `frontend`