### PR TITLE
[BUGFIX] DaC SDKs: fix generated label matchers not compatible with multi-select variables

### DIFF
--- a/cue/dac-utils/prometheus/filter/filter.cue
+++ b/cue/dac-utils/prometheus/filter/filter.cue
@@ -24,8 +24,8 @@ import (
 filter: strings.Join(
 	[for var in #input {
 		[// switch
-			if var.#kind == "TextVariable" {"\(var.#name)=\"$\(var.#name)\""},
-			if var.#kind == "ListVariable" if var.#pluginKind != labelNamesVar.kind {"\(var.#name)=\"$\(var.#name)\""},
+			if var.#kind == "TextVariable" {"\(var.#name)=~\"$\(var.#name)\""},
+			if var.#kind == "ListVariable" if var.#pluginKind != labelNamesVar.kind {"\(var.#name)=~\"$\(var.#name)\""},
 		][0]
 	}],
 	",",

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	filter    = "stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\""
+	filter    = "stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\""
 	memMetric = "container_memory_rss"
 	cpuMetric = "container_cpu_usage_seconds"
 	grouping  = "by (container)"
@@ -88,22 +88,22 @@ func TestDashboardBuilder(t *testing.T) {
 			),
 		),
 		AddVariable("namespace", listVar.List(
-			promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
+			promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
 			listVar.AllowMultiple(true),
 		)),
 		AddVariable("namespaceLabels", listVar.List(
 			labelNamesVar.PrometheusLabelNames(
-				labelNamesVar.Matchers("kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"}"),
+				labelNamesVar.Matchers("kube_namespace_labels{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\"}"),
 				labelNamesVar.Datasource("promDemo"),
 			),
 		)),
 		AddVariable("pod", listVar.List(
-			promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
+			promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
 			listVar.AllowMultiple(true),
 			listVar.AllowAllValue(true),
 		)),
 		AddVariable("container", listVar.List(
-			promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
+			promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
 			listVar.AllowMultiple(true),
 			listVar.AllowAllValue(true),
 			listVar.CustomAllValue(".*"),
@@ -112,7 +112,7 @@ func TestDashboardBuilder(t *testing.T) {
 			listVar.Description("simply the list of labels for the considered metric"),
 			listVar.Hidden(true),
 			labelNamesVar.PrometheusLabelNames(
-				labelNamesVar.Matchers("kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"}"),
+				labelNamesVar.Matchers("kube_pod_container_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\"}"),
 				labelNamesVar.Datasource("promDemo"),
 			),
 			listVar.SortingBy("alphabetical-ci-desc"),
@@ -188,7 +188,7 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 				),
 			),
 			variablegroup.AddVariable("namespace", listVar.List(
-				promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
+				promqlVar.PrometheusPromQL("group by (namespace) (kube_namespace_labels{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\"})", promqlVar.LabelName("namespace"), promqlVar.Datasource("promDemo")),
 				listVar.AllowMultiple(true),
 			)),
 			variablegroup.AddIgnoredVariable("namespaceLabels", listVar.List(
@@ -198,12 +198,12 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 				),
 			)),
 			variablegroup.AddVariable("pod", listVar.List(
-				promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
+				promqlVar.PrometheusPromQL("group by (pod) (kube_pod_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\"})", promqlVar.LabelName("pod"), promqlVar.Datasource("promDemo")),
 				listVar.AllowMultiple(true),
 				listVar.AllowAllValue(true),
 			)),
 			variablegroup.AddVariable("container", listVar.List(
-				promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
+				promqlVar.PrometheusPromQL("group by (container) (kube_pod_container_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\"})", promqlVar.LabelName("container"), promqlVar.Datasource("promDemo")),
 				listVar.AllowMultiple(true),
 				listVar.AllowAllValue(true),
 				listVar.CustomAllValue(".*"),

--- a/go-sdk/prometheus/variable/label-names/label-names.go
+++ b/go-sdk/prometheus/variable/label-names/label-names.go
@@ -68,7 +68,7 @@ type Builder struct {
 func (b *Builder) ApplyFilters() error {
 	var filters []string
 	for _, variables := range b.Filters {
-		filters = append(filters, fmt.Sprintf("%s=\"$%s\"", variables.Metadata.Name, variables.Metadata.Name))
+		filters = append(filters, fmt.Sprintf("%s=~\"$%s\"", variables.Metadata.Name, variables.Metadata.Name))
 	}
 
 	for index, matcher := range b.PluginSpec.Matchers {

--- a/go-sdk/prometheus/variable/label-values/label-values.go
+++ b/go-sdk/prometheus/variable/label-values/label-values.go
@@ -72,7 +72,7 @@ type Builder struct {
 func (b *Builder) ApplyFilters() error {
 	var filters []string
 	for _, variables := range b.Filters {
-		filters = append(filters, fmt.Sprintf("%s=\"$%s\"", variables.Metadata.Name, variables.Metadata.Name))
+		filters = append(filters, fmt.Sprintf("%s=~\"$%s\"", variables.Metadata.Name, variables.Metadata.Name))
 	}
 
 	for index, matcher := range b.PluginSpec.Matchers {

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -71,7 +71,7 @@
                 "kind": "PrometheusDatasource",
                 "name": "promDemo"
               },
-              "expr": "group by (namespace) (kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\"})",
+              "expr": "group by (namespace) (kube_namespace_labels{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\"})",
               "labelName": "namespace"
             }
           }
@@ -91,7 +91,7 @@
                 "name": "promDemo"
               },
               "matchers": [
-                "kube_namespace_labels{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"}"
+                "kube_namespace_labels{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\"}"
               ]
             }
           }
@@ -110,7 +110,7 @@
                 "kind": "PrometheusDatasource",
                 "name": "promDemo"
               },
