### PR TITLE
[ENHANCEMENT] Add 'comfortable' density for Table panel

### DIFF
--- a/cue/schemas/panels/table/migrate.cue
+++ b/cue/schemas/panels/table/migrate.cue
@@ -5,7 +5,7 @@ if #panel.type != _|_ if #panel.type == "table" {
 			density: [
 				if #panel.options.cellHeight == "sm" { "compact" },
 				if #panel.options.cellHeight == "md" { "standard" },
-				if #panel.options.cellHeight == "lg" { "standard" }
+				if #panel.options.cellHeight == "lg" { "comfortable" }
 			][0]
 		}
 

--- a/cue/schemas/panels/table/table.cue
+++ b/cue/schemas/panels/table/table.cue
@@ -17,7 +17,7 @@ import "strings"
 
 kind: "Table"
 spec: close({
-	density?: "compact" | "standard"
+	density?: "compact" | "standard" | "comfortable"
 	columnSettings?: [...#columnSettings]
 })
 

--- a/ui/components/src/DensitySelector/DensitySelector.tsx
+++ b/ui/components/src/DensitySelector/DensitySelector.tsx
@@ -17,9 +17,10 @@ import { SettingsAutocomplete } from '../SettingsAutocomplete';
 const DENSITY_OPTIONS: Array<{ id: DensityOption; label: string }> = [
   { id: 'compact', label: 'Compact' },
   { id: 'standard', label: 'Standard' },
+  { id: 'comfortable', label: 'Comfortable' },
 ];
 
-export type DensityOption = 'compact' | 'standard';
+export type DensityOption = 'compact' | 'standard' | 'comfortable';
 
 export interface DensitySelectorProps {
   onChange: (density: DensityOption) => void;

--- a/ui/components/src/Table/InnerTable.tsx
+++ b/ui/components/src/Table/InnerTable.tsx
@@ -29,6 +29,7 @@ type InnerTableProps = Omit<MuiTableProps, 'size'> & {
 const TABLE_DENSITY_CONFIG: Record<TableDensity, MuiTableProps['size']> = {
   compact: 'small',
   standard: 'medium',
+  comfortable: 'medium',
 };
 
 export const InnerTable = forwardRef<HTMLTableElement, InnerTableProps>(function InnerTable(

--- a/ui/components/src/Table/model/table-model.ts
+++ b/ui/components/src/Table/model/table-model.ts
@@ -23,7 +23,7 @@ import {
 } from '@tanstack/react-table';
 import { CSSProperties } from 'react';
 
-export type TableDensity = 'compact' | 'standard';
+export type TableDensity = 'compact' | 'standard' | 'comfortable';
 export type SortDirection = 'asc' | 'desc' | undefined;
 
 export type TableRowEventOpts = {
@@ -163,36 +163,39 @@ export function getTableCellLayout(
   density: TableDensity,
   { isLastColumn, isFirstColumn }: GetTableCellLayoutOpts = {}
 ): TableCellLayout {
+  // Density Standard
+  let paddingY = theme.spacing(1);
+  let basePaddingX = theme.spacing(1.25);
+  let edgePaddingX = theme.spacing(2);
+  let paddingLeft = isFirstColumn ? edgePaddingX : basePaddingX;
+  let paddingRight = isLastColumn ? edgePaddingX : basePaddingX;
+  let lineHeight = theme.typography.body1.lineHeight;
+  let fontSize = theme.typography.body1.fontSize;
+
   if (density === 'compact') {
-    const paddingY = theme.spacing(0.5);
-
-    const basePaddingX = theme.spacing(0.5);
-    const edgePaddingX = theme.spacing(1);
-    const paddingLeft = isFirstColumn ? edgePaddingX : basePaddingX;
-    const paddingRight = isLastColumn ? edgePaddingX : basePaddingX;
-
-    const lineHeight = theme.typography.body2.lineHeight;
-
-    return {
-      padding: `${paddingY} ${paddingRight} ${paddingY} ${paddingLeft}`,
-      height: calculateTableCellHeight(lineHeight, paddingY),
-      fontSize: theme.typography.body2.fontSize,
-      lineHeight: lineHeight,
-    };
+    paddingY = theme.spacing(0.5);
+    basePaddingX = theme.spacing(0.5);
+    edgePaddingX = theme.spacing(1);
+    paddingLeft = isFirstColumn ? edgePaddingX : basePaddingX;
+    paddingRight = isLastColumn ? edgePaddingX : basePaddingX;
+    lineHeight = theme.typography.body2.lineHeight;
+    fontSize = theme.typography.body2.fontSize;
   }
 
-  // standard density
-  const paddingY = theme.spacing(1);
-  const basePaddingX = theme.spacing(1.25);
-  const edgePaddingX = theme.spacing(2);
-  const paddingLeft = isFirstColumn ? edgePaddingX : basePaddingX;
-  const paddingRight = isLastColumn ? edgePaddingX : basePaddingX;
-  const lineHeight = theme.typography.body1.lineHeight;
+  if (density === 'comfortable') {
+    paddingY = theme.spacing(2);
+    basePaddingX = theme.spacing(1.5);
+    edgePaddingX = theme.spacing(2);
+    paddingLeft = isFirstColumn ? edgePaddingX : basePaddingX;
+    paddingRight = isLastColumn ? edgePaddingX : basePaddingX;
+    lineHeight = theme.typography.body1.lineHeight;
+    fontSize = theme.typography.body1.fontSize;
+  }
 
   return {
     padding: `${paddingY} ${paddingRight} ${paddingY} ${paddingLeft}`,
     height: calculateTableCellHeight(lineHeight, paddingY),
-    fontSize: theme.typography.body1.fontSize,
+    fontSize: fontSize,
     lineHeight: lineHeight,
   };
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Add a new density to Table panel

# Screenshots

<!-- If there are UI changes -->
Comfortable:
![image](https://github.com/user-attachments/assets/d92ca8b3-dfe0-44c8-8cb8-358bb45eabab)

For reminder:

Standard:
![image](https://github.com/user-attachments/assets/afe45aca-8ed5-4ab4-abe2-29e6108f4bb0)


Compact:
![image](https://github.com/user-attachments/assets/81852841-5833-478e-a7e6-331cef59bf27)



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
