### PR TITLE
[IGNORE] move <NoContentRowOverlay> to components package, add <LoadingOverlay>

### DIFF
--- a/ui/app/src/components/DashboardList/DashboardDataGrid.tsx
+++ b/ui/app/src/components/DashboardList/DashboardDataGrid.tsx
@@ -15,12 +15,12 @@ import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   DataGridProperties,
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_DISPLAY_NAME,
   GridToolbar,
-  NoContentRowOverlay,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
 } from '../datagrid';
@@ -36,7 +36,7 @@ export interface Row extends CommonRow {
 }
 
 function NoDashboardRowOverlay() {
-  return <NoContentRowOverlay resource="dashboards" />;
+  return <NoDataOverlay resource="dashboards" />;
 }
 
 export function DashboardDataGrid(props: DataGridProperties<Row>) {

--- a/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardDataGrid.tsx
+++ b/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardDataGrid.tsx
@@ -15,12 +15,12 @@ import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   DataGridProperties,
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_DISPLAY_NAME,
   GridToolbar,
-  NoContentRowOverlay,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
 } from '../datagrid';
@@ -36,7 +36,7 @@ export interface Row extends CommonRow {
 }
 
 function NoEphemeralDashboardRowOverlay() {
-  return <NoContentRowOverlay resource="ephemeral dashboards" />;
+  return <NoDataOverlay resource="ephemeral dashboards" />;
 }
 
 export function EphemeralDashboardDataGrid(props: DataGridProperties<Row>) {

--- a/ui/app/src/components/datagrid.tsx
+++ b/ui/app/src/components/datagrid.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Stack, Typography } from '@mui/material';
+import { Stack } from '@mui/material';
 import {
   GridColDef,
   GridToolbarColumnsButton,
@@ -96,17 +96,4 @@ export interface DataGridProperties<T extends GridValidRowModel> {
 
 export interface DataGridPropertiesWithCallback<T extends GridValidRowModel> extends DataGridProperties<T> {
   onRowClick: (name: string, project?: string) => void;
-}
-export interface NoContentRowOverlayProps {
-  resource: string;
-}
-
-export function NoContentRowOverlay(props: NoContentRowOverlayProps) {
-  const { resource } = props;
-
-  return (
-    <Stack sx={{ alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-      <Typography>No {resource}</Typography>
-    </Stack>
-  );
 }

--- a/ui/app/src/components/datasource/DatasourceDataGrid.tsx
+++ b/ui/app/src/components/datasource/DatasourceDataGrid.tsx
@@ -14,12 +14,12 @@
 import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_DISPLAY_NAME,
   GridToolbar,
   DataGridPropertiesWithCallback,
-  NoContentRowOverlay,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
 } from '../datagrid';
@@ -38,7 +38,7 @@ export interface Row extends CommonRow {
 }
 
 function NoDatasourceRowOverlay() {
-  return <NoContentRowOverlay resource="datasources" />;
+  return <NoDataOverlay resource="datasources" />;
 }
 
 export function DatasourceDataGrid(props: DataGridPropertiesWithCallback<Row>) {

--- a/ui/app/src/components/rolebindings/RoleBindingDataGrid.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingDataGrid.tsx
@@ -14,12 +14,12 @@
 import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_NAME,
   GridToolbar,
   DataGridPropertiesWithCallback,
-  NoContentRowOverlay,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
 } from '../datagrid';
@@ -34,7 +34,7 @@ export interface Row extends CommonRow {
 }
 
 function NoRoleBindingRowOverlay() {
-  return <NoContentRowOverlay resource="role bindings" />;
+  return <NoDataOverlay resource="role bindings" />;
 }
 
 export function RoleBindingDataGrid(props: DataGridPropertiesWithCallback<Row>) {

--- a/ui/app/src/components/roles/RoleDataGrid.tsx
+++ b/ui/app/src/components/roles/RoleDataGrid.tsx
@@ -14,6 +14,7 @@
 import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_NAME,
@@ -21,7 +22,6 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
-  NoContentRowOverlay,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -34,7 +34,7 @@ export interface Row extends CommonRow {
 }
 
 function NoRoleRowOverlay() {
-  return <NoContentRowOverlay resource="roles" />;
+  return <NoDataOverlay resource="roles" />;
 }
 
 export function RoleDataGrid(props: DataGridPropertiesWithCallback<Row>) {

--- a/ui/app/src/components/secrets/SecretDataGrid.tsx
+++ b/ui/app/src/components/secrets/SecretDataGrid.tsx
@@ -14,12 +14,12 @@
 import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_NAME,
   GridToolbar,
   DataGridPropertiesWithCallback,
-  NoContentRowOverlay,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
 } from '../datagrid';
@@ -36,7 +36,7 @@ export interface Row extends CommonRow {
 }
 
 function NoSecretsRowOverlay() {
-  return <NoContentRowOverlay resource="secrets" />;
+  return <NoDataOverlay resource="secrets" />;
 }
 
 export function SecretDataGrid(props: DataGridPropertiesWithCallback<Row>) {

--- a/ui/app/src/components/users/UserDataGrid.tsx
+++ b/ui/app/src/components/users/UserDataGrid.tsx
@@ -14,6 +14,7 @@
 import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_NAME,
@@ -21,7 +22,6 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
-  NoContentRowOverlay,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -34,7 +34,7 @@ export interface Row extends CommonRow {
 }
 
 function NoUserRowOverlay() {
-  return <NoContentRowOverlay resource="users" />;
+  return <NoDataOverlay resource="users" />;
 }
 
 export function UserDataGrid(props: DataGridPropertiesWithCallback<Row>) {

--- a/ui/app/src/components/variable/VariableDataGrid.tsx
+++ b/ui/app/src/components/variable/VariableDataGrid.tsx
@@ -14,12 +14,12 @@
 import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, useMemo } from 'react';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
+import { NoDataOverlay } from '@perses-dev/components';
 import {
   CommonRow,
   DATA_GRID_INITIAL_STATE_SORT_BY_DISPLAY_NAME,
   GridToolbar,
   DataGridPropertiesWithCallback,
-  NoContentRowOverlay,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
 } from '../datagrid';
@@ -37,7 +37,7 @@ export interface Row extends CommonRow {
 }
 
 function NoVariableRowOverlay() {
-  return <NoContentRowOverlay resource="variables" />;
+  return <NoDataOverlay resource="variables" />;
 }
 
 export function VariableDataGrid(props: DataGridPropertiesWithCallback<Row>) {

--- a/ui/components/src/Overlay/Overlay.tsx
+++ b/ui/components/src/Overlay/Overlay.tsx
@@ -1,0 +1,52 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Skeleton, SkeletonOwnProps, Stack, Typography } from '@mui/material';
+
+interface TextOverlayProps {
+  message: string;
+}
+
+export function TextOverlay(props: TextOverlayProps) {
+  const { message } = props;
+
+  return (
+    <Stack sx={{ height: '100%', alignItems: 'center', justifyContent: 'center' }}>
+      <Typography>{message}</Typography>
+    </Stack>
+  );
+}
+
+interface NoDataOverlayProps {
+  resource: string;
+}
+
+export function NoDataOverlay(props: NoDataOverlayProps) {
+  const { resource } = props;
+
+  return <TextOverlay message={`No ${resource}`} />;
+}
+
+interface LoadingOverlayProps {
+  variant?: SkeletonOwnProps['variant'];
+}
+
+export function LoadingOverlay(props: LoadingOverlayProps) {
+  const { variant = 'rounded' } = props;
+
+  return (
+    <Stack sx={{ height: '100%', alignItems: 'center', justifyContent: 'center' }}>
+      <Skeleton variant={variant} width="95%" height="30%" aria-label="Loading..." />
+    </Stack>
+  );
+}

--- a/ui/components/src/Overlay/Overlay.tsx
+++ b/ui/components/src/Overlay/Overlay.tsx
@@ -45,8 +45,8 @@ export function LoadingOverlay(props: LoadingOverlayProps) {
   const { variant = 'rounded' } = props;
 
   return (
-    <Stack sx={{ height: '100%', alignItems: 'center', justifyContent: 'center' }}>
-      <Skeleton variant={variant} width="95%" height="30%" aria-label="Loading..." />
+    <Stack sx={{ height: '100%', alignItems: 'center', justifyContent: 'center', padding: '0 10px' }}>
+      <Skeleton variant={variant} width="100%" height="30%" aria-label="Loading..." />
     </Stack>
   );
 }

--- a/ui/components/src/Overlay/index.ts
+++ b/ui/components/src/Overlay/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './Overlay';

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -28,6 +28,7 @@ export * from './LineChart';
 export * from './LinksEditor';
 export * from './ModeSelector';
 export * from './OptionsEditorLayout';
+export * from './Overlay';
 export * from './SettingsAutocomplete';
 export * from './SortSelector';
 export * from './StatChart';

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartPanel.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { BarChart, BarChartData, useChartsTheme } from '@perses-dev/components';
-import { Box, Skeleton } from '@mui/material';
+import { BarChart, BarChartData, LoadingOverlay, useChartsTheme } from '@perses-dev/components';
+import { Box } from '@mui/material';
 import { useMemo } from 'react';
 import { CalculationType, CalculationsMap } from '@perses-dev/core';
 import { useDataQueries, PanelProps } from '@perses-dev/plugin-system';
@@ -61,15 +61,7 @@ export function BarChartPanel(props: BarChartPanelProps) {
   if (contentDimensions === undefined) return null;
 
   if (isLoading || isFetching) {
-    return (
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        width={contentDimensions.width}
-        height={contentDimensions.height}
-      >
-        <Skeleton variant="text" width={contentDimensions.width - 20} height={contentDimensions.height / 2} />
-      </Box>
-    );
+    return <LoadingOverlay />;
   }
 
   return (

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.test.tsx
@@ -99,7 +99,7 @@ describe('ScatterChartPanel', () => {
       isFetching: false,
     });
     renderPanel();
-    expect(await screen?.findByTestId('ScatterChartPanel_ScatterPlot')).toBeInTheDocument();
+    expect(await screen.findByTestId('ScatterChartPanel_ScatterPlot')).toBeInTheDocument();
   });
 
   it('should not render a ScatterPlot because trace results are empty', async () => {
@@ -110,6 +110,6 @@ describe('ScatterChartPanel', () => {
     });
     renderPanel();
     // expect it to return a Alert because the query produces no trace results
-    expect(await screen?.findByTestId('ScatterChartPanel_ErrorAlert')).toBeInTheDocument();
+    expect(await screen.findByText('No traces')).toBeInTheDocument();
   });
 });

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
@@ -12,11 +12,10 @@
 // limitations under the License.
 
 import { PanelProps, useDataQueries } from '@perses-dev/plugin-system';
-import { Box, Skeleton } from '@mui/material';
 import { useMemo } from 'react';
 import { TraceValue } from '@perses-dev/core';
 import { EChartsOption, SeriesOption } from 'echarts';
-import { ErrorAlert, useChartsTheme } from '@perses-dev/components';
+import { LoadingOverlay, NoDataOverlay, useChartsTheme } from '@perses-dev/components';
 import { Scatterplot } from './Scatterplot';
 import { ScatterChartOptions } from './scatter-chart-model';
 
@@ -26,18 +25,6 @@ export interface EChartTraceValue extends Omit<TraceValue, 'startTimeUnixMs' | '
   spanCount: number;
   errorCount: number;
 }
-
-const generateErrorAlert = (message: string) => {
-  const alertMessage = {
-    name: message,
-    message: message,
-  };
-  return (
-    <div data-testid="ScatterChartPanel_ErrorAlert">
-      <ErrorAlert error={alertMessage} />
-    </div>
-  );
-};
 
 export type ScatterChartPanelProps = PanelProps<ScatterChartOptions>;
 
@@ -143,8 +130,7 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
   // Error check: specify an alert if no traces are returned from the query
   const traceData = traceResults[0]?.data;
   if (!traceIsLoading && traceData?.traces.length === 0) {
-    const query = traceData?.metadata?.executedQueryString;
-    return generateErrorAlert(`No traces found for the query: " ${query} " .`);
+    return <NoDataOverlay resource="traces" />;
   }
 
   const options: EChartsOption = {
@@ -155,15 +141,7 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
   if (contentDimensions === undefined) return null;
 
   if (traceIsLoading === true) {
-    return (
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        width={contentDimensions.width}
-        height={contentDimensions.height}
-      >
-        <Skeleton variant="text" width={contentDimensions.width - 20} height={contentDimensions.height / 2} />
-      </Box>
-    );
+    return <LoadingOverlay />;
   }
 
   return (

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import { TitleComponentOption } from 'echarts';
-import { StatChart, StatChartData, useChartsTheme, GraphSeries } from '@perses-dev/components';
-import { Box, Stack, Skeleton, Typography, SxProps } from '@mui/material';
+import { StatChart, StatChartData, useChartsTheme, GraphSeries, LoadingOverlay } from '@perses-dev/components';
+import { Stack, Typography, SxProps } from '@mui/material';
 import { useMemo } from 'react';
 import { CalculationsMap, CalculationType, DEFAULT_CALCULATION, TimeSeriesData } from '@perses-dev/core';
 import { useDataQueries, UseDataQueryResults, PanelProps } from '@perses-dev/plugin-system';
@@ -42,15 +42,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
   if (contentDimensions === undefined) return null;
 
   if (isLoading || isFetching) {
-    return (
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        width={contentDimensions.width}
-        height={contentDimensions.height}
-      >
-        <Skeleton variant="text" width={contentDimensions.width - 20} height={contentDimensions.height / 2} />
-      </Box>
-    );
+    return <LoadingOverlay />;
   }
 
   // Calculates chart width

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useMemo, useRef, useState } from 'react';
-import { Box, Skeleton, useTheme } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import type { GridComponentOption } from 'echarts';
 import merge from 'lodash/merge';
 import {
@@ -47,6 +47,7 @@ import {
   TimeChartSeriesMapping,
   TooltipConfig,
   DEFAULT_TOOLTIP_CONFIG,
+  LoadingOverlay,
 } from '@perses-dev/components';
 import {
   TimeSeriesChartOptions,
@@ -347,20 +348,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
   }
 
   if (isLoading || isFetching) {
-    return (
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        width={adjustedContentDimensions.width}
-        height={adjustedContentDimensions.height}
-      >
-        <Skeleton
-          variant="text"
-          width={adjustedContentDimensions.width - 20}
-          height={adjustedContentDimensions.height / 2}
-          aria-label="Loading..."
-        />
-      </Box>
-    );
+    return <LoadingOverlay />;
   }
 
   // At this point, we have a response from the backend for all queries. (We're past loading === true).

--- a/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.tsx
@@ -12,9 +12,8 @@
 // limitations under the License.
 
 import { useDataQueries } from '@perses-dev/plugin-system';
-import React from 'react';
-import { Box, Skeleton } from '@mui/material';
-import { useChartsTheme } from '@perses-dev/components';
+import { Box } from '@mui/material';
+import { LoadingOverlay, useChartsTheme } from '@perses-dev/components';
 import { TimeSeriesTableProps } from './TimeSeriesTable';
 import DataTable from './DataTable';
 
@@ -22,39 +21,10 @@ export function TimeSeriesTablePanel(props: TimeSeriesTableProps) {
   const { contentDimensions } = props;
   const chartsTheme = useChartsTheme();
   const { isFetching, isLoading, queryResults } = useDataQueries('TimeSeriesQuery');
-
-  // TODO: consider refactoring how the layout/spacing/alignment are calculated
-  // the next time significant changes are made to the time series panel (e.g.
-  // when making improvements to the legend to more closely match designs).
-  // This may also want to include moving some of this logic down to the shared,
-  // embeddable components.
   const contentPadding = chartsTheme.container.padding.default;
-  const adjustedContentDimensions: typeof contentDimensions = contentDimensions
-    ? {
-        width: contentDimensions.width - contentPadding * 2,
-        height: contentDimensions.height - contentPadding * 2,
-      }
-    : undefined;
-
-  if (adjustedContentDimensions === undefined) {
-    return null;
-  }
 
   if (isLoading || isFetching) {
-    return (
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        width={adjustedContentDimensions.width}
-        height={adjustedContentDimensions.height}
-      >
-        <Skeleton
-          variant="text"
-          width={adjustedContentDimensions.width - 20}
-          height={adjustedContentDimensions.height / 2}
-          aria-label="Loading..."
-        />
-      </Box>
-    );
+    return <LoadingOverlay />;
   }
 
   return (

--- a/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import { PanelProps, useDataQueries } from '@perses-dev/plugin-system';
-import { Box, Skeleton, Stack, Typography } from '@mui/material';
-import { useChartsTheme } from '@perses-dev/components';
+import { Box } from '@mui/material';
+import { LoadingOverlay, NoDataOverlay, useChartsTheme } from '@perses-dev/components';
 import { DataTable } from './DataTable';
 import { TraceTableOptions } from './trace-table-model';
 
@@ -30,29 +30,12 @@ export function TraceTablePanel(props: TraceTableProps) {
   }
 
   if (isLoading || isFetching) {
-    return (
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        width={contentDimensions.width}
-        height={contentDimensions.height}
-      >
-        <Skeleton
-          variant="text"
-          width={contentDimensions.width - 20}
-          height={contentDimensions.height / 2}
-          aria-label="Loading..."
-        />
-      </Box>
-    );
+    return <LoadingOverlay />;
   }
 
   const tracesFound = queryResults.some((traceData) => (traceData.data?.traces ?? []).length > 0);
   if (!tracesFound) {
-    return (
-      <Stack sx={{ alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-        <Typography>No traces found</Typography>
-      </Stack>
-    );
+    return <NoDataOverlay resource="traces" />;
   }
 
   return (


### PR DESCRIPTION
# Description

To improve consistency across components, let's move `<NoContentRowOverlay>` from `apps` to `components` package, and also use it in panels.

Additionally, add a new `<LoadingOverlay>` component, for usage in e.g. panels.

# Screenshots

no visible UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
