### PR TITLE
[BUGFIX] Fix  misaligned in some resource datagrids

### DIFF
--- a/ui/app/src/components/datasource/DatasourceList.tsx
+++ b/ui/app/src/components/datasource/DatasourceList.tsx
@@ -14,7 +14,7 @@
 import { getResourceDisplayName, getMetadataProject, Datasource, Action } from '@perses-dev/core';
 import { Stack } from '@mui/material';
 import { GridColDef, GridRowParams } from '@mui/x-data-grid';
-import { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import ContentCopyIcon from 'mdi-material-ui/ContentCopy';
@@ -143,7 +143,7 @@ export function DatasourceList<T extends Datasource>(props: ListPropertiesWithCa
         headerName: 'Name',
         type: 'string',
         flex: 2,
-        renderCell: (params) => <pre>{params.value}</pre>,
+        renderCell: (params) => <span style={{ fontFamily: 'monospace' }}>{params.value}</span>,
       },
       VERSION_COL_DEF,
       DESCRIPTION_COL_DEF,

--- a/ui/app/src/components/secrets/SecretList.tsx
+++ b/ui/app/src/components/secrets/SecretList.tsx
@@ -154,7 +154,7 @@ export function SecretList<T extends Secret>({
         valueGetter: (_, row) => row.name,
         renderCell: (params) => (
           <>
-            <pre>{params.value}</pre>
+            <span style={{ fontFamily: 'monospace' }}>{params.value}</span>
             <Tooltip title="Copy secret to clipboard" placement="top">
               <IconButton
                 onClick={async ($event) => {

--- a/ui/app/src/components/variable/VariableList.tsx
+++ b/ui/app/src/components/variable/VariableList.tsx
@@ -150,7 +150,7 @@ export function VariableList<T extends Variable>(props: ListPropertiesWithCallba
         valueGetter: (_, row) => `$${row.name}`,
         renderCell: (params) => (
           <>
-            <pre>{params.value}</pre>
+            <span style={{ fontFamily: 'monospace' }}>{params.value}</span>
             <Tooltip title="Copy variable to clipboard" placement="top">
               <IconButton
                 onClick={async ($event) => {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixes #2087 

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/perses/perses/assets/5657041/f12fe6ac-cff5-42fc-9346-805f06e70297)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
