### PR TITLE
[BUGFIX] Remove semicolon under queries

### DIFF
--- a/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
@@ -80,7 +80,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
 
   return (
     <QueryCountProvider queryCount={(panelDefinition.spec.queries ?? []).length}>
-      <OptionsEditorTabs key={tabs.length} tabs={tabs} />;
+      <OptionsEditorTabs key={tabs.length} tabs={tabs} />
     </QueryCountProvider>
   );
 }


### PR DESCRIPTION
# Description

Noticed a visible semicolon under the queries when editing a panel.

# Screenshots
## Before
<img width="453" alt="image" src="https://github.com/perses/perses/assets/9369625/00f2ce0b-0d96-45c5-8584-a55512f08655">

## After
<img width="667" alt="image" src="https://github.com/perses/perses/assets/9369625/f0b88704-9852-4a5b-a870-6fe1ead28f1c">

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
