### PR TITLE
[ENHANCEMENT] Avoid json decoding and encoding on query when it's possible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
+	github.com/tidwall/gjson v1.17.1
 	github.com/zitadel/oidc/v3 v3.23.2
 	golang.org/x/crypto v0.23.0
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
@@ -106,6 +107,8 @@ require (
 	github.com/sanity-io/litter v1.5.5 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.34.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,13 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tailscale/depaware v0.0.0-20210622194025-720c4b409502/go.mod h1:p9lPsd+cx33L3H9nNoecRRxPssFKUwwI50I3pZ0yT+8=
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.34.0 h1:d3AAQJ2DRcxJYHm7OXNXtXt2as1vMDfxeIcFvhmGGm4=

--- a/internal/api/dashboard/cleaner_test.go
+++ b/internal/api/dashboard/cleaner_test.go
@@ -15,6 +15,7 @@ package dashboard
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/perses/perses/pkg/model/api"
 	"testing"
 	"time"
@@ -33,6 +34,15 @@ func (d *mockDAO) List(_ *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, e
 	return d.dashboards, nil
 }
 
+func (d *mockDAO) RawList(_ *ephemeraldashboard.Query) ([][]byte, error) {
+	result := make([][]byte, 0, len(d.dashboards))
+	for _, dash := range d.dashboards {
+		b, _ := json.Marshal(dash)
+		result = append(result, b)
+	}
+	return result, nil
+}
+
 func (d *mockDAO) MetadataList(_ *ephemeraldashboard.Query) ([]api.Entity, error) {
 	var result []api.Entity
 	for _, dashboard := range d.dashboards {
@@ -41,6 +51,20 @@ func (d *mockDAO) MetadataList(_ *ephemeraldashboard.Query) ([]api.Entity, error
 			Metadata: dashboard.Metadata,
 			Spec:     struct{}{},
 		})
+	}
+	return result, nil
+}
+
+func (d *mockDAO) RawMetadataList(_ *ephemeraldashboard.Query) ([][]byte, error) {
+	result := make([][]byte, 0, len(d.dashboards))
+	for _, dash := range d.dashboards {
+		partial := &v1.PartialProjectEntity{
+			Kind:     dash.Kind,
+			Metadata: dash.Metadata,
+			Spec:     struct{}{},
+		}
+		b, _ := json.Marshal(partial)
+		result = append(result, b)
 	}
 	return result, nil
 }

