### PR TITLE
[ENHANCEMENT] Schemas load: avoid breaking too early in case of error + add monitoring for it

### DIFF
--- a/cmd/perses/main.go
+++ b/cmd/perses/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/perses/perses/internal/api/core"
 	"github.com/perses/perses/internal/api/impl/v1/view"
+	"github.com/perses/perses/internal/api/schemas"
 	"github.com/perses/perses/pkg/model/api/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -41,6 +42,7 @@ func registerMetrics(register prometheus.Registerer) {
 	register.MustRegister(collectors.NewGoCollector())
 	register.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	view.RegisterMetrics(register)
+	schemas.RegisterMetrics(register)
 }
 
 func main() {

--- a/internal/api/migrate/migrate.go
+++ b/internal/api/migrate/migrate.go
@@ -184,7 +184,7 @@ func (m *mig) Migrate(userInput []byte) (*v1.Dashboard, error) {
 }
 
 func (m *mig) init() error {
-	err := schemas.RunLoaders(m.GetLoaders(), "migration", "full")
+	err := schemas.RunLoaders(m.GetLoaders(), schemas.Migration, schemas.Full)
 	if err != nil {
 		return err
 	}

--- a/internal/api/migrate/migrate.go
+++ b/internal/api/migrate/migrate.go
@@ -184,10 +184,9 @@ func (m *mig) Migrate(userInput []byte) (*v1.Dashboard, error) {
 }
 
 func (m *mig) init() error {
-	for _, l := range m.loaders {
-		if err := l.Load(); err != nil {
-			return err
-		}
+	err := schemas.RunLoaders(m.GetLoaders(), "migration", "full")
+	if err != nil {
+		return err
 	}
 	m.BuildMigrationSchemaString()
 	return nil

--- a/internal/api/schemas/loader.go
+++ b/internal/api/schemas/loader.go
@@ -192,7 +192,7 @@ func (w *Watcher) Execute(ctx context.Context, cancel context.CancelFunc) error 
 						}
 					}
 				}
-				MonitorLoadAttempts(totalSuccessfulLoads, totalFailedLoads, "model", "change")
+				MonitorLoadAttempts(totalSuccessfulLoads, totalFailedLoads, Model, Change)
 				if w.LoaderCallback != nil {
 					w.LoaderCallback()
 				}
@@ -231,7 +231,7 @@ func (r *Reloader) Execute(ctx context.Context, _ context.CancelFunc) error {
 		logrus.Infof("canceled %s", r.String())
 		break
 	default:
-		err := RunLoaders(r.Loaders, "model", "full")
+		err := RunLoaders(r.Loaders, Model, Full)
 		if err != nil {
 			return err
 		}

--- a/internal/api/schemas/loader.go
+++ b/internal/api/schemas/loader.go
@@ -16,6 +16,7 @@ package schemas
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +31,7 @@ import (
 )
 
 type Loader interface {
-	Load() error
+	Load() (int, int, error)
 	GetSchemaPath() string
 }
 
@@ -47,10 +48,11 @@ func (c *cueDefs) GetSchemaPath() string {
 }
 
 // Load the list of available plugins as CUE schemas
-func (c *cueDefs) Load() error {
-	files, err := os.ReadDir(c.schemasPath)
+func (c *cueDefs) Load() (successfulLoadsCount, failedLoadsCount int, err error) {
+	var files []fs.DirEntry
+	files, err = os.ReadDir(c.schemasPath)
 	if err != nil {
-		return err
+		return
 	}
 	// The Cue context is keeping track of loaded instances.
 	// Which means this context must be recreated every time Load is called to avoid a memory leak.
@@ -60,12 +62,10 @@ func (c *cueDefs) Load() error {
 	newSchemas := make(map[string]cue.Value)
 
 	// process each schema plugin to convert it into a CUE Value
-	isError := false
-	i := 0
-	for i < len(files) && !isError {
-		file := files[i]
+	for _, file := range files {
 		if !file.IsDir() {
-			logrus.Warningf("Plugin %s will not be loaded: it is not a folder", file.Name())
+			failedLoadsCount++
+			logrus.Errorf("Plugin %s will not be loaded: it is not a folder", file.Name())
 			continue
 		}
 
@@ -77,7 +77,7 @@ func (c *cueDefs) Load() error {
 		// we strongly assume that only 1 buildInstance should be returned, otherwise we skip it
 		// TODO can probably be improved
 		if len(buildInstances) != 1 {
-			isError = true
+			failedLoadsCount++
 			logrus.Errorf("Plugin %s will not be loaded: The number of build instances is != 1", schemaPath)
 			continue
 		}
@@ -85,7 +85,7 @@ func (c *cueDefs) Load() error {
 
 		// check for errors on the instances (these are typically parsing errors)
 		if buildInstance.Err != nil {
-			isError = true
+			failedLoadsCount++
 			logrus.WithError(buildInstance.Err).Errorf("Plugin %s will not be loaded: file loading error", schemaPath)
 			continue
 		}
@@ -93,7 +93,7 @@ func (c *cueDefs) Load() error {
 		// build Value from the Instance
 		schema := cueContext.BuildInstance(buildInstance)
 		if schema.Err() != nil {
-			isError = true
+			failedLoadsCount++
 			logrus.WithError(schema.Err()).Errorf("Plugin %s will not be loaded: build error", schemaPath)
 			continue
 		}
@@ -102,7 +102,7 @@ func (c *cueDefs) Load() error {
 			// unify with the base def to complete defaults + check if the plugin fulfils the base requirements
 			schema = c.baseDef.Unify(schema)
 			if schema.Err() != nil {
-				isError = true
+				failedLoadsCount++
 				logrus.WithError(schema.Err()).Errorf("Plugin %s will not be loaded: it doesn't meet the expected format for its plugin type", schemaPath)
 				continue
 			}
@@ -110,21 +110,27 @@ func (c *cueDefs) Load() error {
 		// check if another schema for the same Kind was already registered
 		kind, _ := schema.LookupPath(cue.ParsePath(kindPath)).String()
 		if _, ok := newSchemas[kind]; ok {
-			logrus.Warningf("Plugin %s will not be loaded: conflicting schema already exists for kind %s", schemaPath, kind)
+			failedLoadsCount++
+			logrus.Errorf("Plugin %s will not be loaded: conflicting schema already exists for kind %s", schemaPath, kind)
 			continue
 		}
 
 		newSchemas[kind] = schema
+		successfulLoadsCount++
 		logrus.Debugf("%s plugin loaded from file %s", kind, schemaPath)
-		i++
 	}
 
-	if !isError {
-		// in case there is no error, we are saving the schemas loaded and the cue context that will be used during the plugin validation phase
-		c.schemas.Store(&newSchemas)
-		c.context.Store(cueContext)
+	// If at this stage we got only errors (= no schemas registered), we consider that there is
+	// a general problem with the system, therefore we preserve the previous state of schemas.
+	if failedLoadsCount > 0 && len(newSchemas) == 0 {
+		logrus.Error("no schemas were loaded, keeping previous state")
+		return
 	}
-	return nil
+
+	c.schemas.Store(&newSchemas)
+	c.context.Store(cueContext)
+
+	return
 }
 
 func NewHotReloaders(loaders []Loader) (async.SimpleTask, async.SimpleTask, error) {
@@ -174,13 +180,19 @@ func (w *Watcher) Execute(ctx context.Context, cancel context.CancelFunc) error 
 			// NB room for improvement: the event fsnotify.Remove could be used to actually remove the CUE schema from the map
 			logrus.Tracef("%s event on %s", event.Op, event.Name)
 			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) || event.Has(fsnotify.Remove) {
+				totalSuccessfulLoads := 0
+				totalFailedLoads := 0
 				for _, l := range w.Loaders {
 					if strings.HasPrefix(event.Name, filepath.FromSlash(l.GetSchemaPath())) {
-						if err := l.Load(); err != nil {
+						successfulLoads, failedLoads, err := l.Load()
+						totalSuccessfulLoads += successfulLoads
+						totalFailedLoads += failedLoads
+						if err != nil {
 							logrus.WithError(err).Errorf("unable to load the schemas in %s", l.GetSchemaPath())
 						}
 					}
 				}
+				MonitorLoadAttempts(totalSuccessfulLoads, totalFailedLoads, "model", "change")
 				if w.LoaderCallback != nil {
 					w.LoaderCallback()
 				}
@@ -213,15 +225,15 @@ func (r *Reloader) String() string {
 }
 
 func (r *Reloader) Execute(ctx context.Context, _ context.CancelFunc) error {
+
 	select {
 	case <-ctx.Done():
 		logrus.Infof("canceled %s", r.String())
 		break
 	default:
-		for _, l := range r.Loaders {
-			if err := l.Load(); err != nil {
-				logrus.WithError(err).Errorf("unable to load a schema")
-			}
+		err := RunLoaders(r.Loaders, "model", "full")
+		if err != nil {
+			return err
 		}
 		if r.LoaderCallback != nil {
 			r.LoaderCallback()

--- a/internal/api/schemas/monitoring.go
+++ b/internal/api/schemas/monitoring.go
@@ -23,6 +23,22 @@ const (
 	errorStatus   = "error"
 )
 
+// Enums for label values related to schemas load monitoring:
+
+type LoadType string
+
+const (
+	Change LoadType = "change" // tracks the case of dynamic changes detected by file watch
+	Full   LoadType = "full"   // tracks the case of full schemas load (at start & cron task)
+)
+
+type SchemaType string
+
+const (
+	Migration SchemaType = "migration" // tracks the migration schemas only
+	Model     SchemaType = "model"     // tracks the "real" plugin schema to be used for backend validation.
+)
+
 var labelNames = []string{"status", "schema", "load"}
 
 // A gauge that keeps track of the amount of (failed & successful) attempts to load plugin schemas.
@@ -36,7 +52,7 @@ func RegisterMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(loadAttempts)
 }
 
-func MonitorLoadAttempts(successCount, errorCount int, schema, load string) {
-	loadAttempts.WithLabelValues(successStatus, schema, load).Set(float64(successCount))
-	loadAttempts.WithLabelValues(errorStatus, schema, load).Set(float64(errorCount))
+func MonitorLoadAttempts(successCount, errorCount int, schema SchemaType, load LoadType) {
+	loadAttempts.WithLabelValues(successStatus, string(schema), string(load)).Set(float64(successCount))
+	loadAttempts.WithLabelValues(errorStatus, string(schema), string(load)).Set(float64(errorCount))
 }

--- a/internal/api/schemas/monitoring.go
+++ b/internal/api/schemas/monitoring.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemas
+
+import (
+	"github.com/perses/perses/internal/api/utils"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	successStatus = "success"
+	errorStatus   = "error"
+)
+
+var labelNames = []string{"status", "schema", "load"}
+
+// A gauge that keeps track of the amount of (failed & successful) attempts to load plugin schemas.
+var loadAttempts = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: utils.MetricNamespace,
+	Name:      "plugin_schemas_load_attempts",
+	Help:      "Amount of attempts to load plugin schemas",
+}, labelNames)
+
+func RegisterMetrics(reg prometheus.Registerer) {
+	reg.MustRegister(loadAttempts)
+}
+
+func MonitorLoadAttempts(successCount, errorCount int, schema, load string) {
+	loadAttempts.WithLabelValues(successStatus, schema, load).Set(float64(successCount))
+	loadAttempts.WithLabelValues(errorStatus, schema, load).Set(float64(errorCount))
+}

--- a/internal/api/schemas/schemas.go
+++ b/internal/api/schemas/schemas.go
@@ -269,10 +269,20 @@ func (s *sch) validatePlugin(plugin common.Plugin, modelKind string, modelName s
 }
 
 func (s *sch) init() error {
-	for _, l := range s.loaders {
-		if err := l.Load(); err != nil {
+	return RunLoaders(s.loaders, "model", "full")
+}
+
+func RunLoaders(loaders []Loader, schemaType, loadType string) error {
+	totalSuccessfulLoads := 0
+	totalFailedLoads := 0
+	for _, l := range loaders {
+		successfulLoads, failedLoads, err := l.Load()
+		totalSuccessfulLoads += successfulLoads
+		totalFailedLoads += failedLoads
+		if err != nil {
 			return err
 		}
 	}
+	MonitorLoadAttempts(totalSuccessfulLoads, totalFailedLoads, schemaType, loadType)
 	return nil
 }

--- a/internal/api/schemas/schemas.go
+++ b/internal/api/schemas/schemas.go
@@ -269,10 +269,10 @@ func (s *sch) validatePlugin(plugin common.Plugin, modelKind string, modelName s
 }
 
 func (s *sch) init() error {
-	return RunLoaders(s.loaders, "model", "full")
+	return RunLoaders(s.loaders, Model, Full)
 }
 
-func RunLoaders(loaders []Loader, schemaType, loadType string) error {
+func RunLoaders(loaders []Loader, schemaType SchemaType, loadType LoadType) error {
 	totalSuccessfulLoads := 0
 	totalFailedLoads := 0
 	for _, l := range loaders {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Currently if we have e.g 10 panels plugin installed and the 4th one in alphabetical order is faulty/corrupted, the 6 following plugins wont be loaded even though they'd be valid, which is too bad..
This PR aims to change that + take advantage of changing this part of the code to add instrumentation of schemas load.

New metrics overview:
```
# HELP perses_plugin_schemas_load_attempts Amount of attempts to load plugin schemas
# TYPE perses_plugin_schemas_load_attempts gauge
perses_plugin_schemas_load_attempts{load="change",schema="model",status="error"} 0
perses_plugin_schemas_load_attempts{load="change",schema="model",status="success"} 4
perses_plugin_schemas_load_attempts{load="full",schema="migration",status="error"} 0
perses_plugin_schemas_load_attempts{load="full",schema="migration",status="success"} 9
perses_plugin_schemas_load_attempts{load="full",schema="model",status="error"} 0
perses_plugin_schemas_load_attempts{load="full",schema="model",status="success"} 15
```
Just in case, because I assume it may not be fully self-explanatory:
- `load="change"` tracks the case of dynamic changes detected by file watch
- `load="full"` tracks the case of full schemas load (= at start + cron task)
- `schema="migration"` tracks the migration schemas only (= `migrate.cue` files). _Btw the error timeserie is always 0 here because we have no relevant error case to detect for these in the current state._
- `schema="model"` tracks the "real" plugin schema to be used for backend validation.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
