### PR TITLE
[IGNORE] use useStoreWithEqualityFn() instead of useStore() with equalityFn

### DIFF
--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -11,7 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createStore, useStore } from 'zustand';
+import { createStore } from 'zustand';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import type { StoreApi } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
@@ -83,7 +84,7 @@ export function useDashboardStore<T>(selector: (state: DashboardStoreState) => T
   if (store === undefined) {
     throw new Error('No DashboardContext found. Did you forget a Provider?');
   }
-  return useStore(store, selector, shallow);
+  return useStoreWithEqualityFn(store, selector, shallow);
 }
 
 export function DashboardProvider(props: DashboardProviderProps) {

--- a/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
+++ b/ui/dashboards/src/context/TemplateVariableProvider/TemplateVariableProvider.tsx
@@ -13,6 +13,7 @@
 
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 import { createStore, useStore } from 'zustand';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { immer } from 'zustand/middleware/immer';
 import { devtools } from 'zustand/middleware';
 import produce from 'immer';
@@ -63,7 +64,7 @@ export function useTemplateVariableStoreCtx() {
 
 export function useTemplateVariableValues(variableNames?: string[]) {
   const store = useTemplateVariableStoreCtx();
-  return useStore(
+  return useStoreWithEqualityFn(
     store,
     (s) => {
       const vars: VariableStateMap = {};


### PR DESCRIPTION
# Description
use `useStoreWithEqualityFn()` instead of `useStore()` with `equalityFn`, because `useStore()` with `equalityFn` is deprecated:
https://github.com/pmndrs/zustand/discussions/1937
https://github.com/pmndrs/zustand/pull/1945

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
