### PR TITLE
[BUGFIX] fix React warning when using TraceQL Editor

### DIFF
--- a/ui/tempo-plugin/src/plugins/tempo-trace-query/DashboardTempoTraceQueryEditor.tsx
+++ b/ui/tempo-plugin/src/plugins/tempo-trace-query/DashboardTempoTraceQueryEditor.tsx
@@ -45,7 +45,6 @@ export function DashboardTempoTraceQueryEditor(props: DashboardTempoTraceQueryEd
         />
       </FormControl>
       <TraceQLEditor
-        completeConfig={{ remote: { url: datasourceURL } }}
         value={query}
         onChange={handleQueryChange}
         onBlur={handleQueryBlur}


### PR DESCRIPTION
# Description

Fixes the following React warning:
```
Warning: React does not recognize the `completeConfig` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `completeconfig` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

The completeConfig is required for the PromQLExtension, however for TraceQL no such extension exists at the moment.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
