### PR TITLE
[BUGFIX] Fix explorer failing to load query params when explorer is not set

### DIFF
--- a/ui/explore/src/components/ExploreManager/ExplorerManagerProvider.tsx
+++ b/ui/explore/src/components/ExploreManager/ExplorerManagerProvider.tsx
@@ -46,10 +46,10 @@ interface ExplorerManagerProviderProps {
 
 function initExplorerStates(initialState?: ExplorerManagerInitialState): ExplorerState[] {
   const result: ExplorerState[] = [];
-  if (initialState?.explorer !== undefined) {
-    result[initialState.explorer] = {
-      tab: initialState.tab ?? 0,
-      queries: initialState.queries ?? [],
+  if (initialState?.explorer || initialState?.tab || initialState?.queries) {
+    result[initialState?.explorer ?? 0] = {
+      tab: initialState?.tab ?? 0,
+      queries: initialState?.queries ?? [],
     };
   }
   return result;


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
When explorer is not set in query params, it will use the default one by default (tab: 0).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
