### PR TITLE
[ENHANCEMENT] Adjust empty dashboard message width

### DIFF
--- a/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.tsx
+++ b/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.tsx
@@ -62,7 +62,7 @@ const DEFAULT_DESCRIPTION = {
 };
 
 // Constants from specifics in designs to make the default messaging look good.
-const CONTAINER_WIDTH = '450px';
+const CONTAINER_WIDTH = '500px';
 const PRIMARY_CONTENT_WIDTH = '289px';
 
 const COMMON_BUTTON_PROPS = {


### PR DESCRIPTION
# Description

👋 I wanted a quick PR so I could remember how to get local dev working. I thought that "panel!" in the empty dashboard message looked awkward how it wrapped to another line. Increasing the width fixes it and the text still wraps nicely on mobile automatically.

# Screenshots

https://happo.io/a/1009/p/1488/compare/3f92d334f907c3d2042ed5d458a4005640053100/9ee4f333f69d913c4bc049689aa00782bf1e0d76

## Before
<img width="475" alt="Screenshot 2024-06-16 at 12 05 16 AM" src="https://github.com/perses/perses/assets/9369625/c682d517-3455-42b0-8aa6-7eea8d3aae3a">

## After

No longer wraps to another line on desktop
<img width="472" alt="image" src="https://github.com/perses/perses/assets/9369625/23c34ea5-1c40-413f-8362-a12def7a7cf8">

Still looks good on mobile
<img width="572" alt="image" src="https://github.com/perses/perses/assets/9369625/baa6433d-3c41-4ea4-8047-083094c57509">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
