### PR TITLE
[BREAKINGCHANGE] GO-SDK: remove the possibility to create the plugin builder

### DIFF
--- a/go-sdk/panel/bar/bar.go
+++ b/go-sdk/panel/bar/bar.go
@@ -45,7 +45,7 @@ type Builder struct {
 	PluginSpec `json:",inline" yaml:",inline"`
 }
 
-func New(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	builder := &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -65,7 +65,7 @@ func New(options ...Option) (Builder, error) {
 
 func Chart(options ...Option) panel.Option {
 	return func(builder *panel.Builder) error {
-		r, err := New(options...)
+		r, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/panel/gauge/gauge.go
+++ b/go-sdk/panel/gauge/gauge.go
@@ -31,7 +31,7 @@ type Builder struct {
 	PluginSpec `json:",inline" yaml:",inline"`
 }
 
-func New(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	builder := &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -51,7 +51,7 @@ func New(options ...Option) (Builder, error) {
 
 func Chart(options ...Option) panel.Option {
 	return func(builder *panel.Builder) error {
-		r, err := New(options...)
+		r, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/panel/markdown/markdown.go
+++ b/go-sdk/panel/markdown/markdown.go
@@ -25,7 +25,7 @@ type Builder struct {
 	PluginSpec `json:",inline" yaml:",inline"`
 }
 
-func New(text string, options ...Option) (Builder, error) {
+func create(text string, options ...Option) (Builder, error) {
 	builder := &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -45,7 +45,7 @@ func New(text string, options ...Option) (Builder, error) {
 
 func Markdown(text string, options ...Option) panel.Option {
 	return func(builder *panel.Builder) error {
-		r, err := New(text, options...)
+		r, err := create(text, options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/panel/stat/stat.go
+++ b/go-sdk/panel/stat/stat.go
@@ -37,7 +37,7 @@ type Builder struct {
 	PluginSpec `json:",inline" yaml:",inline"`
 }
 
-func New(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	builder := &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -57,7 +57,7 @@ func New(options ...Option) (Builder, error) {
 
 func Chart(options ...Option) panel.Option {
 	return func(builder *panel.Builder) error {
-		r, err := New(options...)
+		r, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/panel/time-series/time-series.go
+++ b/go-sdk/panel/time-series/time-series.go
@@ -125,7 +125,7 @@ type QuerySettingsItem struct {
 
 type Option func(plugin *Builder) error
 
-func New(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	builder := &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -145,7 +145,7 @@ type Builder struct {
 
 func Chart(options ...Option) panel.Option {
 	return func(builder *panel.Builder) error {
-		plugin, err := New(options...)
+		plugin, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/prometheus/datasource/datasource.go
+++ b/go-sdk/prometheus/datasource/datasource.go
@@ -70,7 +70,7 @@ func (s *PluginSpec) validate() error {
 
 type Option func(plugin *Builder) error
 
-func NewPlugin(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	builder := &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -92,7 +92,7 @@ type Builder struct {
 
 func Prometheus(options ...Option) datasource.Option {
 	return func(builder *datasource.Builder) error {
-		plugin, err := NewPlugin(options...)
+		plugin, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/prometheus/query/query.go
+++ b/go-sdk/prometheus/query/query.go
@@ -29,7 +29,7 @@ type PluginSpec struct {
 
 type Option func(plugin *Builder) error
 
-func NewPlugin(query string, options ...Option) (Builder, error) {
+func create(query string, options ...Option) (Builder, error) {
 	builder := &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -53,7 +53,7 @@ type Builder struct {
 
 func PromQL(expr string, options ...Option) query.Option {
 	return func(builder *query.Builder) error {
-		plugin, err := NewPlugin(expr, options...)
+		plugin, err := create(expr, options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/prometheus/variable/label-names/label-names.go
+++ b/go-sdk/prometheus/variable/label-names/label-names.go
@@ -29,7 +29,7 @@ type PluginSpec struct {
 
 type Option func(plugin *Builder) error
 
-func New(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	var builder = &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -50,7 +50,7 @@ func New(options ...Option) (Builder, error) {
 func PrometheusLabelNames(options ...Option) list_variable.Option {
 	return func(builder *list_variable.Builder) error {
 		options = append([]Option{Filter(builder.Filters...)}, options...)
-		t, err := New(options...)
+		t, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/prometheus/variable/label-values/label-values.go
+++ b/go-sdk/prometheus/variable/label-values/label-values.go
@@ -30,7 +30,7 @@ type PluginSpec struct {
 
 type Option func(plugin *Builder) error
 
-func New(labelName string, options ...Option) (Builder, error) {
+func create(labelName string, options ...Option) (Builder, error) {
 	var builder = &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -54,7 +54,7 @@ func New(labelName string, options ...Option) (Builder, error) {
 
 func PrometheusLabelValues(labelName string, options ...Option) list_variable.Option {
 	return func(builder *list_variable.Builder) error {
-		t, err := New(labelName, options...)
+		t, err := create(labelName, options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/prometheus/variable/promql/promql.go
+++ b/go-sdk/prometheus/variable/promql/promql.go
@@ -26,7 +26,7 @@ type PluginSpec struct {
 
 type Option func(plugin *Builder) error
 
-func New(expr string, options ...Option) (Builder, error) {
+func create(expr string, options ...Option) (Builder, error) {
 	var builder = &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -46,7 +46,7 @@ func New(expr string, options ...Option) (Builder, error) {
 
 func PrometheusPromQL(expr string, options ...Option) list_variable.Option {
 	return func(builder *list_variable.Builder) error {
-		t, err := New(expr, options...)
+		t, err := create(expr, options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/variable/list-variable/list-variable.go
+++ b/go-sdk/variable/list-variable/list-variable.go
@@ -27,7 +27,7 @@ type Builder struct {
 	Filters          []v1.Variable              `json:"-" yaml:"-"`
 }
 
-func New(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	var builder = &Builder{
 		ListVariableSpec: dashboard.ListVariableSpec{
 			ListSpec: variable2.ListSpec{},
@@ -50,7 +50,7 @@ func New(options ...Option) (Builder, error) {
 func List(options ...Option) variable.Option {
 	return func(builder *variable.Builder) error {
 		options = append([]Option{Filter(builder.Filters...)}, options...)
-		t, err := New(options...)
+		t, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/variable/plugin/static-list/static-list.go
+++ b/go-sdk/variable/plugin/static-list/static-list.go
@@ -27,7 +27,7 @@ type Builder struct {
 	PluginSpec
 }
 
-func New(options ...Option) (Builder, error) {
+func create(options ...Option) (Builder, error) {
 	var builder = &Builder{
 		PluginSpec: PluginSpec{},
 	}
@@ -45,7 +45,7 @@ func New(options ...Option) (Builder, error) {
 
 func StaticList(options ...Option) list_variable.Option {
 	return func(builder *list_variable.Builder) error {
-		t, err := New(options...)
+		t, err := create(options...)
 		if err != nil {
 			return err
 		}

--- a/go-sdk/variable/text-variable/text-variable.go
+++ b/go-sdk/variable/text-variable/text-variable.go
@@ -26,7 +26,7 @@ type Builder struct {
 	Filters          []v1.Variable              `json:"-" yaml:"-"`
 }
 
-func New(value string, options ...Option) (Builder, error) {
+func create(value string, options ...Option) (Builder, error) {
 	var builder = &Builder{
 		TextVariableSpec: dashboard.TextVariableSpec{
 			//Name:     "", // TODO: handle conversion
@@ -48,7 +48,7 @@ func New(value string, options ...Option) (Builder, error) {
 func Text(value string, options ...Option) variable.Option {
 	return func(builder *variable.Builder) error {
 		options = append([]Option{Filter(builder.Filters...)}, options...)
-		t, err := New(value, options...)
+		t, err := create(value, options...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In the different plugin supported, it was possible to create the builder for each plugin which is not the way the SDK has been thought.

On each plugin, there is only one method exposed that should be used to create the plugin. Builder is just the internal way we used to create the plugin