### PR TITLE
[BUGFIX] fix TraceQL query escaping

### DIFF
--- a/ui/tempo-plugin/src/model/api-types.ts
+++ b/ui/tempo-plugin/src/model/api-types.ts
@@ -26,6 +26,15 @@ export type AttributeValue =
   | { arrayValue: { values: AttributeValue[] } };
 
 /**
+ * Parameters of Tempo HTTP API endpoint GET /api/search
+ */
+export interface SearchRequestParameters {
+  q: string;
+  start?: number;
+  end?: number;
+}
+
+/**
  * Response of Tempo HTTP API endpoint GET /api/search/<query>
  */
 export interface SearchTraceQueryResponse {

--- a/ui/tempo-plugin/src/model/tempo-client.test.ts
+++ b/ui/tempo-plugin/src/model/tempo-client.test.ts
@@ -20,7 +20,7 @@ describe('tempo-client', () => {
   it('should return query results as-is when serviceStats are present', async () => {
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(MOCK_SEARCH_RESPONSE_VPARQUET4) });
 
-    const results = await searchTraceQueryFallback('{}', '');
+    const results = await searchTraceQueryFallback({ q: '{}' }, { datasourceUrl: '' });
     expect(results).toEqual(MOCK_SEARCH_RESPONSE_VPARQUET4);
   });
 
@@ -28,7 +28,7 @@ describe('tempo-client', () => {
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(MOCK_SEARCH_RESPONSE_VPARQUET3) });
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(MOCK_TRACE_RESPONSE) });
 
-    const results = await searchTraceQueryFallback('{}', '');
+    const results = await searchTraceQueryFallback({ q: '{}' }, { datasourceUrl: '' });
     expect(results).toEqual(MOCK_SEARCH_RESPONSE_VPARQUET4);
   });
 });

--- a/ui/tempo-plugin/src/plugins/tempo-datasource.tsx
+++ b/ui/tempo-plugin/src/plugins/tempo-datasource.tsx
@@ -32,9 +32,9 @@ const createClient: DatasourcePlugin<TempoDatasourceSpec, TempoClient>['createCl
     options: {
       datasourceUrl,
     },
-    searchTraceQuery: (query: string) => searchTraceQuery(query, datasourceUrl),
-    searchTraceQueryFallback: (query: string) => searchTraceQueryFallback(query, datasourceUrl),
-    searchTraceID: (traceID: string) => searchTraceID(traceID, datasourceUrl),
+    searchTraceQuery: (params, queryOptions) => searchTraceQuery(params, queryOptions),
+    searchTraceQueryFallback: (params, queryOptions) => searchTraceQueryFallback(params, queryOptions),
+    searchTraceID: (traceID, queryOptions) => searchTraceID(traceID, queryOptions),
   };
 };
 


### PR DESCRIPTION
# Description

Previously, TraceQL queries with `&&` were not escaped when accessing the Tempo API. This PR refactors the client code, to use the URLSearchParams API to construct the URL and align with the Prometheus API client (`queryOptions`, support custom headers).

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
