### PR TITLE
[BUGFIX] Remove TimeSeriesQuery type from MultiQueryEditor

### DIFF
--- a/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 import { produce } from 'immer';
 import { Button, Stack } from '@mui/material';
 import AddIcon from 'mdi-material-ui/Plus';
-import { TimeSeriesQueryDefinition, QueryDefinition, QueryPluginType } from '@perses-dev/core';
+import { QueryDefinition, QueryPluginType } from '@perses-dev/core';
 import { useListPluginMetadata, usePlugin, usePluginRegistry } from '../../runtime';
 import { QueryEditorContainer } from './QueryEditorContainer';
 
@@ -67,7 +67,7 @@ export function MultiQueryEditor({ queryTypes, queries = [], onChange }: MultiQu
   const [queriesCollapsed, setQueriesCollapsed] = useState(queries.map(() => false));
 
   // Query handlers
-  const handleQueryChange = (index: number, queryDef: TimeSeriesQueryDefinition) => {
+  const handleQueryChange = (index: number, queryDef: QueryDefinition) => {
     onChange(
       produce(queries, (draft) => {
         if (draft) {
@@ -115,7 +115,7 @@ export function MultiQueryEditor({ queryTypes, queries = [], onChange }: MultiQu
   };
 
   // show one query input if queries is empty
-  const queryDefinitions: TimeSeriesQueryDefinition[] = queries.length ? queries : [defaultInitialQueryDefinition];
+  const queryDefinitions: QueryDefinition[] = queries.length ? queries : [defaultInitialQueryDefinition];
 
   return (
     <>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Was not that harmful but clearly bring confusion

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
