### PR TITLE
[ENHANCEMENT] Add formating to series name in explorer and use MUI Table

### DIFF
--- a/ui/explore/src/components/ExploreManager/constants.ts
+++ b/ui/explore/src/components/ExploreManager/constants.ts
@@ -11,5 +11,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const PANEL_PREVIEW_HEIGHT = 300;
+export const PANEL_PREVIEW_HEIGHT = 700;
 export const PANEL_PREVIEW_DEFAULT_WIDTH = 840;

--- a/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
@@ -17,6 +17,9 @@ import { Fragment, ReactNode } from 'react';
 import { Table } from '@mui/material';
 import { TimeSeries, TimeSeriesData } from '@perses-dev/core';
 import { QueryData } from '@perses-dev/plugin-system';
+import { SeriesName } from './SeriesName';
+
+const MAX_FORMATABLE_SERIES = 1000;
 
 export interface DataTableProps {
   result: Array<QueryData<TimeSeriesData>>;
@@ -47,6 +50,7 @@ const DataTable = ({ result }: DataTableProps) => {
 };
 
 function buildRows(series: TimeSeries[]): ReactNode[] {
+  const isFormatted = series.length < MAX_FORMATABLE_SERIES; // only format series names if we have less than 1000 series for performance reasons
   return series.map((s, seriesIdx) => {
     const displayTimeStamps = (s.values?.length || 0) > 1;
     const valuesAndTimes = s.values
@@ -71,7 +75,9 @@ function buildRows(series: TimeSeries[]): ReactNode[] {
       : [];
     return (
       <tr style={{ whiteSpace: 'pre' }} key={seriesIdx}>
-        <td>{s.formattedName || s.name}</td>
+        <td>
+          <SeriesName name={s.name} formattedName={s.formattedName} labels={s.labels} isFormatted={isFormatted} />
+        </td>
         <td>
           {valuesAndTimes} {histogramsAndTimes}
         </td>

--- a/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
@@ -14,7 +14,7 @@
  eslint-disable @typescript-eslint/no-explicit-any
  */
 import { Fragment, ReactNode } from 'react';
-import { Table } from '@mui/material';
+import { Alert, Table } from '@mui/material';
 import { TimeSeries, TimeSeriesData } from '@perses-dev/core';
 import { QueryData } from '@perses-dev/plugin-system';
 import { SeriesName } from './SeriesName';
@@ -42,6 +42,11 @@ const DataTable = ({ result }: DataTableProps) => {
 
   return (
     <>
+      {series.length >= MAX_FORMATABLE_SERIES && (
+        <Alert severity="warning">
+          Showing more than 1000 series, turning off label formatting for performance reasons.
+        </Alert>
+      )}
       <Table className="data-table">
         <tbody>{rows}</tbody>
       </Table>

--- a/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/DataTable.tsx
@@ -14,7 +14,7 @@
  eslint-disable @typescript-eslint/no-explicit-any
  */
 import { Fragment, ReactNode } from 'react';
-import { Alert, Table } from '@mui/material';
+import { Alert, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
 import { TimeSeries, TimeSeriesData } from '@perses-dev/core';
 import { QueryData } from '@perses-dev/plugin-system';
 import { SeriesName } from './SeriesName';
@@ -44,11 +44,11 @@ const DataTable = ({ result }: DataTableProps) => {
     <>
       {series.length >= MAX_FORMATABLE_SERIES && (
         <Alert severity="warning">
-          Showing more than 1000 series, turning off label formatting for performance reasons.
+          Showing more than {MAX_FORMATABLE_SERIES} series, turning off label formatting for performance reasons.
         </Alert>
       )}
       <Table className="data-table">
-        <tbody>{rows}</tbody>
+        <TableBody>{rows}</TableBody>
       </Table>
     </>
   );
@@ -57,14 +57,13 @@ const DataTable = ({ result }: DataTableProps) => {
 function buildRows(series: TimeSeries[]): ReactNode[] {
   const isFormatted = series.length < MAX_FORMATABLE_SERIES; // only format series names if we have less than 1000 series for performance reasons
   return series.map((s, seriesIdx) => {
-    const displayTimeStamps = (s.values?.length || 0) > 1;
+    const displayTimeStamps = (s.values?.length ?? 0) > 1;
     const valuesAndTimes = s.values
       ? s.values.map((v, valIdx) => {
           return (
-            <Fragment key={valIdx}>
+            <Typography key={valIdx}>
               {v[1]} {displayTimeStamps && <span>@{v[0]}</span>}
-              <br />
-            </Fragment>
+            </Typography>
           );
         })
       : [];
@@ -73,20 +72,20 @@ function buildRows(series: TimeSeries[]): ReactNode[] {
           return (
             <Fragment key={-hisIdx}>
               {histogramTable(h[1])} @<span>{h[0]}</span>
-              <br />
             </Fragment>
           );
         })
       : [];
     return (
-      <tr style={{ whiteSpace: 'pre' }} key={seriesIdx}>
-        <td>
+      <TableRow style={{ whiteSpace: 'pre' }} key={seriesIdx}>
+        <TableCell>
           <SeriesName name={s.name} formattedName={s.formattedName} labels={s.labels} isFormatted={isFormatted} />
-        </td>
-        <td>
-          {valuesAndTimes} {histogramsAndTimes}
-        </td>
-      </tr>
+        </TableCell>
+        <TableCell>
+          {valuesAndTimes}
+          {histogramsAndTimes}
+        </TableCell>
+      </TableRow>
     );
   });
 }
@@ -105,25 +104,25 @@ export const bucketRangeString = ([boundaryRule, leftBoundary, rightBoundary, _]
 
 export const histogramTable = (h: any): ReactNode => (
   <Table>
-    <thead>
-      <tr>
-        <th style={{ textAlign: 'center' }} colSpan={2}>
+    <TableHead>
+      <TableRow>
+        <TableCell style={{ textAlign: 'center' }} colSpan={2}>
           Histogram Sample
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th>Range</th>
-        <th>Count</th>
-      </tr>
+        </TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      <TableRow>
+        <TableCell>Range</TableCell>
+        <TableCell>Count</TableCell>
+      </TableRow>
       {h.buckets?.map((b: any, i: any) => (
-        <tr key={i}>
-          <td>{bucketRangeString(b)}</td>
-          <td>{b[3]}</td>
-        </tr>
+        <TableRow key={i}>
+          <TableCell>{bucketRangeString(b)}</TableCell>
+          <TableCell>{b[3]}</TableCell>
+        </TableRow>
       ))}
-    </tbody>
+    </TableBody>
   </Table>
 );
 export default DataTable;

--- a/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Labels } from '@perses-dev/core';
-import { ReactElement, MouseEvent, ReactNode } from 'react';
+import { ReactElement, MouseEvent } from 'react';
 import { useSnackbar } from '@perses-dev/components';
 import { Typography } from '@mui/material';
 
@@ -28,7 +28,7 @@ interface SeriesNameProps {
  * Else it will only display the series in plain text (mostly use for performance reasons)
  */
 export function SeriesName({ name, labels, formattedName, isFormatted }: SeriesNameProps) {
-  if (isFormatted && labels) {
+  if (isFormatted && labels && Object.keys(labels).length > 0) {
     return <FormatedSeriesName labels={labels} />;
   }
   return <span>{formattedName ?? name}</span>;

--- a/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
@@ -31,7 +31,7 @@ export function SeriesName({ name, labels, formattedName, isFormatted }: SeriesN
   if (isFormatted && labels && Object.keys(labels).length > 0) {
     return <FormatedSeriesName labels={labels} />;
   }
-  return <span>{formattedName ?? name}</span>;
+  return <Typography>{formattedName ?? name}</Typography>;
 }
 
 function FormatedSeriesName({ labels }: { labels: Labels }) {
@@ -82,11 +82,11 @@ function FormatedSeriesName({ labels }: { labels: Labels }) {
   }
 
   return (
-    <span>
+    <Typography>
       {labels ? labels.__name__ : ''}
       {'{'}
       {labelNodes}
       {'}'}
-    </span>
+    </Typography>
   );
 }

--- a/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
@@ -1,0 +1,92 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Labels } from '@perses-dev/core';
+import { ReactElement, MouseEvent, ReactNode } from 'react';
+import { useSnackbar } from '@perses-dev/components';
+import { Typography } from '@mui/material';
+
+interface SeriesNameProps {
+  name: string;
+  labels?: Labels;
+  formattedName?: string;
+  isFormatted?: boolean;
+}
+
+/*
+ * Display a series with labels in bold and with a copy to clipboard feature if isFormatted is enabled
+ * Else it will only display the series in plain text (mostly use for performance reasons)
+ */
+export function SeriesName({ name, labels, formattedName, isFormatted }: SeriesNameProps) {
+  if (isFormatted && labels) {
+    return <FormatedSeriesName labels={labels} />;
+  }
+  return <span>{formattedName ?? name}</span>;
+}
+
+function FormatedSeriesName({ labels }: { labels: Labels }) {
+  const { infoSnackbar } = useSnackbar();
+
+  const labelNodes: ReactElement[] = [];
+  let first = true;
+
+  function copyToClipboard(e: MouseEvent<HTMLSpanElement>) {
+    const copyText = e.currentTarget.innerText || '';
+    navigator.clipboard
+      .writeText(copyText.trim())
+      .then(() => {
+        infoSnackbar(`Copied label matcher: ${copyText}`);
+      })
+      .catch((reason) => {
+        console.error(`unable to copy text: ${reason}`);
+      });
+  }
+
+  for (const label in labels) {
+    if (label === '__name__') {
+      continue;
+    }
+
+    labelNodes.push(
+      <span key={label}>
+        {!first && ', '}
+        <Typography
+          display="inline"
+          sx={{
+            '&:hover': {
+              cursor: 'pointer',
+              textDecoration: 'underline',
+            },
+          }}
+          onClick={copyToClipboard}
+          title="Click to copy label matcher"
+        >
+          <strong>{label}</strong>=<span>&quot;{labels[label]}&quot;</span>
+        </Typography>
+      </span>
+    );
+
+    if (first) {
+      first = false;
+    }
+  }
+
+  return (
+    <span>
+      {labels ? labels.__name__ : ''}
+      {'{'}
+      {labelNodes}
+      {'}'}
+    </span>
+  );
+}

--- a/ui/prometheus-plugin/src/utils/utils.test.ts
+++ b/ui/prometheus-plugin/src/utils/utils.test.ts
@@ -77,7 +77,7 @@ describe('getFormattedPrometheusSeriesName', () => {
   it('should resolve empty metric to instead show query', () => {
     const query = 'node_load15{instance=~"(demo.do.prometheus.io:9100)"';
     const metric = {};
-    const output = { name: query, formattedName: query };
+    const output = { name: '{}', formattedName: '{}' };
     expect(getFormattedPrometheusSeriesName(query, metric)).toEqual(output);
   });
 
@@ -85,7 +85,7 @@ describe('getFormattedPrometheusSeriesName', () => {
     const query = 'up';
     const metric = {};
     const seriesNameFormat = 'Custom series name';
-    const output = { name: query, formattedName: 'Custom series name' };
+    const output = { name: '{}', formattedName: 'Custom series name' };
     expect(getFormattedPrometheusSeriesName(query, metric, seriesNameFormat)).toEqual(output);
   });
 

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { isEmptyObject } from '@perses-dev/core';
 import { Metric } from '../model/api-types';
 
 /**
@@ -53,7 +52,7 @@ function stringifyPrometheusMetricLabels(labels: { [key: string]: unknown }, rem
 }
 
 /*
- * Metric labels formattter which checks for __name__ and outputs valid PromQL for series name
+ * Metric labels formatter which checks for __name__ and outputs valid PromQL for series name
  */
 export function getUniqueKeyForPrometheusResult(
   metricLabels: {
@@ -62,24 +61,21 @@ export function getUniqueKeyForPrometheusResult(
   { removeExprWrap }: { removeExprWrap?: boolean } = {}
 ) {
   const metricNameKey = '__name__';
-  if (metricLabels) {
-    if (Object.prototype.hasOwnProperty.call(metricLabels, metricNameKey)) {
-      const stringifiedLabels = stringifyPrometheusMetricLabels(
-        {
-          ...metricLabels,
-          [metricNameKey]: undefined,
-        },
-        removeExprWrap
-      );
-      if (removeExprWrap === true) {
-        return `${stringifiedLabels}`;
-      } else {
-        return `${metricLabels[metricNameKey]}${stringifiedLabels}`;
-      }
+  if (Object.prototype.hasOwnProperty.call(metricLabels, metricNameKey)) {
+    const stringifiedLabels = stringifyPrometheusMetricLabels(
+      {
+        ...metricLabels,
+        [metricNameKey]: undefined,
+      },
+      removeExprWrap
+    );
+    if (removeExprWrap) {
+      return `${stringifiedLabels}`;
+    } else {
+      return `${metricLabels[metricNameKey]}${stringifiedLabels}`;
     }
-    return stringifyPrometheusMetricLabels(metricLabels, removeExprWrap);
   }
-  return '';
+  return stringifyPrometheusMetricLabels(metricLabels, removeExprWrap);
 }
 
 /*
@@ -87,11 +83,7 @@ export function getUniqueKeyForPrometheusResult(
  */
 export function getFormattedPrometheusSeriesName(query: string, metric: Metric, formatter?: string) {
   // Name the series after the metric labels by default.
-  // Use the query if no metric or metric labels are empty.
-  let name = getUniqueKeyForPrometheusResult(metric);
-  if (name === '' || isEmptyObject(metric)) {
-    name = query;
-  }
+  const name = getUniqueKeyForPrometheusResult(metric);
 
   // Query editor allows you to define an optional seriesNameFormat property.
   // This controls the regex used to customize legend and tooltip display.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Importing Prometheus series name formating to Perses explorer.
You can click on the label="value" for copying in the clipboard
Using same limit, if there is more than 1000 series, only show plain text time series name.
Use MUI Table + increase panel height

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/perses/perses/assets/5657041/777546c5-e7f6-4d3e-9a1f-e61021a20532)
![image](https://github.com/perses/perses/assets/5657041/7b4c4ecc-c29e-4fe7-a103-5eac84db128b)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
