### PR TITLE
[IGNORE] Upgrade tanstack/react-query to v5

### DIFF
--- a/internal/cli/cmd/dac/build/testdata/go/go.mod
+++ b/internal/cli/cmd/dac/build/testdata/go/go.mod
@@ -13,7 +13,9 @@
 
 module dac
 
-go 1.21.6
+go 1.22
+
+toolchain go1.22.3
 
 replace github.com/perses/perses => ../../../../../../../ // Use current version
 

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -27,7 +27,7 @@
     "@perses-dev/plugin-system": "0.45.0",
     "@perses-dev/prometheus-plugin": "0.45.0",
     "@perses-dev/tempo-plugin": "0.45.0",
-    "@tanstack/react-query": "^4.7.1",
+    "@tanstack/react-query": "^5.37.1",
     "date-fns": "^2.29.3",
     "immer": "^9.0.15",
     "lodash": "^4.17.21",

--- a/ui/app/src/components/Footer.tsx
+++ b/ui/app/src/components/Footer.tsx
@@ -24,8 +24,12 @@ const style: SxProps<Theme> = {
 };
 
 export default function Footer(): JSX.Element {
+  const { data, isLoading, error } = useHealth();
   const { exceptionSnackbar } = useSnackbar();
-  const { data, isLoading } = useHealth({ onError: exceptionSnackbar });
+  if (error) {
+    exceptionSnackbar(error);
+  }
+
   return (
     <Box component="footer" sx={style}>
       <ul

--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -201,7 +201,7 @@ function ToolMenu() {
 
 function ProjectMenu(): JSX.Element {
   const { exceptionSnackbar } = useSnackbar();
-  const { data, isLoading } = useProjectList({ onError: exceptionSnackbar });
+  const { data, isLoading, error } = useProjectList();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleMenu = (event: MouseEvent<HTMLElement>) => {
@@ -213,6 +213,10 @@ function ProjectMenu(): JSX.Element {
 
   if (isLoading) {
     return <CircularProgress size="1rem" />;
+  }
+
+  if (error) {
+    exceptionSnackbar(error);
   }
 
   return (

--- a/ui/app/src/model/admin-client.ts
+++ b/ui/app/src/model/admin-client.ts
@@ -32,7 +32,7 @@ export function useCreateGlobalDatasourceMutation() {
       return createGlobalDatasource(datasource);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([globalDatasourceResource]);
+      return queryClient.invalidateQueries({ queryKey: [globalDatasourceResource] });
     },
   });
 }
@@ -50,7 +50,7 @@ export function useUpdateGlobalDatasourceMutation() {
       return updateGlobalDatasource(datasource);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([globalDatasourceResource]);
+      return queryClient.invalidateQueries({ queryKey: [globalDatasourceResource] });
     },
   });
 }
@@ -63,14 +63,13 @@ export function useDeleteGlobalDatasourceMutation() {
   const queryClient = useQueryClient();
   return useMutation<GlobalDatasource, Error, GlobalDatasource>({
     mutationKey: [globalDatasourceResource],
-    mutationFn: (entity: GlobalDatasource) => {
-      return deleteGlobalDatasource(entity).then(() => {
-        return entity;
-      });
+    mutationFn: async (entity: GlobalDatasource) => {
+      await deleteGlobalDatasource(entity);
+      return entity;
     },
     onSuccess: (datasource) => {
-      queryClient.removeQueries([globalDatasourceResource, datasource.metadata.name]);
-      return queryClient.invalidateQueries([globalDatasourceResource]);
+      queryClient.removeQueries({ queryKey: [globalDatasourceResource, datasource.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey: [globalDatasourceResource] });
     },
   });
 }
@@ -80,8 +79,11 @@ export function useDeleteGlobalDatasourceMutation() {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalDatasource(name: string) {
-  return useQuery<GlobalDatasource, Error>([globalDatasourceResource, name], () => {
-    return getGlobalDatasource(name);
+  return useQuery<GlobalDatasource, Error>({
+    queryKey: [globalDatasourceResource, name],
+    queryFn: () => {
+      return getGlobalDatasource(name);
+    },
   });
 }
 
@@ -90,8 +92,11 @@ export function useGlobalDatasource(name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalDatasourceList() {
-  return useQuery<GlobalDatasource[], Error>([globalDatasourceResource], () => {
-    return getGlobalDatasources();
+  return useQuery<GlobalDatasource[], Error>({
+    queryKey: [globalDatasourceResource],
+    queryFn: () => {
+      return getGlobalDatasources();
+    },
   });
 }
 

--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -52,7 +52,11 @@ export function useAuthToken(): UseQueryResult<Payload | null> {
   // It doesn't need the accurate signature to decode the payload.
   // That's why we are creating a fake signature.
   const fakeSignature = 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-  return useQuery(['jwt'], () => decodeToken<Payload>(`${partialToken}.${fakeSignature}`), { enabled: !!partialToken });
+  return useQuery({
+    queryKey: ['jwt'],
+    queryFn: () => decodeToken<Payload>(`${partialToken}.${fakeSignature}`),
+    enabled: !!partialToken,
+  });
 }
 
 export function useNativeAuthMutation() {
@@ -63,7 +67,7 @@ export function useNativeAuthMutation() {
       return nativeAuth(body);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([authResource]);
+      return queryClient.invalidateQueries({ queryKey: [authResource] });
     },
   });
 }

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { DashboardSelector, fetchJson, Permission } from '@perses-dev/core';
 import buildURL from './url-builder';
 
@@ -143,16 +143,13 @@ export interface ConfigModel {
   frontend: FrontendConfig;
 }
 
-type ConfigOptions = Omit<UseQueryOptions<ConfigModel, Error>, 'queryKey' | 'queryFn'>;
-
-export function useConfig(options?: ConfigOptions) {
-  return useQuery<ConfigModel, Error>(
-    [resource],
-    () => {
+export function useConfig() {
+  return useQuery<ConfigModel, Error>({
+    queryKey: [resource],
+    queryFn: () => {
       return fetchConfig();
     },
-    options
-  );
+  });
 }
 
 export function fetchConfig() {

--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -38,7 +38,7 @@ export function useCreateDashboardMutation(
     },
     onSuccess: onSuccess,
     onSettled: () => {
-      return queryClient.invalidateQueries([resource]);
+      return queryClient.invalidateQueries({ queryKey: [resource] });
     },
   });
 }
@@ -48,8 +48,11 @@ export function useCreateDashboardMutation(
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDashboard(project: string, name: string) {
-  return useQuery<DashboardResource, Error>([resource, project, name], () => {
-    return getDashboard(project, name);
+  return useQuery<DashboardResource, Error>({
+    queryKey: [resource, project, name],
+    queryFn: () => {
+      return getDashboard(project, name);
+    },
   });
 }
 
@@ -58,8 +61,11 @@ export function useDashboard(project: string, name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDashboardList(project?: string, metadataOnly?: boolean) {
-  return useQuery<DashboardResource[], Error>([resource, project], () => {
-    return getDashboards(project, metadataOnly);
+  return useQuery<DashboardResource[], Error>({
+    queryKey: [resource, project],
+    queryFn: () => {
+      return getDashboards(project, metadataOnly);
+    },
   });
 }
 
@@ -138,7 +144,7 @@ export function useUpdateDashboardMutation() {
       return updateDashboard(dashboard);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([resource]);
+      return queryClient.invalidateQueries({ queryKey: [resource] });
     },
   });
 }
@@ -157,8 +163,8 @@ export function useDeleteDashboardMutation() {
       });
     },
     onSuccess: (dashboard) => {
-      queryClient.removeQueries([resource, dashboard.metadata.project, dashboard.metadata.name]);
-      return queryClient.invalidateQueries([resource]);
+      queryClient.removeQueries({ queryKey: [resource, dashboard.metadata.project, dashboard.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey: [resource] });
     },
   });
 }

--- a/ui/app/src/model/datasource-client.ts
+++ b/ui/app/src/model/datasource-client.ts
@@ -49,15 +49,15 @@ export function fetchDatasourceList(project: string, kind?: string, defaultDatas
  */
 export function useCreateDatasourceMutation(projectName: string) {
   const queryClient = useQueryClient();
-  const key = buildQueryKey({ resource, parent: projectName });
+  const queryKey = buildQueryKey({ resource, parent: projectName });
 
   return useMutation<ProjectDatasource, Error, ProjectDatasource>({
-    mutationKey: key,
+    mutationKey: queryKey,
     mutationFn: (datasource: ProjectDatasource) => {
       return createDatasource(datasource);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries(key);
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }
@@ -68,15 +68,15 @@ export function useCreateDatasourceMutation(projectName: string) {
  */
 export function useUpdateDatasourceMutation(projectName: string) {
   const queryClient = useQueryClient();
-  const key = buildQueryKey({ resource, parent: projectName });
+  const queryKey = buildQueryKey({ resource, parent: projectName });
 
   return useMutation<ProjectDatasource, Error, ProjectDatasource>({
-    mutationKey: key,
+    mutationKey: queryKey,
     mutationFn: (datasource: ProjectDatasource) => {
       return updateDatasource(datasource);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries(key);
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }
@@ -87,18 +87,18 @@ export function useUpdateDatasourceMutation(projectName: string) {
  */
 export function useDeleteDatasourceMutation(projectName: string) {
   const queryClient = useQueryClient();
-  const key = buildQueryKey({ resource, parent: projectName });
+  const queryKey = buildQueryKey({ resource, parent: projectName });
 
   return useMutation<ProjectDatasource, Error, ProjectDatasource>({
-    mutationKey: key,
+    mutationKey: queryKey,
     mutationFn: (entity: ProjectDatasource) => {
       return deleteDatasource(entity).then(() => {
         return entity;
       });
     },
     onSuccess: (datasource) => {
-      queryClient.removeQueries([...key, datasource.metadata.name]);
-      return queryClient.invalidateQueries(key);
+      queryClient.removeQueries({ queryKey: [...queryKey, datasource.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }
@@ -108,8 +108,11 @@ export function useDeleteDatasourceMutation(projectName: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDatasource(project: string, name: string) {
-  return useQuery<ProjectDatasource, Error>(buildQueryKey({ resource, parent: project, name }), () => {
-    return getDatasource(project, name);
+  return useQuery<ProjectDatasource, Error>({
+    queryKey: buildQueryKey({ resource, parent: project, name }),
+    queryFn: () => {
+      return getDatasource(project, name);
+    },
   });
 }
 
@@ -118,8 +121,11 @@ export function useDatasource(project: string, name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useDatasourceList(project: string) {
-  return useQuery<ProjectDatasource[], Error>(buildQueryKey({ resource, parent: project }), () => {
-    return getDatasources(project);
+  return useQuery<ProjectDatasource[], Error>({
+    queryKey: buildQueryKey({ resource, parent: project }),
+    queryFn: () => {
+      return getDatasources(project);
+    },
   });
 }
 

--- a/ui/app/src/model/ephemeral-dashboard-client.ts
+++ b/ui/app/src/model/ephemeral-dashboard-client.ts
@@ -35,7 +35,7 @@ export function useCreateEphemeralDashboardMutation(
     },
     onSuccess: onSuccess,
     onSettled: () => {
-      return queryClient.invalidateQueries([resource]);
+      return queryClient.invalidateQueries({ queryKey: [resource] });
     },
   });
 }
@@ -53,7 +53,7 @@ export function useUpdateEphemeralDashboardMutation() {
       return updateEphemeralDashboard(ephemeralDashboard);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([resource]);
+      return queryClient.invalidateQueries({ queryKey: [resource] });
     },
   });
 }
@@ -72,8 +72,10 @@ export function useDeleteEphemeralDashboardMutation() {
       });
     },
     onSuccess: (ephemeralDashboard) => {
-      queryClient.removeQueries([resource, ephemeralDashboard.metadata.project, ephemeralDashboard.metadata.name]);
-      return queryClient.invalidateQueries([resource]);
+      queryClient.removeQueries({
+        queryKey: [resource, ephemeralDashboard.metadata.project, ephemeralDashboard.metadata.name],
+      });
+      return queryClient.invalidateQueries({ queryKey: [resource] });
     },
   });
 }
@@ -83,8 +85,11 @@ export function useDeleteEphemeralDashboardMutation() {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useEphemeralDashboard(project: string, name: string) {
-  return useQuery<EphemeralDashboardResource, Error>([resource, project, name], () => {
-    return getEphemeralDashboard(project, name);
+  return useQuery<EphemeralDashboardResource, Error>({
+    queryKey: [resource, project, name],
+    queryFn: () => {
+      return getEphemeralDashboard(project, name);
+    },
   });
 }
 
@@ -93,8 +98,11 @@ export function useEphemeralDashboard(project: string, name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useEphemeralDashboardList(project?: string) {
-  return useQuery<EphemeralDashboardResource[], Error>([resource, project], () => {
-    return getEphemeralDashboards(project);
+  return useQuery<EphemeralDashboardResource[], Error>({
+    queryKey: [resource, project],
+    queryFn: () => {
+      return getEphemeralDashboards(project);
+    },
   });
 }
 

--- a/ui/app/src/model/global-role-client.ts
+++ b/ui/app/src/model/global-role-client.ts
@@ -68,8 +68,11 @@ export function deleteGlobalRole(entity: GlobalRoleResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalRole(name: string) {
-  return useQuery<GlobalRoleResource, Error>(buildQueryKey({ resource, name }), () => {
-    return getGlobalRole(name);
+  return useQuery<GlobalRoleResource, Error>({
+    queryKey: buildQueryKey({ resource, name }),
+    queryFn: () => {
+      return getGlobalRole(name);
+    },
   });
 }
 
@@ -78,8 +81,11 @@ export function useGlobalRole(name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalRoleList() {
-  return useQuery<GlobalRoleResource[], Error>(buildQueryKey({ resource }), () => {
-    return getGlobalRoles();
+  return useQuery<GlobalRoleResource[], Error>({
+    queryKey: buildQueryKey({ resource }),
+    queryFn: () => {
+      return getGlobalRoles();
+    },
   });
 }
 
@@ -97,7 +103,7 @@ export function useCreateGlobalRoleMutation() {
       return createGlobalRole(globalRole);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([...queryKey]);
+      return queryClient.invalidateQueries({ queryKey: [...queryKey] });
     },
   });
 }
@@ -116,8 +122,8 @@ export function useUpdateGlobalRoleMutation() {
     },
     onSuccess: (entity: GlobalRoleResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -138,8 +144,8 @@ export function useDeleteGlobalRoleMutation() {
       return entity;
     },
     onSuccess: (entity: GlobalRoleResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/model/global-rolebinding-client.ts
+++ b/ui/app/src/model/global-rolebinding-client.ts
@@ -68,8 +68,11 @@ export function deleteGlobalRoleBinding(entity: GlobalRoleBindingResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalRoleBinding(name: string) {
-  return useQuery<GlobalRoleBindingResource, Error>(buildQueryKey({ resource, name }), () => {
-    return getGlobalRoleBinding(name);
+  return useQuery<GlobalRoleBindingResource, Error>({
+    queryKey: buildQueryKey({ resource, name }),
+    queryFn: () => {
+      return getGlobalRoleBinding(name);
+    },
   });
 }
 
@@ -78,8 +81,11 @@ export function useGlobalRoleBinding(name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalRoleBindingList() {
-  return useQuery<GlobalRoleBindingResource[], Error>(buildQueryKey({ resource }), () => {
-    return getGlobalRoleBindings();
+  return useQuery<GlobalRoleBindingResource[], Error>({
+    queryKey: buildQueryKey({ resource }),
+    queryFn: () => {
+      return getGlobalRoleBindings();
+    },
   });
 }
 
@@ -97,7 +103,7 @@ export function useCreateGlobalRoleBindingMutation() {
       return createGlobalRoleBinding(globalRoleBinding);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([...queryKey]);
+      return queryClient.invalidateQueries({ queryKey: [...queryKey] });
     },
   });
 }
@@ -116,8 +122,8 @@ export function useUpdateGlobalRoleBindingMutation() {
     },
     onSuccess: (entity: GlobalRoleBindingResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -138,8 +144,8 @@ export function useDeleteGlobalRoleBindingMutation() {
       return entity;
     },
     onSuccess: (entity: GlobalRoleBindingResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/model/global-secret-client.ts
+++ b/ui/app/src/model/global-secret-client.ts
@@ -69,8 +69,11 @@ export function deleteGlobalSecret(entity: GlobalSecretResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalSecret(name: string) {
-  return useQuery<GlobalSecretResource, Error>(buildQueryKey({ resource, name }), () => {
-    return getGlobalSecret(name);
+  return useQuery<GlobalSecretResource, Error>({
+    queryKey: buildQueryKey({ resource, name }),
+    queryFn: () => {
+      return getGlobalSecret(name);
+    },
   });
 }
 
@@ -79,8 +82,11 @@ export function useGlobalSecret(name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalSecretList() {
-  return useQuery<GlobalSecretResource[], Error>(buildQueryKey({ resource }), () => {
-    return getGlobalSecrets();
+  return useQuery<GlobalSecretResource[], Error>({
+    queryKey: buildQueryKey({ resource }),
+    queryFn: () => {
+      return getGlobalSecrets();
+    },
   });
 }
 
@@ -98,7 +104,7 @@ export function useCreateGlobalSecretMutation() {
       return createGlobalSecret(entity);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries(queryKey);
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }
@@ -118,8 +124,8 @@ export function useUpdateGlobalSecretMutation() {
     },
     onSuccess: (entity: GlobalSecretResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -140,8 +146,8 @@ export function useDeleteGlobalSecretMutation() {
       return entity;
     },
     onSuccess: (entity: GlobalSecretResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/model/global-variable-client.ts
+++ b/ui/app/src/model/global-variable-client.ts
@@ -69,8 +69,11 @@ export function deleteGlobalVariable(entity: GlobalVariableResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalVariable(name: string) {
-  return useQuery<GlobalVariableResource, Error>(buildQueryKey({ resource, name }), () => {
-    return getGlobalVariable(name);
+  return useQuery<GlobalVariableResource, Error>({
+    queryKey: buildQueryKey({ resource, name }),
+    queryFn: () => {
+      return getGlobalVariable(name);
+    },
   });
 }
 
@@ -79,8 +82,11 @@ export function useGlobalVariable(name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useGlobalVariableList() {
-  return useQuery<GlobalVariableResource[], Error>(buildQueryKey({ resource }), () => {
-    return getGlobalVariables();
+  return useQuery<GlobalVariableResource[], Error>({
+    queryKey: buildQueryKey({ resource }),
+    queryFn: () => {
+      return getGlobalVariables();
+    },
   });
 }
 
@@ -98,7 +104,7 @@ export function useCreateGlobalVariableMutation() {
       return createGlobalVariable(entity);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries(queryKey);
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }
@@ -118,8 +124,8 @@ export function useUpdateGlobalVariableMutation() {
     },
     onSuccess: (entity: GlobalVariableResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -140,8 +146,8 @@ export function useDeleteGlobalVariableMutation() {
       return entity;
     },
     onSuccess: (entity: GlobalVariableResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/model/health-client.ts
+++ b/ui/app/src/model/health-client.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { fetchJson } from '@perses-dev/core';
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import buildURL from './url-builder';
 
 const resource = 'health';
@@ -23,18 +23,15 @@ export interface HealthModel {
   commit: string;
 }
 
-type HealthOptions = Omit<UseQueryOptions<HealthModel, Error>, 'queryKey' | 'queryFn'>;
-
 /**
  * Gets version information from the Perses server API.
  */
-export function useHealth(options?: HealthOptions) {
-  return useQuery<HealthModel, Error>(
-    [resource],
-    () => {
+export function useHealth() {
+  return useQuery<HealthModel, Error>({
+    queryKey: [resource],
+    queryFn: () => {
       const url = buildURL({ resource });
       return fetchJson<HealthModel>(url);
     },
-    options
-  );
+  });
 }

--- a/ui/app/src/model/role-client.ts
+++ b/ui/app/src/model/role-client.ts
@@ -72,8 +72,11 @@ export function deleteRole(entity: RoleResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useRole(name: string, project: string) {
-  return useQuery<RoleResource, Error>(buildQueryKey({ resource, name, parent: project }), () => {
-    return getRole(name, project);
+  return useQuery<RoleResource, Error>({
+    queryKey: buildQueryKey({ resource, name, parent: project }),
+    queryFn: () => {
+      return getRole(name, project);
+    },
   });
 }
 
@@ -82,8 +85,11 @@ export function useRole(name: string, project: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useRoleList(project?: string) {
-  return useQuery<RoleResource[], Error>(buildQueryKey({ resource, parent: project }), () => {
-    return getRoles(project);
+  return useQuery<RoleResource[], Error>({
+    queryKey: buildQueryKey({ resource, parent: project }),
+    queryFn: () => {
+      return getRoles(project);
+    },
   });
 }
 
@@ -104,7 +110,7 @@ export function useCreateRoleMutation(project: string) {
       return createRole(role);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([...queryKey]);
+      return queryClient.invalidateQueries({ queryKey: [...queryKey] });
     },
   });
 }
@@ -126,8 +132,8 @@ export function useUpdateRoleMutation(project: string) {
     },
     onSuccess: (entity: RoleResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -151,8 +157,8 @@ export function useDeleteRoleMutation(project: string) {
       return entity;
     },
     onSuccess: (entity: RoleResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/model/rolebinding-client.ts
+++ b/ui/app/src/model/rolebinding-client.ts
@@ -72,8 +72,11 @@ export function deleteRoleBinding(entity: RoleBindingResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useRoleBinding(name: string, project: string) {
-  return useQuery<RoleBindingResource, Error>(buildQueryKey({ resource, name, parent: project }), () => {
-    return getRoleBinding(name, project);
+  return useQuery<RoleBindingResource, Error>({
+    queryKey: buildQueryKey({ resource, name, parent: project }),
+    queryFn: () => {
+      return getRoleBinding(name, project);
+    },
   });
 }
 
@@ -82,8 +85,11 @@ export function useRoleBinding(name: string, project: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useRoleBindingList(project?: string) {
-  return useQuery<RoleBindingResource[], Error>(buildQueryKey({ resource, parent: project }), () => {
-    return getRoleBindings(project);
+  return useQuery<RoleBindingResource[], Error>({
+    queryKey: buildQueryKey({ resource, parent: project }),
+    queryFn: () => {
+      return getRoleBindings(project);
+    },
   });
 }
 
@@ -104,7 +110,7 @@ export function useCreateRoleBindingMutation(project: string) {
       return createRoleBinding(roleBinding);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([...queryKey]);
+      return queryClient.invalidateQueries({ queryKey: [...queryKey] });
     },
   });
 }
@@ -126,8 +132,8 @@ export function useUpdateRoleBindingMutation(project: string) {
     },
     onSuccess: (entity: RoleBindingResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -151,8 +157,8 @@ export function useDeleteRoleBindingMutation(project: string) {
       return entity;
     },
     onSuccess: (entity: RoleBindingResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/model/secret-client.ts
+++ b/ui/app/src/model/secret-client.ts
@@ -72,8 +72,11 @@ export function deleteSecret(entity: SecretResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useSecret(name: string, project: string) {
-  return useQuery<SecretResource, Error>(buildQueryKey({ resource, name, parent: project }), () => {
-    return getSecret(name, project);
+  return useQuery<SecretResource, Error>({
+    queryKey: buildQueryKey({ resource, name, parent: project }),
+    queryFn: () => {
+      return getSecret(name, project);
+    },
   });
 }
 
@@ -82,8 +85,11 @@ export function useSecret(name: string, project: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useSecretList(project?: string) {
-  return useQuery<SecretResource[], Error>(buildQueryKey({ resource, parent: project }), () => {
-    return getSecrets(project);
+  return useQuery<SecretResource[], Error>({
+    queryKey: buildQueryKey({ resource, parent: project }),
+    queryFn: () => {
+      return getSecrets(project);
+    },
   });
 }
 
@@ -104,7 +110,7 @@ export function useCreateSecretMutation(project: string) {
       return createSecret(secret);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([...queryKey]);
+      return queryClient.invalidateQueries({ queryKey: [...queryKey] });
     },
   });
 }
@@ -126,8 +132,8 @@ export function useUpdateSecretMutation(project: string) {
     },
     onSuccess: (entity: SecretResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -151,8 +157,8 @@ export function useDeleteSecretMutation(project: string) {
       return entity;
     },
     onSuccess: (entity: SecretResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/model/user-client.ts
+++ b/ui/app/src/model/user-client.ts
@@ -98,8 +98,11 @@ function getUserPermissions(username: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useUser(name: string) {
-  return useQuery<UserResource, Error>(buildQueryKey({ resource, name }), () => {
-    return getUser(name);
+  return useQuery<UserResource, Error>({
+    queryKey: buildQueryKey({ resource, name }),
+    queryFn: () => {
+      return getUser(name);
+    },
   });
 }
 
@@ -108,8 +111,11 @@ export function useUser(name: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useUserList() {
-  return useQuery<UserResource[], Error>(buildQueryKey({ resource }), () => {
-    return getUsers();
+  return useQuery<UserResource[], Error>({
+    queryKey: buildQueryKey({ resource }),
+    queryFn: () => {
+      return getUsers();
+    },
   });
 }
 
@@ -127,7 +133,7 @@ export function useCreateUserMutation() {
       return createUser(entity);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries(queryKey);
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }
@@ -147,8 +153,8 @@ export function useUpdateUserMutation() {
     },
     onSuccess: (entity: UserResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -169,8 +175,8 @@ export function useDeleteUserMutation() {
       return entity;
     },
     onSuccess: (entity: UserResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }
@@ -180,7 +186,10 @@ export function useDeleteUserMutation() {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useUserPermissions(username: string) {
-  return useQuery<Record<string, Permission[]>, Error>([userKey, username, 'permissions'], () => {
-    return getUserPermissions(username);
+  return useQuery<Record<string, Permission[]>, Error>({
+    queryKey: [userKey, username, 'permissions'],
+    queryFn: () => {
+      return getUserPermissions(username);
+    },
   });
 }

--- a/ui/app/src/model/variable-client.ts
+++ b/ui/app/src/model/variable-client.ts
@@ -72,8 +72,11 @@ export function deleteVariable(entity: VariableResource) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useVariable(name: string, project: string) {
-  return useQuery<VariableResource, Error>(buildQueryKey({ resource, name, parent: project }), () => {
-    return getVariable(name, project);
+  return useQuery<VariableResource, Error>({
+    queryKey: buildQueryKey({ resource, name, parent: project }),
+    queryFn: () => {
+      return getVariable(name, project);
+    },
   });
 }
 
@@ -82,8 +85,11 @@ export function useVariable(name: string, project: string) {
  * Will automatically be refreshed when cache is invalidated
  */
 export function useVariableList(project?: string) {
-  return useQuery<VariableResource[], Error>(buildQueryKey({ resource, parent: project }), () => {
-    return getVariables(project);
+  return useQuery<VariableResource[], Error>({
+    queryKey: buildQueryKey({ resource, parent: project }),
+    queryFn: () => {
+      return getVariables(project);
+    },
   });
 }
 
@@ -104,7 +110,7 @@ export function useCreateVariableMutation(project: string) {
       return createVariable(variable);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries([...queryKey]);
+      return queryClient.invalidateQueries({ queryKey: [...queryKey] });
     },
   });
 }
@@ -126,8 +132,8 @@ export function useUpdateVariableMutation(project: string) {
     },
     onSuccess: (entity: VariableResource) => {
       return Promise.all([
-        queryClient.invalidateQueries([...queryKey, entity.metadata.name]),
-        queryClient.invalidateQueries(queryKey),
+        queryClient.invalidateQueries({ queryKey: [...queryKey, entity.metadata.name] }),
+        queryClient.invalidateQueries({ queryKey }),
       ]);
     },
   });
@@ -151,8 +157,8 @@ export function useDeleteVariableMutation(project: string) {
       return entity;
     },
     onSuccess: (entity: VariableResource) => {
-      queryClient.removeQueries([...queryKey, entity.metadata.name]);
-      return queryClient.invalidateQueries(queryKey);
+      queryClient.removeQueries({ queryKey: [...queryKey, entity.metadata.name] });
+      return queryClient.invalidateQueries({ queryKey });
     },
   });
 }

--- a/ui/app/src/views/auth/SignInView.tsx
+++ b/ui/app/src/views/auth/SignInView.tsx
@@ -45,7 +45,7 @@ function SignInView() {
   };
 
   const isSignInDisabled = () => {
-    return authMutation.isLoading || login === '' || password === '';
+    return authMutation.isPending || login === '' || password === '';
   };
 
   const handleKeypress = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -78,7 +78,7 @@ function SignInView() {
       <Button variant="contained" disabled={isSignInDisabled()} onClick={() => handleLogin()}>
         Sign in
       </Button>
-      {authMutation.isLoading && <LinearProgress />}
+      {authMutation.isPending && <LinearProgress />}
       {!isSignUpDisable && (
         <Typography sx={{ textAlign: 'center' }}>
           Don&lsquo;t have an account yet?&nbsp;

--- a/ui/app/src/views/auth/SignUpView.tsx
+++ b/ui/app/src/views/auth/SignUpView.tsx
@@ -48,7 +48,7 @@ function SignUpView() {
   };
 
   const isSignUpDisabled = () => {
-    return createUserMutation.isLoading || login === '' || password === '';
+    return createUserMutation.isPending || login === '' || password === '';
   };
 
   const handleKeypress = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -79,7 +79,7 @@ function SignUpView() {
       <Button variant="contained" disabled={isSignUpDisabled()} onClick={() => handleRegister()}>
         Register
       </Button>
-      {createUserMutation.isLoading && <LinearProgress />}
+      {createUserMutation.isPending && <LinearProgress />}
       <Typography sx={{ textAlign: 'center' }}>
         Already have an account?&nbsp;
         <Link underline="hover" component={RouterLink} to={SignInRoute}>

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -48,7 +48,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps) {
   const { exceptionSnackbar } = useSnackbar();
   const [projectName, setProjectName] = useState<string>('');
   const [grafanaInput, setGrafanaInput] = useState<Record<string, string>>({});
-  const { data, isLoading } = useProjectList({ onError: exceptionSnackbar });
+  const { data, isLoading, error } = useProjectList();
   const dashboardMutation = useCreateDashboardMutation((data) => {
     navigate(`/projects/${data.metadata.project}/dashboards/${data.metadata.name}`);
   });
@@ -71,6 +71,10 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps) {
     dashboard.metadata.project = projectName;
     dashboardMutation.mutate(dashboard);
   };
+
+  if (error) {
+    exceptionSnackbar(error);
+  }
 
   return (
     <>
@@ -98,7 +102,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps) {
       </Alert>
       <Button
         variant="contained"
-        disabled={migrateMutation.isLoading}
+        disabled={migrateMutation.isPending}
         startIcon={<AutoFix />}
         onClick={() => {
           migrateMutation.mutate({ input: grafanaInput, grafanaDashboard: dashboard ?? {} });
@@ -106,7 +110,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps) {
       >
         Migrate
       </Button>
-      {migrateMutation.isLoading && <CircularProgress sx={{ alignSelf: 'center' }} />}
+      {migrateMutation.isPending && <CircularProgress sx={{ alignSelf: 'center' }} />}
       {migrateMutation.isError && (
         <Alert variant="outlined" severity="error">
           {migrateMutation.error.message}
@@ -140,7 +144,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps) {
             />
             <Button
               variant="contained"
-              disabled={dashboardMutation.isLoading || projectName.length === 0 || isReadonly}
+              disabled={dashboardMutation.isPending || projectName.length === 0 || isReadonly}
               startIcon={<Import />}
               onClick={importOnClick}
             >

--- a/ui/app/src/views/import/PersesFlow.tsx
+++ b/ui/app/src/views/import/PersesFlow.tsx
@@ -31,7 +31,7 @@ function PersesFlow({ dashboard }: PersesFlowProps) {
   const isReadonly = useIsReadonly();
   const { exceptionSnackbar } = useSnackbar();
   const [projectName, setProjectName] = useState<string>('');
-  const { data } = useProjectList({ onError: exceptionSnackbar });
+  const { data, error } = useProjectList();
   const dashboardMutation = useCreateDashboardMutation((data) => {
     navigate(`/projects/${data.metadata.project}/dashboards/${data.metadata.name}`);
   });
@@ -40,6 +40,10 @@ function PersesFlow({ dashboard }: PersesFlowProps) {
     dashboard.metadata.project = projectName;
     dashboardMutation.mutate(dashboard);
   };
+
+  if (error) {
+    exceptionSnackbar(error);
+  }
 
   return (
     <>
@@ -67,7 +71,7 @@ function PersesFlow({ dashboard }: PersesFlowProps) {
             />
             <Button
               variant="contained"
-              disabled={dashboardMutation.isLoading || projectName.length === 0 || isReadonly}
+              disabled={dashboardMutation.isPending || projectName.length === 0 || isReadonly}
               startIcon={<Import />}
               onClick={importOnClick}
             >

--- a/ui/app/src/views/projects/dashboards/DashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/DashboardView.tsx
@@ -72,7 +72,7 @@ function DashboardView() {
     );
   }
   if (dashboardNotFoundError !== null) {
-    exceptionSnackbar(dashboardNotFoundError);
+    exceptionSnackbar(`Dashboard '${dashboardName}' not found!`);
     navigate(`/projects/${projectName}`);
   }
   if (!data || data.spec === undefined || isReadonly === undefined) return null;

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@mui/material": "^5.10.0",
-    "@tanstack/react-query": "^4.7.1",
+    "@tanstack/react-query": "^5.37.1",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"
   },

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -26,7 +26,7 @@ export interface PanelContentProps extends PanelProps<UnknownSpec> {
  */
 export function PanelContent(props: PanelContentProps) {
   const { panelPluginKind, contentDimensions, definition, ...others } = props;
-  const { data: plugin, isLoading } = usePlugin('Panel', panelPluginKind, { useErrorBoundary: true });
+  const { data: plugin, isLoading } = usePlugin('Panel', panelPluginKind, { throwOnError: true });
   const PanelComponent = plugin?.PanelComponent;
 
   if (isLoading) {

--- a/ui/dashboards/src/components/QuerySummaryTable/QuerySummaryTable.tsx
+++ b/ui/dashboards/src/components/QuerySummaryTable/QuerySummaryTable.tsx
@@ -47,7 +47,7 @@ export function QuerySummaryTable(props: QuerySummaryTableProps) {
   // for displaying a summary of recent query results
   const queryClient = useQueryClient();
   const queries = queryClient.getQueryCache().findAll();
-  const activeQueries = queries.filter((query) => query.state.status === 'loading');
+  const activeQueries = queries.filter((query) => query.state.status === 'pending');
   const completedQueries = queries.filter((query) => query.state.status === 'success');
   const querySummary = useActiveTimeSeriesQueries();
 

--- a/ui/explore/package.json
+++ b/ui/explore/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@mui/material": "^5.10.0",
-    "@tanstack/react-query": "^4.7.1",
+    "@tanstack/react-query": "^5.37.1",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"
   },

--- a/ui/explore/src/components/ExploreManager/MetricsExplorer.tsx
+++ b/ui/explore/src/components/ExploreManager/MetricsExplorer.tsx
@@ -96,7 +96,7 @@ export function MetricsExplorer() {
         <Tab label="Table" />
         <Tab label="Graph" />
       </Tabs>
-      <Stack gap={1}>
+      <Stack>
         {tab === 0 && <MetricDataTable queries={queries} />}
         {tab === 1 && <TimeSeriesPanel queries={queries} />}
       </Stack>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -80,7 +80,7 @@
         "@perses-dev/plugin-system": "0.45.0",
         "@perses-dev/prometheus-plugin": "0.45.0",
         "@perses-dev/tempo-plugin": "0.45.0",
-        "@tanstack/react-query": "^4.7.1",
+        "@tanstack/react-query": "^5.37.1",
         "date-fns": "^2.29.3",
         "immer": "^9.0.15",
         "lodash": "^4.17.21",
@@ -204,7 +204,7 @@
       },
       "peerDependencies": {
         "@mui/material": "^5.10.0",
-        "@tanstack/react-query": "^4.7.1",
+        "@tanstack/react-query": "^5.37.1",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
       }
@@ -256,7 +256,7 @@
       },
       "peerDependencies": {
         "@mui/material": "^5.10.0",
-        "@tanstack/react-query": "^4.7.1",
+        "@tanstack/react-query": "^5.37.1",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
       }
@@ -10434,38 +10434,27 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz",
-      "integrity": "sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==",
+      "version": "5.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.36.1.tgz",
+      "integrity": "sha512-BteWYEPUcucEu3NBcDAgKuI4U25R9aPrHSP6YSf2NvaD2pSlIQTdqOfLRsxH9WdRYg7k0Uom35Uacb6nvbIMJg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
-      "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
+      "version": "5.37.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.37.1.tgz",
+      "integrity": "sha512-EhtBNA8GL3XFeSx6VYUjXQ96n44xe3JGKZCzBINrCYlxbZP6UwBafv7ti4eSRWc2Fy+fybQre0w17gR6lMzULA==",
       "dependencies": {
-        "@tanstack/query-core": "4.36.1",
-        "use-sync-external-store": "^1.2.0"
+        "@tanstack/query-core": "5.36.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
+        "react": "^18.0.0"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -30571,7 +30560,7 @@
       },
       "peerDependencies": {
         "@mui/material": "^5.10.0",
-        "@tanstack/react-query": "^4.7.1",
+        "@tanstack/react-query": "^5.37.1",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
       }

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@mui/material": "^5.10.0",
-    "@tanstack/react-query": "^4.7.1",
+    "@tanstack/react-query": "^5.37.1",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"
   },

--- a/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
@@ -39,7 +39,7 @@ function useDefaultQueryDefinition(queryTypes: QueryPluginType[]): QueryDefiniti
   const defaultQueryKind = defaultPluginKinds?.[defaultQueryType] ?? queryPlugins?.[0]?.kind ?? '';
 
   const { data: defaultQueryPlugin } = usePlugin(defaultQueryType, defaultQueryKind, {
-    useErrorBoundary: true,
+    throwOnError: true,
     enabled: true,
   });
 

--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -66,9 +66,9 @@ export function useListVariablePluginValues(definition: ListVariableDefinition) 
 
   const variablesValueKey = getVariableValuesKey(variables);
 
-  return useQuery(
-    [definition, variablesValueKey, timeRange, refreshKey],
-    async () => {
+  return useQuery({
+    queryKey: [definition, variablesValueKey, timeRange, refreshKey],
+    queryFn: async () => {
       const resp = await variablePlugin?.getVariableOptions(spec, { datasourceStore, variables, timeRange });
       if (resp === undefined) {
         return [];
@@ -78,8 +78,8 @@ export function useListVariablePluginValues(definition: ListVariableDefinition) 
       }
       return filterVariableList(resp.data, capturingRegexp);
     },
-    { enabled: !!variablePlugin || waitToLoad }
-  );
+    enabled: !!variablePlugin || waitToLoad,
+  });
 }
 
 /**

--- a/ui/plugin-system/src/context/ProjectStoreProvider.tsx
+++ b/ui/plugin-system/src/context/ProjectStoreProvider.tsx
@@ -29,8 +29,11 @@ export interface ProjectStoreProviderProps {
 export const ProjectStoreContext = createContext<ProjectStore | undefined>(undefined);
 
 export function useProjectList(): UseQueryResult<ProjectResource[], Error> {
-  return useQuery<ProjectResource[], Error>(['projects'], () => {
-    return fetchJson<ProjectResource[]>('/api/v1/projects');
+  return useQuery<ProjectResource[], Error>({
+    queryKey: ['projects'],
+    queryFn: () => {
+      return fetchJson<ProjectResource[]>('/api/v1/projects');
+    },
   });
 }
 

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -21,7 +21,7 @@ export interface DataQueriesProviderProps<QueryPluginSpec = UnknownSpec> {
   definitions: Array<Definition<QueryPluginSpec>>;
   children?: ReactNode;
   options?: QueryOptions;
-  queryOptions?: QueryObserverOptions;
+  queryOptions?: Omit<QueryObserverOptions, 'queryKey'>;
 }
 
 export interface DataQueriesContextType {

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -91,9 +91,10 @@ export function useDatasourceStore() {
  */
 export function useListDatasourceSelectItems(datasourcePluginKind: string, project?: string) {
   const { listDatasourceSelectItems } = useDatasourceStore();
-  return useQuery(['listDatasourceSelectItems', datasourcePluginKind, project], () =>
-    listDatasourceSelectItems(datasourcePluginKind)
-  );
+  return useQuery({
+    queryKey: ['listDatasourceSelectItems', datasourcePluginKind, project],
+    queryFn: () => listDatasourceSelectItems(datasourcePluginKind),
+  });
 }
 
 /**
@@ -101,10 +102,16 @@ export function useListDatasourceSelectItems(datasourcePluginKind: string, proje
  */
 export function useDatasourceClient<Client>(selector: DatasourceSelector) {
   const store = useDatasourceStore();
-  return useQuery<Client>(['getDatasourceClient', selector], () => store.getDatasourceClient<Client>(selector));
+  return useQuery<Client>({
+    queryKey: ['getDatasourceClient', selector],
+    queryFn: () => store.getDatasourceClient<Client>(selector),
+  });
 }
 
 export function useDatasource(selector: DatasourceSelector) {
   const store = useDatasourceStore();
-  return useQuery(['getDatasource', selector], () => store.getDatasource(selector));
+  return useQuery({
+    queryKey: ['getDatasource', selector],
+    queryFn: () => store.getDatasource(selector),
+  });
 }

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -56,7 +56,11 @@ export function usePlugin<T extends PluginType>(
     enabled: (options?.enabled ?? true) && pluginType !== undefined && kind !== '',
   };
   const { getPlugin } = usePluginRegistry();
-  return useQuery(['getPlugin', pluginType, kind], () => getPlugin(pluginType!, kind), options);
+  return useQuery({
+    queryKey: ['getPlugin', pluginType, kind],
+    queryFn: () => getPlugin(pluginType!, kind),
+    ...options,
+  });
 }
 
 /**
@@ -85,22 +89,29 @@ type UseListPluginMetadataOptions = Omit<
  */
 export function useListPluginMetadata(pluginTypes: PluginType[], options?: UseListPluginMetadataOptions) {
   const { listPluginMetadata } = usePluginRegistry();
-  return useQuery(['listPluginMetadata', pluginTypes], () => listPluginMetadata(pluginTypes), options);
+  return useQuery({
+    queryKey: ['listPluginMetadata', pluginTypes],
+    queryFn: () => listPluginMetadata(pluginTypes),
+    ...options,
+  });
 }
 
 export function usePluginBuiltinVariableDefinitions() {
   const { getPlugin, listPluginMetadata } = usePluginRegistry();
 
-  return useQuery(['usePluginBuiltinVariableDefinitions'], async () => {
-    const datasources = await listPluginMetadata(['Datasource']);
-    const datasourceKinds = new Set(datasources.map((datasource) => datasource.kind));
-    const result: BuiltinVariableDefinition[] = [];
-    for (const kind of datasourceKinds) {
-      const plugin = await getPlugin('Datasource', kind);
-      if (plugin.getBuiltinVariableDefinitions) {
-        plugin.getBuiltinVariableDefinitions().forEach((definition) => result.push(definition));
+  return useQuery({
+    queryKey: ['usePluginBuiltinVariableDefinitions'],
+    queryFn: async () => {
+      const datasources = await listPluginMetadata(['Datasource']);
+      const datasourceKinds = new Set(datasources.map((datasource) => datasource.kind));
+      const result: BuiltinVariableDefinition[] = [];
+      for (const kind of datasourceKinds) {
+        const plugin = await getPlugin('Datasource', kind);
+        if (plugin.getBuiltinVariableDefinitions) {
+          plugin.getBuiltinVariableDefinitions().forEach((definition) => result.push(definition));
+        }
       }
-    }
-    return result;
+      return result;
+    },
   });
 }

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -124,7 +124,7 @@ export const useTimeSeriesQuery = (
 export function useTimeSeriesQueries(
   definitions: TimeSeriesQueryDefinition[],
   options?: UseTimeSeriesQueryOptions,
-  queryOptions?: QueryObserverOptions
+  queryOptions?: Omit<QueryObserverOptions, 'queryKey'>
 ) {
   const { getPlugin } = usePluginRegistry();
   const context = {

--- a/ui/plugin-system/src/test/render.tsx
+++ b/ui/plugin-system/src/test/render.tsx
@@ -13,17 +13,10 @@
 
 import { render, RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { PluginRegistry } from '../components/PluginRegistry';
+import { ReactNode } from 'react';
+import { PluginRegistry } from '../components';
 import { DefaultPluginKinds } from '../model';
 import { testPluginLoader } from './test-plugins';
-
-const testLogger = {
-  log: console.log,
-  warn: console.warn,
-  error: () => {
-    // Don't log network errors in tests to the console
-  },
-};
 
 type ContextOptions = {
   defaultPluginKinds?: DefaultPluginKinds;
@@ -34,14 +27,13 @@ type ContextOptions = {
  * wrapped around it.
  */
 export function renderWithContext(
-  ui: React.ReactNode,
+  ui: ReactNode,
   renderOptions?: Omit<RenderOptions, 'queries'>,
   contextOptions?: ContextOptions
 ) {
   // Create a new QueryClient for each test to avoid caching issues
   const queryClient = new QueryClient({
     defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } },
-    logger: testLogger,
   });
   return render(
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Upgrading  tanstack/react-query to v5. Biggest change for us is the removal of callbacks onError. More details: [https://tkdodo.eu/blog/breaking-react-querys-api-on-purpose](https://tkdodo.eu/blog/breaking-react-querys-api-on-purpose)

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
