### PR TITLE
[ENHANCEMENT] Optimize query to get dashboards on the home page

### DIFF
--- a/ui/app/src/model/project-client.ts
+++ b/ui/app/src/model/project-client.ts
@@ -183,12 +183,20 @@ export function useDeleteProjectMutation() {
 
 async function getProjectsWithDashboard(): Promise<ProjectWithDashboards[]> {
   const projects = await getProjects();
-  const result: ProjectWithDashboards[] = [];
-  for (const project of projects ?? []) {
-    const dashboards = await getDashboards(project.metadata.name);
-    result.push({ project: project, dashboards: dashboards });
+  const dashboards = await getDashboards();
+  const dashboardList: Record<string, DashboardResource[]> = {};
+
+  for (const dashboard of dashboards) {
+    const list = dashboardList[dashboard.metadata.project] ?? [];
+    list.push(dashboard);
+    dashboardList[dashboard.metadata.project] = list;
   }
 
+  const result: ProjectWithDashboards[] = [];
+  for (const project of projects ?? []) {
+    const list = dashboardList[project.metadata.name] ?? [];
+    result.push({ project: project, dashboards: list });
+  }
   return result;
 }
 


### PR DESCRIPTION
In the current home page, for each project listed we are getting one by one the list of dashboards by project. That's something that cannot scale as we will have a lot of queries when a lot of projects are created.

This PR aims to simplify this process by getting all dashboards at once and them map it to the list of dashboard.