### PR TITLE
[ENHANCEMENT] Use DateTimeField in DateTimeRangePicker

### DIFF
--- a/ui/components/src/TimeRangeSelector/DateTimeRangePicker.tsx
+++ b/ui/components/src/TimeRangeSelector/DateTimeRangePicker.tsx
@@ -12,11 +12,13 @@
 // limitations under the License.
 
 import { useState } from 'react';
-import { Box, Stack, TextField, Typography, Button } from '@mui/material';
-import { LocalizationProvider, StaticDateTimePicker } from '@mui/x-date-pickers';
+import { Box, Stack, Typography, Button } from '@mui/material';
+import { DateTimeField, LocalizationProvider, StaticDateTimePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { AbsoluteTimeRange } from '@perses-dev/core';
 import { useTimeZone } from '../context';
+import { ErrorBoundary } from '../ErrorBoundary';
+import { ErrorAlert } from '../ErrorAlert';
 import { DATE_TIME_FORMAT, validateDateRange } from './utils';
 
 interface AbsoluteTimeFormProps {
@@ -170,28 +172,34 @@ export const DateTimeRangePicker = ({ initialTimeRange, onChange, onCancel }: Ab
           </Box>
         )}
         <Stack direction="row" alignItems="center" gap={1} pl={1} pr={1}>
-          <TextField
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              // TODO: add helperText, fix validation after we decide on form state solution
-              onChangeStartTime(event.target.value);
-            }}
-            onBlur={() => updateDateRange()}
-            value={timeRangeInputs.start}
-            label="Start Time"
-            placeholder={DATE_TIME_FORMAT}
-            // tel used to match MUI DateTimePicker, may change in future: https://github.com/mui/material-ui/issues/27590
-            type="tel"
-          />
-          <TextField
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              onChangeEndTime(event.target.value);
-            }}
-            onBlur={() => updateDateRange()}
-            value={timeRangeInputs.end}
-            label="End Time"
-            placeholder={DATE_TIME_FORMAT}
-            type="tel"
-          />
+          <ErrorBoundary FallbackComponent={ErrorAlert}>
+            <DateTimeField
+              label="Start Time"
+              // @ts-expect-error: because the value is a Date, but the component expects a string
+              value={new Date(timeRangeInputs.start)}
+              onChange={(event: string | null) => {
+                if (event) {
+                  onChangeStartTime(event);
+                }
+              }}
+              onBlur={() => updateDateRange()}
+              format={DATE_TIME_FORMAT}
+            />
+          </ErrorBoundary>
+          <ErrorBoundary FallbackComponent={ErrorAlert}>
+            <DateTimeField
+              label="End Time"
+              // @ts-expect-error: because the value is a Date, but the component expects a string
+              value={new Date(timeRangeInputs.end)}
+              onChange={(event: string | null) => {
+                if (event) {
+                  onChangeEndTime(event);
+                }
+              }}
+              onBlur={() => updateDateRange()}
+              format={DATE_TIME_FORMAT}
+            />
+          </ErrorBoundary>
         </Stack>
         <Stack direction="row" sx={{ padding: (theme) => theme.spacing(0, 1) }} gap={1}>
           <Button variant="contained" onClick={() => onApply()} fullWidth>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
With the upgrade to latest MUI X version, we can use MUI X DateTimeField directly (https://mui.com/x/react-date-pickers/date-time-field/)

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/perses/perses/assets/5657041/ffb451ea-8e4c-4cc8-875b-7570ef839acb)



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
