### PR TITLE
[ENHANCEMENT] use relative bubble size in scatter plot, remove zoom bar

### DIFF
--- a/ui/panels-plugin/src/plugins/scatterplot/Scatterplot.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/Scatterplot.tsx
@@ -50,6 +50,7 @@ export function Scatterplot(props: ScatterplotProps) {
   const eChartOptions: EChartsCoreOption = {
     dataset: options.dataset,
     series: options.series,
+    dataZoom: options.dataZoom,
     grid: {
       bottom: 40,
       top: 50,
@@ -89,17 +90,6 @@ export function Scatterplot(props: ScatterplotProps) {
         ].join('');
       },
     },
-    dataZoom: [
-      {
-        type: 'inside',
-        start: 0,
-        end: 20,
-      },
-      {
-        start: 0,
-        end: 20,
-      },
-    ],
     legend: {
       show: true,
       type: 'scroll',


### PR DESCRIPTION
# Description

Currently the bubble size is calculated as `10 * numSpans`, which makes the plot unreadable for traces with 100 or more spans. As we cannot predict the maximum number of spans in a trace, let's compute the maximum and show the size relative to the calculated maximum.

Additionally, I've removed the zoom bar at the bottom, imho the panel should show all results by default, and the time range selector at the top ("last 1 hour", etc.) should be used to select the time range.

# Screenshots

Old:
![grafik](https://github.com/perses/perses/assets/538011/0b7a655b-e73c-4377-a3bb-fea3c4fa49c1)

New:
![grafik](https://github.com/perses/perses/assets/538011/b2cc85c4-c137-4cfb-a1a4-78ca7d953ba2)

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
