### PR TITLE
[BREAKINGCHANGE] Rename various config to use the same wording

### DIFF
--- a/dev/config-mariadb.yaml
+++ b/dev/config-mariadb.yaml
@@ -36,7 +36,7 @@ schemas:
   interval: "5m"
 
 ephemeral_dashboard:
-  activate: true
+  enable: true
   cleanup_interval: 1h
 
 frontend:

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -34,7 +34,7 @@ schemas:
   interval: "5m"
 
 ephemeral_dashboard:
-  activate: true
+  enable: true
   cleanup_interval: 1h
 
 frontend:

--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -462,7 +462,7 @@ folders:
 
 ```yaml
 # When true user will be able to use the ephemeral dashboard at project level
-[ activate: <bool> | default = false ]
+[ enable: <bool> | default = false ]
 
 # The interval at which to trigger the cleanup of ephemeral dashboards, based on their TTLs.
 [ cleanup_interval: <duration> | default = 1d ]
@@ -472,7 +472,7 @@ folders:
 
 ```yaml
 # When it is true, Perses won't serve the frontend anymore.
-[ deactivate: <bool> | default = false ]
+[ disable: <bool> | default = false ]
 
 # A list of dashboards you would like to display in the UI home page
 important_dashboards:

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -64,7 +64,7 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 		return nil, nil, fmt.Errorf("unable to instantiate the tasks for hot reload of migration schema: %w", err)
 	}
 	// enable cleanup of the ephemeral dashboards once their ttl is reached
-	if conf.EphemeralDashboard.Activate {
+	if conf.EphemeralDashboard.Enable {
 		ephemeralDashboardsCleaner, err := dashboard.NewEphemeralDashboardCleaner(persistenceManager.GetEphemeralDashboard())
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to instantiate the task for cleaning ephemeral dashboards: %w", err)
@@ -96,7 +96,7 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 		}).
 		Middleware(middleware.HandleError()).
 		Middleware(middleware.CheckProject(serviceManager.GetProject()))
