### PR TITLE
[ENHANCEMENT] Reduce default line width, more subtle hover state

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/time-series-chart-model.ts
@@ -89,7 +89,7 @@ export const Y_AXIS_CONFIG = {
   max: { label: 'Max' },
 };
 
-export const DEFAULT_LINE_WIDTH = 1.5;
+export const DEFAULT_LINE_WIDTH = 1.25;
 export const DEFAULT_AREA_OPACITY = 0;
 
 // How much larger datapoint symbols are than line width, also applied in VisualOptionsEditor.

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -175,7 +175,7 @@ export function getTimeSeries(
     symbolSize: pointRadius,
     lineStyle: {
       width: lineWidth,
-      opacity: 0.8,
+      opacity: 0.95,
     },
     areaStyle: {
       opacity: visual.areaOpacity ?? DEFAULT_AREA_OPACITY,
@@ -185,7 +185,7 @@ export function getTimeSeries(
       focus: 'series',
       disabled: visual.areaOpacity !== undefined && visual.areaOpacity > 0, // prevents flicker when moving cursor between shaded regions
       lineStyle: {
-        width: lineWidth + 1.5,
+        width: lineWidth + 1,
         opacity: 1,
       },
     },


### PR DESCRIPTION
# Description

Default line width seems large so I adjusted and tweaked the hover state (since reducing the line width made a higher opacity necessary).

# Screenshots

https://happo.io/a/1009/p/1488/compare/3f92d334f907c3d2042ed5d458a4005640053100/7dc3820d9d773be4f172187f6790037fa4553178

## Before

<img width="868" alt="image" src="https://github.com/perses/perses/assets/9369625/5a498fa3-6d41-4090-87cd-fe914fbbec0f">

## After

<img width="866" alt="image" src="https://github.com/perses/perses/assets/9369625/628d3dbe-9989-4014-a211-8624e27d981f">


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
