### PR TITLE
[FEATURE] Provide a way to prefix the API

### DIFF
--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -49,7 +49,7 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 		return nil, nil, fmt.Errorf("unable to initialize the service manager: %w", err)
 	}
 	persesAPI := NewPersesAPI(serviceManager, persistenceManager, conf)
-	persesFrontend := ui.NewPersesFrontend()
+	persesFrontend := ui.NewPersesFrontend(conf)
 	runner := app.NewRunner().WithDefaultHTTPServerAndPrometheusRegisterer(utils.MetricNamespace, registry, registry).SetBanner(banner)
 
 	// enable hot reload of CUE schemas for dashboard validation:

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -51,6 +51,7 @@ type api struct {
 	apiEndpoints   []route.Endpoint
 	proxyEndpoint  route.Endpoint
 	jwtMiddleware  echo.MiddlewareFunc
+	apiPrefix      string
 }
 
 func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager dependency.PersistenceManager, cfg config.Config) echoUtils.Register {
@@ -98,6 +99,7 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		jwtMiddleware: serviceManager.GetJWT().Middleware(func(_ echo.Context) bool {
 			return !cfg.Security.EnableAuth
 		}),
+		apiPrefix: cfg.APIPrefix,
 	}
 }
 
@@ -146,15 +148,15 @@ func (a *api) RegisterRoute(e *echo.Echo) {
 }
 
 func (a *api) collectRoutes() []*route.Group {
-	apiGroup := &route.Group{Path: utils.APIPrefix}
+	apiGroup := &route.Group{Path: a.apiPrefix + utils.APIPrefix}
 	for _, ept := range a.apiEndpoints {
 		ept.CollectRoutes(apiGroup)
 	}
-	apiV1Group := &route.Group{Path: utils.APIV1Prefix}
+	apiV1Group := &route.Group{Path: a.apiPrefix + utils.APIV1Prefix}
 	for _, ept := range a.apiV1Endpoints {
 		ept.CollectRoutes(apiV1Group)
 	}
-	proxyGroup := &route.Group{Path: "/proxy"}
+	proxyGroup := &route.Group{Path: a.apiPrefix + "/proxy"}
 	a.proxyEndpoint.CollectRoutes(proxyGroup)
 	return []*route.Group{apiGroup, apiV1Group, proxyGroup}
 }

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -46,6 +46,8 @@ type dashboardSelector struct {
 	Dashboard string `json:"dashboard" yaml:"dashboard"`
 }
 type Config struct {
+	// Use it in case you want prefix the API path.
+	APIPrefix string `json:"api_prefix,omitempty" yaml:"api_prefix,omitempty"`
 	// Security contains any configuration that changes the API behavior like the endpoints exposed or if the permissions are activated.
 	Security Security `json:"security,omitempty" yaml:"security,omitempty"`
 	// Database contains the different configuration depending on the database you want to use

--- a/ui/app/src/model/route.test.ts
+++ b/ui/app/src/model/route.test.ts
@@ -1,0 +1,54 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AdminRoute, extractBasePathName } from './route';
+
+describe('extractBasePathName', () => {
+  const testSuite = [
+    {
+      title: 'empty base path',
+      path: '/',
+      expectedBasePath: '',
+    },
+    {
+      title: 'empty base path with prefix',
+      path: '/foo',
+      expectedBasePath: '/foo',
+    },
+    {
+      title: 'regular path with no prefix',
+      path: AdminRoute,
+      expectedBasePath: '',
+    },
+    {
+      title: 'regular path with prefix',
+      path: `/foo${AdminRoute}`,
+      expectedBasePath: '/foo',
+    },
+    {
+      title: 'regular dashboard path with no prefix',
+      path: '/projects/perses/dashboards/dashboardA',
+      expectedBasePath: '',
+    },
+    {
+      title: 'regular dashboard path with prefix',
+      path: '/foo/projects/perses/dashboards/dashboardA',
+      expectedBasePath: '/foo',
+    },
+  ];
+  testSuite.forEach(({ title, path, expectedBasePath }) => {
+    it(title, () => {
+      expect(extractBasePathName(path)).toEqual(expectedBasePath);
+    });
+  });
+});

