### PR TITLE
[BREAKINGCHANGE] Reword "Template Variable" as "Variable" everywhere

### DIFF
--- a/docs/user-guides/embedding-panels.md
+++ b/docs/user-guides/embedding-panels.md
@@ -38,7 +38,7 @@ import {
 import { TimeSeriesChart } from '@perses-dev/panels-plugin';
 import { ThemeProvider } from "@mui/material";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { DatasourceStoreProvider, TemplateVariableProvider } from "@perses-dev/dashboards";
+import { DatasourceStoreProvider, VariableProvider } from "@perses-dev/dashboards";
 import prometheusResource from '@perses-dev/prometheus-plugin/plugin.json';
 import panelsResource from '@perses-dev/panels-plugin/plugin.json';
 import { DashboardResource, GlobalDatasource, ProjectDatasource } from '@perses-dev/core';
@@ -118,7 +118,7 @@ function App() {
           >
             <QueryClientProvider client={queryClient}>
               <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
-                <TemplateVariableProvider>
+                <VariableProvider>
                   <DatasourceStoreProvider dashboardResource={fakeDashboard} datasourceApi={fakeDatasourceApi}>
                     <DataQueriesProvider
                       definitions={[
@@ -142,7 +142,7 @@ function App() {
                       />
                     </DataQueriesProvider>
                   </DatasourceStoreProvider>
-                </TemplateVariableProvider>
+                </VariableProvider>
               </TimeRangeProvider>
             </QueryClientProvider>
           </PluginRegistry>
@@ -168,7 +168,7 @@ You should see a perses panel going to your browser
 - `DataQueriesProvider`: Provide the queries' definition, with the query type, the value. This is to be inside the
   chart below. For each query, one line will be displayed in the chart.
 - `DatasourceStoreProvider`: Provide the datasources. In other terms, the place from which the data will be collected.
-- `TemplateVariableProvider`: Provide the variables that can be used inside the chart.
+- `VariableProvider`: Provide the variables that can be used inside the chart.
   It will allow you to reference any variable into the queries thanks to the `${myVar}` syntax.
   Available variables will be either the builtin variables or the local/external variables that you can pass to the provider.
 - `TimeRangeProvider`: Provide `time range` of the query, but also the `refresh interval` (time between each query

--- a/internal/api/validate/validate.go
+++ b/internal/api/validate/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -28,9 +28,9 @@ import (
 
 // We want to keep only variables that are not only a number.
 // A number that represents a variable is not meaningful, and so we don't want to consider it.
-// It's also a way to avoid a collision in terms of variable template syntax.
-// For example in PromQL, in the function `label_replace`, it used the syntax $1, $2, for the placeholder.
-var variableTemplateNameRegexp = regexp.MustCompile(`^\w*?[^0-9]\w*$`)
+// It's also a way to avoid a collision in terms of variable syntax.
+// For example in PromQL, the function `label_replace` uses the syntax "$1", "$2" for the placeholders.
+var variableNameRegexp = regexp.MustCompile(`^\w*?[^0-9]\w*$`)
 
 func DashboardSpec(spec modelV1.DashboardSpec, sch schemas.Schemas) error {
 	if _, err := utils.BuildVariableOrder(spec.Variables, nil, nil); err != nil {
@@ -87,7 +87,7 @@ func validateUnicityOfDefaultDTS[T modelV1.DatasourceInterface](entity T, list [
 }
 
 func validateVariableName(variable string) error {
-	valid := variableTemplateNameRegexp.MatchString(variable)
+	valid := variableNameRegexp.MatchString(variable)
 	if !valid {
 		return fmt.Errorf("variable name '%s' is not valid", variable)
 	}

--- a/ui/README.md
+++ b/ui/README.md
@@ -66,7 +66,7 @@ These packages are published to npm with the `@perses-dev` namespace.
 - [`panels-plugin`](./panels-plugin): a plugin module with `Panel` plugins for
   the core visualizations supported by Perses.
 - [`plugin-system`](./plugin-system): All the type definitions and components that power our plugins, also includes the
-  definitions for the runtime available to plugins (e.g. the current time range state, the current template variable
+  definitions for the runtime available to plugins (e.g. the current time range state, the current variable
   state).
 - [`prometheus-plugin`](./prometheus-plugin): a plugin module with multiple
   plugin types (e.g. `Variable`, `ChartQuery`, etc.) for supporting Prometheus

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,7 +13,7 @@
 
 import { Variable, VariableDefinition, getVariableProject } from '@perses-dev/core';
 import React, { useEffect, useMemo, useState } from 'react';
-import { DatasourceStoreProvider, TemplateVariableProviderWithQueryParams } from '@perses-dev/dashboards';
+import { DatasourceStoreProvider, VariableProviderWithQueryParams } from '@perses-dev/dashboards';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import {
   PluginRegistry,
@@ -70,7 +70,7 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
         <PluginRegistry pluginLoader={bundledPluginLoader}>
           <DatasourceStoreProvider datasourceApi={datasourceApi} projectName={projectName}>
             <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>
-              <TemplateVariableProviderWithQueryParams initialVariableDefinitions={[]}>
+              <VariableProviderWithQueryParams initialVariableDefinitions={[]}>
                 <VariableEditorForm
                   initialVariableDefinition={variableDef}
                   initialAction={action}
@@ -80,7 +80,7 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
                   onClose={onClose}
                   onDelete={onDelete ? () => setDeleteVariableDialogStateOpened(true) : undefined}
                 />
-              </TemplateVariableProviderWithQueryParams>
+              </VariableProviderWithQueryParams>
             </TimeRangeProviderWithQueryParams>
           </DatasourceStoreProvider>
         </PluginRegistry>

--- a/ui/dashboards/src/components/AddPanelButton/AddPanelButton.stories.tsx
+++ b/ui/dashboards/src/components/AddPanelButton/AddPanelButton.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,18 +15,11 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { AddPanelButton } from '@perses-dev/dashboards';
 import { WithPluginRegistry, WithTimeRange } from '@perses-dev/plugin-system/src/stories/shared-utils';
 import { WithQueryClient, WithQueryParams } from '@perses-dev/storybook';
-import { WithTemplateVariables, WithDashboard } from '../../stories/decorators';
+import { WithVariables, WithDashboard } from '../../stories/decorators';
 
 const meta: Meta<typeof AddPanelButton> = {
   component: AddPanelButton,
-  decorators: [
-    WithTemplateVariables,
-    WithTimeRange,
-    WithDashboard,
-    WithPluginRegistry,
-    WithQueryClient,
-    WithQueryParams,
-  ],
+  decorators: [WithVariables, WithTimeRange, WithDashboard, WithPluginRegistry, WithQueryClient, WithQueryParams],
 };
 
 export default meta;

--- a/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
+++ b/ui/dashboards/src/components/Dashboard/Dashboard.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { Dashboard, TemplateVariableList } from '@perses-dev/dashboards';
+import { Dashboard, VariableList } from '@perses-dev/dashboards';
 import { action } from '@storybook/addon-actions';
 import { Button, Stack } from '@mui/material';
 import { DashboardResource } from '@perses-dev/core';
@@ -24,13 +24,13 @@ import {
 } from '@perses-dev/internal-utils';
 import { mockQueryRangeRequests, waitForStableCanvas, WithQueryClient, WithQueryParams } from '@perses-dev/storybook';
 import { WithPluginRegistry, WithTimeRange } from '@perses-dev/plugin-system/src/stories/shared-utils';
-import { WithDashboard, WithDatasourceStore, WithTemplateVariables } from '../../stories/decorators';
+import { WithDashboard, WithDatasourceStore, WithVariables } from '../../stories/decorators';
 
 const meta: Meta<typeof Dashboard> = {
   component: Dashboard,
   decorators: [
     WithDashboard,
-    WithTemplateVariables,
+    WithVariables,
     WithTimeRange,
     WithDatasourceStore,
     WithPluginRegistry,
@@ -225,7 +225,7 @@ function formatProviderParameters(dashboardState: DashboardResource) {
         dashboardResource: dashboardState,
       },
     },
-    withTemplateVariables: {
+    withVariables: {
       props: {
         initialVariableDefinitions: dashboardState.spec.variables,
       },
@@ -249,7 +249,7 @@ export const ListVariableWithDefaultAll: Story = {
   render: (args) => {
     return (
       <Stack spacing={1}>
-        <TemplateVariableList />
+        <VariableList />
         <Dashboard {...args} />
       </Stack>
     );

--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,7 +26,7 @@ import {
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
 import { TimeRangeControls } from '@perses-dev/plugin-system';
-import { TemplateVariableList } from '../Variables';
+import { VariableList } from '../Variables';
 
 interface DashboardStickyToolbarProps {
   initialVariableIsSticky?: boolean;
@@ -82,7 +82,7 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps) {
             }}
             gap={1}
           >
-            <TemplateVariableList />
+            <VariableList />
             {props.initialVariableIsSticky && (
               <IconButton style={{ width: 'fit-content', height: 'fit-content' }} onClick={() => setIsPin(!isPin)}>
                 {isPin ? <PinOutline /> : <PinOffOutline />}

--- a/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.stories.tsx
+++ b/ui/dashboards/src/components/EmptyDashboard/EmptyDashboard.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,18 +18,11 @@ import { action } from '@storybook/addon-actions';
 import ViewDashboardVariantOutline from 'mdi-material-ui/ViewDashboardVariantOutline';
 import { WithPluginRegistry, WithTimeRange } from '@perses-dev/plugin-system/src/stories/shared-utils';
 import { WithQueryClient, WithQueryParams } from '@perses-dev/storybook';
-import { WithTemplateVariables, WithDashboard, EMPTY_DASHBOARD_RESOURCE } from '../../stories/decorators';
+import { WithVariables, WithDashboard, EMPTY_DASHBOARD_RESOURCE } from '../../stories/decorators';
 
 const meta: Meta<typeof EmptyDashboard> = {
   component: EmptyDashboard,
-  decorators: [
-    WithTemplateVariables,
-    WithTimeRange,
-    WithDashboard,
-    WithPluginRegistry,
-    WithQueryClient,
-    WithQueryParams,
-  ],
+  decorators: [WithVariables, WithTimeRange, WithDashboard, WithPluginRegistry, WithQueryClient, WithQueryParams],
 };
 
 export default meta;

--- a/ui/dashboards/src/components/Panel/Panel.stories.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,7 +18,7 @@ import { Panel } from '@perses-dev/dashboards';
 import { PanelDefinition } from '@perses-dev/core';
 import { WithPluginRegistry, WithTimeRange, WithDataQueries } from '@perses-dev/plugin-system/src/stories/shared-utils';
 import { WithQueryClient, WithQueryParams } from '@perses-dev/storybook';
-import { WithTemplateVariables, WithDatasourceStore } from '../../stories/decorators';
+import { WithVariables, WithDatasourceStore } from '../../stories/decorators';
 
 const panelDefinition: PanelDefinition = {
   kind: 'Panel',
@@ -48,7 +48,7 @@ const meta: Meta<typeof Panel> = {
   component: Panel,
   decorators: [
     WithDataQueries,
-    WithTemplateVariables,
+    WithVariables,
     WithTimeRange,
     WithDatasourceStore,
     WithPluginRegistry,

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import userEvent from '@testing-library/user-event';
 import { PanelDefinition } from '@perses-dev/core';
 import { TimeRangeProvider } from '@perses-dev/plugin-system';
 import { renderWithContext } from '../../test';
-import { TemplateVariableProvider } from '../../context';
+import { VariableProvider } from '../../context';
 import { Panel, PanelProps } from './Panel';
 describe('Panel', () => {
   const createTestPanel = (): PanelDefinition => ({
@@ -53,7 +53,7 @@ describe('Panel', () => {
 
     renderWithContext(
       <TimeRangeProvider timeRange={{ pastDuration: '1h' }}>
-        <TemplateVariableProvider
+        <VariableProvider
           initialVariableDefinitions={[
             {
               kind: 'TextVariable',
@@ -65,7 +65,7 @@ describe('Panel', () => {
           ]}
         >
           <Panel definition={definition} editHandlers={editHandlers} panelOptions={panelOptions} />
-        </TemplateVariableProvider>
+        </VariableProvider>
       </TimeRangeProvider>
     );
   };

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 import { TimeRangeProvider } from '@perses-dev/plugin-system';
-import { DashboardProvider, TemplateVariableProvider } from '../../context';
+import { DashboardProvider, VariableProvider } from '../../context';
 import { createDashboardProviderSpy, getTestDashboard, renderWithContext } from '../../test';
 import { PanelGroupDialog } from './PanelGroupDialog';
 describe('Add Panel Group', () => {
@@ -25,10 +25,10 @@ describe('Add Panel Group', () => {
     renderWithContext(
       <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
         <TimeRangeProvider timeRange={{ pastDuration: '1h' }}>
-          <TemplateVariableProvider>
+          <VariableProvider>
             <DashboardProviderSpy />
             <PanelGroupDialog />
-          </TemplateVariableProvider>
+          </VariableProvider>
         </TimeRangeProvider>
       </DashboardProvider>
     );

--- a/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import { Checkbox, FormGroup, FormControlLabel, Typography } from '@mui/material
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { isRelativeTimeRange, SAVE_DEFAULTS_DIALOG_TEXT } from '@perses-dev/core';
 import { Dialog } from '@perses-dev/components';
-import { useSaveChangesConfirmationDialog, useTemplateVariableActions } from '../../context';
+import { useSaveChangesConfirmationDialog, useVariableActions } from '../../context';
 
 export const SaveChangesConfirmationDialog = () => {
   const { saveChangesConfirmationDialog: dialog } = useSaveChangesConfirmationDialog();
@@ -25,7 +25,7 @@ export const SaveChangesConfirmationDialog = () => {
   const [saveDefaultTimeRange, setSaveDefaultTimeRange] = useState(isSavedDurationModified);
   const [saveDefaultVariables, setSaveDefaultVariables] = useState(isSavedVariableModified);
 
-  const { getSavedVariablesStatus } = useTemplateVariableActions();
+  const { getSavedVariablesStatus } = useVariableActions();
   const { modifiedVariableNames } = getSavedVariablesStatus();
 
   const isOpen = dialog !== undefined;

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import {
   useDashboard,
   useEditMode,
   useSaveChangesConfirmationDialog,
-  useTemplateVariableActions,
+  useVariableActions,
 } from '../../context';
 
 export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'> {
@@ -32,7 +32,7 @@ export interface SaveDashboardButtonProps extends Pick<ButtonProps, 'fullWidth'>
 export const SaveDashboardButton = ({ onSave, isDisabled, variant = 'contained' }: SaveDashboardButtonProps) => {
   const [isSavingDashboard, setSavingDashboard] = useState<boolean>(false);
   const { dashboard, setDashboard } = useDashboard();
-  const { getSavedVariablesStatus, setVariableDefaultValues } = useTemplateVariableActions();
+  const { getSavedVariablesStatus, setVariableDefaultValues } = useVariableActions();
   const { isSavedVariableModified } = getSavedVariablesStatus();
   const { timeRange } = useTimeRange();
   const { setEditMode } = useEditMode();

--- a/ui/dashboards/src/components/Variables/EditVariablesButton.stories.tsx
+++ b/ui/dashboards/src/components/Variables/EditVariablesButton.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,18 +15,11 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { EditVariablesButton } from '@perses-dev/dashboards';
 import { WithPluginRegistry, WithTimeRange } from '@perses-dev/plugin-system/src/stories/shared-utils';
 import { WithQueryClient, WithQueryParams } from '@perses-dev/storybook';
-import { WithTemplateVariables, WithDashboard } from '../../stories/decorators';
+import { WithVariables, WithDashboard } from '../../stories/decorators';
 
 const meta: Meta<typeof EditVariablesButton> = {
   component: EditVariablesButton,
-  decorators: [
-    WithTemplateVariables,
-    WithTimeRange,
-    WithDashboard,
-    WithPluginRegistry,
-    WithQueryClient,
-    WithQueryParams,
-  ],
+  decorators: [WithVariables, WithTimeRange, WithDashboard, WithPluginRegistry, WithQueryClient, WithQueryParams],
 };
 
 export default meta;

--- a/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
+++ b/ui/dashboards/src/components/Variables/EditVariablesButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,9 +20,9 @@ import { useBuiltinVariableDefinitions } from '@perses-dev/plugin-system';
 import { TOOLTIP_TEXT, editButtonStyle } from '../../constants';
 import {
   ExternalVariableDefinition,
-  useTemplateExternalVariableDefinitions,
-  useTemplateVariableActions,
-  useTemplateVariableDefinitions,
+  useExternalVariableDefinitions,
+  useVariableActions,
+  useVariableDefinitions,
 } from '../../context';
 import { VariableEditor } from './VariableEditor';
 
@@ -50,10 +50,10 @@ export function EditVariablesButton({
   fullWidth,
 }: EditVariablesButtonProps) {
   const [isVariableEditorOpen, setIsVariableEditorOpen] = useState(false);
-  const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
-  const externalVariableDefinitions: ExternalVariableDefinition[] = useTemplateExternalVariableDefinitions();
+  const variableDefinitions: VariableDefinition[] = useVariableDefinitions();
+  const externalVariableDefinitions: ExternalVariableDefinition[] = useExternalVariableDefinitions();
   const builtinVariableDefinitions: BuiltinVariableDefinition[] = useBuiltinVariableDefinitions();
-  const { setVariableDefinitions } = useTemplateVariableActions();
+  const { setVariableDefinitions } = useVariableActions();
 
   const openVariableEditor = () => {
     setIsVariableEditorOpen(true);

--- a/ui/dashboards/src/components/Variables/Variable.test.ts
+++ b/ui/dashboards/src/components/Variables/Variable.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,10 +24,10 @@ import {
 } from '@perses-dev/core';
 import { useListVariablePluginValues, VariableOption, VariableState } from '@perses-dev/plugin-system';
 import { UseQueryResult } from '@tanstack/react-query';
-import { useTemplateVariable, useTemplateVariableActions } from '../../context';
-import { MAX_TEMPLATE_VARIABLE_WIDTH, MIN_TEMPLATE_VARIABLE_WIDTH } from '../../constants';
+import { useVariable, useVariableActions } from '../../context';
+import { MAX_VARIABLE_WIDTH, MIN_VARIABLE_WIDTH } from '../../constants';
 
-type TemplateVariableProps = {
+type VariableProps = {
   name: VariableName;
   source?: string;
 };
@@ -44,8 +44,8 @@ function variableOptionToVariableValue(options: VariableOption | VariableOption[
   return options.value;
 }
 
-export function TemplateVariable({ name, source }: TemplateVariableProps) {
-  const ctx = useTemplateVariable(name, source);
+export function Variable({ name, source }: VariableProps) {
+  const ctx = useVariable(name, source);
   const kind = ctx.definition?.kind;
   switch (kind) {
     case 'TextVariable':
@@ -171,27 +171,27 @@ const LETTER_HSIZE = 8; // approximation
 const ARROW_OFFSET = 40; // right offset for list variables (= take into account the dropdown toggle size)
 const getWidthPx = (inputValue: string, kind: 'list' | 'text'): number => {
   const width = (inputValue.length + 1) * LETTER_HSIZE + (kind === 'list' ? ARROW_OFFSET : 0);
-  if (width < MIN_TEMPLATE_VARIABLE_WIDTH) {
-    return MIN_TEMPLATE_VARIABLE_WIDTH;
-  } else if (width > MAX_TEMPLATE_VARIABLE_WIDTH) {
-    return MAX_TEMPLATE_VARIABLE_WIDTH;
+  if (width < MIN_VARIABLE_WIDTH) {
+    return MIN_VARIABLE_WIDTH;
+  } else if (width > MAX_VARIABLE_WIDTH) {
+    return MAX_VARIABLE_WIDTH;
   } else {
     return width;
   }
 };
 
-function ListVariable({ name, source }: TemplateVariableProps) {
-  const ctx = useTemplateVariable(name, source);
+function ListVariable({ name, source }: VariableProps) {
+  const ctx = useVariable(name, source);
   const definition = ctx.definition as ListVariableDefinition;
   const variablesOptionsQuery = useListVariablePluginValues(definition);
-  const { setVariableValue, setVariableLoading, setVariableOptions } = useTemplateVariableActions();
+  const { setVariableValue, setVariableLoading, setVariableOptions } = useVariableActions();
   const { selectedOptions, value, loading, options, viewOptions } = useListVariableState(
     definition?.spec,
     ctx.state,
     variablesOptionsQuery
   );
   const [inputValue, setInputValue] = useState<string>('');
-  const [inputWidth, setInputWidth] = useState(MIN_TEMPLATE_VARIABLE_WIDTH);
+  const [inputWidth, setInputWidth] = useState(MIN_VARIABLE_WIDTH);
 
   const title = definition?.spec.display?.name ?? name;
   const allowMultiple = definition?.spec.allowMultiple === true;
@@ -265,13 +265,13 @@ function ListVariable({ name, source }: TemplateVariableProps) {
   );
 }
 
-function TextVariable({ name, source }: TemplateVariableProps) {
-  const ctx = useTemplateVariable(name, source);
+function TextVariable({ name, source }: VariableProps) {
+  const ctx = useVariable(name, source);
   const state = ctx.state;
   const definition = ctx.definition as TextVariableDefinition;
   const [tempValue, setTempValue] = useState(state?.value ?? '');
   const [inputWidth, setInputWidth] = useState(getWidthPx(tempValue as string, 'text'));
-  const { setVariableValue } = useTemplateVariableActions();
+  const { setVariableValue } = useVariableActions();
 
   useEffect(() => {
     setTempValue(state?.value ?? '');

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -47,7 +47,7 @@ import ExpandMoreIcon from 'mdi-material-ui/ChevronUp';
 import { VariableEditorForm, VariableState, VARIABLE_TYPES } from '@perses-dev/plugin-system';
 import { InfoTooltip } from '@perses-dev/components';
 import { ExternalVariableDefinition, useDiscardChangesConfirmationDialog } from '../../context';
-import { hydrateTemplateVariableStates } from '../../context/TemplateVariableProvider/hydrationUtils';
+import { hydrateVariableStates } from '../../context/VariableProvider/hydrationUtils';
 import { BuiltinVariableAccordions } from './BuiltinVariableAccordions';
 
 function getVariableLabelByKind(kind: string) {
@@ -84,7 +84,7 @@ export function VariableEditor(props: {
   const builtinVariableDefinitions = props.builtinVariableDefinitions;
   const validation = useMemo(() => getValidation(variableDefinitions), [variableDefinitions]);
   const [variableState] = useMemo(() => {
-    return [hydrateTemplateVariableStates(variableDefinitions, {}, externalVariableDefinitions)];
+    return [hydrateVariableStates(variableDefinitions, {}, externalVariableDefinitions)];
   }, [externalVariableDefinitions, variableDefinitions]);
   const currentEditingVariableDefinition = typeof variableEditIdx === 'number' && variableDefinitions[variableEditIdx];
 

--- a/ui/dashboards/src/components/Variables/VariableList.tsx
+++ b/ui/dashboards/src/components/Variables/VariableList.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,16 +15,16 @@ import { Box } from '@mui/material';
 import { VariableDefinition, VariableSpec } from '@perses-dev/core';
 import {
   ExternalVariableDefinition,
-  useTemplateExternalVariableDefinitions,
-  useTemplateVariable,
-  useTemplateVariableDefinitions,
+  useExternalVariableDefinitions,
+  useVariable,
+  useVariableDefinitions,
 } from '../../context';
-import { MAX_TEMPLATE_VARIABLE_WIDTH, MIN_TEMPLATE_VARIABLE_WIDTH } from '../../constants';
-import { TemplateVariable } from './TemplateVariable';
+import { MAX_VARIABLE_WIDTH, MIN_VARIABLE_WIDTH } from '../../constants';
+import { Variable } from './Variable';
 
-export function TemplateVariableList() {
-  const variableDefinitions: VariableDefinition[] = useTemplateVariableDefinitions();
-  const externalVariableDefinitions: ExternalVariableDefinition[] = useTemplateExternalVariableDefinitions();
+export function VariableList() {
+  const variableDefinitions: VariableDefinition[] = useVariableDefinitions();
+  const externalVariableDefinitions: ExternalVariableDefinition[] = useExternalVariableDefinitions();
 
   return (
     <>
@@ -33,18 +33,18 @@ export function TemplateVariableList() {
         .reverse() // We reverse to have the most prioritized on top
         .map((def) =>
           def.definitions.map((v) => (
-            <TemplateVariableListItem key={v.spec.name + def.source} spec={v.spec} source={def.source} />
+            <VariableListItem key={v.spec.name + def.source} spec={v.spec} source={def.source} />
           ))
         )}
       {variableDefinitions.map((v) => (
-        <TemplateVariableListItem key={v.spec.name} spec={v.spec} />
+        <VariableListItem key={v.spec.name} spec={v.spec} />
       ))}
     </>
   );
 }
 
-export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec; source?: string }) {
-  const ctx = useTemplateVariable(spec.name, source);
+export function VariableListItem({ spec, source }: { spec: VariableSpec; source?: string }) {
+  const ctx = useVariable(spec.name, source);
   if (ctx.state?.overridden) {
     return null;
   }
@@ -52,12 +52,12 @@ export function TemplateVariableListItem({ spec, source }: { spec: VariableSpec;
     <Box
       key={spec.name + source ?? ''}
       display={spec.display?.hidden ? 'none' : undefined}
-      minWidth={`${MIN_TEMPLATE_VARIABLE_WIDTH}px`}
-      maxWidth={`${MAX_TEMPLATE_VARIABLE_WIDTH}px`}
+      minWidth={`${MIN_VARIABLE_WIDTH}px`}
+      maxWidth={`${MAX_VARIABLE_WIDTH}px`}
       flexShrink={0}
-      data-testid={'template-variable-' + spec.name}
+      data-testid={'variable-' + spec.name}
     >
-      <TemplateVariable key={spec.name + source ?? ''} name={spec.name} source={source} />
+      <Variable key={spec.name + source ?? ''} name={spec.name} source={source} />
     </Box>
   );
 }

--- a/ui/dashboards/src/components/Variables/index.tsx
+++ b/ui/dashboards/src/components/Variables/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,6 +13,6 @@
 
 export * from './BuiltinVariableAccordions';
 export * from './EditVariablesButton';
-export * from './TemplateVariable';
+export * from './Variable';
 export * from './VariableEditor';
 export * from './VariableList';

--- a/ui/dashboards/src/constants/styles.ts
+++ b/ui/dashboards/src/constants/styles.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,5 +21,5 @@ export const editButtonStyle: SxProps<Theme> = {
   },
 };
 
-export const MIN_TEMPLATE_VARIABLE_WIDTH = 120;
-export const MAX_TEMPLATE_VARIABLE_WIDTH = 500;
+export const MIN_VARIABLE_WIDTH = 120;
+export const MAX_VARIABLE_WIDTH = 500;

--- a/ui/dashboards/src/context/VariableProvider/hydrationUtils.test.ts
+++ b/ui/dashboards/src/context/VariableProvider/hydrationUtils.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,9 +13,9 @@
 
 import { DEFAULT_ALL_VALUE, VariableDefinition } from '@perses-dev/core';
 import { ExternalVariableDefinition } from '@perses-dev/dashboards';
-import { hydrateTemplateVariableStates } from './hydrationUtils';
+import { hydrateVariableStates } from './hydrationUtils';
 
-describe('hydrateTemplateVariableStates', () => {
+describe('hydrateVariableStates', () => {
   test('normalizes single "all" value in an array', () => {
     const definitions: VariableDefinition[] = [
       {
@@ -38,7 +38,7 @@ describe('hydrateTemplateVariableStates', () => {
         },
       },
     ];
-    const result = hydrateTemplateVariableStates(definitions, {});
+    const result = hydrateVariableStates(definitions, {});
     expect(result?.get({ name: 'instance' })?.value).toEqual(DEFAULT_ALL_VALUE);
   });
   test('external definitions overridden and overriding', () => {
@@ -106,7 +106,7 @@ describe('hydrateTemplateVariableStates', () => {
       },
     ];
 
-    const localStateResult = hydrateTemplateVariableStates(definitions, {}, externalDefinitions);
+    const localStateResult = hydrateVariableStates(definitions, {}, externalDefinitions);
 
     // Verify hydration of local variable state
     expect(localStateResult.get({ name: 'project_var' })).toEqual({

--- a/ui/dashboards/src/context/VariableProvider/hydrationUtils.ts
+++ b/ui/dashboards/src/context/VariableProvider/hydrationUtils.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,8 +15,8 @@ import { DEFAULT_ALL_VALUE, VariableValue, VariableDefinition } from '@perses-de
 import { VariableStoreStateMap, VariableState } from '@perses-dev/plugin-system';
 import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 
-// TODO: move to TemplateVariableProvider/utils.ts
-function hydrateTemplateVariableState(variable: VariableDefinition, initialValue?: VariableValue): VariableState {
+// TODO: move to VariableProvider/utils.ts
+function hydrateVariableState(variable: VariableDefinition, initialValue?: VariableValue): VariableState {
   const varState: VariableState = {
     value: null,
     loading: false,
@@ -60,7 +60,7 @@ function hydrateTemplateVariableState(variable: VariableDefinition, initialValue
  * @param externalDefinitions external variables definitions. Static part.
  * @param initialValues values coming from query parameters
  */
-export function hydrateTemplateVariableStates(
+export function hydrateVariableStates(
   localDefinitions: VariableDefinition[],
   initialValues: Record<string, VariableValue>,
   externalDefinitions: ExternalVariableDefinition[] = []
@@ -89,7 +89,7 @@ export function hydrateTemplateVariableStates(
         state.set(
           { source, name },
           {
-            ...hydrateTemplateVariableState(v, initialValue),
+            ...hydrateVariableState(v, initialValue),
             overridden: !!overridingNames[name],
           }
         );
@@ -110,7 +110,7 @@ export function hydrateTemplateVariableStates(
     state.set(
       { name },
       {
-        ...hydrateTemplateVariableState(v, initialValue),
+        ...hydrateVariableState(v, initialValue),
         overriding: !!overriddenNames[name],
       }
     );

--- a/ui/dashboards/src/context/VariableProvider/index.ts
+++ b/ui/dashboards/src/context/VariableProvider/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,4 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './TemplateVariableProvider';
+export * from './VariableProvider';

--- a/ui/dashboards/src/context/VariableProvider/query-params.test.ts
+++ b/ui/dashboards/src/context/VariableProvider/query-params.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/dashboards/src/context/VariableProvider/query-params.ts
+++ b/ui/dashboards/src/context/VariableProvider/query-params.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/dashboards/src/context/VariableProvider/utils.test.ts
+++ b/ui/dashboards/src/context/VariableProvider/utils.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/dashboards/src/context/VariableProvider/utils.ts
+++ b/ui/dashboards/src/context/VariableProvider/utils.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/dashboards/src/context/index.ts
+++ b/ui/dashboards/src/context/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,5 +13,5 @@
 
 export * from './DashboardProvider';
 export * from './DatasourceStoreProvider';
-export * from './TemplateVariableProvider';
+export * from './VariableProvider';
 export * from './useDashboard';

--- a/ui/dashboards/src/context/useDashboard.tsx
+++ b/ui/dashboards/src/context/useDashboard.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,7 +13,7 @@
 
 import { createPanelRef, DashboardResource, EphemeralDashboardResource, GridDefinition } from '@perses-dev/core';
 import { PanelGroupDefinition, PanelGroupId, useDashboardStore } from './DashboardProvider';
-import { useTemplateVariableActions, useTemplateVariableDefinitions } from './TemplateVariableProvider';
+import { useVariableActions, useVariableDefinitions } from './VariableProvider';
 
 export function useDashboard() {
   const {
@@ -55,8 +55,8 @@ export function useDashboard() {
       ttl,
     })
   );
-  const { setVariableDefinitions } = useTemplateVariableActions();
-  const variables = useTemplateVariableDefinitions();
+  const { setVariableDefinitions } = useVariableActions();
+  const variables = useVariableDefinitions();
   const layouts = convertPanelGroupsToLayouts(panelGroups, panelGroupOrder);
 
   const dashboard =

--- a/ui/dashboards/src/stories/decorators/WithVariables.tsx
+++ b/ui/dashboards/src/stories/decorators/WithVariables.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,33 +12,31 @@
 // limitations under the License.
 
 import { StoryFn, StoryContext } from '@storybook/react';
-import { TemplateVariableProvider, TemplateVariableProviderProps } from '@perses-dev/dashboards';
+import { VariableProvider, VariableProviderProps } from '@perses-dev/dashboards';
 
 declare module '@storybook/react' {
   interface Parameters {
-    withTemplateVariables?: WithTemplateVariableParameter;
+    withVariables?: WithVariableParameter;
   }
 }
 
-export type WithTemplateVariableParameter = {
-  props: Partial<TemplateVariableProviderProps>;
+export type WithVariableParameter = {
+  props: Partial<VariableProviderProps>;
 };
 
 // Type guard because storybook types parameters as `any`
-function isWithTemplateVariableParameter(
-  parameter: unknown | WithTemplateVariableParameter
-): parameter is WithTemplateVariableParameter {
+function isWithVariableParameter(parameter: unknown | WithVariableParameter): parameter is WithVariableParameter {
   return !!parameter && typeof parameter === 'object' && 'props' in parameter;
 }
 
-export const WithTemplateVariables = (Story: StoryFn, context: StoryContext<unknown>) => {
-  const initParameter = context.parameters.withTemplateVariables;
-  const parameter = isWithTemplateVariableParameter(initParameter) ? initParameter : undefined;
+export const WithVariables = (Story: StoryFn, context: StoryContext<unknown>) => {
+  const initParameter = context.parameters.withVariables;
+  const parameter = isWithVariableParameter(initParameter) ? initParameter : undefined;
   const props = parameter?.props;
 
   return (
-    <TemplateVariableProvider {...props}>
+    <VariableProvider {...props}>
       <Story />
-    </TemplateVariableProvider>
+    </VariableProvider>
   );
 };

--- a/ui/dashboards/src/stories/decorators/index.ts
+++ b/ui/dashboards/src/stories/decorators/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,4 +14,4 @@
 export * from './constants';
 export * from './WithDashboard';
 export * from './WithDatasourceStore';
-export * from './WithTemplateVariables';
+export * from './WithVariables';

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,15 +24,15 @@ import { useMemo } from 'react';
 import {
   DatasourceStoreProviderProps,
   DatasourceStoreProvider,
-  TemplateVariableProviderProps,
-  TemplateVariableProviderWithQueryParams,
+  VariableProviderProps,
+  VariableProviderWithQueryParams,
 } from '../../context';
 import { DashboardProviderWithQueryParams } from '../../context/DashboardProvider/DashboardProviderWithQueryParams';
 import { DashboardApp, DashboardAppProps } from './DashboardApp';
 
 export interface ViewDashboardProps extends Omit<BoxProps, 'children'>, DashboardAppProps {
   datasourceApi: DatasourceStoreProviderProps['datasourceApi'];
-  externalVariableDefinitions?: TemplateVariableProviderProps['externalVariableDefinitions'];
+  externalVariableDefinitions?: VariableProviderProps['externalVariableDefinitions'];
   isEditing?: boolean;
   isCreating?: boolean;
 }
@@ -110,7 +110,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
           initialTimeRange={initialTimeRange}
           initialRefreshInterval={initialRefreshInterval}
         >
-          <TemplateVariableProviderWithQueryParams
+          <VariableProviderWithQueryParams
             initialVariableDefinitions={spec.variables}
             externalVariableDefinitions={externalVariableDefinitions}
             builtinVariables={builtinVariables}
@@ -141,7 +141,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
                 />
               </ErrorBoundary>
             </Box>
-          </TemplateVariableProviderWithQueryParams>
+          </VariableProviderWithQueryParams>
         </TimeRangeProviderWithQueryParams>
       </DashboardProviderWithQueryParams>
     </DatasourceStoreProvider>

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TimeRangeProvider } from '@perses-dev/plugin-system';
-import { DashboardProvider, DatasourceStoreProvider, TemplateVariableProvider } from '../../../context';
+import { DashboardProvider, DatasourceStoreProvider, VariableProvider } from '../../../context';
 import { defaultDatasourceProps, getTestDashboard, renderWithContext } from '../../../test';
 import { DashboardApp } from '../DashboardApp';
 
@@ -23,11 +23,11 @@ describe('Panel Groups', () => {
     renderWithContext(
       <DatasourceStoreProvider {...defaultDatasourceProps}>
         <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
-          <TemplateVariableProvider>
+          <VariableProvider>
             <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
               <DashboardApp dashboardResource={getTestDashboard()} isReadonly={false} />
             </DashboardProvider>
-          </TemplateVariableProvider>
+          </VariableProvider>
         </TimeRangeProvider>
       </DatasourceStoreProvider>
     );

--- a/ui/e2e/src/pages/DashboardPage.ts
+++ b/ui/e2e/src/pages/DashboardPage.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -135,8 +135,8 @@ export class DashboardPage {
     });
   }
 
-  getTemplateVariable(name: string) {
-    return this.page.getByTestId('template-variable-' + name).getByRole('combobox');
+  getVariable(name: string) {
+    return this.page.getByTestId('variable-' + name).getByRole('combobox');
   }
 
   /**

--- a/ui/e2e/src/tests/jsonEditor.spec.ts
+++ b/ui/e2e/src/tests/jsonEditor.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -30,6 +30,6 @@ test.describe('Dashboard: EditJson', () => {
     await dashboardPage.saveChanges();
     await expect(page.url()).toContain('start=5m');
     await expect(dashboardPage.timePicker).toContainText('Last 5 minutes');
-    await expect(dashboardPage.page.getByTestId('template-variable-interval').getByRole('combobox')).toHaveValue('5m');
+    await expect(dashboardPage.page.getByTestId('variable-interval').getByRole('combobox')).toHaveValue('5m');
   });
 });

--- a/ui/e2e/src/tests/saveDefaults.spec.ts
+++ b/ui/e2e/src/tests/saveDefaults.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -34,8 +34,8 @@ test.describe('Dashboard: Defaults', () => {
     await expect(page.url()).toContain('start=6h');
 
     // Changed selected interval variable
-    await expect(dashboardPage.getTemplateVariable('interval')).toHaveValue('1m');
-    await dashboardPage.getTemplateVariable('interval').click();
+    await expect(dashboardPage.getVariable('interval')).toHaveValue('1m');
+    await dashboardPage.getVariable('interval').click();
     await page.getByRole('option', { name: '5m' }).click();
 
     // Change text variable
@@ -63,7 +63,7 @@ test.describe('Dashboard: Defaults', () => {
     await page.getByRole('button', { name: 'Refresh', exact: true }).click();
     await expect(page.url()).toContain('start=6h');
     await expect(dashboardPage.timePicker).toContainText('Last 6 hours');
-    await expect(dashboardPage.getTemplateVariable('interval')).toHaveValue('5m');
+    await expect(dashboardPage.getVariable('interval')).toHaveValue('5m');
 
     // Confirm text variable value is persisted
     const newTextVariableInput = await page.getByRole('textbox', { name: 'Text variable' });

--- a/ui/explore/src/views/ViewExplore/ViewExplore.tsx
+++ b/ui/explore/src/views/ViewExplore/ViewExplore.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,16 +21,16 @@ import { DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL } from '@perses-de
 import { ErrorAlert, ErrorBoundary, combineSx } from '@perses-dev/components';
 import {
   DatasourceStoreProviderProps,
-  TemplateVariableProviderProps,
+  VariableProviderProps,
   DatasourceStoreProvider,
-  TemplateVariableProvider,
+  VariableProvider,
 } from '@perses-dev/dashboards';
 import React from 'react';
 import { ViewExploreApp } from './ViewExploreApp';
 
 export interface ViewExploreProps extends Omit<BoxProps, 'children'> {
   datasourceApi: DatasourceStoreProviderProps['datasourceApi'];
-  externalVariableDefinitions?: TemplateVariableProviderProps['externalVariableDefinitions'];
+  externalVariableDefinitions?: VariableProviderProps['externalVariableDefinitions'];
   exploreTitleComponent?: React.ReactNode;
 }
 
@@ -46,7 +46,7 @@ export function ViewExplore(props: ViewExploreProps) {
         initialTimeRange={initialTimeRange}
         initialRefreshInterval={initialRefreshInterval}
       >
-        <TemplateVariableProvider externalVariableDefinitions={externalVariableDefinitions}>
+        <VariableProvider externalVariableDefinitions={externalVariableDefinitions}>
           <Box
             sx={combineSx(
               {
@@ -64,7 +64,7 @@ export function ViewExplore(props: ViewExploreProps) {
               <ViewExploreApp exploreTitleComponent={exploreTitleComponent} />
             </ErrorBoundary>
           </Box>
-        </TemplateVariableProvider>
+        </VariableProvider>
       </TimeRangeProviderWithQueryParams>
     </DatasourceStoreProvider>
   );

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartPanelComponent.stories.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartPanelComponent.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,7 +18,7 @@ import {
   WithDataQueries,
   WithPluginRegistry,
   WithTimeRange,
-  WithPluginSystemTemplateVariables,
+  WithPluginSystemVariables,
   WithPluginSystemDatasourceStore,
   WithPluginSystemBuiltinVariables,
 } from '@perses-dev/plugin-system/src/stories/shared-utils';
@@ -92,7 +92,7 @@ const meta: Meta<typeof BarChart.PanelComponent> = {
   decorators: [
     WithDataQueries,
     WithPluginSystemBuiltinVariables,
-    WithPluginSystemTemplateVariables,
+    WithPluginSystemVariables,
     WithPluginSystemDatasourceStore,
     WithPluginRegistry,
     WithTimeRange,

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanelComponent.stories.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanelComponent.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import {
   WithDataQueries,
   WithPluginRegistry,
   WithTimeRange,
-  WithPluginSystemTemplateVariables,
+  WithPluginSystemVariables,
   WithPluginSystemDatasourceStore,
   WithPluginSystemBuiltinVariables,
 } from '@perses-dev/plugin-system/src/stories/shared-utils';
@@ -114,7 +114,7 @@ const meta: Meta<typeof TimeSeriesChart.PanelComponent> = {
   decorators: [
     WithDataQueries,
     WithPluginSystemBuiltinVariables,
-    WithPluginSystemTemplateVariables,
+    WithPluginSystemVariables,
     WithPluginSystemDatasourceStore,
     WithPluginRegistry,
     WithTimeRange,

--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 import { ListVariableDefinition } from '@perses-dev/core';
 import { useQuery } from '@tanstack/react-query';
 import { VariableOption } from '../../model';
-import { useDatasourceStore, usePlugin, useTimeRange, useVariableValues, VariableStateMap } from '../../runtime';
+import { useDatasourceStore, usePlugin, useTimeRange, useAllVariableValues, VariableStateMap } from '../../runtime';
 
 export function filterVariableList(data: VariableOption[], capturedRegexp: RegExp): VariableOption[] {
   const result: VariableOption[] = [];
@@ -42,7 +42,7 @@ export function filterVariableList(data: VariableOption[], capturedRegexp: RegEx
 export function useListVariablePluginValues(definition: ListVariableDefinition) {
   const { data: variablePlugin } = usePlugin('Variable', definition.spec.plugin.kind);
   const datasourceStore = useDatasourceStore();
-  const allVariables = useVariableValues();
+  const allVariables = useAllVariableValues();
   const { absoluteTimeRange: timeRange, refreshKey } = useTimeRange();
 
   const variablePluginCtx = { timeRange, datasourceStore, variables: allVariables };
@@ -57,7 +57,7 @@ export function useListVariablePluginValues(definition: ListVariableDefinition) 
     dependsOnVariables = dependencies.variables;
   }
 
-  const variables = useVariableValues(dependsOnVariables);
+  const variables = useAllVariableValues(dependsOnVariables);
 
   let waitToLoad = false;
   if (dependsOnVariables) {

--- a/ui/plugin-system/src/runtime/builtin-variables.ts
+++ b/ui/plugin-system/src/runtime/builtin-variables.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,7 +13,7 @@
 
 import { createContext, useContext, useMemo } from 'react';
 import { BuiltinVariableDefinition } from '@perses-dev/core';
-import { VariableStateMap } from './template-variables';
+import { VariableStateMap } from './variables';
 
 export type BuiltinVariableSrv = {
   variables: BuiltinVariableDefinition[];

--- a/ui/plugin-system/src/runtime/index.ts
+++ b/ui/plugin-system/src/runtime/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 export * from './builtin-variables';
 export * from './datasources';
 export * from './plugin-registry';
-export * from './template-variables';
+export * from './variables';
 export * from './TimeRangeProvider';
 export * from './time-series-queries';
 export * from './trace-queries';

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,7 +22,7 @@ import {
 } from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec, TimeSeriesData } from '@perses-dev/core';
 import { TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryMode, TimeSeriesQueryPlugin } from '../model';
-import { VariableStateMap, useVariableValues } from './template-variables';
+import { VariableStateMap, useAllVariableValues } from './variables';
 import { useTimeRange } from './TimeRangeProvider';
 import { useDatasourceStore } from './datasources';
 import { usePlugin, usePluginRegistry, usePlugins } from './plugin-registry';
@@ -165,7 +165,7 @@ export function useTimeSeriesQueries(
  */
 function useTimeSeriesQueryContext(): TimeSeriesQueryContext {
   const { absoluteTimeRange, refreshKey } = useTimeRange();
-  const variableState = useVariableValues();
+  const variableState = useAllVariableValues();
   const datasourceStore = useDatasourceStore();
 
   return {

--- a/ui/plugin-system/src/runtime/variable.test.ts
+++ b/ui/plugin-system/src/runtime/variable.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemVariables.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemVariables.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,42 +12,42 @@
 // limitations under the License.
 
 import { StoryFn, StoryContext } from '@storybook/react';
-import { TemplateVariableContext, TemplateVariableSrv } from '../../../runtime';
+import { VariableContext, VariableSrv } from '../../../runtime';
 
 declare module '@storybook/react' {
   interface Parameters {
-    withPluginSystemTemplateVariables?: WithPluginSystemTemplateVariableParameter;
+    withPluginSystemVariables?: WithPluginSystemVariableParameter;
   }
 }
 
-export type WithPluginSystemTemplateVariableParameter = {
-  props: TemplateVariableSrv;
+export type WithPluginSystemVariableParameter = {
+  props: VariableSrv;
 };
 
 // Type guard because storybook types parameters as `any`
-function isWithTemplateVariableParameter(
-  parameter: unknown | WithPluginSystemTemplateVariableParameter
-): parameter is WithPluginSystemTemplateVariableParameter {
+function isWithVariableParameter(
+  parameter: unknown | WithPluginSystemVariableParameter
+): parameter is WithPluginSystemVariableParameter {
   return !!parameter && typeof parameter === 'object' && 'props' in parameter;
 }
 
-// This decorator is used for non-dashboards package template variable needs.
+// This decorator is used for non-dashboards package variable needs.
 // Use the more specific decorator in the dashboards package when working with
 // dashboards.
 // This decorator includes "PluginSystem" in the name to differentiate it from
 // the datasource store decorator in the `dashboards` package.
-export const WithPluginSystemTemplateVariables = (Story: StoryFn, context: StoryContext<unknown>) => {
-  const initParameter = context.parameters.withPluginSystemTemplateVariables;
-  const defaultValue: TemplateVariableSrv = {
+export const WithPluginSystemVariables = (Story: StoryFn, context: StoryContext<unknown>) => {
+  const initParameter = context.parameters.withPluginSystemVariables;
+  const defaultValue: VariableSrv = {
     state: {},
   };
-  const parameter = isWithTemplateVariableParameter(initParameter) ? initParameter : { props: defaultValue };
+  const parameter = isWithVariableParameter(initParameter) ? initParameter : { props: defaultValue };
 
   const props = parameter?.props;
 
   return (
-    <TemplateVariableContext.Provider value={props}>
+    <VariableContext.Provider value={props}>
       <Story />
-    </TemplateVariableContext.Provider>
+    </VariableContext.Provider>
   );
 };

--- a/ui/plugin-system/src/stories/shared-utils/decorators/index.ts
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,5 +15,5 @@ export * from './WithDataQueries';
 export * from './WithPluginRegistry';
 export * from './WithPluginSystemBuiltinVariables';
 export * from './WithPluginSystemDatasourceStore';
-export * from './WithPluginSystemTemplateVariables';
+export * from './WithPluginSystemVariables';
 export * from './WithTimeRange';

--- a/ui/plugin-system/src/utils/variables.test.ts
+++ b/ui/plugin-system/src/utils/variables.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { parseTemplateVariables, replaceTemplateVariable, replaceTemplateVariables } from './variables';
+import { parseVariables, replaceVariable, replaceVariables } from './variables';
 
-describe('parseTemplateVariables()', () => {
+describe('parseVariables()', () => {
   const tests = [
     {
       text: 'hello $var1 world $var2',
@@ -23,12 +23,12 @@ describe('parseTemplateVariables()', () => {
 
   tests.forEach(({ text, variables }) => {
     it(`parses ${text}`, () => {
-      expect(parseTemplateVariables(text)).toEqual(variables);
+      expect(parseVariables(text)).toEqual(variables);
     });
   });
 });
 
-describe('replaceTemplateVariable()', () => {
+describe('replaceVariable()', () => {
   const tests = [
     {
       text: 'hello $var1',
@@ -58,12 +58,12 @@ describe('replaceTemplateVariable()', () => {
 
   tests.forEach(({ text, value, varName, expected }) => {
     it(`replaces ${text} ${value}`, () => {
-      expect(replaceTemplateVariable(text, varName, value)).toEqual(expected);
+      expect(replaceVariable(text, varName, value)).toEqual(expected);
     });
   });
 });
 
-describe('replaceTemplateVariables()', () => {
+describe('replaceVariables()', () => {
   const tests = [
     {
       text: 'hello $var1 $var2',
@@ -93,7 +93,7 @@ describe('replaceTemplateVariables()', () => {
 
   tests.forEach(({ text, state, expected }) => {
     it(`replaces ${text} ${JSON.stringify(state)}`, () => {
-      expect(replaceTemplateVariables(text, state)).toEqual(expected);
+      expect(replaceVariables(text, state)).toEqual(expected);
     });
   });
 });

--- a/ui/plugin-system/src/utils/variables.ts
+++ b/ui/plugin-system/src/utils/variables.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,8 +14,8 @@
 import { VariableValue } from '@perses-dev/core';
 import { VariableStateMap } from '@perses-dev/plugin-system';
 
-export function replaceTemplateVariables(text: string, variableState: VariableStateMap): string {
-  const variables = parseTemplateVariables(text);
+export function replaceVariables(text: string, variableState: VariableStateMap): string {
+  const variables = parseVariables(text);
   let finalText = text;
   variables
     // Sorting variables by their length.
@@ -25,43 +25,43 @@ export function replaceTemplateVariables(text: string, variableState: VariableSt
     .forEach((v) => {
       const variable = variableState[v];
       if (variable && variable?.value) {
-        finalText = replaceTemplateVariable(finalText, v, variable?.value);
+        finalText = replaceVariable(finalText, v, variable?.value);
       }
     });
 
   return finalText;
 }
 
-export function replaceTemplateVariable(text: string, varName: string, templateVariableValue: VariableValue) {
-  const variableTemplate = '$' + varName;
-  const bracketsVariableTemplate = '${' + varName + '}';
+export function replaceVariable(text: string, varName: string, variableValue: VariableValue) {
+  const variableSyntax = '$' + varName;
+  const alternativeVariableSyntax = '${' + varName + '}';
 
   let replaceString = '';
-  if (Array.isArray(templateVariableValue)) {
-    replaceString = `(${templateVariableValue.join('|')})`; // regex style
+  if (Array.isArray(variableValue)) {
+    replaceString = `(${variableValue.join('|')})`; // regex style
   }
-  if (typeof templateVariableValue === 'string') {
-    replaceString = templateVariableValue;
+  if (typeof variableValue === 'string') {
+    replaceString = variableValue;
   }
 
-  text = text.replaceAll(variableTemplate, replaceString);
-  return text.replaceAll(bracketsVariableTemplate, replaceString);
+  text = text.replaceAll(variableSyntax, replaceString);
+  return text.replaceAll(alternativeVariableSyntax, replaceString);
 }
 
-// This regular expression is designed to identify variable references in a template string.
+// This regular expression is designed to identify variable references in a string.
 // It supports two formats for referencing variables:
 // 1. $variableName - This is a simpler format, and the regular expression captures the variable name (\w+ matches one or more word characters).
 // 2. ${variableName} - This is a more complex format and the regular expression captures the variable name (\w+ matches one or more word characters) in the curly braces.
 // 3. [COMING SOON] ${variableName:value} - This is a more complex format that allows specifying a format function as well.
 // TODO: Fix this lint error
 // eslint-disable-next-line no-useless-escape
-const TEMPLATE_VARIABLE_REGEX = /\$(\w+)|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/gm;
+const VARIABLE_REGEX = /\$(\w+)|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/gm;
 
 /**
- * Returns a list of template variables
+ * Returns a list of variables
  */
-export const parseTemplateVariables = (text: string) => {
-  const regex = TEMPLATE_VARIABLE_REGEX;
+export const parseVariables = (text: string) => {
+  const regex = VARIABLE_REGEX;
   const matches = new Set<string>();
   let match;
 

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TimeSeriesQueryPlugin, parseTemplateVariables } from '@perses-dev/plugin-system';
+import { TimeSeriesQueryPlugin, parseVariables } from '@perses-dev/plugin-system';
 import { getTimeSeriesData } from './get-time-series-data';
 import { PrometheusTimeSeriesQueryEditor } from './PrometheusTimeSeriesQueryEditor';
 import { PrometheusTimeSeriesQuerySpec } from './time-series-query-model';
@@ -28,8 +28,8 @@ export const PrometheusTimeSeriesQuery: TimeSeriesQueryPlugin<PrometheusTimeSeri
   }),
   dependsOn: (spec) => {
     // Variables can be used in the query and/or in the legend format string
-    const queryVariables = parseTemplateVariables(spec.query);
-    const legendVariables = parseTemplateVariables(spec.seriesNameFormat || '');
+    const queryVariables = parseVariables(spec.query);
+    const legendVariables = parseVariables(spec.seriesNameFormat || '');
     const allVariables = [...new Set([...queryVariables, ...legendVariables])];
     return {
       variables: allVariables,

--- a/ui/storybook/src/stories/Introduction.stories.mdx
+++ b/ui/storybook/src/stories/Introduction.stories.mdx
@@ -21,6 +21,6 @@ blocks can also be used to build other applications.
   visualizations supported by Perses.
 - <LinkTo kind="Plugin System/About" story="docs">@perses-dev/plugin-system</LinkTo> - All the type definitions and components that power
   our plugins, also includes the definitions for the runtime available to plugins (e.g. the current time range state, the
-  current template variable state).
+  current variable state).
 - <LinkTo kind="Prometheus Plugin/About" story="docs">@perses-dev/prometheus-plugin</LinkTo> - A plugin module with multiple plugin types
   (e.g. Variable, ChartQuery, etc.) for supporting Prometheus in Perses.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Get rid of the "Template Variable" wording in the frontend code, that most probably came from Grafana vocabulary while we simply called this object "Variable" in Perses.

As a consequence, the current `<TemplateVariableProvider>` is renamed `<VariableProvider>`, hence the breaking change for the embed use case.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
