### PR TITLE
[BUGFIX] replace unstable JSON.stringify() with custom string in <PluginKindSelect>

### DIFF
--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
@@ -83,7 +83,7 @@ const OPTION_VALUE_DELIMITER = '_____';
 
 /**
  * Given a PluginEditorSelection,
- * returns a string value like `{kind}_____{type}` that can be used as a Select input value.
+ * returns a string value like `{type}_____{kind}` that can be used as a Select input value.
  * @param selector
  */
 function selectionToOptionValue(selector: PluginEditorSelection): string {
@@ -91,7 +91,7 @@ function selectionToOptionValue(selector: PluginEditorSelection): string {
 }
 
 /**
- * Given an option value name like `{kind}_____{type}`,
+ * Given an option value name like `{type}_____{kind}`,
  * returns a PluginEditorSelection to be used by the query data model.
  * @param optionValue
  */

--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
@@ -13,7 +13,7 @@
 
 import { MenuItem, TextField, TextFieldProps } from '@mui/material';
 import { forwardRef, useCallback } from 'react';
-import { PluginType } from '../../model';
+import { PluginMetadata, PluginType } from '../../model';
 import { useListPluginMetadata } from '../../runtime';
 import { PluginEditorSelection } from '../PluginEditor';
 
@@ -35,18 +35,18 @@ export const PluginKindSelect = forwardRef((props: PluginKindSelectProps, ref) =
   const { data, isLoading } = useListPluginMetadata(pluginTypes);
 
   // Pass an empty value while options are still loading so MUI doesn't complain about us using an "out of range" value
-  const value = propValue && isLoading ? '' : JSON.stringify(propValue);
+  const value = !propValue || isLoading ? '' : selectionToOptionValue(propValue);
 
   const handleChange = (event: { target: { value: string } }) => {
-    onChange?.(JSON.parse(event.target.value));
+    onChange?.(optionValueToSelection(event.target.value));
   };
 
   const renderValue = useCallback(
     (selected: unknown) => {
-      const selectedValue = JSON.parse(selected as string);
-      if (!selectedValue.kind) {
+      if (selected === '') {
         return '';
       }
+      const selectedValue = optionValueToSelection(selected as string);
       return data?.find((v) => v.pluginType === selectedValue.type && v.kind === selectedValue.kind)?.display.name;
     },
     [data]
@@ -68,7 +68,7 @@ export const PluginKindSelect = forwardRef((props: PluginKindSelectProps, ref) =
         <MenuItem
           data-testid="option"
           key={metadata.pluginType + metadata.kind}
-          value={JSON.stringify({ type: metadata.pluginType, kind: metadata.kind })}
+          value={selectionToOptionValue({ type: metadata.pluginType, kind: metadata.kind })}
         >
           {metadata.display.name}
         </MenuItem>
@@ -77,3 +77,33 @@ export const PluginKindSelect = forwardRef((props: PluginKindSelectProps, ref) =
   );
 });
 PluginKindSelect.displayName = 'PluginKindSelect';
+
+// Delimiter used to stringify/parse option values
+const OPTION_VALUE_DELIMITER = '_____';
+
+/**
+ * Given a PluginEditorSelection,
+ * returns a string value like `{kind}_____{type}` that can be used as a Select input value.
+ * @param selector
+ */
+function selectionToOptionValue(selector: PluginEditorSelection): string {
+  return [selector.kind, selector.type].join(OPTION_VALUE_DELIMITER);
+}
+
+/**
+ * Given an option value name like `{kind}_____{type}`,
+ * returns a PluginEditorSelection to be used by the query data model.
+ * @param optionValue
+ */
+function optionValueToSelection(optionValue: string): PluginEditorSelection {
+  const words = optionValue.split(OPTION_VALUE_DELIMITER);
+  const kind = words[0];
+  const type = words[1] as PluginType|undefined;
+  if (kind === undefined || type === undefined) {
+    throw new Error('Invalid optionValue string');
+  }
+  return {
+    kind,
+    type,
+  };
+}

--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
@@ -87,7 +87,7 @@ const OPTION_VALUE_DELIMITER = '_____';
  * @param selector
  */
 function selectionToOptionValue(selector: PluginEditorSelection): string {
-  return [selector.kind, selector.type].join(OPTION_VALUE_DELIMITER);
+  return [selector.type, selector.kind].join(OPTION_VALUE_DELIMITER);
 }
 
 /**
@@ -97,13 +97,13 @@ function selectionToOptionValue(selector: PluginEditorSelection): string {
  */
 function optionValueToSelection(optionValue: string): PluginEditorSelection {
   const words = optionValue.split(OPTION_VALUE_DELIMITER);
-  const kind = words[0];
-  const type = words[1] as PluginType | undefined;
-  if (kind === undefined || type === undefined) {
+  const type = words[0] as PluginType | undefined;
+  const kind = words[1];
+  if (type === undefined || kind === undefined) {
     throw new Error('Invalid optionValue string');
   }
   return {
-    kind,
     type,
+    kind,
   };
 }

--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
@@ -13,7 +13,7 @@
 
 import { MenuItem, TextField, TextFieldProps } from '@mui/material';
 import { forwardRef, useCallback } from 'react';
-import { PluginMetadata, PluginType } from '../../model';
+import { PluginType } from '../../model';
 import { useListPluginMetadata } from '../../runtime';
 import { PluginEditorSelection } from '../PluginEditor';
 
@@ -98,7 +98,7 @@ function selectionToOptionValue(selector: PluginEditorSelection): string {
 function optionValueToSelection(optionValue: string): PluginEditorSelection {
   const words = optionValue.split(OPTION_VALUE_DELIMITER);
   const kind = words[0];
-  const type = words[1] as PluginType|undefined;
+  const type = words[1] as PluginType | undefined;
   if (kind === undefined || type === undefined) {
     throw new Error('Invalid optionValue string');
   }


### PR DESCRIPTION
# Description

I'm seeing this error on the Explore page in the JS console on Firefox:
```
MUI: You have provided an out-of-range value `{"kind":"PrometheusTimeSeriesQuery","type":"TimeSeriesQuery"}` for the select component.
Consider providing a value that matches one of the available options or ''.
The available values are `{"type":"TimeSeriesQuery","kind":"PrometheusTimeSeriesQuery"}`.
```

This is because the order of keys in Objects is undefined, therefore the output of JSON.stringify() is not guaranteed to be the same for two objects with the same keys and values.

I followed the same approach as for DatasourceSelect: https://github.com/perses/perses/blob/cf87ec4b6bd474f2d58c01709a36ff37bcde9512/ui/plugin-system/src/components/DatasourceSelect.tsx#L139-L167

# Screenshots

no visible UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
