### PR TITLE
[ENHANCEMENT] Improve searchbar display

### DIFF
--- a/ui/app/src/components/Header/AccountMenu.tsx
+++ b/ui/app/src/components/Header/AccountMenu.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import React, { MouseEvent, useState } from 'react';
-import { Box, Divider, IconButton, ListItemIcon, Menu, MenuItem } from '@mui/material';
+import { Divider, IconButton, ListItemIcon, Menu, MenuItem } from '@mui/material';
 import AccountCircle from 'mdi-material-ui/AccountCircle';
 import Logout from 'mdi-material-ui/Logout';
 import { useAuthToken } from '../../model/auth-client';
@@ -29,7 +29,7 @@ export function AccountMenu() {
     setAnchorEl(null);
   };
   return (
-    <Box>
+    <>
       <IconButton
         aria-label="Account menu"
         aria-controls="menu-account-list-appbar"
@@ -65,6 +65,6 @@ export function AccountMenu() {
           Logout
         </MenuItem>
       </Menu>
-    </Box>
+    </>
   );
 }

--- a/ui/app/src/components/Header/Header.tsx
+++ b/ui/app/src/components/Header/Header.tsx
@@ -53,7 +53,6 @@ export default function Header(): JSX.Element {
             paddingLeft: 0,
             paddingRight: 0.75,
           },
-          justifyContent: 'space-between',
         }}
       >
         <Box
@@ -61,6 +60,8 @@ export default function Header(): JSX.Element {
             display: 'flex',
             flexDirection: 'row',
             alignItems: 'center',
+            width: '100%',
+            flexShrink: isMobileSize ? 2 : 1,
           }}
         >
           <Button
@@ -119,7 +120,16 @@ export default function Header(): JSX.Element {
           )}
         </Box>
         <SearchBar />
-        {isAuthEnabled ? <AccountMenu /> : <ThemeSwitch isAuthEnabled={false} />}
+        <Box
+          sx={{
+            width: '100%',
+            flexShrink: isMobileSize ? 2 : 1,
+            display: 'flex',
+            justifyContent: 'end',
+          }}
+        >
+          {isAuthEnabled ? <AccountMenu /> : <ThemeSwitch isAuthEnabled={false} />}
+        </Box>
       </Toolbar>
     </AppBar>
   );

--- a/ui/app/src/components/Header/SearchBar/SearchBar.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchBar.tsx
@@ -114,7 +114,7 @@ export function SearchBar() {
   useHandleShortCut(handleOpen);
 
   return (
-    <Paper sx={{ flexGrow: 2, maxWidth: isMobileSize ? '50%' : '30%' }}>
+    <Paper sx={{ width: '100%', flexShrink: 1 }}>
       <Button size="small" fullWidth sx={{ display: 'flex', justifyContent: 'space-between' }} onClick={handleOpen}>
         <Box sx={{ display: 'flex' }} flexDirection="row" alignItems="center">
           <Magnify sx={{ marginRight: 0.5 }} fontSize="medium" />


### PR DESCRIPTION
# Description

Vertically-center the search bar with the viewport + make it take more available space on mobile.

# Screenshots

Before:
![2024-07-31_14h50_25](https://github.com/user-attachments/assets/d2aaaada-a914-46f3-9fa5-06d2dc940eed)

After:
![2024-07-31_14h49_55](https://github.com/user-attachments/assets/c9238f22-1d73-4fa7-8f71-da859a0a9e11)

Responsiveness:

https://github.com/user-attachments/assets/143c3c3e-74a4-46ff-a460-fc43cbfb3eca

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
