### PR TITLE
[BUGFIX] Fix dashboard delete + fix dialog width with long name

### DIFF
--- a/ui/app/src/components/DashboardList/DashboardList.tsx
+++ b/ui/app/src/components/DashboardList/DashboardList.tsx
@@ -240,7 +240,7 @@ export function DashboardList(props: DashboardListProperties) {
             <DeleteResourceDialog
               open={isDeleteDashboardDialogStateOpened}
               resource={targetedDashboard}
-              onSubmit={() => handleDashboardDelete(targetedDashboard)}
+              onSubmit={(v) => handleDashboardDelete(v).then(() => setDeleteDashboardDialogStateOpened(false))}
               onClose={() => setDeleteDashboardDialogStateOpened(false)}
             />
           </>

--- a/ui/components/src/Dialog/Dialog.tsx
+++ b/ui/components/src/Dialog/Dialog.tsx
@@ -38,17 +38,14 @@ export interface DialogHeaderProps extends DialogTitleProps {
 
 export type DialogButtonProps = Omit<ButtonProps, 'variant' | 'color' | 'type'>;
 
-export interface DialogContentProps extends MuiDialogContentProps {
-  /**
-   * @default 500
-   */
-  width?: number;
-}
+export type DialogContentProps = MuiDialogContentProps;
 
 const Header = ({ children, onClose, ...props }: DialogHeaderProps) => {
   return (
     <>
-      <DialogTitle {...props}>{children}</DialogTitle>
+      <DialogTitle style={{ textOverflow: 'ellipsis', overflow: 'hidden' }} {...props}>
+        {children}
+      </DialogTitle>
       {onClose && (
         <IconButton aria-label="Close" onClick={onClose} sx={dialogCloseIconButtonStyle}>
           <CloseIcon />
@@ -58,8 +55,8 @@ const Header = ({ children, onClose, ...props }: DialogHeaderProps) => {
   );
 };
 
-const Content = ({ children, width = 500, sx, ...props }: DialogContentProps) => (
-  <DialogContent dividers {...props} sx={combineSx({ width: `${width}px` }, sx)}>
+const Content = ({ children, sx, ...props }: DialogContentProps) => (
+  <DialogContent dividers {...props} sx={combineSx({ minWidth: `500px`, textWrap: 'balance' }, sx)}>
     {children}
   </DialogContent>
 );


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixing dialogs width + fix dashboard delete dialog

# Screenshots

<!-- If there are UI changes -->
BEFORE:
![image](https://github.com/perses/perses/assets/5657041/9f8db156-7924-4a25-8bb0-943cc431ff88)


AFTER:
![image](https://github.com/perses/perses/assets/5657041/08d22823-9c1c-460f-9585-e964f54db953)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
