### PR TITLE
[IGNORE] Fix React warning in TimeSeriesTable

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/SeriesName.tsx
@@ -62,6 +62,7 @@ function FormatedSeriesName({ labels }: { labels: Labels }) {
         {!first && ', '}
         <Typography
           display="inline"
+          component="span"
           sx={{
             '&:hover': {
               cursor: 'pointer',


### PR DESCRIPTION
# Description
Fixes the following warning created by nesting `<Typography>` (which default to `<p>` elements):
```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
```

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
