### PR TITLE
[FEATURE] Instant query table view

### DIFF
--- a/cue/schemas/panels/time-series-table/time-series-table.cue
+++ b/cue/schemas/panels/time-series-table/time-series-table.cue
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,10 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './plugins/time-series-chart';
-export * from './plugins/gauge-chart';
-export * from './plugins/stat-chart';
-export * from './plugins/markdown';
-export * from './plugins/bar-chart';
-export * from './plugins/scatterplot';
-export * from './plugins/time-series-table';
+package model
+
+kind: "TimeSeriesTable"
+spec: close({})

--- a/cue/schemas/panels/time-series-table/time-series-table.json
+++ b/cue/schemas/panels/time-series-table/time-series-table.json
@@ -1,0 +1,4 @@
+{
+  "kind": "TimeSeriesTable",
+  "spec": {}
+}

--- a/ui/.eslintrc.base.js
+++ b/ui/.eslintrc.base.js
@@ -64,7 +64,14 @@ module.exports = {
     'import/order': 'error',
     // you must disable the base rule as it can report incorrect errors
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error'],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
 
     'react/prop-types': 'off',
     'react-hooks/exhaustive-deps': 'error',

--- a/ui/core/src/model/time-series-data.ts
+++ b/ui/core/src/model/time-series-data.ts
@@ -32,6 +32,7 @@ export interface TimeSeriesData {
 export interface TimeSeries {
   name: string;
   values: TimeSeriesValueTuple[];
+  histograms?: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
   formattedName?: string;
   labels?: Labels;
 }

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -13,7 +13,7 @@
 
 import { Box } from '@mui/material';
 import { useInView } from 'react-intersection-observer';
-import { DataQueriesProvider, useSuggestedStepMs } from '@perses-dev/plugin-system';
+import { DataQueriesProvider, usePlugin, useSuggestedStepMs } from '@perses-dev/plugin-system';
 import { PanelGroupItemId, useEditMode, usePanel, usePanelActions } from '../../context';
 import { Panel, PanelProps } from '../Panel/Panel';
 import { PanelOptions } from '../Panel';
@@ -54,6 +54,9 @@ export function GridItemContent(props: GridItemContentProps) {
 
   // map TimeSeriesQueryDefinition to Definition<UnknownSpec>
   const suggestedStepMs = useSuggestedStepMs(width);
+
+  const { data: plugin } = usePlugin('Panel', panelDefinition.spec.plugin.kind);
+
   const queryDefinitions = queries ?? [];
   const definitions = queryDefinitions.map((query) => {
     return {
@@ -70,7 +73,11 @@ export function GridItemContent(props: GridItemContentProps) {
         height: '100%',
       }}
     >
-      <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs }} queryOptions={{ enabled: inView }}>
+      <DataQueriesProvider
+        definitions={definitions}
+        options={{ suggestedStepMs, ...plugin?.queryOptions }}
+        queryOptions={{ enabled: inView }}
+      >
         {inView && (
           <Panel
             definition={panelDefinition}

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState, useMemo, memo } from 'react';
+import { useState, useMemo, memo, ReactNode } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import { ErrorBoundary, ErrorAlert, combineSx, useId, useChartsTheme } from '@perses-dev/components';
 import { PanelDefinition } from '@perses-dev/core';
@@ -29,10 +29,15 @@ export interface PanelProps extends CardProps<'section'> {
 
 export type PanelOptions = {
   /**
-   * Content to render in the top-right corner of the panel. It will only be
-   * rendered when the panel is in edit mode.
+   * Allow you to hide the panel header if desired.
+   * This can be useful in embedded mode for example.
    */
-  extra?: (props: PanelExtraProps) => React.ReactNode;
+  hideHeader?: boolean;
+  /**
+   * Content to render in right of the panel header. (top right of the panel)
+   * It will only be rendered when the panel is in edit mode.
+   */
+  extra?: (props: PanelExtraProps) => ReactNode;
 };
 
 export type PanelExtraProps = {
@@ -95,15 +100,17 @@ export const Panel = memo(function Panel(props: PanelProps) {
       data-testid="panel"
       {...others}
     >
-      <PanelHeader
-        extra={panelOptions?.extra?.({ panelDefinition: definition, panelGroupItemId })}
-        id={headerId}
-        title={definition.spec.display.name}
-        description={definition.spec.display.description}
-        editHandlers={editHandlers}
-        links={definition.spec.links}
-        sx={{ paddingX: `${chartsTheme.container.padding.default}px` }}
-      />
+      {!panelOptions?.hideHeader && (
+        <PanelHeader
+          extra={panelOptions?.extra?.({ panelDefinition: definition, panelGroupItemId })}
+          id={headerId}
+          title={definition.spec.display.name}
+          description={definition.spec.display.description}
+          editHandlers={editHandlers}
+          links={definition.spec.links}
+          sx={{ paddingX: `${chartsTheme.container.padding.default}px` }}
+        />
+      )}
       <CardContent
         component="figure"
         sx={{

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -13,7 +13,7 @@
 
 import { useRef } from 'react';
 import { Box } from '@mui/material';
-import { DataQueriesProvider, useSuggestedStepMs } from '@perses-dev/plugin-system';
+import { DataQueriesProvider, usePlugin, useSuggestedStepMs } from '@perses-dev/plugin-system';
 import { PanelEditorValues } from '../../context';
 import { Panel } from '../Panel';
 
@@ -27,6 +27,11 @@ export function PanelPreview({ panelDefinition }: Pick<PanelEditorValues, 'panel
     width = boxRef.current.getBoundingClientRect().width;
   }
   const suggestedStepMs = useSuggestedStepMs(width);
+
+  const { data: plugin, isLoading } = usePlugin('Panel', panelDefinition.spec.plugin.kind);
+  if (isLoading) {
+    return null;
+  }
 
   if (panelDefinition.spec.plugin.kind === '') {
     return null;
@@ -46,7 +51,7 @@ export function PanelPreview({ panelDefinition }: Pick<PanelEditorValues, 'panel
 
   return (
     <Box ref={boxRef} height={PANEL_PREVIEW_HEIGHT}>
-      <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs }}>
+      <DataQueriesProvider definitions={definitions} options={{ suggestedStepMs, ...plugin?.queryOptions }}>
         <Panel definition={panelDefinition} />
       </DataQueriesProvider>
     </Box>

--- a/ui/panels-plugin/plugin.json
+++ b/ui/panels-plugin/plugin.json
@@ -15,6 +15,14 @@
       },
       {
         "pluginType": "Panel",
+        "kind": "TimeSeriesTable",
+        "display": {
+          "name": "Time Series Table",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "Panel",
         "kind": "BarChart",
         "display": {
           "name": "Bar Chart",

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -24,7 +24,7 @@ import {
   MockPlugin,
 } from '@perses-dev/plugin-system';
 import { VirtuosoMockContext } from 'react-virtuoso';
-import { MOCK_TIME_SERIES_QUERY_RESULT, MOCK_TIME_SERIES_DATA } from '../../test';
+import { MOCK_TIME_SERIES_QUERY_RESULT_MULTIVALUE, MOCK_TIME_SERIES_DATA_MULTIVALUE } from '../../test';
 import { TimeSeriesChartPanel, TimeSeriesChartProps } from './TimeSeriesChartPanel';
 
 jest.mock('@perses-dev/plugin-system', () => {
@@ -36,7 +36,7 @@ jest.mock('@perses-dev/plugin-system', () => {
 
 const FakeTimeSeriesQuery: TimeSeriesQueryPlugin<UnknownSpec> = {
   getTimeSeriesData: async () => {
-    return MOCK_TIME_SERIES_DATA;
+    return MOCK_TIME_SERIES_DATA_MULTIVALUE;
   },
   OptionsEditorComponent: () => {
     return <div>Edit options here</div>;
@@ -83,7 +83,7 @@ describe('TimeSeriesChartPanel', () => {
   beforeEach(() => {
     // TODO: remove and instead use addMockPlugin after rest of runtime dependencies are mocked
     (useDataQueries as jest.Mock).mockReturnValue({
-      queryResults: MOCK_TIME_SERIES_QUERY_RESULT,
+      queryResults: MOCK_TIME_SERIES_QUERY_RESULT_MULTIVALUE,
       isLoading: false,
       isFetching: false,
     });
@@ -126,7 +126,7 @@ describe('TimeSeriesChartPanel', () => {
   it('should toggle selected state when a legend item is clicked', async () => {
     renderPanel();
 
-    const seriesArr = MOCK_TIME_SERIES_DATA.series;
+    const seriesArr = MOCK_TIME_SERIES_DATA_MULTIVALUE.series;
     const firstName = seriesArr[0]?.name;
     const secondName = seriesArr[1]?.name;
 
@@ -141,7 +141,7 @@ describe('TimeSeriesChartPanel', () => {
 
   it('should modify selected state when a legend item is clicked with shift key', async () => {
     renderPanel();
-    const seriesArr = MOCK_TIME_SERIES_DATA.series;
+    const seriesArr = MOCK_TIME_SERIES_DATA_MULTIVALUE.series;
 
     const firstName = seriesArr[0]?.name;
     const secondName = seriesArr[1]?.name;
@@ -177,7 +177,7 @@ describe('TimeSeriesChartPanel', () => {
 
   it('should modify selected state when a legend item is clicked with meta key', async () => {
     renderPanel();
-    const seriesArr = MOCK_TIME_SERIES_DATA.series;
+    const seriesArr = MOCK_TIME_SERIES_DATA_MULTIVALUE.series;
 
     // Falling back to a bogus string if not set to appease typescript.
     const firstName = seriesArr[0]?.name;

--- a/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
@@ -1,0 +1,118 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+ eslint-disable @typescript-eslint/no-explicit-any
+ */
+import { Fragment, ReactNode } from 'react';
+import { Table } from '@mui/material';
+import { TimeSeries, TimeSeriesData } from '@perses-dev/core';
+import { QueryData } from '@perses-dev/plugin-system';
+
+export interface DataTableProps {
+  result: Array<QueryData<TimeSeriesData>>;
+}
+
+/**
+ * Designed to display timeseries data in a prometheus like table format.
+ * The first column will contain the metric name and label combination, and the second column will contain the values.
+ * This is inspired by prometheus DataTable.
+ * https://github.com/prometheus/prometheus/blob/2524a915915d7eb1b1207152d2e0ce5771193404/web/ui/react-app/src/pages/graph/DataTable.tsx
+ * @param result timeseries query result
+ * @constructor
+ */
+const DataTable = ({ result }: DataTableProps) => {
+  if (!result) {
+    return null;
+  }
+  const series = result.flatMap((d) => d.data).flatMap((d) => d?.series || []);
+  const rows = buildRows(series);
+
+  return (
+    <>
+      <Table className="data-table">
+        <tbody>{rows}</tbody>
+      </Table>
+    </>
+  );
+};
+
+function buildRows(series: TimeSeries[]): ReactNode[] {
+  return series.map((s, seriesIdx) => {
+    const displayTimeStamps = (s.values?.length || 0) > 1;
+    const valuesAndTimes = s.values
+      ? s.values.map((v, valIdx) => {
+          return (
+            <Fragment key={valIdx}>
+              {v[1]} {displayTimeStamps && <span>@{v[0]}</span>}
+              <br />
+            </Fragment>
+          );
+        })
+      : [];
+    const histogramsAndTimes = s.histograms
+      ? s.histograms.map((h: any, hisIdx: number) => {
+          return (
+            <Fragment key={-hisIdx}>
+              {histogramTable(h[1])} @<span>{h[0]}</span>
+              <br />
+            </Fragment>
+          );
+        })
+      : [];
+    return (
+      <tr style={{ whiteSpace: 'pre' }} key={seriesIdx}>
+        <td>{s.formattedName || s.name}</td>
+        <td>
+          {valuesAndTimes} {histogramsAndTimes}
+        </td>
+      </tr>
+    );
+  });
+}
+
+const leftDelim = (br: number): string => (br === 3 || br === 1 ? '[' : '(');
+const rightDelim = (br: number): string => (br === 3 || br === 0 ? ']' : ')');
+
+export const bucketRangeString = ([boundaryRule, leftBoundary, rightBoundary, _]: [
+  number,
+  string,
+  string,
+  string,
+]): string => {
+  return `${leftDelim(boundaryRule)}${leftBoundary} -> ${rightBoundary}${rightDelim(boundaryRule)}`;
+};
+
+export const histogramTable = (h: any): ReactNode => (
+  <Table>
+    <thead>
+      <tr>
+        <th style={{ textAlign: 'center' }} colSpan={2}>
+          Histogram Sample
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>Range</th>
+        <th>Count</th>
+      </tr>
+      {h.buckets?.map((b: any, i: any) => (
+        <tr key={i}>
+          <td>{bucketRangeString(b)}</td>
+          <td>{b[3]}</td>
+        </tr>
+      ))}
+    </tbody>
+  </Table>
+);
+export default DataTable;

--- a/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTable.ts
+++ b/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTable.ts
@@ -1,0 +1,33 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PanelPlugin, PanelProps } from '@perses-dev/plugin-system';
+import { TimeSeriesTablePanel } from './TimeSeriesTablePanel';
+
+interface TimeSeriesTableOptions {}
+
+/**
+ * The core TimeSeriesTable panel plugin for Perses.
+ */
+export const TimeSeriesTable: PanelPlugin<TimeSeriesTableOptions> = {
+  PanelComponent: TimeSeriesTablePanel,
+  supportedQueryTypes: ['TimeSeriesQuery'],
+  queryOptions: {
+    mode: 'instant',
+  },
+  createInitialOptions: () => {
+    return {};
+  },
+};
+
+export type TimeSeriesTableProps = PanelProps<TimeSeriesTableOptions>;

--- a/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.test.tsx
@@ -1,0 +1,132 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  MockPlugin,
+  mockPluginRegistry,
+  PluginRegistry,
+  TimeRangeContext,
+  TimeSeriesQueryPlugin,
+  useDataQueries,
+} from '@perses-dev/plugin-system';
+import { TimeRangeValue, TimeSeriesData, toAbsoluteTimeRange, UnknownSpec } from '@perses-dev/core';
+import { TimeSeriesTableProps } from '@perses-dev/panels-plugin';
+import { render, screen } from '@testing-library/react';
+import { VirtuosoMockContext } from 'react-virtuoso';
+import { ChartsProvider, testChartsTheme } from '@perses-dev/components';
+import {
+  MOCK_TIME_SERIES_DATA_MULTIVALUE,
+  MOCK_TIME_SERIES_DATA_SINGLEVALUE,
+  MOCK_TIME_SERIES_QUERY_RESULT_MULTIVALUE,
+  MOCK_TIME_SERIES_QUERY_RESULT_SINGLEVALUE,
+} from '../../test';
+import { TimeSeriesTablePanel } from './TimeSeriesTablePanel';
+
+jest.mock('@perses-dev/plugin-system', () => {
+  return {
+    ...jest.requireActual('@perses-dev/plugin-system'),
+    useDataQueries: jest.fn(),
+  };
+});
+
+const TEST_TIME_RANGE: TimeRangeValue = { pastDuration: '1h' };
+
+function buildFakeTimeSeriesQuery(data: TimeSeriesData): TimeSeriesQueryPlugin<UnknownSpec> {
+  return {
+    getTimeSeriesData: async () => {
+      return data;
+    },
+    OptionsEditorComponent: () => {
+      return <div>Edit options here</div>;
+    },
+    createInitialOptions: () => ({}),
+  };
+}
+
+function buildMockQueryPlugin(data: TimeSeriesData): MockPlugin {
+  return {
+    pluginType: 'TimeSeriesQuery',
+    kind: 'PrometheusTimeSeriesQuery',
+    plugin: buildFakeTimeSeriesQuery(data),
+  };
+}
+
+const TEST_TIME_SERIES_TABLE_PROPS: TimeSeriesTableProps = {
+  contentDimensions: {
+    width: 500,
+    height: 500,
+  },
+  spec: {},
+};
+
+describe('TimeSeriesTablePanel', () => {
+  // Helper to render the panel with some context set
+  const renderPanel = (data: TimeSeriesData) => {
+    const mockTimeRangeContext = {
+      refreshIntervalInMs: 0,
+      setRefreshInterval: () => ({}),
+      timeRange: TEST_TIME_RANGE,
+      setTimeRange: () => ({}),
+      absoluteTimeRange: toAbsoluteTimeRange(TEST_TIME_RANGE),
+      refresh: jest.fn(),
+      refreshKey: `${TEST_TIME_RANGE.pastDuration}:0`,
+    };
+
+    render(
+      <VirtuosoMockContext.Provider value={{ viewportHeight: 600, itemHeight: 100 }}>
+        <PluginRegistry {...mockPluginRegistry(buildMockQueryPlugin(data))}>
+          <ChartsProvider chartsTheme={testChartsTheme}>
+            <TimeRangeContext.Provider value={mockTimeRangeContext}>
+              <TimeSeriesTablePanel {...TEST_TIME_SERIES_TABLE_PROPS} />
+            </TimeRangeContext.Provider>
+          </ChartsProvider>
+        </PluginRegistry>
+      </VirtuosoMockContext.Provider>
+    );
+  };
+
+  it('should render multi values with timestamps', async () => {
+    (useDataQueries as jest.Mock).mockReturnValue({
+      queryResults: MOCK_TIME_SERIES_QUERY_RESULT_MULTIVALUE,
+      isLoading: false,
+      isFetching: false,
+    });
+    renderPanel(MOCK_TIME_SERIES_DATA_MULTIVALUE);
+    expect(
+      await screen.findByText(
+        'device="/dev/vda1", env="demo", fstype="ext4", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/"'
+      )
+    ).toBeInTheDocument();
+
+    expect(await screen.findAllByRole('cell')).toHaveLength(4); // 2 lines with 2 column
+    expect(await screen.findAllByText('@1666479357903')).toHaveLength(2); // first timestamp appear once per line
+    expect(await screen.findAllByText('@1666479382282')).toHaveLength(2); // second timestamp appear once per line
+  });
+
+  it('should render single value without timestamp', async () => {
+    (useDataQueries as jest.Mock).mockReturnValue({
+      queryResults: MOCK_TIME_SERIES_QUERY_RESULT_SINGLEVALUE,
+      isLoading: false,
+      isFetching: false,
+    });
+    renderPanel(MOCK_TIME_SERIES_DATA_SINGLEVALUE);
+    expect(
+      await screen.findByText(
+        'device="/dev/vda1", env="demo", fstype="ext4", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/"'
+      )
+    ).toBeInTheDocument();
+
+    expect(await screen.findAllByRole('cell')).toHaveLength(4); // 2 lines with 2 column
+    expect(screen.queryByText('@')).toBeNull(); // No @ as no timestamp
+  });
+});

--- a/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.tsx
@@ -1,0 +1,65 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useDataQueries } from '@perses-dev/plugin-system';
+import React from 'react';
+import { Box, Skeleton } from '@mui/material';
+import { useChartsTheme } from '@perses-dev/components';
+import { TimeSeriesTableProps } from './TimeSeriesTable';
+import DataTable from './DataTable';
+
+export function TimeSeriesTablePanel(props: TimeSeriesTableProps) {
+  const { contentDimensions } = props;
+  const chartsTheme = useChartsTheme();
+  const { isFetching, isLoading, queryResults } = useDataQueries('TimeSeriesQuery');
+
+  // TODO: consider refactoring how the layout/spacing/alignment are calculated
+  // the next time significant changes are made to the time series panel (e.g.
+  // when making improvements to the legend to more closely match designs).
+  // This may also want to include moving some of this logic down to the shared,
+  // embeddable components.
+  const contentPadding = chartsTheme.container.padding.default;
+  const adjustedContentDimensions: typeof contentDimensions = contentDimensions
+    ? {
+        width: contentDimensions.width - contentPadding * 2,
+        height: contentDimensions.height - contentPadding * 2,
+      }
+    : undefined;
+
+  if (adjustedContentDimensions === undefined) {
+    return null;
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        width={adjustedContentDimensions.width}
+        height={adjustedContentDimensions.height}
+      >
+        <Skeleton
+          variant="text"
+          width={adjustedContentDimensions.width - 20}
+          height={adjustedContentDimensions.height / 2}
+          aria-label="Loading..."
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: contentDimensions?.height || 0, padding: `${contentPadding}px`, overflowY: 'scroll' }}>
+      <DataTable result={queryResults} />
+    </Box>
+  );
+}

--- a/ui/panels-plugin/src/plugins/time-series-table/index.ts
+++ b/ui/panels-plugin/src/plugins/time-series-table/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,10 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './plugins/time-series-chart';
-export * from './plugins/gauge-chart';
-export * from './plugins/stat-chart';
-export * from './plugins/markdown';
-export * from './plugins/bar-chart';
-export * from './plugins/scatterplot';
-export * from './plugins/time-series-table';
+export * from './TimeSeriesTable';

--- a/ui/panels-plugin/src/test/mock-query-results.ts
+++ b/ui/panels-plugin/src/test/mock-query-results.ts
@@ -13,7 +13,7 @@
 
 import { TimeSeriesData } from '@perses-dev/core';
 
-export const MOCK_TIME_SERIES_QUERY_RESULT = [
+export const MOCK_TIME_SERIES_QUERY_RESULT_MULTIVALUE = [
   {
     status: 'success',
     fetchStatus: 'idle',
@@ -61,7 +61,49 @@ export const MOCK_TIME_SERIES_QUERY_RESULT = [
   },
 ];
 
-export const MOCK_TIME_SERIES_DATA: TimeSeriesData = {
+export const MOCK_TIME_SERIES_QUERY_RESULT_SINGLEVALUE = [
+  {
+    status: 'success',
+    fetchStatus: 'idle',
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    data: {
+      timeRange: {
+        start: new Date(1666625535000),
+        end: new Date(1666625535000),
+      },
+      stepMs: 24379,
+      series: [
+        {
+          name: 'device="/dev/vda1", env="demo", fstype="ext4", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/"',
+          values: [[1666479357903, 0.27700745551584494]],
+        },
+        {
+          name: 'device="/dev/vda15", env="demo", fstype="vfat", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/boot/efi"',
+          values: [[1666479357903, 0.08486496097624885]],
+        },
+      ],
+    },
+    dataUpdatedAt: 1666500979895,
+    error: null,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    errorUpdateCount: 0,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isRefetching: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isPreviousData: false,
+    isRefetchError: false,
+    isStale: true,
+  },
+];
+
+export const MOCK_TIME_SERIES_DATA_MULTIVALUE: TimeSeriesData = {
   timeRange: {
     start: new Date(1666625490000),
     end: new Date(1666625535000),
@@ -81,6 +123,24 @@ export const MOCK_TIME_SERIES_DATA: TimeSeriesData = {
         [1666479357903, 0.08486496097624885],
         [1666479382282, 0.08486496097624885],
       ],
+    },
+  ],
+};
+
+export const MOCK_TIME_SERIES_DATA_SINGLEVALUE: TimeSeriesData = {
+  timeRange: {
+    start: new Date(1666625535000),
+    end: new Date(1666625535000),
+  },
+  stepMs: 24379,
+  series: [
+    {
+      name: 'device="/dev/vda1", env="demo", fstype="ext4", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/"',
+      values: [[1666479357903, 0.27700745551584494]],
+    },
+    {
+      name: 'device="/dev/vda15", env="demo", fstype="vfat", instance="demo.do.prometheus.io:9100", job="node", mountpoint="/boot/efi"',
+      values: [[1666479357903, 0.08486496097624885]],
     },
   ],
 };

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -14,6 +14,7 @@
 import React from 'react';
 import { UnknownSpec, PanelDefinition, QueryPluginType } from '@perses-dev/core';
 import { OptionsEditorTab } from '../components';
+import { QueryOptions } from '../runtime';
 import { OptionsEditorProps, Plugin } from './plugin-base';
 
 export type PanelOptionsEditorComponent<T> = Pick<OptionsEditorTab, 'label'> & {
@@ -34,6 +35,12 @@ export interface PanelPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
    * @default [] (no query types supported) only relevant if hideQueryEditor is true
    */
   supportedQueryTypes?: QueryPluginType[];
+  /**
+   * Static options for the queries that will be executed.
+   * Each {@link QueryPluginType} implementation can have its own options.
+   * For example see {@link UseTimeSeriesQueryOptions} for time series queries.
+   */
+  queryOptions?: QueryOptions;
   /**
    * If true, query editor will be hidden for panel plugin
    * @default false

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -35,11 +35,14 @@ export interface TimeSeriesQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> 
   dependsOn?: (spec: Spec, ctx: TimeSeriesQueryContext) => TimeSeriesQueryPluginDependencies;
 }
 
+export type TimeSeriesQueryMode = 'instant' | 'range';
+
 /**
  * Context available to TimeSeriesQuery plugins at runtime.
  */
 export interface TimeSeriesQueryContext {
   suggestedStepMs?: number;
+  mode?: TimeSeriesQueryMode;
   timeRange: AbsoluteTimeRange;
   variableState: VariableStateMap;
   datasourceStore: DatasourceStore;

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
@@ -31,7 +31,7 @@ jest.mock('../plugin-registry', () => ({
     data: [
       {
         display: {
-          name: 'Prometheus Range Query',
+          name: 'Prometheus Query',
         },
         kind: 'PrometheusTimeSeriesQuery',
         pluginType: 'TimeSeriesQuery',

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -79,7 +79,6 @@ export function DataQueriesProvider(props: DataQueriesProviderProps) {
     (definition) => definition.kind === 'TimeSeriesQuery'
   ) as TimeSeriesQueryDefinition[];
   const timeSeriesResults = useTimeSeriesQueries(timeSeriesQueries, options, queryOptions);
-
   const traceQueries = queryDefinitions.filter(
     (definition) => definition.kind === 'TraceQuery'
   ) as TraceQueryDefinition[];

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -13,13 +13,13 @@
 
 import { Definition, QueryDefinition, UnknownSpec, QueryDataType } from '@perses-dev/core';
 import { QueryObserverOptions, UseQueryResult } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { ReactNode, useCallback, useMemo } from 'react';
 import { useListPluginMetadata } from '../plugin-registry';
 
-type QueryOptions = Record<string, unknown>;
+export type QueryOptions = Record<string, unknown>;
 export interface DataQueriesProviderProps<QueryPluginSpec = UnknownSpec> {
   definitions: Array<Definition<QueryPluginSpec>>;
-  children?: React.ReactNode;
+  children?: ReactNode;
   options?: QueryOptions;
   queryOptions?: QueryObserverOptions;
 }

--- a/ui/prometheus-plugin/plugin.json
+++ b/ui/prometheus-plugin/plugin.json
@@ -41,7 +41,7 @@
         "pluginType": "TimeSeriesQuery",
         "kind": "PrometheusTimeSeriesQuery",
         "display": {
-          "name": "Prometheus Range Query",
+          "name": "Prometheus Query",
           "description": ""
         }
       },


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

ref #1456 (not fix as it's not addressing all the problems. Only the explorer one)

Introduction of the ``TimeSeriesTable`` panel. It allow users to display "prometheus like" table results as a panel in a dashboard. It is also used in TimeSeries explorer.

![image](https://github.com/perses/perses/assets/10258608/a165da91-52f8-4d8c-9030-d6dd2c5e15aa)

This led to the creation of several new fields but no **breaking change**. 

### New ``mode`` field in ``DataQueriesProvider`` options
The new mode field is used to tell the DataQueriesProvider to execute the time series queries in `instant` mode (e.g /query endpoint used for prometheus)  or `range` mode (e.g /range endpoint used for prometheus)
Default mode is ``range``.

```html
<DataQueriesProvider definitions={definitions} options={{ mode: 'instant' }}>
```

### New ``queryOptions`` in ``PanelPlugin``
This allow to declare the mode at panel plugin level. Basically for now only the timeseries table panel will tell the queries to be done on instant mode.

```ts
// Example for timeseries table
export const TimeSeriesTable: PanelPlugin<TimeSeriesTableOptions> = {
  PanelComponent: TimeSeriesTablePanel,
  supportedQueryTypes: ['TimeSeriesQuery'],
  queryOptions: {
    mode: 'instant',
  },
  createInitialOptions: () => {
    return {};
  },
};
```

### A new ``hideHeader`` field in ``PanelOptions``
A minor change also is that you hide panel header which can be useful in embedded mode, and reduce the space taken by the panel in the explorer.
```html
<Panel
  panelOptions={{
    hideHeader: true,
  }}
  definition={{...}}
/>
```

### Explorer improvement
Used in explorer, the new timeseries table chart looks like this
![image](https://github.com/perses/perses/assets/10258608/d271cf2e-53fd-4873-88c1-fe6c63099896)
![image](https://github.com/perses/perses/assets/10258608/9c231e83-fb26-487d-a471-bae1247c25a6)
![image](https://github.com/perses/perses/assets/10258608/dbbc7ff7-cf64-4c97-968f-bab9af2005c1)
![image](https://github.com/perses/perses/assets/10258608/04294f2e-e08c-489e-b241-7bba8213d0e3)




<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
