### PR TITLE
[ENHANCEMENT] Add query param 'metadata_only' on almost all query endpoints

### DIFF
--- a/internal/api/dashboard/cleaner_test.go
+++ b/internal/api/dashboard/cleaner_test.go
@@ -15,6 +15,7 @@ package dashboard
 
 import (
 	"context"
+	"github.com/perses/perses/pkg/model/api"
 	"testing"
 	"time"
 
@@ -30,6 +31,18 @@ type mockDAO struct {
 
 func (d *mockDAO) List(_ *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, error) {
 	return d.dashboards, nil
+}
+
+func (d *mockDAO) MetadataList(_ *ephemeraldashboard.Query) ([]api.Entity, error) {
+	var result []api.Entity
+	for _, dashboard := range d.dashboards {
+		result = append(result, &v1.PartialProjectEntity{
+			Kind:     dashboard.Kind,
+			Metadata: dashboard.Metadata,
+			Spec:     struct{}{},
+		})
+	}
+	return result, nil
 }
 
 func (d *mockDAO) Delete(project string, name string) error {

--- a/internal/api/database/model/dao.go
+++ b/internal/api/database/model/dao.go
@@ -21,6 +21,7 @@ import (
 )
 
 type Query interface {
+	GetMetadataOnlyQueryParam() bool
 }
 
 type DAO interface {

--- a/internal/api/impl/v1/dashboard/persistence.go
+++ b/internal/api/impl/v1/dashboard/persistence.go
@@ -16,6 +16,7 @@ package dashboard
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -56,5 +57,15 @@ func (d *dao) Get(project string, name string) (*v1.Dashboard, error) {
 func (d *dao) List(q *dashboard.Query) ([]*v1.Dashboard, error) {
 	var result []*v1.Dashboard
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *dashboard.Query) ([]api.Entity, error) {
+	var list []*v1.PartialProjectEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/dashboard/service.go
+++ b/internal/api/impl/v1/dashboard/service.go
@@ -15,6 +15,7 @@ package dashboard
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -113,19 +114,19 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 }
 
 func (s *service) List(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([]*v1.Dashboard, error) {
-	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
-	query, err := deep.Copy(q)
+	query, err := manageQuery(q, params)
 	if err != nil {
-		return nil, fmt.Errorf("unable to copy the query: %w", err)
+		return nil, err
 	}
-	return s.list(query, params)
+	return s.dao.List(query)
 }
 
-func (s *service) list(q *dashboard.Query, params apiInterface.Parameters) ([]*v1.Dashboard, error) {
-	if len(q.Project) == 0 {
-		q.Project = params.Project
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([]api.Entity, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
 	}
-	return s.dao.List(q)
+	return s.dao.MetadataList(query)
 }
 
 func (s *service) Validate(entity *v1.Dashboard) error {
@@ -154,4 +155,16 @@ func (s *service) collectProjectVariables(project string) ([]*v1.Variable, error
 
 func (s *service) collectGlobalVariables() ([]*v1.GlobalVariable, error) {
 	return s.globalVarDAO.List(&globalvariable.Query{})
+}
+
+func manageQuery(q *dashboard.Query, params apiInterface.Parameters) (*dashboard.Query, error) {
+	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
+	query, err := deep.Copy(q)
+	if err != nil {
+		return nil, fmt.Errorf("unable to copy the query: %w", err)
+	}
+	if len(query.Project) == 0 {
+		query.Project = params.Project
+	}
+	return query, nil
 }

--- a/internal/api/impl/v1/ephemeraldashboard/persistence.go
+++ b/internal/api/impl/v1/ephemeraldashboard/persistence.go
@@ -16,6 +16,7 @@ package ephemeraldashboard
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -56,5 +57,15 @@ func (d *dao) Get(project string, name string) (*v1.EphemeralDashboard, error) {
 func (d *dao) List(q *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, error) {
 	var result []*v1.EphemeralDashboard
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *ephemeraldashboard.Query) ([]api.Entity, error) {
+	var list []*v1.PartialProjectEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/folder/persistence.go
+++ b/internal/api/impl/v1/folder/persistence.go
@@ -16,6 +16,7 @@ package folder
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -56,5 +57,15 @@ func (d *dao) Get(project string, name string) (*v1.Folder, error) {
 func (d *dao) List(q *folder.Query) ([]*v1.Folder, error) {
 	var result []*v1.Folder
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *folder.Query) ([]api.Entity, error) {
+	var list []*v1.PartialProjectEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/folder/service.go
+++ b/internal/api/impl/v1/folder/service.go
@@ -15,10 +15,10 @@ package folder
 
 import (
 	"fmt"
-
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -92,17 +92,29 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 }
 
 func (s *service) List(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([]*v1.Folder, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.List(query)
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([]api.Entity, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.MetadataList(query)
+}
+
+func manageQuery(q *folder.Query, params apiInterface.Parameters) (*folder.Query, error) {
 	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
 	query, err := deep.Copy(q)
 	if err != nil {
 		return nil, fmt.Errorf("unable to copy the query: %w", err)
 	}
-	return s.list(query, params)
-}
-
-func (s *service) list(q *folder.Query, params apiInterface.Parameters) ([]*v1.Folder, error) {
-	if len(q.Project) == 0 {
-		q.Project = params.Project
+	if len(query.Project) == 0 {
+		query.Project = params.Project
 	}
-	return s.dao.List(q)
+	return query, nil
 }

--- a/internal/api/impl/v1/globalrole/persistence.go
+++ b/internal/api/impl/v1/globalrole/persistence.go
@@ -16,6 +16,7 @@ package globalrole
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalrole"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -52,5 +53,15 @@ func (d *dao) Get(name string) (*v1.GlobalRole, error) {
 func (d *dao) List(q *globalrole.Query) ([]*v1.GlobalRole, error) {
 	var result []*v1.GlobalRole
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *globalrole.Query) ([]api.Entity, error) {
+	var list []*v1.PartialEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/globalrole/service.go
+++ b/internal/api/impl/v1/globalrole/service.go
@@ -15,6 +15,7 @@ package globalrole
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -109,4 +110,8 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 
 func (s *service) List(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([]*v1.GlobalRole, error) {
 	return s.dao.List(q)
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return s.dao.MetadataList(q)
 }

--- a/internal/api/impl/v1/globalrolebinding/persistence.go
+++ b/internal/api/impl/v1/globalrolebinding/persistence.go
@@ -16,6 +16,7 @@ package globalrolebinding
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalrolebinding"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -52,5 +53,15 @@ func (d *dao) Get(name string) (*v1.GlobalRoleBinding, error) {
 func (d *dao) List(q *globalrolebinding.Query) ([]*v1.GlobalRoleBinding, error) {
 	var result []*v1.GlobalRoleBinding
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *globalrolebinding.Query) ([]api.Entity, error) {
+	var list []*v1.PartialEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/globalrolebinding/service.go
+++ b/internal/api/impl/v1/globalrolebinding/service.go
@@ -15,6 +15,7 @@ package globalrolebinding
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	databaseModel "github.com/perses/perses/internal/api/database/model"
@@ -131,6 +132,10 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 
 func (s *service) List(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([]*v1.GlobalRoleBinding, error) {
 	return s.dao.List(q)
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return s.dao.MetadataList(q)
 }
 
 // Validating role and subjects are existing

--- a/internal/api/impl/v1/globalsecret/persistence.go
+++ b/internal/api/impl/v1/globalsecret/persistence.go
@@ -16,6 +16,7 @@ package globalsecret
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalsecret"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -55,5 +56,15 @@ func (d *dao) Get(name string) (*v1.GlobalSecret, error) {
 func (d *dao) List(q *globalsecret.Query) ([]*v1.GlobalSecret, error) {
 	var result []*v1.GlobalSecret
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *globalsecret.Query) ([]api.Entity, error) {
+	var list []*v1.PartialEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/globalsecret/service.go
+++ b/internal/api/impl/v1/globalsecret/service.go
@@ -15,6 +15,7 @@ package globalsecret
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	"github.com/perses/perses/internal/api/crypto"
@@ -111,4 +112,8 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalsecret.Query, _ ap
 		result = append(result, v1.NewPublicGlobalSecret(scrt))
 	}
 	return result, nil
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalsecret.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return s.dao.MetadataList(q)
 }

--- a/internal/api/impl/v1/globalvariable/persistence.go
+++ b/internal/api/impl/v1/globalvariable/persistence.go
@@ -16,6 +16,7 @@ package globalvariable
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -52,5 +53,15 @@ func (d *dao) Get(name string) (*v1.GlobalVariable, error) {
 func (d *dao) List(q *globalvariable.Query) ([]*v1.GlobalVariable, error) {
 	var result []*v1.GlobalVariable
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *globalvariable.Query) ([]api.Entity, error) {
+	var list []*v1.PartialEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/globalvariable/service.go
+++ b/internal/api/impl/v1/globalvariable/service.go
@@ -15,6 +15,7 @@ package globalvariable
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -98,4 +99,8 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 
 func (s *service) List(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([]*v1.GlobalVariable, error) {
 	return s.dao.List(q)
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return s.dao.MetadataList(q)
 }

--- a/internal/api/impl/v1/project/persistence.go
+++ b/internal/api/impl/v1/project/persistence.go
@@ -16,6 +16,7 @@ package project
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -52,5 +53,15 @@ func (d *dao) Delete(name string) error {
 func (d *dao) List(q *project.Query) ([]*v1.Project, error) {
 	var result []*v1.Project
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *project.Query) ([]api.Entity, error) {
+	var list []*v1.PartialEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/project/service.go
+++ b/internal/api/impl/v1/project/service.go
@@ -15,6 +15,7 @@ package project
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -177,4 +178,8 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 
 func (s *service) List(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([]*v1.Project, error) {
 	return s.dao.List(q)
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return s.dao.MetadataList(q)
 }

--- a/internal/api/impl/v1/role/persistence.go
+++ b/internal/api/impl/v1/role/persistence.go
@@ -16,6 +16,7 @@ package role
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/role"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -56,5 +57,15 @@ func (d *dao) Get(project string, name string) (*v1.Role, error) {
 func (d *dao) List(q *role.Query) ([]*v1.Role, error) {
 	var result []*v1.Role
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *role.Query) ([]api.Entity, error) {
+	var list []*v1.PartialProjectEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/role/service.go
+++ b/internal/api/impl/v1/role/service.go
@@ -15,6 +15,7 @@ package role
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -115,17 +116,29 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 }
 
 func (s *service) List(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([]*v1.Role, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.List(query)
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([]api.Entity, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.MetadataList(query)
+}
+
+func manageQuery(q *role.Query, params apiInterface.Parameters) (*role.Query, error) {
 	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
 	query, err := deep.Copy(q)
 	if err != nil {
 		return nil, fmt.Errorf("unable to copy the query: %w", err)
 	}
-	return s.list(query, params)
-}
-
-func (s *service) list(q *role.Query, params apiInterface.Parameters) ([]*v1.Role, error) {
-	if len(q.Project) == 0 {
-		q.Project = params.Project
+	if len(query.Project) == 0 {
+		query.Project = params.Project
 	}
-	return s.dao.List(q)
+	return query, nil
 }

--- a/internal/api/impl/v1/rolebinding/persistence.go
+++ b/internal/api/impl/v1/rolebinding/persistence.go
@@ -16,6 +16,7 @@ package rolebinding
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/rolebinding"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -56,5 +57,15 @@ func (d *dao) Get(project string, name string) (*v1.RoleBinding, error) {
 func (d *dao) List(q *rolebinding.Query) ([]*v1.RoleBinding, error) {
 	var result []*v1.RoleBinding
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *rolebinding.Query) ([]api.Entity, error) {
+	var list []*v1.PartialProjectEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/rolebinding/service.go
+++ b/internal/api/impl/v1/rolebinding/service.go
@@ -15,6 +15,7 @@ package rolebinding
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -136,19 +137,19 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 }
 
 func (s *service) List(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([]*v1.RoleBinding, error) {
-	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
-	query, err := deep.Copy(q)
+	query, err := manageQuery(q, params)
 	if err != nil {
-		return nil, fmt.Errorf("unable to copy the query: %w", err)
+		return nil, err
 	}
-	return s.list(query, params)
+	return s.dao.List(query)
 }
 
-func (s *service) list(q *rolebinding.Query, params apiInterface.Parameters) ([]*v1.RoleBinding, error) {
-	if len(q.Project) == 0 {
-		q.Project = params.Project
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([]api.Entity, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
 	}
-	return s.dao.List(q)
+	return s.dao.MetadataList(query)
 }
 
 // Validating role and subjects are existing
@@ -169,4 +170,16 @@ func (s *service) validateRoleBinding(roleBinding *v1.RoleBinding) error {
 		}
 	}
 	return nil
+}
+
+func manageQuery(q *rolebinding.Query, params apiInterface.Parameters) (*rolebinding.Query, error) {
+	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
+	query, err := deep.Copy(q)
+	if err != nil {
+		return nil, fmt.Errorf("unable to copy the query: %w", err)
+	}
+	if len(query.Project) == 0 {
+		query.Project = params.Project
+	}
+	return query, nil
 }

--- a/internal/api/impl/v1/secret/persistence.go
+++ b/internal/api/impl/v1/secret/persistence.go
@@ -16,6 +16,7 @@ package secret
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/secret"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -59,5 +60,15 @@ func (d *dao) Get(project string, name string) (*v1.Secret, error) {
 func (d *dao) List(q *secret.Query) ([]*v1.Secret, error) {
 	var result []*v1.Secret
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *secret.Query) ([]api.Entity, error) {
+	var list []*v1.PartialProjectEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/user/persistence.go
+++ b/internal/api/impl/v1/user/persistence.go
@@ -16,6 +16,7 @@ package user
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/user"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -55,5 +56,15 @@ func (d *dao) Get(name string) (*v1.User, error) {
 func (d *dao) List(q *user.Query) ([]*v1.User, error) {
 	var result []*v1.User
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *user.Query) ([]api.Entity, error) {
+	var list []*v1.PartialEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -15,6 +15,7 @@ package user
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -130,4 +131,8 @@ func (s *service) List(_ apiInterface.PersesContext, q *user.Query, _ apiInterfa
 		result = append(result, v1.NewPublicUser(usr))
 	}
 	return result, nil
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *user.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return s.dao.MetadataList(q)
 }

--- a/internal/api/impl/v1/variable/persistence.go
+++ b/internal/api/impl/v1/variable/persistence.go
@@ -16,6 +16,7 @@ package variable
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -56,5 +57,15 @@ func (d *dao) Get(project string, name string) (*v1.Variable, error) {
 func (d *dao) List(q *variable.Query) ([]*v1.Variable, error) {
 	var result []*v1.Variable
 	err := d.client.Query(q, &result)
+	return result, err
+}
+
+func (d *dao) MetadataList(q *variable.Query) ([]api.Entity, error) {
+	var list []*v1.PartialProjectEntity
+	err := d.client.Query(q, &list)
+	result := make([]api.Entity, 0, len(list))
+	for _, el := range list {
+		result = append(result, el)
+	}
 	return result, err
 }

--- a/internal/api/impl/v1/variable/service.go
+++ b/internal/api/impl/v1/variable/service.go
@@ -15,6 +15,7 @@ package variable
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -105,17 +106,29 @@ func (s *service) Get(_ apiInterface.PersesContext, parameters apiInterface.Para
 }
 
 func (s *service) List(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([]*v1.Variable, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.List(query)
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([]api.Entity, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.MetadataList(query)
+}
+
+func manageQuery(q *variable.Query, params apiInterface.Parameters) (*variable.Query, error) {
 	// Query is copied because it can be modified by the toolbox.go: listWhenPermissionIsActivated(...) and need to `q` need to keep initial value
 	query, err := deep.Copy(q)
 	if err != nil {
 		return nil, fmt.Errorf("unable to copy the query: %w", err)
 	}
-	return s.list(query, params)
-}
-
-func (s *service) list(q *variable.Query, params apiInterface.Parameters) ([]*v1.Variable, error) {
-	if len(q.Project) == 0 {
-		q.Project = params.Project
+	if len(query.Project) == 0 {
+		query.Project = params.Project
 	}
-	return s.dao.List(q)
+	return query, nil
 }

--- a/internal/api/impl/v1/view/endpoint_test.go
+++ b/internal/api/impl/v1/view/endpoint_test.go
@@ -15,6 +15,7 @@ package view
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -84,6 +85,10 @@ func (m *mockDashboardService) Get(_ apiInterface.PersesContext, _ apiInterface.
 }
 
 func (*mockDashboardService) List(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([]*v1.Dashboard, error) {
+	panic("unimplemented")
+}
+
+func (*mockDashboardService) MetadataList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
 	panic("unimplemented")
 }
 

--- a/internal/api/interface/service.go
+++ b/internal/api/interface/service.go
@@ -60,5 +60,6 @@ type Service[T api.Entity, K api.Entity, V databaseModel.Query] interface {
 	Update(ctx PersesContext, entity T, parameters Parameters) (K, error)
 	Delete(ctx PersesContext, parameters Parameters) error
 	Get(ctx PersesContext, parameters Parameters) (K, error)
-	List(ctx PersesContext, q V, parameters Parameters) ([]K, error)
+	List(ctx PersesContext, query V, parameters Parameters) ([]K, error)
+	MetadataList(ctx PersesContext, query V, parameters Parameters) ([]api.Entity, error)
 }

--- a/internal/api/interface/v1/dashboard/interface.go
+++ b/internal/api/interface/v1/dashboard/interface.go
@@ -16,6 +16,7 @@ package dashboard
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -26,7 +27,12 @@ type Query struct {
 	NamePrefix string `query:"name"`
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
-	Project string `param:"project" query:"project"`
+	Project      string `param:"project" query:"project"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -36,6 +42,7 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Dashboard, error)
 	List(q *Query) ([]*v1.Dashboard, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/datasource/interface.go
+++ b/internal/api/interface/v1/datasource/interface.go
@@ -33,6 +33,10 @@ type Query struct {
 	Default *bool `query:"default"`
 }
 
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return false
+}
+
 type DAO interface {
 	Create(entity *v1.Datasource) error
 	Update(entity *v1.Datasource) error

--- a/internal/api/interface/v1/ephemeraldashboard/interface.go
+++ b/internal/api/interface/v1/ephemeraldashboard/interface.go
@@ -16,6 +16,7 @@ package ephemeraldashboard
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -26,7 +27,12 @@ type Query struct {
 	NamePrefix string `query:"name"`
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
-	Project string `param:"project" query:"project"`
+	Project      string `param:"project" query:"project"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -36,6 +42,7 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.EphemeralDashboard, error)
 	List(q *Query) ([]*v1.EphemeralDashboard, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/folder/interface.go
+++ b/internal/api/interface/v1/folder/interface.go
@@ -16,6 +16,7 @@ package folder
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -26,7 +27,12 @@ type Query struct {
 	NamePrefix string `query:"name"`
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
-	Project string `param:"project" query:"project"`
+	Project      string `param:"project" query:"project"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -36,6 +42,7 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Folder, error)
 	List(q *Query) ([]*v1.Folder, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globaldatasource/interface.go
+++ b/internal/api/interface/v1/globaldatasource/interface.go
@@ -30,6 +30,10 @@ type Query struct {
 	Default *bool `query:"default"`
 }
 
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return false
+}
+
 type DAO interface {
 	Create(entity *v1.GlobalDatasource) error
 	Update(entity *v1.GlobalDatasource) error

--- a/internal/api/interface/v1/globalrole/interface.go
+++ b/internal/api/interface/v1/globalrole/interface.go
@@ -16,6 +16,7 @@ package globalrole
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -23,7 +24,12 @@ type Query struct {
 	databaseModel.Query
 	// NamePrefix is a prefix of the GlobalRole.metadata.name that is used to filter the list of the GlobalRole.
 	// NamePrefix can be empty in case you want to return the full list of GlobalRole available.
-	NamePrefix string `query:"name"`
+	NamePrefix   string `query:"name"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -32,6 +38,7 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRole, error)
 	List(q *Query) ([]*v1.GlobalRole, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalrolebinding/interface.go
+++ b/internal/api/interface/v1/globalrolebinding/interface.go
@@ -16,6 +16,7 @@ package globalrolebinding
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -23,7 +24,12 @@ type Query struct {
 	databaseModel.Query
 	// NamePrefix is a prefix of the GlobalRoleBinding.metadata.name that is used to filter the list of the GlobalRoleBinding.
 	// NamePrefix can be empty in case you want to return the full list of GlobalRoleBinding available.
-	NamePrefix string `query:"name"`
+	NamePrefix   string `query:"name"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -32,6 +38,7 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRoleBinding, error)
 	List(q *Query) ([]*v1.GlobalRoleBinding, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalsecret/interface.go
+++ b/internal/api/interface/v1/globalsecret/interface.go
@@ -16,6 +16,7 @@ package globalsecret
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -23,7 +24,12 @@ type Query struct {
 	databaseModel.Query
 	// NamePrefix is a prefix of the GlobalSecret.metadata.name that is used to filter the list of the GlobalSecret.
 	// NamePrefix can be empty in case you want to return the full list of GlobalSecret available.
-	NamePrefix string `query:"name"`
+	NamePrefix   string `query:"name"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -32,6 +38,7 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.GlobalSecret, error)
 	List(q *Query) ([]*v1.GlobalSecret, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalvariable/interface.go
+++ b/internal/api/interface/v1/globalvariable/interface.go
@@ -16,6 +16,7 @@ package globalvariable
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -23,7 +24,12 @@ type Query struct {
 	databaseModel.Query
 	// NamePrefix is a prefix of the GlobalVariable.metadata.name that is used to filter the list of the GlobalVariable.
 	// NamePrefix can be empty in case you want to return the full list of GlobalVariable available.
-	NamePrefix string `query:"name"`
+	NamePrefix   string `query:"name"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -32,6 +38,7 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.GlobalVariable, error)
 	List(q *Query) ([]*v1.GlobalVariable, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/project/interface.go
+++ b/internal/api/interface/v1/project/interface.go
@@ -16,6 +16,7 @@ package project
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -23,7 +24,12 @@ type Query struct {
 	databaseModel.Query
 	// NamePrefix is a prefix of the project.metadata.name that is used to filter the list of the project.
 	// NamePrefix can be empty in case you want to return the full list of project available.
-	NamePrefix string `query:"name"`
+	NamePrefix   string `query:"name"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -32,6 +38,7 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.Project, error)
 	List(q *Query) ([]*v1.Project, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/role/interface.go
+++ b/internal/api/interface/v1/role/interface.go
@@ -16,6 +16,7 @@ package role
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -26,7 +27,12 @@ type Query struct {
 	NamePrefix string `query:"name"`
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
-	Project string `param:"project" query:"project"`
+	Project      string `param:"project" query:"project"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -36,6 +42,7 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Role, error)
 	List(q *Query) ([]*v1.Role, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/rolebinding/interface.go
+++ b/internal/api/interface/v1/rolebinding/interface.go
@@ -16,6 +16,7 @@ package rolebinding
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -26,7 +27,12 @@ type Query struct {
 	NamePrefix string `query:"name"`
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
-	Project string `param:"project" query:"project"`
+	Project      string `param:"project" query:"project"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -36,6 +42,7 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.RoleBinding, error)
 	List(q *Query) ([]*v1.RoleBinding, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/secret/interface.go
+++ b/internal/api/interface/v1/secret/interface.go
@@ -16,6 +16,7 @@ package secret
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -26,17 +27,22 @@ type Query struct {
 	NamePrefix string `query:"name"`
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
-	Project string `param:"project" query:"project"`
+	Project      string `param:"project" query:"project"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
 	Create(entity *v1.Secret) error
 	Update(entity *v1.Secret) error
 	Delete(project string, name string) error
-
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Secret, error)
 	List(q *Query) ([]*v1.Secret, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/user/interface.go
+++ b/internal/api/interface/v1/user/interface.go
@@ -16,6 +16,7 @@ package user
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -23,7 +24,12 @@ type Query struct {
 	databaseModel.Query
 	// NamePrefix is a prefix of the User.metadata.name that is used to filter the list of the User.
 	// NamePrefix can be empty in case you want to return the full list of User available.
-	NamePrefix string `query:"name"`
+	NamePrefix   string `query:"name"`
+	MetadataOnly bool   `query:"metadata_only"`
+}
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
 }
 
 type DAO interface {
@@ -32,6 +38,7 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.User, error)
 	List(q *Query) ([]*v1.User, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/variable/interface.go
+++ b/internal/api/interface/v1/variable/interface.go
@@ -16,6 +16,7 @@ package variable
 import (
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
@@ -26,8 +27,14 @@ type Query struct {
 	NamePrefix string `query:"name"`
 	// Project is the exact name of the project.
 	// The value can come from the path of the URL or from the query parameter
-	Project string `param:"project" query:"project"`
+	Project      string `param:"project" query:"project"`
+	MetadataOnly bool   `query:"metadata_only"`
 }
+
+func (q *Query) GetMetadataOnlyQueryParam() bool {
+	return q.MetadataOnly
+}
+
 type DAO interface {
 	Create(entity *v1.Variable) error
 	Update(entity *v1.Variable) error
@@ -35,6 +42,7 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Variable, error)
 	List(q *Query) ([]*v1.Variable, error)
+	MetadataList(q *Query) ([]api.Entity, error)
 }
 
 type Service interface {

--- a/internal/api/toolbox/toolbox.go
+++ b/internal/api/toolbox/toolbox.go
@@ -63,7 +63,7 @@ func New[T api.Entity, K api.Entity, V databaseModel.Query](service apiInterface
 }
 
 type toolbox[T api.Entity, K api.Entity, V databaseModel.Query] struct {
-	Toolbox[T, K]
+	Toolbox[T, V]
 	service       apiInterface.Service[T, K, V]
 	rbac          rbac.RBAC
 	kind          v1.Kind

--- a/pkg/model/api/v1/partial.go
+++ b/pkg/model/api/v1/partial.go
@@ -1,0 +1,52 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import modelAPI "github.com/perses/perses/pkg/model/api"
+
+type PartialEntity struct {
+	Kind     Kind     `json:"kind" yaml:"kind"`
+	Metadata Metadata `json:"metadata" yaml:"metadata"`
+	Spec     struct{} `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+func (p *PartialEntity) GetMetadata() modelAPI.Metadata {
+	return &p.Metadata
+}
+
+func (p *PartialEntity) GetKind() string {
+	return string(p.Kind)
+}
+
+func (p *PartialEntity) GetSpec() interface{} {
+	return p.Spec
+}
+
+type PartialProjectEntity struct {
+	Kind     Kind            `json:"kind" yaml:"kind"`
+	Metadata ProjectMetadata `json:"metadata" yaml:"metadata"`
+	Spec     struct{}        `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+func (p *PartialProjectEntity) GetMetadata() modelAPI.Metadata {
+	return &p.Metadata
+}
+
+func (p *PartialProjectEntity) GetKind() string {
+	return string(p.Kind)
+}
+
+func (p *PartialProjectEntity) GetSpec() interface{} {
+	return p.Spec
+}

--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -181,7 +181,9 @@ export function getDashboard(project: string, name: string) {
 }
 
 export function getDashboards(project?: string) {
-  const url = buildURL({ resource: resource, project: project });
+  const queryParams = new URLSearchParams();
+  queryParams.set('metadata_only', 'true');
+  const url = buildURL({ resource: resource, project: project, queryParams: queryParams });
   return fetchJson<DashboardResource[]>(url, {
     method: HTTPMethodGET,
     headers: HTTPHeader,

--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -57,9 +57,9 @@ export function useDashboard(project: string, name: string) {
  * Used to get dashboards in the API.
  * Will automatically be refreshed when cache is invalidated
  */
-export function useDashboardList(project?: string) {
+export function useDashboardList(project?: string, metadataOnly?: boolean) {
   return useQuery<DashboardResource[], Error>([resource, project], () => {
-    return getDashboards(project);
+    return getDashboards(project, metadataOnly);
   });
 }
 
@@ -73,7 +73,7 @@ export interface DatedDashboards {
  * Will automatically be refreshed when cache is invalidated or history modified
  */
 export function useRecentDashboardList(project?: string, maxSize?: number) {
-  const { data, isLoading } = useDashboardList(project);
+  const { data, isLoading } = useDashboardList(project, true);
   const history = useNavHistory();
 
   const result = useMemo(() => {
@@ -106,7 +106,7 @@ export function useRecentDashboardList(project?: string, maxSize?: number) {
  * Will automatically be refreshed when cache is invalidated or history modified
  */
 export function useImportantDashboardList(project?: string) {
-  const { data: dashboards, isLoading } = useDashboardList(project);
+  const { data: dashboards, isLoading } = useDashboardList(project, true);
   const importantDashboardSelectors = useImportantDashboardSelectors();
 
   const importantDashboards = useMemo(() => {
@@ -180,9 +180,11 @@ export function getDashboard(project: string, name: string) {
   });
 }
 
-export function getDashboards(project?: string) {
+export function getDashboards(project?: string, metadataOnly?: boolean) {
   const queryParams = new URLSearchParams();
-  queryParams.set('metadata_only', 'true');
+  if (metadataOnly) {
+    queryParams.set('metadata_only', 'true');
+  }
   const url = buildURL({ resource: resource, project: project, queryParams: queryParams });
   return fetchJson<DashboardResource[]>(url, {
     method: HTTPMethodGET,

--- a/ui/app/src/model/project-client.ts
+++ b/ui/app/src/model/project-client.ts
@@ -183,7 +183,7 @@ export function useDeleteProjectMutation() {
 
 async function getProjectsWithDashboard(): Promise<ProjectWithDashboards[]> {
   const projects = await getProjects();
-  const dashboards = await getDashboards();
+  const dashboards = await getDashboards(undefined, true);
   const dashboardList: Record<string, DashboardResource[]> = {};
 
   for (const dashboard of dashboards) {


### PR DESCRIPTION
This PR is introducing the query param `metadata_only` on every endpoint excepting the `datasource` one.

On the datasource endpoint, the query param `default` and `kind` are used to filter the list. But for that we need to have access to the spec.

On the home page, when it's loading ~1k dashboards, it takes around 3s to load. With this PR it's taking 500ms. 