### PR TITLE
[DOC] fix wrong type in API doc

### DIFF
--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -23,11 +23,14 @@ See the next section to get details about the `<dashboard_specification>`.
   # `display` allows to provide a rich name and a description for your dashboard.
   [ display: <Display specification> ]
 
+  # `datasources` is a map where the key is the reference of the datasource. The value is the actual datasource definition.
+  # A datasource can be referenced by the different panels and/or variables.
   datasources:
     [ <string>: <Datasource specification> ]
 
   # `variables` is the list of dashboard variables. A variable can be referenced by the different panels and/or by other variables.
-  [ variables: <Variable specification> ]
+  variables:
+    - [ <Variable specification> ]
 
   # `panels` is a map where the key is the reference of the panel. The value is the actual panel definition that describes
   # the kind of chart this panel is using. A panel can only hold one chart.


### PR DESCRIPTION
# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).