### PR TITLE
[IGNORE] support fetching entire trace

### DIFF
--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
@@ -14,13 +14,13 @@
 import { PanelProps, useDataQueries } from '@perses-dev/plugin-system';
 import { Box, Skeleton } from '@mui/material';
 import { useMemo } from 'react';
-import { TraceValue } from '@perses-dev/core';
+import { TraceSearchResult } from '@perses-dev/core';
 import { EChartsOption, SeriesOption } from 'echarts';
 import { ErrorAlert, useChartsTheme } from '@perses-dev/components';
 import { Scatterplot } from './Scatterplot';
 import { ScatterChartOptions } from './scatter-chart-model';
 
-export interface EChartTraceValue extends Omit<TraceValue, 'startTimeUnixMs' | 'serviceStats'> {
+export interface EChartTraceValue extends Omit<TraceSearchResult, 'startTimeUnixMs' | 'serviceStats'> {
   name: string;
   startTime: Date;
   spanCount: number;
@@ -73,8 +73,8 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
     const dataset = [];
     let maxSpanCount = 1;
     for (const result of traceResults) {
-      if (result.isLoading || result.data === undefined) continue;
-      const dataSeries = result.data.traces.map((trace) => {
+      if (result.isLoading || result.data === undefined || result.data.searchResult === undefined) continue;
+      const dataSeries = result.data.searchResult.map((trace) => {
         let spanCount = 0;
         let errorCount = 0;
         for (const stats of Object.values(trace.serviceStats)) {
@@ -141,10 +141,9 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
   }, [dataset, defaultColor, maxSpanCount]);
 
   // Error check: specify an alert if no traces are returned from the query
-  const traceData = traceResults[0]?.data;
-  if (!traceIsLoading && traceData?.traces.length === 0) {
-    const query = traceData?.metadata?.executedQueryString;
-    return generateErrorAlert(`No traces found for the query: " ${query} " .`);
+  const tracesFound = traceResults.some((traceData) => (traceData.data?.searchResult ?? []).length > 0);
+  if (!traceIsLoading && !tracesFound) {
+    return generateErrorAlert('No traces found');
   }
 
   const options: EChartsOption = {

--- a/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
@@ -16,7 +16,7 @@ import { PersesChartsTheme, useChartsTheme } from '@perses-dev/components';
 import {
   ServiceStats,
   TraceData,
-  TraceValue,
+  TraceSearchResult,
   formatDuration,
   msToPrometheusDuration,
   traceServiceColor,
@@ -42,7 +42,7 @@ export function DataTable({ result }: DataTableProps) {
     return null;
   }
 
-  const traces = result.flatMap((d) => d.data).flatMap((d) => d?.traces || []);
+  const traces = result.flatMap((d) => d.data).flatMap((d) => d?.searchResult || []);
   const rows = traces.map((trace) => buildRow(theme, trace));
 
   return (
@@ -70,7 +70,7 @@ export function DataTable({ result }: DataTableProps) {
   );
 }
 
-function buildRow(theme: PersesChartsTheme, trace: TraceValue): ReactNode {
+function buildRow(theme: PersesChartsTheme, trace: TraceSearchResult): ReactNode {
   let totalSpanCount = 0;
   let totalErrorCount = 0;
   for (const stats of Object.values(trace.serviceStats)) {

--- a/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
@@ -46,7 +46,7 @@ export function TraceTablePanel(props: TraceTableProps) {
     );
   }
 
-  const tracesFound = queryResults.some((traceData) => (traceData.data?.traces ?? []).length > 0);
+  const tracesFound = queryResults.some((traceData) => (traceData.data?.searchResult ?? []).length > 0);
   if (!tracesFound) {
     return (
       <Stack sx={{ alignItems: 'center', justifyContent: 'center', height: '100%' }}>

--- a/ui/panels-plugin/src/test/mock-trace-query-results.ts
+++ b/ui/panels-plugin/src/test/mock-trace-query-results.ts
@@ -17,7 +17,7 @@ import { TraceData } from '@perses-dev/core';
  * Mock data we get from getTraceData() in @perses/tempo-plugin.
  */
 export const MOCK_TRACE_DATA: TraceData = {
-  traces: [
+  searchResult: [
     {
       startTimeUnixMs: 1702915645000, // unix epoch time in milliseconds
       durationMs: 100,
@@ -41,7 +41,7 @@ export const MOCK_TRACE_DATA: TraceData = {
 };
 
 export const MOCK_EMPTY_TRACE_DATA: TraceData = {
-  traces: [],
+  searchResult: [],
   metadata: {
     executedQueryString: '{duration > 500ms}',
   },

--- a/ui/plugin-system/src/test/mock-data.ts
+++ b/ui/plugin-system/src/test/mock-data.ts
@@ -38,7 +38,7 @@ export const MOCK_TIME_SERIES_DATA: TimeSeriesData = {
 };
 
 export const MOCK_TRACE_DATA: TraceData = {
-  traces: [
+  searchResult: [
     {
       durationMs: 1120,
       serviceStats: {

--- a/ui/tempo-plugin/src/model/tempo-client.ts
+++ b/ui/tempo-plugin/src/model/tempo-client.ts
@@ -13,7 +13,7 @@
 
 import { fetch, RequestHeaders } from '@perses-dev/core';
 import { DatasourceClient } from '@perses-dev/plugin-system';
-import { SearchTraceIDResponse, SearchTraceQueryResponse, ServiceStats } from './api-types';
+import { SearchTraceIDResponse, SearchTraceQueryResponse, ServiceStats, SpanStatusError } from './api-types';
 
 interface TempoClientOptions {
   datasourceUrl: string;
@@ -97,7 +97,7 @@ export async function searchTraceQueryFallback(
           for (const scopeSpan of batch.scopeSpans) {
             stats.spanCount += scopeSpan.spans.length;
             for (const span of scopeSpan.spans) {
-              if (span.status?.code) {
+              if (span.status?.code === SpanStatusError) {
                 stats.errorCount = (stats.errorCount ?? 0) + 1;
               }
             }

--- a/ui/tempo-plugin/src/plugins/plugin.test.ts
+++ b/ui/tempo-plugin/src/plugins/plugin.test.ts
@@ -13,7 +13,12 @@
 
 import { DatasourceSpec } from '@perses-dev/core';
 import { TraceQueryContext } from '@perses-dev/plugin-system';
-import { MOCK_SEARCH_RESPONSE_VPARQUET4, MOCK_TRACE_DATA } from '../test';
+import {
+  MOCK_SEARCH_RESPONSE_VPARQUET4,
+  MOCK_TRACE_DATA_SEARCHRESULT,
+  MOCK_TRACE_DATA_TRACE,
+  MOCK_TRACE_RESPONSE_SMALL,
+} from '../test';
 import { TempoDatasourceSpec } from './tempo-datasource-types';
 import { TempoDatasource } from './tempo-datasource';
 import { TempoTraceQuery } from './tempo-trace-query/TempoTraceQuery';
@@ -25,6 +30,7 @@ const datasource: TempoDatasourceSpec = {
 };
 
 const tempoStubClient = TempoDatasource.createClient(datasource, {});
+tempoStubClient.searchTraceID = jest.fn(async () => MOCK_TRACE_RESPONSE_SMALL);
 tempoStubClient.searchTraceQueryFallback = jest.fn(async () => MOCK_SEARCH_RESPONSE_VPARQUET4);
 
 const getDatasourceClient: jest.Mock = jest.fn(() => {
@@ -66,6 +72,16 @@ describe('TempoTraceQuery', () => {
       },
       stubTempoContext
     );
-    expect(results).toEqual(MOCK_TRACE_DATA);
+    expect(results).toEqual(MOCK_TRACE_DATA_SEARCHRESULT);
+  });
+
+  it('should build a span tree', async () => {
+    const results = await TempoTraceQuery.getTraceData(
+      {
+        query: '61a1487c461d9e08',
+      },
+      stubTempoContext
+    );
+    expect(results).toEqual(MOCK_TRACE_DATA_TRACE);
   });
 });

--- a/ui/tempo-plugin/src/test/mock-data.ts
+++ b/ui/tempo-plugin/src/test/mock-data.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TraceData } from '@perses-dev/core';
+import { Span, TraceData } from '@perses-dev/core';
 import { SearchTraceIDResponse, SearchTraceQueryResponse } from '../model/api-types';
 
 export const MOCK_TRACE_RESPONSE: SearchTraceIDResponse = {
@@ -2075,6 +2075,151 @@ export const MOCK_TRACE_RESPONSE: SearchTraceIDResponse = {
   ],
 };
 
+export const MOCK_TRACE_RESPONSE_SMALL: SearchTraceIDResponse = {
+  batches: [
+    {
+      resource: {
+        attributes: [
+          {
+            key: 'service.name',
+            value: {
+              stringValue: 'shop-backend',
+            },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: {
+            name: 'k6',
+          },
+          spans: [
+            {
+              traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+              spanId: 'nCLrd8tcFMc=',
+              name: 'article-to-cart',
+              kind: 'SPAN_KIND_SERVER',
+              startTimeUnixNano: '1718122135898442804',
+              endTimeUnixNano: '1718122136696651946',
+              attributes: [
+                {
+                  key: 'http.url',
+                  value: {
+                    stringValue: 'https://shop-backend.local:8523/article-to-cart',
+                  },
+                },
+                {
+                  key: 'http.status_code',
+                  value: {
+                    intValue: '202',
+                  },
+                },
+              ],
+              status: {},
+            },
+            {
+              traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+              spanId: 'hGe8oRN3wWY=',
+              parentSpanId: 'nCLrd8tcFMc=',
+              name: 'authenticate',
+              kind: 'SPAN_KIND_CLIENT',
+              startTimeUnixNano: '1718122135954765948',
+              endTimeUnixNano: '1718122136154227489',
+              attributes: [
+                {
+                  key: 'net.transport',
+                  value: {
+                    stringValue: 'ip_tcp',
+                  },
+                },
+              ],
+              events: [
+                {
+                  timeUnixNano: '1718122136068613856',
+                  name: 'event_k6.7W272ywYih',
+                  attributes: [
+                    {
+                      key: 'k6.sJekvnAr5h7vJfK',
+                      value: {
+                        stringValue: 'SZ9vwpLkAzAm2Bju1VJroUlGD8u3pS',
+                      },
+                    },
+                    {
+                      key: 'k6.81JLO5NlT1lAeF1',
+                      value: {
+                        stringValue: '4AzrPTOML11aIN3dYgbKSaAe9HErnZ',
+                      },
+                    },
+                    {
+                      key: 'k6.tdj0bfOxLndyJuN',
+                      value: {
+                        stringValue: 'PeMAsdQ5469IjQgGtifBA7OgfFdoMb',
+                      },
+                    },
+                  ],
+                },
+              ],
+              status: {},
+            },
+            {
+              traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+              spanId: 'r2NxHHPjciM=',
+              parentSpanId: 'nCLrd8tcFMc=',
+              name: 'get-article',
+              kind: 'SPAN_KIND_CLIENT',
+              startTimeUnixNano: '1718122135965210897',
+              endTimeUnixNano: '1718122136520157839',
+              attributes: [
+                {
+                  key: 'http.method',
+                  value: {
+                    stringValue: 'DELETE',
+                  },
+                },
+              ],
+              status: {},
+            },
+          ],
+        },
+      ],
+    },
+    {
+      resource: {
+        attributes: [
+          {
+            key: 'service.name',
+            value: {
+              stringValue: 'auth-service',
+            },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: {
+            name: 'k6',
+          },
+          spans: [
+            {
+              traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+              spanId: 'AYBIFdTlycc=',
+              parentSpanId: 'hGe8oRN3wWY=',
+              name: 'authenticate',
+              kind: 'SPAN_KIND_SERVER',
+              startTimeUnixNano: '1718122135970602296',
+              endTimeUnixNano: '1718122136107740742',
+              status: {
+                message: 'Forbidden',
+                code: 'STATUS_CODE_ERROR',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 export const MOCK_SEARCH_RESPONSE_VPARQUET3: SearchTraceQueryResponse = {
   traces: [
     {
@@ -2196,8 +2341,8 @@ export const MOCK_SEARCH_RESPONSE_VPARQUET4: SearchTraceQueryResponse = {
   ],
 };
 
-export const MOCK_TRACE_DATA: TraceData = {
-  traces: [
+export const MOCK_TRACE_DATA_SEARCHRESULT: TraceData = {
+  searchResult: [
     {
       startTimeUnixMs: 1718122135898.4426,
       durationMs: 798,
@@ -2224,4 +2369,166 @@ export const MOCK_TRACE_DATA: TraceData = {
     },
   ],
   metadata: { executedQueryString: 'duration > 900ms' },
+};
+
+const shopBackendResource = {
+  serviceName: 'shop-backend',
+  attributes: [
+    {
+      key: 'service.name',
+      value: {
+        stringValue: 'shop-backend',
+      },
+    },
+  ],
+};
+
+const authServiceResource = {
+  serviceName: 'auth-service',
+  attributes: [
+    {
+      key: 'service.name',
+      value: {
+        stringValue: 'auth-service',
+      },
+    },
+  ],
+};
+
+const k6scope = {
+  name: 'k6',
+};
+
+const span4: Span = {
+  resource: authServiceResource,
+  scope: k6scope,
+  childSpans: [],
+
+  traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+  spanId: 'AYBIFdTlycc=',
+  parentSpanId: 'hGe8oRN3wWY=',
+  name: 'authenticate',
+  kind: 'SPAN_KIND_SERVER',
+  startTimeUnixMs: 1718122135970.602,
+  endTimeUnixMs: 1718122136107.7405,
+  attributes: [],
+  events: [],
+  status: {
+    message: 'Forbidden',
+    code: 'STATUS_CODE_ERROR',
+  },
+};
+
+const span3: Span = {
+  resource: shopBackendResource,
+  scope: k6scope,
+  childSpans: [],
+
+  traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+  spanId: 'r2NxHHPjciM=',
+  parentSpanId: 'nCLrd8tcFMc=',
+  name: 'get-article',
+  kind: 'SPAN_KIND_CLIENT',
+  startTimeUnixMs: 1718122135965.2107,
+  endTimeUnixMs: 1718122136520.158,
+  attributes: [
+    {
+      key: 'http.method',
+      value: {
+        stringValue: 'DELETE',
+      },
+    },
+  ],
+  events: [],
+  status: {},
+};
+
+const span2: Span = {
+  resource: shopBackendResource,
+  scope: k6scope,
+  childSpans: [span4],
+
+  traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+  spanId: 'hGe8oRN3wWY=',
+  parentSpanId: 'nCLrd8tcFMc=',
+  name: 'authenticate',
+  kind: 'SPAN_KIND_CLIENT',
+  startTimeUnixMs: 1718122135954.7656,
+  endTimeUnixMs: 1718122136154.2273,
+  attributes: [
+    {
+      key: 'net.transport',
+      value: {
+        stringValue: 'ip_tcp',
+      },
+    },
+  ],
+  events: [
+    {
+      timeUnixMs: 1718122136068.6138,
+      name: 'event_k6.7W272ywYih',
+      attributes: [
+        {
+          key: 'k6.sJekvnAr5h7vJfK',
+          value: {
+            stringValue: 'SZ9vwpLkAzAm2Bju1VJroUlGD8u3pS',
+          },
+        },
+        {
+          key: 'k6.81JLO5NlT1lAeF1',
+          value: {
+            stringValue: '4AzrPTOML11aIN3dYgbKSaAe9HErnZ',
+          },
+        },
+        {
+          key: 'k6.tdj0bfOxLndyJuN',
+          value: {
+            stringValue: 'PeMAsdQ5469IjQgGtifBA7OgfFdoMb',
+          },
+        },
+      ],
+    },
+  ],
+  status: {},
+};
+
+const span1: Span = {
+  resource: shopBackendResource,
+  scope: k6scope,
+  childSpans: [span2, span3],
+
+  traceId: '+9N4RSCdQ83M1BjcX5/wIQ==',
+  spanId: 'nCLrd8tcFMc=',
+  parentSpanId: undefined,
+  name: 'article-to-cart',
+  kind: 'SPAN_KIND_SERVER',
+  startTimeUnixMs: 1718122135898.4426,
+  endTimeUnixMs: 1718122136696.6519,
+  attributes: [
+    {
+      key: 'http.url',
+      value: {
+        stringValue: 'https://shop-backend.local:8523/article-to-cart',
+      },
+    },
+    {
+      key: 'http.status_code',
+      value: {
+        intValue: '202',
+      },
+    },
+  ],
+  events: [],
+  status: {},
+};
+
+span4.parentSpan = span2;
+span2.parentSpan = span1;
+span3.parentSpan = span1;
+
+export const MOCK_TRACE_DATA_TRACE: TraceData = {
+  trace: { rootSpan: span1 },
+  metadata: {
+    executedQueryString: '61a1487c461d9e08',
+  },
 };


### PR DESCRIPTION
# Description

* rename partial trace (returned by search endpoint) to `TraceSearchResult`
* add `Trace` data model to core
* execute either a search query or fetch trace by id, depending on query
* build span tree in Tempo client
* prerequisite of #2047

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
