### PR TITLE
[BUGFIX] check content-type header before parsing error message as JSON

### DIFF
--- a/ui/core/src/utils/fetch.ts
+++ b/ui/core/src/utils/fetch.ts
@@ -17,12 +17,20 @@
 export async function fetch(...args: Parameters<typeof global.fetch>) {
   const response = await global.fetch(...args);
   if (response.ok === false) {
-    const json = await response.json();
-    if (json.error) {
-      throw new UserFriendlyError(json.error, response.status);
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      const json = await response.json();
+      if (json.error) {
+        throw new UserFriendlyError(json.error, response.status);
+      }
+      if (json.message) {
+        throw new UserFriendlyError(json.message, response.status);
+      }
     }
-    if (json.message) {
-      throw new UserFriendlyError(json.message, response.status);
+
+    const text = await response.text();
+    if (text) {
+      throw new UserFriendlyError(text, response.status);
     }
     throw new FetchError(response);
   }

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
@@ -127,9 +127,17 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
     return series;
   }, [dataset, defaultColor, maxSpanCount]);
 
-  // Error check: specify an alert if no traces are returned from the query
+  if (traceIsLoading) {
+    return <LoadingOverlay />;
+  }
+
+  const queryError = traceResults.find((d) => d.error);
+  if (queryError) {
+    throw queryError.error;
+  }
+
   const tracesFound = traceResults.some((traceData) => (traceData.data?.searchResult ?? []).length > 0);
-  if (!traceIsLoading && !tracesFound) {
+  if (!tracesFound) {
     return <NoDataOverlay resource="traces" />;
   }
 
@@ -139,10 +147,6 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
   };
 
   if (contentDimensions === undefined) return null;
-
-  if (traceIsLoading === true) {
-    return <LoadingOverlay />;
-  }
 
   return (
     <div data-testid="ScatterChartPanel_ScatterPlot">

--- a/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
@@ -33,6 +33,11 @@ export function TraceTablePanel(props: TraceTableProps) {
     return <LoadingOverlay />;
   }
 
+  const queryError = queryResults.find((d) => d.error);
+  if (queryError) {
+    throw queryError.error;
+  }
+
   const tracesFound = queryResults.some((traceData) => (traceData.data?.searchResult ?? []).length > 0);
   if (!tracesFound) {
     return <NoDataOverlay resource="traces" />;


### PR DESCRIPTION
# Description

Some services (e.g. Tempo) do not return error messages in JSON format. Therefore, we cannot assume the error response is always in JSON format.


# Screenshots

Before:
![grafik](https://github.com/perses/perses/assets/538011/b119fac1-9b80-40dd-9e48-59ab39f7f06a)

After:
![grafik](https://github.com/perses/perses/assets/538011/396533ec-57cc-4302-8aaf-c4eaf83498e5)



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
