### PR TITLE
[ENHANCEMENT] add `bytes/sec` format

### DIFF
--- a/cue/schemas/common/format.cue
+++ b/cue/schemas/common/format.cue
@@ -38,7 +38,7 @@ package common
 }
 
 #throughputFormat: {
-	unit:           "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	unit:           "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
 	decimalPlaces?: number
 	shortValues?:   bool
 }

--- a/go-sdk/common/format.go
+++ b/go-sdk/common/format.go
@@ -35,6 +35,7 @@ const (
 	PercentDecimalUnit     PercentageUnit = "percent-decimal"
 	DecimalUnit            string         = "decimal"
 	BytesUnit              string         = "bytes"
+	BytesPerSecondsUnit    ThroughputUnit = "bytes/sec"
 	CountsPerSecondsUnit   ThroughputUnit = "counts/sec"
 	EventsPerSecondsUnit   ThroughputUnit = "events/sec"
 	MessagesPerSecondsUnit ThroughputUnit = "messages/sec"
@@ -84,9 +85,10 @@ func (f *Format) validate() error {
 	case string(MilliSecondsUnit), string(SecondsUnit), string(MinutesUnit),
 		string(HoursUnit), string(DaysUnit), string(WeeksUnit), string(MonthsUnit),
 		string(YearsUnit), string(PercentUnit), string(PercentDecimalUnit), DecimalUnit, BytesUnit,
-		string(CountsPerSecondsUnit), string(EventsPerSecondsUnit), string(MessagesPerSecondsUnit),
-		string(OpsPerSecondsUnit), string(PacketsPerSecondsUnit), string(ReadsPerSecondsUnit), string(RecordsPerSecondsUnit),
-		string(RequestsPerSecondsUnit), string(RowsPerSecondsUnit), string(WritesPerSecondsUnit):
+		string(BytesPerSecondsUnit), string(CountsPerSecondsUnit), string(EventsPerSecondsUnit),
+		string(MessagesPerSecondsUnit), string(OpsPerSecondsUnit), string(PacketsPerSecondsUnit),
+		string(ReadsPerSecondsUnit), string(RecordsPerSecondsUnit), string(RequestsPerSecondsUnit),
+		string(RowsPerSecondsUnit), string(WritesPerSecondsUnit):
 		return nil
 	default:
 		return fmt.Errorf("unknown format")

--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -10,15 +10,23 @@ import (
 #mapping: {
     // mapping table for the unit attribute (key = grafana unit, value = perses equivalent)
     unit: {
+        // time units
         ms: "milliseconds"
         s: "seconds"
         m: "minutes"
         h: "hours"
         d: "days"
+        // percent units
         percent: "percent"
         percentunit: "percent-decimal"
+        // decimal units
+        // TODO
+        // bytes units
         bytes: "bytes"
         decbytes: "bytes"
+        // throughput units
+        Bps: "bytes/sec"
+        // TODO add mappings for all throughput units
     }
     // mapping table for the calculation attribute (key = grafana unit, value = perses equivalent)
     calc: {

--- a/internal/api/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/simple_grafana_dashboard.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": " A simple grafana dashboard to be converted to perses format",
+  "description": "A simple grafana dashboard to be converted to perses format",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -54,7 +54,7 @@
               }
             ]
           },
-          "unit": "pressurekbar"
+          "unit": "Bps"
         },
         "overrides": []
       },

--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -299,6 +299,9 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "format": {
+                "unit": "bytes/sec"
+              },
               "thresholds": {
                 "steps": [
                   {

--- a/ui/core/src/model/units/throughput.ts
+++ b/ui/core/src/model/units/throughput.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { formatBytes } from './bytes';
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces, shouldShortenValues } from './utils';
@@ -87,6 +88,12 @@ export const THROUGHPUT_UNIT_CONFIG: Readonly<Record<ThroughputUnit, UnitConfig>
 };
 
 export function formatThroughput(value: number, { unit, shortValues, decimalPlaces }: ThroughputFormatOptions): string {
+  // special case for data throughput
+  if (unit == 'bytes/sec') {
+    const denominator = Math.abs(value) < 1000 ? 'sec' : 's';
+    return formatBytes(value, { unit: 'bytes', shortValues, decimalPlaces }) + '/' + denominator;
+  }
+
   const formatterOptions: Intl.NumberFormatOptions = {
     style: 'decimal',
     useGrouping: true,

--- a/ui/core/src/model/units/throughput.ts
+++ b/ui/core/src/model/units/throughput.ts
@@ -16,6 +16,7 @@ import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces, shouldShortenValues } from './utils';
 
 const throughputUnits = [
+  'bytes/sec',
   'counts/sec',
   'events/sec',
   'messages/sec',
@@ -39,6 +40,10 @@ export const THROUGHPUT_GROUP_CONFIG: UnitGroupConfig = {
 };
 const THROUGHPUT_GROUP = 'Throughput';
 export const THROUGHPUT_UNIT_CONFIG: Readonly<Record<ThroughputUnit, UnitConfig>> = {
+  'bytes/sec': {
+    group: THROUGHPUT_GROUP,
+    label: 'Bytes/sec',
+  },
   'counts/sec': {
     group: THROUGHPUT_GROUP,
     label: 'Counts/sec',


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Add `bytes/sec` unit for Y axis to the Throughput category.

# Screenshots

![2024-05-21_22h55_47](https://github.com/perses/perses/assets/7058693/b24645f4-bce1-478a-b101-1d49c6b9c645)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
