### PR TITLE
[BUGFIX] Fix StatChart 'no  defined' in Setting tab

### DIFF
--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -19,9 +19,9 @@ import { use, EChartsCoreOption } from 'echarts/core';
 import { LineChart as EChartsLineChart, LineSeriesOption } from 'echarts/charts';
 import { GridComponent, DatasetComponent, TitleComponent, TooltipComponent } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
-import { useChartsTheme } from '../context/ChartsProvider';
+import { useChartsTheme } from '../context';
 import { EChart } from '../EChart';
-import { GraphSeries } from '../model/graph';
+import { GraphSeries } from '../model';
 import { FontSizeOption } from '../FontSizeSelector';
 import { useOptimalFontSize } from './calculateFontSize';
 
@@ -41,7 +41,7 @@ export interface StatChartProps {
   width: number;
   height: number;
   data: StatChartData;
-  format: FormatOptions;
+  format?: FormatOptions;
   color?: string;
   sparkline?: LineSeriesOption;
   showSeriesName?: boolean;

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartOptionsEditorSettings.tsx
@@ -27,10 +27,15 @@ import {
   FontSizeSelectorProps,
   FontSizeOption,
 } from '@perses-dev/components';
+import merge from 'lodash/merge';
+import { DEFAULT_FORMAT } from '../gauge-chart/gauge-chart-model';
 import { StatChartOptions, StatChartOptionsEditorProps } from './stat-chart-model';
 
 export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProps) {
   const { onChange, value } = props;
+
+  // ensures decimalPlaces defaults to correct value
+  const format = merge({}, DEFAULT_FORMAT, value.format);
 
   const handleCalculationChange: CalculationSelectorProps['onChange'] = (newCalculation) => {
     onChange(
@@ -83,7 +88,7 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
             label="Sparkline"
             control={<Switch checked={!!value.sparkline} onChange={handleSparklineChange} />}
           />
-          <FormatControls value={value.format} onChange={handleUnitChange} />
+          <FormatControls value={format} onChange={handleUnitChange} />
           <CalculationSelector value={value.calculation} onChange={handleCalculationChange} />
           <FontSizeSelector value={value.valueFontSize} onChange={handleFontSizeChange} />
         </OptionsEditorGroup>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Align with gauge chart code 😄 
Fixes #1938

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
