### PR TITLE
[ignore] bump perses/github-actions to v0.5.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
 
       - name: Check Tag
         ## This step is verifying that the tag follow the semver
@@ -61,10 +62,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: Install UI deps
         run: cd ./ui && npm install
       - name: Install Playwright Browsers
@@ -86,10 +88,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: Install UI deps
         run: cd ./ui && npm install
       - name: Build the typedoc docs
@@ -107,10 +110,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: Download react build
         uses: actions/download-artifact@v4
         with:
@@ -159,7 +163,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true

--- a/.github/workflows/delete-snapshot.yml
+++ b/.github/workflows/delete-snapshot.yml
@@ -7,10 +7,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: Remove npm snapshot tag
         run: ./scripts/ui_release.sh --remove-snapshot "${{ github.event.ref }}"
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,11 +22,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
           enable_go: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: Install UI deps
         working-directory: ./ui
         run: npm ci

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -133,7 +133,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -21,10 +21,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: install deps
         run: cd ./ui && npm ci
       - run: cd ./ui && npm run lint
@@ -34,10 +35,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: install deps
         run: cd ./ui && npm ci
       - run: cd ./ui && npm run type-check
@@ -47,10 +49,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.4.0
+      - uses: perses/github-actions@v0.5.2
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
+          nvmrc_path: "./ui/.nvmrc"
       - name: install deps
         run: cd ./ui && npm ci
       - run: cd ./ui && npm run test


### PR DESCRIPTION
currently CI is broken because somehow, the github actions is taking the last version of `perses/github-actions` that request to provide the path to the file `.nvmrc`.

This PR aims to fix that