-	if !conf.Frontend.Deactivate {
+	if !conf.Frontend.Disable {
 		runner.HTTPServerBuilder().APIRegistration(persesFrontend)
 	}
 	return runner, persistenceManager, nil

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -59,7 +59,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 	apiV1Endpoints := []route.Endpoint{
 		dashboard.NewEndpoint(serviceManager.GetDashboard(), serviceManager.GetRBAC(), readonly, caseSensitive),
 		datasource.NewEndpoint(serviceManager.GetDatasource(), serviceManager.GetRBAC(), readonly, caseSensitive),
-		ephemeraldashboard.NewEndpoint(serviceManager.GetEphemeralDashboard(), serviceManager.GetRBAC(), readonly, caseSensitive, cfg.EphemeralDashboard.Activate),
+		ephemeraldashboard.NewEndpoint(serviceManager.GetEphemeralDashboard(), serviceManager.GetRBAC(), readonly, caseSensitive, cfg.EphemeralDashboard.Enable),
 		folder.NewEndpoint(serviceManager.GetFolder(), serviceManager.GetRBAC(), readonly, caseSensitive),
 		globaldatasource.NewEndpoint(serviceManager.GetGlobalDatasource(), serviceManager.GetRBAC(), readonly, caseSensitive),
 		globalrole.NewEndpoint(serviceManager.GetGlobalRole(), serviceManager.GetRBAC(), readonly, caseSensitive),

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -54,7 +54,7 @@ func DefaultConfig() apiConfig.Config {
 			EncryptionKey: secret.Hidden(hex.EncodeToString([]byte("=tW$56zytgB&3jN2E%7-+qrGZE?v6LCc"))),
 		},
 		EphemeralDashboard: apiConfig.EphemeralDashboard{
-			Activate: true,
+			Enable: true,
 		},
 		Schemas: apiConfig.Schemas{
 			PanelsPath:      filepath.Join(projectPath, "cue", apiConfig.DefaultPanelsPath),

--- a/internal/api/impl/v1/ephemeraldashboard/endpoint.go
+++ b/internal/api/impl/v1/ephemeraldashboard/endpoint.go
@@ -28,21 +28,21 @@ import (
 )
 
 type endpoint struct {
-	toolbox     toolbox.Toolbox[*v1.EphemeralDashboard, *ephemeraldashboard.Query]
-	readonly    bool
-	isActivated bool
+	toolbox   toolbox.Toolbox[*v1.EphemeralDashboard, *ephemeraldashboard.Query]
+	readonly  bool
+	isEnabled bool
 }
 
-func NewEndpoint(service ephemeraldashboard.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool, isActivated bool) route.Endpoint {
+func NewEndpoint(service ephemeraldashboard.Service, rbacService rbac.RBAC, readonly bool, caseSensitive bool, isEnabled bool) route.Endpoint {
 	return &endpoint{
-		toolbox:     toolbox.New[*v1.EphemeralDashboard, *v1.EphemeralDashboard, *ephemeraldashboard.Query](service, rbacService, v1.KindEphemeralDashboard, caseSensitive),
-		readonly:    readonly,
-		isActivated: isActivated,
+		toolbox:   toolbox.New[*v1.EphemeralDashboard, *v1.EphemeralDashboard, *ephemeraldashboard.Query](service, rbacService, v1.KindEphemeralDashboard, caseSensitive),
+		readonly:  readonly,
+		isEnabled: isEnabled,
 	}
 }
 
 func (e *endpoint) CollectRoutes(g *route.Group) {
-	if !e.isActivated {
+	if !e.isEnabled {
 		return
 	}
 	group := g.Group(fmt.Sprintf("/%s", utils.PathEphemeralDashboard))

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -26,12 +26,14 @@ const (
 )
 
 type EphemeralDashboard struct {
-	Activate        bool           `json:"activate" yaml:"activate"`
+	// When true user will be able to use the ephemeral dashboard at project level.
+	Enable bool `json:"enable" yaml:"enable"`
+	// The interval at which to trigger the cleanup of ephemeral dashboards, based on their TTLs.
 	CleanupInterval model.Duration `json:"cleanup_interval" yaml:"cleanup_interval"`
 }
 
 func (e *EphemeralDashboard) Verify() error {
-	if e.Activate && e.CleanupInterval <= 0 {
+	if e.Enable && e.CleanupInterval <= 0 {
 		e.CleanupInterval = model.Duration(defaultEphemeralDashboardsCleanupInterval)
 	}
 	return nil
@@ -67,7 +69,7 @@ func (c *Config) Verify() error {
 		logrus.Warn("'ephemeral_dashboards_cleanup_interval' is deprecated. Please use the config 'ephemeral_dashboard' instead")
 		// This is to avoid an immediate breaking change. This code will be removed for the version v0.49.0
 		c.EphemeralDashboard = EphemeralDashboard{
-			Activate:        true,
+			Enable:          true,
 			CleanupInterval: c.EphemeralDashboardsCleanupInterval,
 		}
 	}

--- a/pkg/model/api/config/config_test.go
+++ b/pkg/model/api/config/config_test.go
@@ -61,11 +61,11 @@ func TestJSONMarshalConfig(t *testing.T) {
   "schemas": {},
   "provisioning": {},
   "ephemeral_dashboard": {
-    "activate": false,
+    "enable": false,
     "cleanup_interval": "0s"
   },
   "frontend": {
-    "deactivate": false,
+    "disable": false,
     "explorer": {
       "enable": false
     }
@@ -114,11 +114,11 @@ func TestJSONMarshalConfig(t *testing.T) {
     "interval": "1h"
   },
   "ephemeral_dashboard": {
-    "activate": false,
+    "enable": false,
     "cleanup_interval": "0s"
   },
   "frontend": {
-    "deactivate": false,
+    "disable": false,
     "explorer": {
       "enable": false
     }
@@ -419,7 +419,7 @@ ephemeral_dashboards_cleanup_interval: "2h"
 				},
 				EphemeralDashboardsCleanupInterval: model.Duration(2 * time.Hour),
 				EphemeralDashboard: EphemeralDashboard{
-					Activate:        true,
+					Enable:          true,
 					CleanupInterval: model.Duration(2 * time.Hour),
 				},
 			},

--- a/pkg/model/api/config/frontend.go
+++ b/pkg/model/api/config/frontend.go
@@ -19,7 +19,7 @@ type Explorer struct {
 
 type Frontend struct {
 	// When it is true, Perses won't serve the frontend anymore, and any other config set here will be ignored
-	Deactivate bool `json:"deactivate" yaml:"deactivate"`
+	Disable bool `json:"disable" yaml:"disable"`
 	// Explorer is activating the different kind of explorer supported.
 	// Be sure you have installed an associated plugin for each explorer type.
 	Explorer Explorer `json:"explorer" yaml:"explorer"`

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -29,8 +29,8 @@ import {
 } from './model/route';
 import {
   useIsAuthEnabled,
-  useIsEphemeralDashboardActivated,
-  useIsExplorerActivated,
+  useIsEphemeralDashboardEnabled,
+  useIsExplorerEnabled,
   useIsSignUpDisable,
 } from './context/Config';
 
@@ -49,8 +49,8 @@ const EphemeralDashboardView = lazy(() => import('./views/projects/dashboards/Ep
 function Router() {
   const isAuthEnabled = useIsAuthEnabled();
   const isSignUpDisable = useIsSignUpDisable();
-  const isEphemeralDashboardActivated = useIsEphemeralDashboardActivated();
-  const isExplorerActivated = useIsExplorerActivated();
+  const isEphemeralDashboardEnabled = useIsEphemeralDashboardEnabled();
+  const isExplorerEnabled = useIsExplorerEnabled();
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
       {/* TODO: What sort of loading fallback do we want? */}
@@ -63,16 +63,16 @@ function Router() {
           <Route path={ConfigRoute} element={<ConfigView />} />
           <Route path={ImportRoute} element={<ImportView />} />
           <Route path={ProjectRoute} element={<HomeView />} />
-          {isExplorerActivated && <Route path={ExploreRoute} element={<ExploreView />} />}
+          {isExplorerEnabled && <Route path={ExploreRoute} element={<ExploreView />} />}
           <Route path={`${ProjectRoute}/:projectName`} element={<GuardedProjectRoute />}>
             <Route path="" element={<ProjectView />} />
             <Route path=":tab" element={<ProjectView />} />
             <Route path="dashboard/new" element={<CreateDashboardView />} />
             <Route path="dashboards/:dashboardName" element={<DashboardView />} />
-            {isEphemeralDashboardActivated && (
+            {isEphemeralDashboardEnabled && (
               <Route path="ephemeraldashboard/new" element={<CreateEphemeralDashboardView />} />
             )}
-            {isEphemeralDashboardActivated && (
+            {isEphemeralDashboardEnabled && (
               <Route path="ephemeraldashboards/:ephemeralDashboardName" element={<EphemeralDashboardView />} />
             )}
           </Route>

--- a/ui/app/src/components/Header.tsx
+++ b/ui/app/src/components/Header.tsx
@@ -44,7 +44,7 @@ import { useProjectList } from '../model/project-client';
 import { useDarkMode } from '../context/DarkMode';
 import { useIsLaptopSize, useIsMobileSize } from '../utils/browser-size';
 import { AdminRoute, ConfigRoute, ExploreRoute } from '../model/route';
-import { useIsAuthEnabled, useIsExplorerActivated } from '../context/Config';
+import { useIsAuthEnabled, useIsExplorerEnabled } from '../context/Config';
 import { useAuthToken } from '../model/auth-client';
 import { GlobalProject, useHasPartialPermission } from '../context/Authorization';
 import WhitePersesLogo from './logo/WhitePersesLogo';
@@ -291,7 +291,7 @@ export default function Header(): JSX.Element {
   const isLaptopSize = useIsLaptopSize();
   const isMobileSize = useIsMobileSize();
   const isAuthEnabled = useIsAuthEnabled();
-  const isExplorerActivated = useIsExplorerActivated();
+  const IsExplorerEnabled = useIsExplorerEnabled();
 
   const hasPartialPermission = useHasPartialPermission(['read'], GlobalProject, [
     'GlobalDatasource',
@@ -360,7 +360,7 @@ export default function Header(): JSX.Element {
               >
                 <Cog sx={{ marginRight: 0.5 }} /> Config
               </Button>
-              {isExplorerActivated && (
+              {IsExplorerEnabled && (
                 <Button
                   aria-label="Explore"
                   aria-controls="menu-config-appbar"

--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -44,14 +44,14 @@ export function useConfigContext(): ConfigContextType {
   return ctx;
 }
 
-export function useIsExplorerActivated(): boolean {
+export function useIsExplorerEnabled(): boolean {
   const { config } = useConfigContext();
   return config.frontend.explorer.enable;
 }
 
-export function useIsEphemeralDashboardActivated(): boolean {
+export function useIsEphemeralDashboardEnabled(): boolean {
   const { config } = useConfigContext();
-  return config.ephemeral_dashboard.activate;
+  return config.ephemeral_dashboard.enable;
 }
 
 export function useIsReadonly(): boolean {

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -141,7 +141,7 @@ export interface FrontendConfig {
 }
 
 export interface EphemeralDashboardConfig {
-  activate: boolean;
+  enable: boolean;
   cleanup_interval: string;
 }
 

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -37,7 +37,7 @@ import { VariableDrawer } from '../../components/variable/VariableDrawer';
 import { DatasourceDrawer } from '../../components/datasource/DatasourceDrawer';
 import { useCreateDatasourceMutation } from '../../model/datasource-client';
 import { useCreateVariableMutation } from '../../model/variable-client';
-import { useIsAuthEnabled, useIsEphemeralDashboardActivated, useIsReadonly } from '../../context/Config';
+import { useIsAuthEnabled, useIsEphemeralDashboardEnabled, useIsReadonly } from '../../context/Config';
 import { MenuTab, MenuTabs } from '../../components/tabs';
 import { useCreateRoleBindingMutation } from '../../model/rolebinding-client';
 import { useCreateRoleMutation, useRoleList } from '../../model/role-client';
@@ -418,7 +418,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
 
   const navigate = useNavigate();
   const isMobileSize = useIsMobileSize();
-  const isEphemeralDashboardActivated = useIsEphemeralDashboardActivated();
+  const isEphemeralDashboardEnabled = useIsEphemeralDashboardEnabled();
   const { data } = useEphemeralDashboardList(projectName);
   const hasEphemeralDashboards = (data ?? []).length > 0;
 
@@ -522,7 +522,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps) {
       <TabPanel value={value} index={dashboardsTabIndex} sx={{ marginTop: isMobileSize ? 1 : 2 }}>
         <ProjectDashboards projectName={projectName} id="main-dashboard-list" />
       </TabPanel>
-      {isEphemeralDashboardActivated && hasEphemeralDashboards && (
+      {isEphemeralDashboardEnabled && hasEphemeralDashboards && (
         <TabPanel value={value} index={ephemeralDashboardsTabIndex} sx={{ marginTop: isMobileSize ? 1 : 2 }}>
           <ProjectEphemeralDashboards projectName={projectName} id="project-ephemeral-dashboard-list" />
         </TabPanel>


### PR DESCRIPTION
I am renaming all `deactivate/activate` by `disable/enable` key.

The config impacted shouldn't be an issue for end user as for most case, the default config is used