### PR TITLE
[BUGFIX] Fix `$__interval` not taking datasource scrape interval as lower bound

### DIFF
--- a/ui/prometheus-plugin/src/model/time.test.ts
+++ b/ui/prometheus-plugin/src/model/time.test.ts
@@ -1,0 +1,40 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getRangeStep } from './time';
+
+describe('getRangeStep', () => {
+  it('should return the provided min step when the time range is narrow', () => {
+    // = 5m time range
+    const timerangeStart = 1718956800; // Fri Jun 21 2024 08:00:00 GMT+0000
+    const timerangeEnd = 1718957100; // Fri Jun 21 2024 08:05:00 GMT+0000
+    const minStepSeconds = 15;
+    const resolution = 1;
+    const suggestedStepMs = 200;
+    expect(
+      getRangeStep({ start: timerangeStart, end: timerangeEnd }, minStepSeconds, resolution, suggestedStepMs)
+    ).toEqual(minStepSeconds);
+  });
+
+  it('should return the suggested step when the time range is wide enough', () => {
+    // = 2w time range
+    const timerangeStart = 1718956800; // Fri Jun 21 2024 08:00:00 GMT+0000
+    const timerangeEnd = 1720166400; // Fri Jul 05 2024 08:00:00 GMT+0000
+    const minStepSeconds = 15;
+    const resolution = 1;
+    const suggestedStepMs = 600000;
+    expect(
+      getRangeStep({ start: timerangeStart, end: timerangeEnd }, minStepSeconds, resolution, suggestedStepMs)
+    ).toEqual(suggestedStepMs / 1000);
+  });
+});

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -54,6 +54,8 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
     milliseconds(parseDurationString(datasource.plugin.spec.scrapeInterval ?? DEFAULT_SCRAPE_INTERVAL)) / 1000
   );
 
+  // Min step is the lower bound of the interval between data points
+  // If no value is provided for it, it should default to the scrape interval of the datasource
   const minStep =
     getDurationStringSeconds(
       // resolve any variable that may have been provided
@@ -73,7 +75,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   end = alignedEnd;
 
   // Replace variable placeholders in PromQL query
-  const intervalMs = context.suggestedStepMs ?? step * 1000; // Step is in seconds
+  const intervalMs = step * 1000; // step is in seconds
   let query = replaceVariable(spec.query, '__interval_ms', intervalMs.toString());
   query = replaceVariable(spec.query, '__interval', formatDuration(msToPrometheusDuration(intervalMs)));
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Closes https://github.com/perses/perses/issues/2086.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