--- a/internal/api/database/model/dao.go
+++ b/internal/api/database/model/dao.go
@@ -22,6 +22,8 @@ import (
 
 type Query interface {
 	GetMetadataOnlyQueryParam() bool
+	IsRawQueryAllowed() bool
+	IsRawMetadataQueryAllowed() bool
 }
 
 type DAO interface {
@@ -36,6 +38,8 @@ type DAO interface {
 	// Query will find a list of resource that is matching the query passed in parameter. The list found will be set in slice.
 	// slice is an interface for casting simplification. But slice must be a pointer to a slice of modelAPI.Metadata
 	Query(query Query, slice interface{}) error
+	RawQuery(query Query) ([][]byte, error)
+	RawMetadataQuery(query Query, kind modelV1.Kind) ([][]byte, error)
 	Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error
 	DeleteByQuery(query Query) error
 	HealthCheck() bool

--- a/internal/api/impl/v1/dashboard/persistence.go
+++ b/internal/api/impl/v1/dashboard/persistence.go
@@ -60,6 +60,10 @@ func (d *dao) List(q *dashboard.Query) ([]*v1.Dashboard, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *dashboard.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *dashboard.Query) ([]api.Entity, error) {
 	var list []*v1.PartialProjectEntity
 	err := d.client.Query(q, &list)
@@ -68,4 +72,8 @@ func (d *dao) MetadataList(q *dashboard.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *dashboard.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/dashboard/service.go
+++ b/internal/api/impl/v1/dashboard/service.go
@@ -121,12 +121,28 @@ func (s *service) List(_ apiInterface.PersesContext, q *dashboard.Query, params 
 	return s.dao.List(query)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawList(query)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([]api.Entity, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
 	}
 	return s.dao.MetadataList(query)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawMetadataList(query)
 }
 
 func (s *service) Validate(entity *v1.Dashboard) error {

--- a/internal/api/impl/v1/datasource/service.go
+++ b/internal/api/impl/v1/datasource/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/schemas"
 	"github.com/perses/perses/internal/api/validate"
+	"github.com/perses/perses/pkg/model/api"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -109,6 +110,18 @@ func (s *service) List(_ apiInterface.PersesContext, q *datasource.Query, params
 		return nil, err
 	}
 	return v1.FilterDatasource(query.Kind, query.Default, dtsList), nil
+}
+
+func (s *service) RawList(_ apiInterface.PersesContext, _ *datasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, _ *datasource.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, _ *datasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (s *service) validate(entity *v1.Datasource) error {

--- a/internal/api/impl/v1/ephemeraldashboard/persistence.go
+++ b/internal/api/impl/v1/ephemeraldashboard/persistence.go
@@ -60,6 +60,10 @@ func (d *dao) List(q *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, error
 	return result, err
 }
 
+func (d *dao) RawList(q *ephemeraldashboard.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *ephemeraldashboard.Query) ([]api.Entity, error) {
 	var list []*v1.PartialProjectEntity
 	err := d.client.Query(q, &list)
@@ -68,4 +72,8 @@ func (d *dao) MetadataList(q *ephemeraldashboard.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *ephemeraldashboard.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/ephemeraldashboard/service.go
+++ b/internal/api/impl/v1/ephemeraldashboard/service.go
@@ -121,12 +121,28 @@ func (s *service) List(_ apiInterface.PersesContext, q *ephemeraldashboard.Query
 	return s.dao.List(query)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawList(query)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, params apiInterface.Parameters) ([]api.Entity, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
 	}
 	return s.dao.MetadataList(query)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawMetadataList(query)
 }
 
 func (s *service) Validate(entity *v1.EphemeralDashboard) error {

--- a/internal/api/impl/v1/folder/persistence.go
+++ b/internal/api/impl/v1/folder/persistence.go
@@ -60,6 +60,10 @@ func (d *dao) List(q *folder.Query) ([]*v1.Folder, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *folder.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *folder.Query) ([]api.Entity, error) {
 	var list []*v1.PartialProjectEntity
 	err := d.client.Query(q, &list)
@@ -68,4 +72,8 @@ func (d *dao) MetadataList(q *folder.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *folder.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/folder/service.go
+++ b/internal/api/impl/v1/folder/service.go
@@ -99,12 +99,28 @@ func (s *service) List(_ apiInterface.PersesContext, q *folder.Query, params api
 	return s.dao.List(query)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawList(query)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([]api.Entity, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
 	}
 	return s.dao.MetadataList(query)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawMetadataList(query)
 }
 
 func manageQuery(q *folder.Query, params apiInterface.Parameters) (*folder.Query, error) {

--- a/internal/api/impl/v1/globaldatasource/service.go
+++ b/internal/api/impl/v1/globaldatasource/service.go
@@ -15,6 +15,7 @@ package globaldatasource
 
 import (
 	"fmt"
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -101,6 +102,18 @@ func (s *service) List(_ apiInterface.PersesContext, q *globaldatasource.Query, 
 		return nil, err
 	}
 	return v1.FilterDatasource(q.Kind, q.Default, dtsList), nil
+}
+
+func (s *service) MetadataList(_ apiInterface.PersesContext, _ *globaldatasource.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *service) RawList(_ apiInterface.PersesContext, _ *globaldatasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, _ *globaldatasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (s *service) validate(entity *v1.GlobalDatasource) error {

--- a/internal/api/impl/v1/globalrole/persistence.go
+++ b/internal/api/impl/v1/globalrole/persistence.go
@@ -56,6 +56,10 @@ func (d *dao) List(q *globalrole.Query) ([]*v1.GlobalRole, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *globalrole.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *globalrole.Query) ([]api.Entity, error) {
 	var list []*v1.PartialEntity
 	err := d.client.Query(q, &list)
@@ -64,4 +68,8 @@ func (d *dao) MetadataList(q *globalrole.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *globalrole.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/globalrole/service.go
+++ b/internal/api/impl/v1/globalrole/service.go
@@ -112,6 +112,14 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalrole.Query, _ apiI
 	return s.dao.List(q)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawList(q)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
 	return s.dao.MetadataList(q)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/globalrolebinding/persistence.go
+++ b/internal/api/impl/v1/globalrolebinding/persistence.go
@@ -56,6 +56,10 @@ func (d *dao) List(q *globalrolebinding.Query) ([]*v1.GlobalRoleBinding, error) 
 	return result, err
 }
 
+func (d *dao) RawList(q *globalrolebinding.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *globalrolebinding.Query) ([]api.Entity, error) {
 	var list []*v1.PartialEntity
 	err := d.client.Query(q, &list)
@@ -64,4 +68,8 @@ func (d *dao) MetadataList(q *globalrolebinding.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *globalrolebinding.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/globalrolebinding/service.go
+++ b/internal/api/impl/v1/globalrolebinding/service.go
@@ -134,8 +134,16 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalrolebinding.Query,
 	return s.dao.List(q)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawList(q)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
 	return s.dao.MetadataList(q)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawMetadataList(q)
 }
 
 // Validating role and subjects are existing

--- a/internal/api/impl/v1/globalsecret/persistence.go
+++ b/internal/api/impl/v1/globalsecret/persistence.go
@@ -68,3 +68,7 @@ func (d *dao) MetadataList(q *globalsecret.Query) ([]api.Entity, error) {
 	}
 	return result, err
 }
+
+func (d *dao) RawMetadataList(q *globalsecret.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
+}

--- a/internal/api/impl/v1/globalsecret/service.go
+++ b/internal/api/impl/v1/globalsecret/service.go
@@ -114,6 +114,14 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalsecret.Query, _ ap
 	return result, nil
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, _ *globalsecret.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalsecret.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
 	return s.dao.MetadataList(q)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalsecret.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/globalvariable/persistence.go
+++ b/internal/api/impl/v1/globalvariable/persistence.go
@@ -56,6 +56,10 @@ func (d *dao) List(q *globalvariable.Query) ([]*v1.GlobalVariable, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *globalvariable.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *globalvariable.Query) ([]api.Entity, error) {
 	var list []*v1.PartialEntity
 	err := d.client.Query(q, &list)
@@ -64,4 +68,8 @@ func (d *dao) MetadataList(q *globalvariable.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *globalvariable.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/globalvariable/service.go
+++ b/internal/api/impl/v1/globalvariable/service.go
@@ -101,6 +101,14 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalvariable.Query, _ 
 	return s.dao.List(q)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawList(q)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
 	return s.dao.MetadataList(q)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/project/persistence.go
+++ b/internal/api/impl/v1/project/persistence.go
@@ -56,6 +56,10 @@ func (d *dao) List(q *project.Query) ([]*v1.Project, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *project.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *project.Query) ([]api.Entity, error) {
 	var list []*v1.PartialEntity
 	err := d.client.Query(q, &list)
@@ -64,4 +68,8 @@ func (d *dao) MetadataList(q *project.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *project.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/project/service.go
+++ b/internal/api/impl/v1/project/service.go
@@ -180,6 +180,14 @@ func (s *service) List(_ apiInterface.PersesContext, q *project.Query, _ apiInte
 	return s.dao.List(q)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawList(q)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
 	return s.dao.MetadataList(q)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/role/persistence.go
+++ b/internal/api/impl/v1/role/persistence.go
@@ -60,6 +60,10 @@ func (d *dao) List(q *role.Query) ([]*v1.Role, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *role.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *role.Query) ([]api.Entity, error) {
 	var list []*v1.PartialProjectEntity
 	err := d.client.Query(q, &list)
@@ -68,4 +72,8 @@ func (d *dao) MetadataList(q *role.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *role.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/role/service.go
+++ b/internal/api/impl/v1/role/service.go
@@ -123,12 +123,28 @@ func (s *service) List(_ apiInterface.PersesContext, q *role.Query, params apiIn
 	return s.dao.List(query)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawList(query)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([]api.Entity, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
 	}
 	return s.dao.MetadataList(query)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawMetadataList(query)
 }
 
 func manageQuery(q *role.Query, params apiInterface.Parameters) (*role.Query, error) {

--- a/internal/api/impl/v1/rolebinding/persistence.go
+++ b/internal/api/impl/v1/rolebinding/persistence.go
@@ -60,6 +60,10 @@ func (d *dao) List(q *rolebinding.Query) ([]*v1.RoleBinding, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *rolebinding.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *rolebinding.Query) ([]api.Entity, error) {
 	var list []*v1.PartialProjectEntity
 	err := d.client.Query(q, &list)
@@ -68,4 +72,8 @@ func (d *dao) MetadataList(q *rolebinding.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *rolebinding.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/rolebinding/service.go
+++ b/internal/api/impl/v1/rolebinding/service.go
@@ -144,12 +144,28 @@ func (s *service) List(_ apiInterface.PersesContext, q *rolebinding.Query, param
 	return s.dao.List(query)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawList(query)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([]api.Entity, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
 	}
 	return s.dao.MetadataList(query)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawMetadataList(query)
 }
 
 // Validating role and subjects are existing

--- a/internal/api/impl/v1/secret/persistence.go
+++ b/internal/api/impl/v1/secret/persistence.go
@@ -72,3 +72,7 @@ func (d *dao) MetadataList(q *secret.Query) ([]api.Entity, error) {
 	}
 	return result, err
 }
+
+func (d *dao) RawMetadataList(q *secret.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
+}

--- a/internal/api/impl/v1/secret/service.go
+++ b/internal/api/impl/v1/secret/service.go
@@ -123,12 +123,24 @@ func (s *service) List(_ apiInterface.PersesContext, q *secret.Query, params api
 	return result, nil
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, _ *secret.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *secret.Query, params apiInterface.Parameters) ([]api.Entity, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
 	}
 	return s.dao.MetadataList(query)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *secret.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawMetadataList(query)
 }
 
 func manageQuery(q *secret.Query, params apiInterface.Parameters) (*secret.Query, error) {

--- a/internal/api/impl/v1/user/persistence.go
+++ b/internal/api/impl/v1/user/persistence.go
@@ -68,3 +68,7 @@ func (d *dao) MetadataList(q *user.Query) ([]api.Entity, error) {
 	}
 	return result, err
 }
+
+func (d *dao) RawMetadataList(q *user.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
+}

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -133,6 +133,14 @@ func (s *service) List(_ apiInterface.PersesContext, q *user.Query, _ apiInterfa
 	return result, nil
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, _ *user.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *user.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
 	return s.dao.MetadataList(q)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *user.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/variable/persistence.go
+++ b/internal/api/impl/v1/variable/persistence.go
@@ -60,6 +60,10 @@ func (d *dao) List(q *variable.Query) ([]*v1.Variable, error) {
 	return result, err
 }
 
+func (d *dao) RawList(q *variable.Query) ([][]byte, error) {
+	return d.client.RawQuery(q)
+}
+
 func (d *dao) MetadataList(q *variable.Query) ([]api.Entity, error) {
 	var list []*v1.PartialProjectEntity
 	err := d.client.Query(q, &list)
@@ -68,4 +72,8 @@ func (d *dao) MetadataList(q *variable.Query) ([]api.Entity, error) {
 		result = append(result, el)
 	}
 	return result, err
+}
+
+func (d *dao) RawMetadataList(q *variable.Query) ([][]byte, error) {
+	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/variable/service.go
+++ b/internal/api/impl/v1/variable/service.go
@@ -113,12 +113,28 @@ func (s *service) List(_ apiInterface.PersesContext, q *variable.Query, params a
 	return s.dao.List(query)
 }
 
+func (s *service) RawList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawList(query)
+}
+
 func (s *service) MetadataList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([]api.Entity, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
 	}
 	return s.dao.MetadataList(query)
+}
+
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([][]byte, error) {
+	query, err := manageQuery(q, params)
+	if err != nil {
+		return nil, err
+	}
+	return s.dao.RawMetadataList(query)
 }
 
 func manageQuery(q *variable.Query, params apiInterface.Parameters) (*variable.Query, error) {

--- a/internal/api/impl/v1/view/endpoint_test.go
+++ b/internal/api/impl/v1/view/endpoint_test.go
@@ -88,7 +88,15 @@ func (*mockDashboardService) List(_ apiInterface.PersesContext, _ *dashboard.Que
 	panic("unimplemented")
 }
 
+func (*mockDashboardService) RawList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([][]byte, error) {
+	panic("unimplemented")
+}
+
 func (*mockDashboardService) MetadataList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([]api.Entity, error) {
+	panic("unimplemented")
+}
+
+func (*mockDashboardService) RawMetadataList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([][]byte, error) {
 	panic("unimplemented")
 }
 

--- a/internal/api/interface/service.go
+++ b/internal/api/interface/service.go
@@ -61,5 +61,7 @@ type Service[T api.Entity, K api.Entity, V databaseModel.Query] interface {
 	Delete(ctx PersesContext, parameters Parameters) error
 	Get(ctx PersesContext, parameters Parameters) (K, error)
 	List(ctx PersesContext, query V, parameters Parameters) ([]K, error)
+	RawList(ctx PersesContext, query V, parameters Parameters) ([][]byte, error)
 	MetadataList(ctx PersesContext, query V, parameters Parameters) ([]api.Entity, error)
+	RawMetadataList(ctx PersesContext, query V, parameters Parameters) ([][]byte, error)
 }

--- a/internal/api/interface/v1/dashboard/interface.go
+++ b/internal/api/interface/v1/dashboard/interface.go
@@ -35,6 +35,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.Dashboard) error
 	Update(entity *v1.Dashboard) error
@@ -42,7 +50,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Dashboard, error)
 	List(q *Query) ([]*v1.Dashboard, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/datasource/interface.go
+++ b/internal/api/interface/v1/datasource/interface.go
@@ -37,6 +37,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return false
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return false
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return false
+}
+
 type DAO interface {
 	Create(entity *v1.Datasource) error
 	Update(entity *v1.Datasource) error

--- a/internal/api/interface/v1/ephemeraldashboard/interface.go
+++ b/internal/api/interface/v1/ephemeraldashboard/interface.go
@@ -35,6 +35,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.EphemeralDashboard) error
 	Update(entity *v1.EphemeralDashboard) error
@@ -42,7 +50,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.EphemeralDashboard, error)
 	List(q *Query) ([]*v1.EphemeralDashboard, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/folder/interface.go
+++ b/internal/api/interface/v1/folder/interface.go
@@ -35,6 +35,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.Folder) error
 	Update(entity *v1.Folder) error
@@ -42,7 +50,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Folder, error)
 	List(q *Query) ([]*v1.Folder, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globaldatasource/interface.go
+++ b/internal/api/interface/v1/globaldatasource/interface.go
@@ -34,6 +34,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return false
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return false
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return false
+}
+
 type DAO interface {
 	Create(entity *v1.GlobalDatasource) error
 	Update(entity *v1.GlobalDatasource) error

--- a/internal/api/interface/v1/globalrole/interface.go
+++ b/internal/api/interface/v1/globalrole/interface.go
@@ -32,13 +32,23 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.GlobalRole) error
 	Update(entity *v1.GlobalRole) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRole, error)
 	List(q *Query) ([]*v1.GlobalRole, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalrolebinding/interface.go
+++ b/internal/api/interface/v1/globalrolebinding/interface.go
@@ -32,13 +32,23 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.GlobalRoleBinding) error
 	Update(entity *v1.GlobalRoleBinding) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRoleBinding, error)
 	List(q *Query) ([]*v1.GlobalRoleBinding, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalsecret/interface.go
+++ b/internal/api/interface/v1/globalsecret/interface.go
@@ -32,6 +32,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return false
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.GlobalSecret) error
 	Update(entity *v1.GlobalSecret) error
@@ -39,6 +47,7 @@ type DAO interface {
 	Get(name string) (*v1.GlobalSecret, error)
 	List(q *Query) ([]*v1.GlobalSecret, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalvariable/interface.go
+++ b/internal/api/interface/v1/globalvariable/interface.go
@@ -32,13 +32,23 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.GlobalVariable) error
 	Update(entity *v1.GlobalVariable) error
 	Delete(name string) error
 	Get(name string) (*v1.GlobalVariable, error)
 	List(q *Query) ([]*v1.GlobalVariable, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/project/interface.go
+++ b/internal/api/interface/v1/project/interface.go
@@ -32,13 +32,23 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.Project) error
 	Update(entity *v1.Project) error
 	Delete(name string) error
 	Get(name string) (*v1.Project, error)
 	List(q *Query) ([]*v1.Project, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/role/interface.go
+++ b/internal/api/interface/v1/role/interface.go
@@ -35,6 +35,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.Role) error
 	Update(entity *v1.Role) error
@@ -42,7 +50,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Role, error)
 	List(q *Query) ([]*v1.Role, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/rolebinding/interface.go
+++ b/internal/api/interface/v1/rolebinding/interface.go
@@ -35,6 +35,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.RoleBinding) error
 	Update(entity *v1.RoleBinding) error
@@ -42,7 +50,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.RoleBinding, error)
 	List(q *Query) ([]*v1.RoleBinding, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/secret/interface.go
+++ b/internal/api/interface/v1/secret/interface.go
@@ -35,6 +35,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return false
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.Secret) error
 	Update(entity *v1.Secret) error
@@ -43,6 +51,7 @@ type DAO interface {
 	Get(project string, name string) (*v1.Secret, error)
 	List(q *Query) ([]*v1.Secret, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/user/interface.go
+++ b/internal/api/interface/v1/user/interface.go
@@ -32,6 +32,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return false
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.User) error
 	Update(entity *v1.User) error
@@ -39,6 +47,7 @@ type DAO interface {
 	Get(name string) (*v1.User, error)
 	List(q *Query) ([]*v1.User, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/variable/interface.go
+++ b/internal/api/interface/v1/variable/interface.go
@@ -35,6 +35,14 @@ func (q *Query) GetMetadataOnlyQueryParam() bool {
 	return q.MetadataOnly
 }
 
+func (q *Query) IsRawQueryAllowed() bool {
+	return true
+}
+
+func (q *Query) IsRawMetadataQueryAllowed() bool {
+	return true
+}
+
 type DAO interface {
 	Create(entity *v1.Variable) error
 	Update(entity *v1.Variable) error
@@ -42,7 +50,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Variable, error)
 	List(q *Query) ([]*v1.Variable, error)
+	RawList(q *Query) ([][]byte, error)
 	MetadataList(q *Query) ([]api.Entity, error)
+	RawMetadataList(q *Query) ([][]byte, error)
 }
 
 type Service interface {

--- a/internal/api/toolbox/toolbox.go
+++ b/internal/api/toolbox/toolbox.go
@@ -43,6 +43,22 @@ func ExtractParameters(ctx echo.Context, caseSensitive bool) apiInterface.Parame
 	}
 }
 
+func buildJSONBlob(raws [][]byte) []byte {
+	var result []byte
+	if len(raws) == 0 {
+		return []byte(`[]`)
+	}
+	result = append(result, '[')
+	i := 0
+	for i < len(raws)-1 {
+		result = append(result, raws[i]...)
+		result = append(result, ',')
+		i++
+	}
+	result = append(result, raws[len(raws)-1]...)
+	return append(result, ']')
+}
+
 // Toolbox is an interface that defines the different methods that can be used in the different endpoint of the API.
 // This is a way to align the code of the different endpoint.
 type Toolbox[T api.Entity, K databaseModel.Query] interface {
@@ -200,6 +216,10 @@ func (t *toolbox[T, K, V]) List(ctx echo.Context, query V) error {
 	list, listErr := t.list(ctx, parameters, query)
 	if listErr != nil {
 		return listErr
+	}
+
+	if blob, ok := list.([][]byte); ok {
+		return ctx.JSONBlob(http.StatusOK, buildJSONBlob(blob))
 	}
 	return ctx.JSON(http.StatusOK, list)
 }


### PR DESCRIPTION
This PR is introducing the `RawQuery`. 

When getting a list of resources from the API, in most of the case, the backend is just forwarding the data from the database.
So I thought it's a good idea to avoid decoding the JSON to encode it immediately after.

Same thought applied when the query parameter `metadata_only` is used.

With that, the home page with 1k dashboards loaded, went from 500ms to ~120ms to load.

Note: for the secret/global secret this logic cannot be applied as we are hiding the different credential stored. And for that we need to decode the json.
It might be possible to do it with the raw json, but when I have started to do it, the code became a mess. So I choose to avoid it.