### PR TITLE
[FEATURE] Provide datasource discovery starting with http discovery

### DIFF
--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"fmt"
+	"github.com/perses/perses/internal/api/discovery"
 	"strings"
 	"time"
 
@@ -77,6 +78,13 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 	if len(conf.Provisioning.Folders) > 0 {
 		provisioningTask := provisioning.New(serviceManager, conf.Provisioning.Folders, persesDAO.IsCaseSensitive())
 		runner.WithTimerTasks(time.Duration(conf.Provisioning.Interval), provisioningTask)
+	}
+	if len(conf.GlobalDatasourceDiscovery) > 0 {
+		datasourceDiscoveryTasks, sdErr := discovery.New(conf, serviceManager, persesDAO.IsCaseSensitive())
+		if sdErr != nil {
+			return nil, nil, fmt.Errorf("unable to instantiate the tasks for datasource discovery: %w", sdErr)
+		}
+		runner.WithTaskHelpers(datasourceDiscoveryTasks...)
 	}
 	if conf.Security.EnableAuth {
 		rbacTask := rbac.NewCronTask(serviceManager.GetRBAC(), persesDAO)

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -15,7 +15,6 @@ package core
 
 import (
 	"fmt"
-	"github.com/perses/perses/internal/api/discovery"
 	"strings"
 	"time"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/perses/perses/internal/api/core/middleware"
 	"github.com/perses/perses/internal/api/dashboard"
 	"github.com/perses/perses/internal/api/dependency"
+	"github.com/perses/perses/internal/api/discovery"
 	"github.com/perses/perses/internal/api/migrate"
 	"github.com/perses/perses/internal/api/provisioning"
 	"github.com/perses/perses/internal/api/rbac"

--- a/internal/api/discovery/discovery.go
+++ b/internal/api/discovery/discovery.go
@@ -17,13 +17,15 @@ import (
 	"github.com/perses/common/async/taskhelper"
 	"github.com/perses/perses/internal/api/dependency"
 	httpsd "github.com/perses/perses/internal/api/discovery/http"
+	"github.com/perses/perses/internal/api/discovery/service"
 	"github.com/perses/perses/pkg/model/api/config"
 )
 
 func New(cfg config.Config, serviceManager dependency.ServiceManager, caseSensitive bool) ([]taskhelper.Helper, error) {
 	var helpers []taskhelper.Helper
+	svc := service.New(caseSensitive, serviceManager.GetGlobalDatasource())
 	for _, c := range cfg.GlobalDatasourceDiscovery {
-		helper, err := httpsd.NewDiscovery(c.HTTPDiscovery, serviceManager.GetGlobalDatasource(), caseSensitive)
+		helper, err := httpsd.NewDiscovery(c.HTTPDiscovery, svc)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/api/discovery/discovery.go
+++ b/internal/api/discovery/discovery.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"github.com/perses/common/async/taskhelper"
+	"github.com/perses/perses/internal/api/dependency"
+	httpsd "github.com/perses/perses/internal/api/discovery/http"
+	"github.com/perses/perses/pkg/model/api/config"
+)
+
+func New(cfg config.Config, serviceManager dependency.ServiceManager, caseSensitive bool) ([]taskhelper.Helper, error) {
+	var helpers []taskhelper.Helper
+	for _, c := range cfg.GlobalDatasourceDiscovery {
+		helper, err := httpsd.NewDiscovery(c.HTTPDiscovery, serviceManager.GetGlobalDatasource(), caseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		helpers = append(helpers, helper)
+	}
+	return helpers, nil
+}

--- a/internal/api/discovery/http/http.go
+++ b/internal/api/discovery/http/http.go
@@ -1,0 +1,83 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsd
+
+import (
+	"context"
+	"github.com/perses/common/async"
+	"github.com/perses/common/async/taskhelper"
+	databaseModel "github.com/perses/perses/internal/api/database/model"
+	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
+	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/model/api/config"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+func NewDiscovery(cfg *config.HTTPDiscovery, svc globaldatasource.Service, caseSensitive bool) (taskhelper.Helper, error) {
+	client, err := perseshttp.NewFromConfig(cfg.RestConfigClient)
+	if err != nil {
+		return nil, err
+	}
+	sd := &discovery{
+		restClient:    client,
+		svc:           svc,
+		name:          cfg.Name,
+		caseSensitive: caseSensitive,
+	}
+	return taskhelper.NewTick(sd, time.Duration(cfg.RefreshInterval))
+}
+
+type discovery struct {
+	async.SimpleTask
+	restClient    *perseshttp.RESTClient
+	svc           globaldatasource.Service
+	name          string
+	caseSensitive bool
+}
+
+func (d *discovery) Execute(_ context.Context, _ context.Context) error {
+	var result []*v1.GlobalDatasource
+	err := d.restClient.Get().
+		Do().
+		Object(&result)
+
+	if err != nil {
+		logrus.Errorf("failed to execute http discovery %q: %v", d.name, err)
+		return nil
+	}
+	for _, entity := range result {
+		entity.GetMetadata().Flatten(d.caseSensitive)
+		_, createErr := d.svc.Create(apiInterface.EmptyCtx, entity)
+		if createErr == nil {
+			continue
+		}
+
+		if !databaseModel.IsKeyConflict(createErr) {
+			logrus.WithError(createErr).Errorf("unable to create the globaldatasource %q", entity.Metadata.Name)
+			continue
+		}
+
+		param := apiInterface.Parameters{
+			Name: entity.Metadata.Name,
+		}
+
+		if _, updateError := d.svc.Update(apiInterface.EmptyCtx, entity, param); updateError != nil {
+			logrus.WithError(updateError).Errorf("unable to update the globaldatasource %q", entity.Metadata.Name)
+		}
+	}
+	return nil
+}

--- a/internal/api/discovery/service/service.go
+++ b/internal/api/discovery/service/service.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	databaseModel "github.com/perses/perses/internal/api/database/model"
+	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
+)
+
+func New(caseSensitive bool, svc globaldatasource.Service) *ApplyService {
+	return &ApplyService{
+		caseSensitive: caseSensitive,
+		svc:           svc,
+	}
+}
+
+type ApplyService struct {
+	caseSensitive bool
+	svc           globaldatasource.Service
+}
+
+func (a *ApplyService) Apply(entities []*v1.GlobalDatasource) {
+	for _, entity := range entities {
+		entity.GetMetadata().Flatten(a.caseSensitive)
+		_, createErr := a.svc.Create(apiInterface.EmptyCtx, entity)
+		if createErr == nil {
+			continue
+		}
+
+		if !databaseModel.IsKeyConflict(createErr) {
+			logrus.WithError(createErr).Errorf("unable to create the globaldatasource %q", entity.Metadata.Name)
+			continue
+		}
+
+		param := apiInterface.Parameters{
+			Name: entity.Metadata.Name,
+		}
+
+		if _, updateError := a.svc.Update(apiInterface.EmptyCtx, entity, param); updateError != nil {
+			logrus.WithError(updateError).Errorf("unable to update the globaldatasource %q", entity.Metadata.Name)
+		}
+	}
+}

--- a/internal/cli/cmd/dac/build/testdata/go/go.mod
+++ b/internal/cli/cmd/dac/build/testdata/go/go.mod
@@ -13,7 +13,9 @@
 
 module dac
 
-go 1.21.6
+go 1.22
+
+toolchain go1.22.3
 
 replace github.com/perses/perses => ../../../../../../../ // Use current version
 

--- a/pkg/client/perseshttp/request_test.go
+++ b/pkg/client/perseshttp/request_test.go
@@ -47,7 +47,6 @@ func TestRequest_BuildPath(t *testing.T) {
 		title          string
 		request        *Request
 		expectedResult string
-		expectedError  bool
 	}{
 		{
 			title: "Resource missing",
@@ -55,8 +54,7 @@ func TestRequest_BuildPath(t *testing.T) {
 				apiPrefix:  defaultAPIPrefix,
 				apiVersion: defaultAPIVersion,
 			},
-			expectedResult: "",
-			expectedError:  true,
+			expectedResult: "/api/v1",
 		},
 		{
 			title: "Basic path with resource",
@@ -66,7 +64,6 @@ func TestRequest_BuildPath(t *testing.T) {
 				resource:   "projects",
 			},
 			expectedResult: "/api/v1/projects",
-			expectedError:  false,
 		},
 		{
 			title: "Path using Projects path",
@@ -77,18 +74,12 @@ func TestRequest_BuildPath(t *testing.T) {
 				resource:   "prometheusrules",
 			},
 			expectedResult: "/api/v1/projects/perses/prometheusrules",
-			expectedError:  false,
 		},
 	}
 	for _, test := range testSuites {
 		t.Run(test.title, func(t *testing.T) {
-			path, err := test.request.buildPath()
-			if test.expectedError {
-				assert.NotNil(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, test.expectedResult, path)
-			}
+			path := test.request.buildPath()
+			assert.Equal(t, test.expectedResult, path)
 		})
 
 	}

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -39,6 +39,8 @@ type Config struct {
 	Schemas Schemas `json:"schemas,omitempty" yaml:"schemas,omitempty"`
 	// Provisioning contains the provisioning config that can be used if you want to provide default resources.
 	Provisioning ProvisioningConfig `json:"provisioning,omitempty" yaml:"provisioning,omitempty"`
+	// GlobalDatasourceDiscovery is the configuration that helps to generate a list of global datasource based on the discovery chosen.
+	GlobalDatasourceDiscovery []GlobalDatasourceDiscovery `json:"global_datasource_discovery,omitempty" yaml:"global_datasource_discovery,omitempty"`
 	// EphemeralDashboardsCleanupInterval is the interval at which the ephemeral dashboards are cleaned up
 	EphemeralDashboardsCleanupInterval model.Duration `json:"ephemeral_dashboards_cleanup_interval,omitempty" yaml:"ephemeral_dashboards_cleanup_interval,omitempty"`
 	// Frontend contains any config that will be used by the frontend itself.

--- a/pkg/model/api/config/datasourcediscovery.go
+++ b/pkg/model/api/config/datasourcediscovery.go
@@ -1,0 +1,35 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/prometheus/common/model"
+)
+
+type HTTPDiscovery struct {
+	perseshttp.RestConfigClient `json:",inline" yaml:",inline"`
+	// The name of the discovery config (optional)
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Refresh interval to re-query the endpoint.
+	RefreshInterval model.Duration `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty"`
+}
+
+type GlobalDatasourceDiscovery struct {
+	// HTTP-based service discovery provides a more generic way to generate a set of global datasource and serves as an interface to plug in custom service discovery mechanisms.
+	// It fetches an HTTP endpoint containing a list of zero or more global datasources.
+	// The target must reply with an HTTP 200 response.
+	// The HTTP header Content-Type must be application/json, and the body must be valid array of JSON.
+	HTTPDiscovery *HTTPDiscovery `json:"http_sd,omitempty" yaml:"http_sd,omitempty"`
+}


### PR DESCRIPTION
This PR introduces the notion of datasource discovery.

I'm starting with a HTTP discovery so we have something generic. The idea is that you can expose an endpoint returning a list of global datasource and Perses will fetch it and inject the data in the database.

I think for the discovery it makes to create only global datasource because that's something you are doing in the backend config. So for me it doesn't really make sense to create data in a project using the discovery. But maybe I am wrong.


Linked to #74 