-              "expr": "group by (pod) (kube_pod_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})",
+              "expr": "group by (pod) (kube_pod_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\"})",
               "labelName": "pod"
             }
           }
@@ -130,7 +130,7 @@
                 "kind": "PrometheusDatasource",
                 "name": "promDemo"
               },
-              "expr": "group by (container) (kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\"})",
+              "expr": "group by (container) (kube_pod_container_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\"})",
               "labelName": "container"
             }
           }
@@ -155,7 +155,7 @@
                 "name": "promDemo"
               },
               "matchers": [
-                "kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"}"
+                "kube_pod_container_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\"}"
               ]
             }
           }
@@ -180,7 +180,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "max  (container_memory_rss{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "max  (container_memory_rss{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\"})"
                   }
                 }
               }
@@ -205,7 +205,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "sum  (container_cpu_usage_seconds{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "sum  (container_cpu_usage_seconds{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\"})"
                   }
                 }
               }
@@ -230,7 +230,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "sum by (container) (container_cpu_usage_seconds{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "sum by (container) (container_cpu_usage_seconds{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\"})"
                   }
                 }
               }
@@ -255,7 +255,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "max by (container) (container_memory_rss{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"})"
+                    "query": "max by (container) (container_memory_rss{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\"})"
                   }
                 }
               }

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -62,7 +62,7 @@ import (
 		},
 		promQLVarBuilder & {
 			#name:           "pod"
-			#query:          "group by (pod) (kube_pod_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\"})"
+			#query:          "group by (pod) (kube_pod_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\"})"
 			#allowAllValue:  true
 			#allowMultiple:  true
 			#datasourceName: "promDemo"
@@ -81,7 +81,7 @@ import (
 				description: "simply the list of labels for the considered metric"
 				hidden:      true
 			}
-			#query:          "kube_pod_container_info{stack=\"$stack\",prometheus=\"$prometheus\",prometheus_namespace=\"$prometheus_namespace\",namespace=\"$namespace\",pod=\"$pod\",container=\"$container\"}"
+			#query:          "kube_pod_container_info{stack=~\"$stack\",prometheus=~\"$prometheus\",prometheus_namespace=~\"$prometheus_namespace\",namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\"}"
 			#datasourceName: "promDemo"
 			#sort:           "alphabetical-ci-desc"
 		},


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

We might think of adding a parameter later to give the user the ability to tune the equality operator, but for now putting `=~` ensures that it will work in all cases.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