--- a/ui/app/src/model/route.ts
+++ b/ui/app/src/model/route.ts
@@ -18,3 +18,34 @@ export const ConfigRoute = '/config';
 export const ImportRoute = '/import';
 export const ProjectRoute = '/projects';
 export const ExploreRoute = '/explore';
+
+const paths = [AdminRoute, SignInRoute, SignUpRoute, ConfigRoute, ImportRoute, ProjectRoute, ExploreRoute];
+
+export function getBasePathName(): string {
+  return extractBasePathName(window.location.pathname);
+}
+
+// This dynamically/generically determines the pathPrefix
+// by stripping the first known endpoint suffix from the window location path.
+// It works out of the box for both direct
+// hosting and reverse proxy deployments with no additional configurations required.
+export function extractBasePathName(path: string): string {
+  let basePath = path;
+  if (basePath.endsWith('/')) {
+    basePath = basePath.slice(0, -1);
+  }
+  for (let i = 0; i < paths.length; i++) {
+    const path = paths[i];
+    if (path && basePath.endsWith(path)) {
+      basePath = basePath.slice(0, basePath.length - path.length);
+      break;
+    }
+  }
+  // In case we are in a dashboard page, then the route ends with /dashboards/<dashboard_name>.
+  // In that particular case, we can remove everything after /projects
+  const split = basePath.split(ProjectRoute)[0];
+  if (split !== undefined) {
+    return split;
+  }
+  return basePath;
+}

--- a/ui/app/src/model/url-builder.ts
+++ b/ui/app/src/model/url-builder.ts
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { getBasePathName } from './route';
+
 const apiPrefix = '/api/v1';
 
 export type URLParams = {
@@ -23,6 +25,7 @@ export type URLParams = {
 };
 
 export default function buildURL(params: URLParams): string {
+  const basePath = getBasePathName();
   let url = params.apiPrefix === undefined ? apiPrefix : params.apiPrefix;
   if (params.project !== undefined && params.project.length > 0) {
     url = `${url}/projects/${encodeURIComponent(params.project)}`;
@@ -39,5 +42,5 @@ export default function buildURL(params: URLParams): string {
   if (params.queryParams !== undefined) {
     url = `${url}?${params.queryParams.toString()}`;
   }
-  return url;
+  return basePath + url;
 }

--- a/ui/app/src/render-app.tsx
+++ b/ui/app/src/render-app.tsx
@@ -23,6 +23,7 @@ import { DarkModeContextProvider } from './context/DarkMode';
 import App from './App';
 import { NavHistoryProvider } from './context/DashboardNavHistory';
 import { ConfigContextProvider } from './context/Config';
+import { getBasePathName } from './model/route';
 
 /**
  * Renders the Perses application in the target container.
@@ -45,10 +46,11 @@ export function renderApp(container: Element | null) {
   });
 
   const root = ReactDOM.createRoot(container);
+  const basePath = getBasePathName();
 
   root.render(
     <React.StrictMode>
-      <BrowserRouter>
+      <BrowserRouter basename={basePath}>
         <CookiesProvider>
           <QueryClientProvider client={queryClient}>
             <ConfigContextProvider>

--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -22,6 +22,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	echoUtils "github.com/perses/common/echo"
 	apiinterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/pkg/model/api/config"
 	"github.com/prometheus/common/assets"
 	"github.com/sirupsen/logrus"
 )
@@ -41,16 +42,17 @@ var (
 
 type frontend struct {
 	echoUtils.Register
+	apiPrefix string
 }
 
-func NewPersesFrontend() echoUtils.Register {
-	return &frontend{}
+func NewPersesFrontend(cfg config.Config) echoUtils.Register {
+	return &frontend{apiPrefix: cfg.APIPrefix}
 }
 
 func (f *frontend) RegisterRoute(e *echo.Echo) {
 	contentHandler := echo.WrapHandler(http.FileServer(asts))
 	contentRewrite := middleware.Rewrite(map[string]string{"/*": "/app/dist/$1"})
-	e.GET("/*", contentHandler, routerMiddleware(), contentRewrite)
+	e.GET(f.apiPrefix+"/*", contentHandler, routerMiddleware(), contentRewrite)
 }
 
 // routerMiddleware is here to serve properly the react app.


### PR DESCRIPTION
This PR is providing a way to prefix the API.

For the backend, you need to set the configuration entry `api_prefix` with the wanted value.

For the frontend, the prefix is deduced.

Closes #2136 