### PR TITLE
[ENHANCEMENT] Dashboards lists - improve metadataOnly safety

### DIFF
--- a/ui/app/src/model/dashboard-client.ts
+++ b/ui/app/src/model/dashboard-client.ts
@@ -57,8 +57,8 @@ export function useDashboard(project: string, name: string) {
  * Used to get dashboards in the API.
  * Will automatically be refreshed when cache is invalidated
  */
-export function useDashboardList(project?: string, metadataOnly?: boolean) {
-  return useQuery<DashboardResource[], Error>([resource, project], () => {
+export function useDashboardList(project?: string, metadataOnly: boolean = false) {
+  return useQuery<DashboardResource[], Error>([resource, project, metadataOnly], () => {
     return getDashboards(project, metadataOnly);
   });
 }
@@ -180,7 +180,7 @@ export function getDashboard(project: string, name: string) {
   });
 }
 
-export function getDashboards(project?: string, metadataOnly?: boolean) {
+export function getDashboards(project?: string, metadataOnly: boolean = false) {
   const queryParams = new URLSearchParams();
   if (metadataOnly) {
     queryParams.set('metadata_only', 'true');


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

As discussed with @Nexucis, I'd find it safer to take the metadataonly into account in the querykey for the dashboards list. 
Even if we actually never use it with false when project is not set and never use it with true when project is set. This situation is either miracle, or genius, but not future proof IMHO 

Extra care ping @Gladorme I know that you struggled with that so I'd prefer to test it with you first. I did in the first place: ``queryKey=[resource, {project, metadataOnly}]`` but I think this would break the query invalidation in the project client.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
