### PR TITLE
[BUGFIX] Fix panel group collapsed + panel height in panel view mode

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridLayout.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridLayout.tsx
@@ -30,7 +30,6 @@ import { GridItemContent } from './GridItemContent';
 import { GridContainer } from './GridContainer';
 const DEFAULT_MARGIN = 10;
 const ROW_HEIGHT = 30;
-const ResponsiveGridLayout = WidthProvider(Responsive);
 
 export interface GridLayoutProps {
   panelGroupId: PanelGroupId;
@@ -60,6 +59,9 @@ export function GridLayout(props: GridLayoutProps) {
   const isGridDisplayed = useMemo(() => {
     if (viewPanelItemId === undefined) {
       return true;
+    }
+    if (hasViewPanel) {
+      setIsOpen(true);
     }
     return hasViewPanel;
   }, [hasViewPanel, viewPanelItemId]);
@@ -112,8 +114,17 @@ export function GridLayout(props: GridLayoutProps) {
     setGridColWidth((containerWidth - marginWidth - containerPaddingWidth) / cols);
   };
 
+  // https://github.com/react-grid-layout/react-grid-layout?tab=readme-ov-file#react-hooks-performance
+  const ResponsiveGridLayout = useMemo(() => WidthProvider(Responsive), []);
+
   return (
-    <GridContainer sx={{ display: isGridDisplayed ? 'block' : 'none' }}>
+    <GridContainer
+      sx={{
+        display: isGridDisplayed ? 'block' : 'none',
+        height: itemLayoutViewed ? `${panelFullHeight}px` : 'unset',
+        overflow: itemLayoutViewed ? 'hidden' : 'unset',
+      }}
+    >
       {groupDefinition.title !== undefined && (
         <GridTitle
           panelGroupId={panelGroupId}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixing some issue with panel full size:
- when you are sharing a panel in full size and the panel group is collapsed by default, the panel is collapsed => now it is opened
- when you are scrolling and expand a panel to full size, the panel height could be too high

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
