### PR TITLE
[BUGFIX] Timeseries Panel should have same left/right margin when yAxis is disabled

### DIFF
--- a/ui/panels-plugin/src/plugins/time-series-chart/QuerySettingsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/QuerySettingsEditor.tsx
@@ -101,9 +101,6 @@ export function QuerySettingsEditor({ querySettingsList, onChange }: QuerySettin
     return allQueryIndexes.filter((_, queryIndex) => !bookedQueryIndexes.includes(queryIndex));
   }, [querySettingsList, queryCount]);
 
-  console.log('availableQueryIndexes');
-  console.log(availableQueryIndexes);
-
   const firstAvailableQueryIndex = useMemo(() => {
     return availableQueryIndexes[0] ?? NO_INDEX_AVAILABLE;
   }, [availableQueryIndexes]);

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.test.ts
@@ -56,7 +56,14 @@ describe('convertPanelYAxis', () => {
     };
     const echartsAxis = convertPanelYAxis(persesAxis);
     // Axis label is handled outside of echarts since it is built with a custom React component.
-    expect(echartsAxis).toEqual({ max: 1, min: 0.1, show: true });
+    expect(echartsAxis).toEqual({
+      show: true,
+      max: 1,
+      min: 0.1,
+      axisLabel: {
+        show: true,
+      },
+    });
   });
 });
 

--- a/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/time-series-chart/utils/data-transform.ts
@@ -288,7 +288,10 @@ function findMax(data: LegacyTimeSeries[] | TimeSeries[]) {
  */
 export function convertPanelYAxis(inputAxis: TimeSeriesChartYAxisOptions = {}): YAXisComponentOption {
   const yAxis: YAXisComponentOption = {
-    show: inputAxis?.show ?? DEFAULT_Y_AXIS.show,
+    show: true,
+    axisLabel: {
+      show: inputAxis?.show ?? DEFAULT_Y_AXIS.show,
+    },
     min: inputAxis?.min,
     max: inputAxis?.max,
   };


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fix #2126. Padding on the panel should be similar on left and right when yAxis is disabled.


# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/user-attachments/assets/e6d0842c-0034-4ec1-b7bd-b46d8ce0e265)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
