### PR TITLE
[ENHANCEMENT] Keep data when switching explorer tabs

### DIFF
--- a/ui/explore/src/components/ExploreManager/ExplorerManagerProvider.tsx
+++ b/ui/explore/src/components/ExploreManager/ExplorerManagerProvider.tsx
@@ -44,19 +44,19 @@ interface ExplorerManagerProviderProps {
   initialState?: ExplorerManagerInitialState;
 }
 
-function initialExplorerState(initialState?: ExplorerManagerInitialState): ExplorerState[] {
+function initExplorerStates(initialState?: ExplorerManagerInitialState): ExplorerState[] {
   const result: ExplorerState[] = [];
-  if (initialState?.explorer && initialState?.tab && initialState?.queries) {
+  if (initialState?.explorer !== undefined) {
     result[initialState.explorer] = {
-      tab: initialState.tab,
-      queries: initialState.queries,
+      tab: initialState.tab ?? 0,
+      queries: initialState.queries ?? [],
     };
   }
   return result;
 }
 
 export function ExplorerManagerProvider({ children, initialState }: ExplorerManagerProviderProps) {
-  const [explorerStates, setExplorerStates] = useState<ExplorerState[]>(initialExplorerState(initialState));
+  const [explorerStates, setExplorerStates] = useState<ExplorerState[]>(initExplorerStates(initialState));
   const [explorer, setInternalExplorer] = useState<number>(initialState?.explorer ?? 0);
   const tab: number = useMemo(() => explorerStates[explorer]?.tab ?? 0, [explorer, explorerStates]);
   const queries: QueryDefinition[] = useMemo(() => explorerStates[explorer]?.queries ?? [], [explorer, explorerStates]);

--- a/ui/explore/src/components/ExploreManager/ExplorerManagerProviderWithQueryParams.tsx
+++ b/ui/explore/src/components/ExploreManager/ExplorerManagerProviderWithQueryParams.tsx
@@ -34,11 +34,11 @@ export function ExplorerManagerProviderWithQueryParams({ children }: ExplorerMan
     explorer: queryParams.explorer ?? undefined, // can be null, forcing to undefined
     tab: queryParams.tab ?? undefined, // can be null, forcing to undefined
     queries: queryParams.queries ? (queryParams.queries as QueryDefinition[]) : undefined,
-    setExplorer: (explorer: number) => {
+    setExplorer: (explorer: number | undefined) => {
       setQueryParams({ explorer, queries: undefined, tab: undefined });
     },
-    setTab: (tab: number) => setQueryParams({ tab }),
-    setQueries: (queries: QueryDefinition[]) => setQueryParams({ queries }),
+    setTab: (tab: number | undefined) => setQueryParams({ tab }),
+    setQueries: (queries: QueryDefinition[] | undefined) => setQueryParams({ queries }),
   };
 
   return <ExplorerManagerProvider initialState={initialState}>{children}</ExplorerManagerProvider>;


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Data is kept when switching tabs on the explorer, you don't lose data anymore 😄 
Note: the url will only track params of the current displayed tab

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
