### PR TITLE
[BUGFIX] DaC Go SDK: Fix unwanted intermediary field append in YAML output

### DIFF
--- a/docs/dac/go/README.md
+++ b/docs/dac/go/README.md
@@ -1,4 +1,4 @@
-# CUE SDK for Dashboard-as-Code
+# Go SDK for Dashboard-as-Code
 
 > [!NOTE]
 > To get started with Dashboard-as-Code in Perses, have a look at the [DaC user guide](../../user-guides/dashboard-as-code.md) first.

--- a/go-sdk/datasource/datasource.go
+++ b/go-sdk/datasource/datasource.go
@@ -40,5 +40,5 @@ func New(name string, options ...Option) (Builder, error) {
 }
 
 type Builder struct {
-	v1.Datasource
+	v1.Datasource `json:",inline" yaml:",inline"`
 }

--- a/go-sdk/http/proxy.go
+++ b/go-sdk/http/proxy.go
@@ -20,7 +20,7 @@ import (
 type Option func(proxy *Builder) error
 
 type Builder struct {
-	http.Proxy
+	http.Proxy `json:",inline" yaml:",inline"`
 }
 
 func New(url string, options ...Option) (Builder, error) {

--- a/go-sdk/link/link.go
+++ b/go-sdk/link/link.go
@@ -36,5 +36,5 @@ func New(url string, options ...Option) (Builder, error) {
 }
 
 type Builder struct {
-	v1.Link
+	v1.Link `json:",inline" yaml:",inline"`
 }

--- a/go-sdk/panel-group/panel-group.go
+++ b/go-sdk/panel-group/panel-group.go
@@ -26,7 +26,7 @@ type PanelGroup struct {
 type Option func(plugin *Builder) error
 
 type Builder struct {
-	PanelGroup
+	PanelGroup `json:",inline" yaml:",inline"`
 }
 
 func New(title string, options ...Option) (Builder, error) {

--- a/go-sdk/panel/bar/bar.go
+++ b/go-sdk/panel/bar/bar.go
@@ -42,7 +42,7 @@ type PluginSpec struct {
 type Option func(plugin *Builder) error
 
 type Builder struct {
-	PluginSpec
+	PluginSpec `json:",inline" yaml:",inline"`
 }
 
 func New(options ...Option) (Builder, error) {

--- a/go-sdk/panel/gauge/gauge.go
+++ b/go-sdk/panel/gauge/gauge.go
@@ -28,7 +28,7 @@ type PluginSpec struct {
 type Option func(plugin *Builder) error
 
 type Builder struct {
-	PluginSpec
+	PluginSpec `json:",inline" yaml:",inline"`
 }
 
 func New(options ...Option) (Builder, error) {

--- a/go-sdk/panel/markdown/markdown.go
+++ b/go-sdk/panel/markdown/markdown.go
@@ -22,7 +22,7 @@ type PluginSpec struct {
 type Option func(plugin *Builder) error
 
 type Builder struct {
-	PluginSpec
+	PluginSpec `json:",inline" yaml:",inline"`
 }
 
 func New(text string, options ...Option) (Builder, error) {

--- a/go-sdk/panel/panel.go
+++ b/go-sdk/panel/panel.go
@@ -39,5 +39,5 @@ func New(title string, options ...Option) (Builder, error) {
 }
 
 type Builder struct {
-	v1.Panel
+	v1.Panel `json:",inline" yaml:",inline"`
 }

--- a/go-sdk/panel/stat/stat.go
+++ b/go-sdk/panel/stat/stat.go
@@ -34,7 +34,7 @@ type PluginSpec struct {
 type Option func(plugin *Builder) error
 
 type Builder struct {
-	PluginSpec
+	PluginSpec `json:",inline" yaml:",inline"`
 }
 
 func New(options ...Option) (Builder, error) {

--- a/go-sdk/panel/time-series/time-series.go
+++ b/go-sdk/panel/time-series/time-series.go
@@ -126,7 +126,7 @@ func New(options ...Option) (Builder, error) {
 }
 
 type Builder struct {
-	PluginSpec
+	PluginSpec `json:",inline" yaml:",inline"`
 }
 
 func Chart(options ...Option) panel.Option {

--- a/go-sdk/prometheus/datasource/datasource.go
+++ b/go-sdk/prometheus/datasource/datasource.go
@@ -87,7 +87,7 @@ func NewPlugin(options ...Option) (Builder, error) {
 }
 
 type Builder struct {
-	PluginSpec
+	PluginSpec `json:",inline" yaml:",inline"`
 }
 
 func Prometheus(options ...Option) datasource.Option {

--- a/go-sdk/prometheus/query/query.go
+++ b/go-sdk/prometheus/query/query.go
@@ -48,7 +48,7 @@ func NewPlugin(query string, options ...Option) (Builder, error) {
 }
 
 type Builder struct {
-	PluginSpec
+	PluginSpec `json:",inline" yaml:",inline"`
 }
 
 func PromQL(expr string, options ...Option) query.Option {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

YAML marshalling was causing such unexpected `pluginspec` field to appear in the final output:
```yaml
queries:
  - kind: TimeSeriesQuery
    spec:
      plugin:
          kind: PrometheusTimeSeriesQuery
          spec:
              pluginspec: # invalid !
                  query: sum by (app_name) (jvm_info_total{stack="$stack"})
```

To solve this I added an explicit `inline` marshall instruction for this field + same for any similar cases in other builders, just in case.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).