### PR TITLE
[IGNORE] refactoring []byte to json.RawMessage in api package

### DIFF
--- a/internal/api/dashboard/cleaner_test.go
+++ b/internal/api/dashboard/cleaner_test.go
@@ -16,9 +16,10 @@ package dashboard
 import (
 	"context"
 	"encoding/json"
-	"github.com/perses/perses/pkg/model/api"
 	"testing"
 	"time"
+
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
@@ -34,8 +35,8 @@ func (d *mockDAO) List(_ *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, e
 	return d.dashboards, nil
 }
 
-func (d *mockDAO) RawList(_ *ephemeraldashboard.Query) ([][]byte, error) {
-	result := make([][]byte, 0, len(d.dashboards))
+func (d *mockDAO) RawList(_ *ephemeraldashboard.Query) ([]json.RawMessage, error) {
+	result := make([]json.RawMessage, 0, len(d.dashboards))
 	for _, dash := range d.dashboards {
 		b, _ := json.Marshal(dash)
 		result = append(result, b)
@@ -55,8 +56,8 @@ func (d *mockDAO) MetadataList(_ *ephemeraldashboard.Query) ([]api.Entity, error
 	return result, nil
 }
 
-func (d *mockDAO) RawMetadataList(_ *ephemeraldashboard.Query) ([][]byte, error) {
-	result := make([][]byte, 0, len(d.dashboards))
+func (d *mockDAO) RawMetadataList(_ *ephemeraldashboard.Query) ([]json.RawMessage, error) {
+	result := make([]json.RawMessage, 0, len(d.dashboards))
 	for _, dash := range d.dashboards {
 		partial := &v1.PartialProjectEntity{
 			Kind:     dash.Kind,

--- a/internal/api/database/database.go
+++ b/internal/api/database/database.go
@@ -15,11 +15,13 @@ package database
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"time"
+
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/tidwall/gjson"
-	"time"
 
 	"github.com/go-sql-driver/mysql"
 	databaseFile "github.com/perses/perses/internal/api/database/file"
@@ -57,16 +59,16 @@ func (d *dao) Get(kind modelV1.Kind, metadata modelAPI.Metadata, entity modelAPI
 func (d *dao) Query(query databaseModel.Query, slice interface{}) error {
 	return d.client.Query(query, slice)
 }
-func (d *dao) RawQuery(query databaseModel.Query) ([][]byte, error) {
+func (d *dao) RawQuery(query databaseModel.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(query)
 }
-func (d *dao) RawMetadataQuery(query databaseModel.Query, kind modelV1.Kind) ([][]byte, error) {
+func (d *dao) RawMetadataQuery(query databaseModel.Query, kind modelV1.Kind) ([]json.RawMessage, error) {
 	raws, err := d.client.RawQuery(query)
 	if err != nil {
 		return nil, err
 	}
 	// now let's extract the metadata and the kind
-	result := make([][]byte, 0, len(raws))
+	result := make([]json.RawMessage, 0, len(raws))
 	for _, raw := range raws {
 		metadata := gjson.GetBytes(raw, "metadata").String()
 		result = append(result, []byte(fmt.Sprintf(`{"kind":"%s","metadata":%s,"spec":{}}`, kind, metadata)))

--- a/internal/api/database/file/file.go
+++ b/internal/api/database/file/file.go
@@ -111,18 +111,18 @@ func (d *DAO) Get(kind modelV1.Kind, metadata modelAPI.Metadata, entity modelAPI
 	return nil
 }
 
-func (d *DAO) RawMetadataQuery(_ databaseModel.Query, _ modelV1.Kind) ([][]byte, error) {
+func (d *DAO) RawMetadataQuery(_ databaseModel.Query, _ modelV1.Kind) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("raw metadata query not implemented")
 }
 
-func (d *DAO) RawQuery(query databaseModel.Query) ([][]byte, error) {
+func (d *DAO) RawQuery(query databaseModel.Query) ([]json.RawMessage, error) {
 	folder, prefix, isExist, err := d.buildQuery(query)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build the query: %s", err)
 	}
 	if !isExist {
 		// There is nothing to return. So let's initialize the slice just to avoid returning a nil slice
-		return make([][]byte, 0), nil
+		return make([]json.RawMessage, 0), nil
 	}
 	// so now we have the proper folder to looking for and potentially a filter to use
 	var files []string
@@ -131,9 +131,9 @@ func (d *DAO) RawQuery(query databaseModel.Query) ([][]byte, error) {
 	}
 	if len(files) <= 0 {
 		// in case the result is empty, let's initialize the slice just to avoid returning a nil slice
-		return make([][]byte, 0), nil
+		return make([]json.RawMessage, 0), nil
 	}
-	var result [][]byte
+	result := []json.RawMessage{}
 
 	for _, file := range files {
 		// now read all files and append them to the final result

--- a/internal/api/database/model/dao.go
+++ b/internal/api/database/model/dao.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"encoding/json"
 	"io"
 
 	modelAPI "github.com/perses/perses/pkg/model/api"
@@ -38,8 +39,8 @@ type DAO interface {
 	// Query will find a list of resource that is matching the query passed in parameter. The list found will be set in slice.
 	// slice is an interface for casting simplification. But slice must be a pointer to a slice of modelAPI.Metadata
 	Query(query Query, slice interface{}) error
-	RawQuery(query Query) ([][]byte, error)
-	RawMetadataQuery(query Query, kind modelV1.Kind) ([][]byte, error)
+	RawQuery(query Query) ([]json.RawMessage, error)
+	RawMetadataQuery(query Query, kind modelV1.Kind) ([]json.RawMessage, error)
 	Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error
 	DeleteByQuery(query Query) error
 	HealthCheck() bool

--- a/internal/api/database/sql/sql.go
+++ b/internal/api/database/sql/sql.go
@@ -263,7 +263,7 @@ func (d *DAO) Get(kind modelV1.Kind, metadata modelAPI.Metadata, entity modelAPI
 	return &databaseModel.Error{Key: id, Code: databaseModel.ErrorCodeNotFound}
 }
 
-func (d *DAO) RawQuery(query databaseModel.Query) ([][]byte, error) {
+func (d *DAO) RawQuery(query databaseModel.Query) ([]json.RawMessage, error) {
 	q, args, buildQueryErr := d.buildQuery(query)
 	if buildQueryErr != nil {
 		return nil, fmt.Errorf("unable to build the query: %s", buildQueryErr)
@@ -274,7 +274,7 @@ func (d *DAO) RawQuery(query databaseModel.Query) ([][]byte, error) {
 	}
 	defer rows.Close()
 
-	var result [][]byte
+	result := []json.RawMessage{}
 
 	for rows.Next() {
 		var rowJSONDoc string
@@ -286,7 +286,7 @@ func (d *DAO) RawQuery(query databaseModel.Query) ([][]byte, error) {
 	return result, nil
 }
 
-func (d *DAO) RawMetadataQuery(_ databaseModel.Query, _ modelV1.Kind) ([][]byte, error) {
+func (d *DAO) RawMetadataQuery(_ databaseModel.Query, _ modelV1.Kind) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("raw metadata query not implemented")
 }
 

--- a/internal/api/impl/v1/dashboard/persistence.go
+++ b/internal/api/impl/v1/dashboard/persistence.go
@@ -14,6 +14,8 @@
 package dashboard
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/pkg/model/api"
@@ -60,7 +62,7 @@ func (d *dao) List(q *dashboard.Query) ([]*v1.Dashboard, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *dashboard.Query) ([][]byte, error) {
+func (d *dao) RawList(q *dashboard.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -74,6 +76,6 @@ func (d *dao) MetadataList(q *dashboard.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *dashboard.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *dashboard.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/dashboard/service.go
+++ b/internal/api/impl/v1/dashboard/service.go
@@ -14,7 +14,9 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -121,7 +123,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *dashboard.Query, params 
 	return s.dao.List(query)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
@@ -137,7 +139,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *dashboard.Query,
 	return s.dao.MetadataList(query)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *dashboard.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/datasource/service.go
+++ b/internal/api/impl/v1/datasource/service.go
@@ -14,7 +14,9 @@
 package datasource
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
@@ -112,7 +114,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *datasource.Query, params
 	return v1.FilterDatasource(query.Kind, query.Default, dtsList), nil
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, _ *datasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, _ *datasource.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -120,7 +122,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, _ *datasource.Query
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, _ *datasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, _ *datasource.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/internal/api/impl/v1/ephemeraldashboard/persistence.go
+++ b/internal/api/impl/v1/ephemeraldashboard/persistence.go
@@ -14,6 +14,8 @@
 package ephemeraldashboard
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
 	"github.com/perses/perses/pkg/model/api"
@@ -60,7 +62,7 @@ func (d *dao) List(q *ephemeraldashboard.Query) ([]*v1.EphemeralDashboard, error
 	return result, err
 }
 
-func (d *dao) RawList(q *ephemeraldashboard.Query) ([][]byte, error) {
+func (d *dao) RawList(q *ephemeraldashboard.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -74,6 +76,6 @@ func (d *dao) MetadataList(q *ephemeraldashboard.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *ephemeraldashboard.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *ephemeraldashboard.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/ephemeraldashboard/service.go
+++ b/internal/api/impl/v1/ephemeraldashboard/service.go
@@ -14,7 +14,9 @@
 package ephemeraldashboard
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -121,7 +123,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *ephemeraldashboard.Query
 	return s.dao.List(query)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
@@ -137,7 +139,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *ephemeraldashboa
 	return s.dao.MetadataList(query)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *ephemeraldashboard.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/folder/persistence.go
+++ b/internal/api/impl/v1/folder/persistence.go
@@ -14,6 +14,8 @@
 package folder
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/pkg/model/api"
@@ -60,7 +62,7 @@ func (d *dao) List(q *folder.Query) ([]*v1.Folder, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *folder.Query) ([][]byte, error) {
+func (d *dao) RawList(q *folder.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -74,6 +76,6 @@ func (d *dao) MetadataList(q *folder.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *folder.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *folder.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/folder/service.go
+++ b/internal/api/impl/v1/folder/service.go
@@ -14,7 +14,9 @@
 package folder
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/brunoga/deep"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
@@ -99,7 +101,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *folder.Query, params api
 	return s.dao.List(query)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
@@ -115,7 +117,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *folder.Query, pa
 	return s.dao.MetadataList(query)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *folder.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/globaldatasource/service.go
+++ b/internal/api/impl/v1/globaldatasource/service.go
@@ -14,7 +14,9 @@
 package globaldatasource
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -108,11 +110,11 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, _ *globaldatasource
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, _ *globaldatasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, _ *globaldatasource.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, _ *globaldatasource.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, _ *globaldatasource.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/internal/api/impl/v1/globalrole/persistence.go
+++ b/internal/api/impl/v1/globalrole/persistence.go
@@ -14,6 +14,8 @@
 package globalrole
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalrole"
 	"github.com/perses/perses/pkg/model/api"
@@ -56,7 +58,7 @@ func (d *dao) List(q *globalrole.Query) ([]*v1.GlobalRole, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *globalrole.Query) ([][]byte, error) {
+func (d *dao) RawList(q *globalrole.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -70,6 +72,6 @@ func (d *dao) MetadataList(q *globalrole.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *globalrole.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *globalrole.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/globalrole/service.go
+++ b/internal/api/impl/v1/globalrole/service.go
@@ -14,7 +14,9 @@
 package globalrole
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -112,7 +114,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalrole.Query, _ apiI
 	return s.dao.List(q)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawList(q)
 }
 
@@ -120,6 +122,6 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalrole.Query
 	return s.dao.MetadataList(q)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalrole.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/globalrolebinding/persistence.go
+++ b/internal/api/impl/v1/globalrolebinding/persistence.go
@@ -14,6 +14,8 @@
 package globalrolebinding
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalrolebinding"
 	"github.com/perses/perses/pkg/model/api"
@@ -56,7 +58,7 @@ func (d *dao) List(q *globalrolebinding.Query) ([]*v1.GlobalRoleBinding, error) 
 	return result, err
 }
 
-func (d *dao) RawList(q *globalrolebinding.Query) ([][]byte, error) {
+func (d *dao) RawList(q *globalrolebinding.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -70,6 +72,6 @@ func (d *dao) MetadataList(q *globalrolebinding.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *globalrolebinding.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *globalrolebinding.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/globalrolebinding/service.go
+++ b/internal/api/impl/v1/globalrolebinding/service.go
@@ -14,7 +14,9 @@
 package globalrolebinding
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -134,7 +136,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalrolebinding.Query,
 	return s.dao.List(q)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawList(q)
 }
 
@@ -142,7 +144,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalrolebindin
 	return s.dao.MetadataList(q)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalrolebinding.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawMetadataList(q)
 }
 

--- a/internal/api/impl/v1/globalsecret/persistence.go
+++ b/internal/api/impl/v1/globalsecret/persistence.go
@@ -14,6 +14,8 @@
 package globalsecret
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalsecret"
 	"github.com/perses/perses/pkg/model/api"
@@ -69,6 +71,6 @@ func (d *dao) MetadataList(q *globalsecret.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *globalsecret.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *globalsecret.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/globalsecret/service.go
+++ b/internal/api/impl/v1/globalsecret/service.go
@@ -14,7 +14,9 @@
 package globalsecret
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -114,7 +116,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalsecret.Query, _ ap
 	return result, nil
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, _ *globalsecret.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, _ *globalsecret.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -122,6 +124,6 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalsecret.Que
 	return s.dao.MetadataList(q)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalsecret.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalsecret.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/globalvariable/persistence.go
+++ b/internal/api/impl/v1/globalvariable/persistence.go
@@ -14,6 +14,8 @@
 package globalvariable
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/pkg/model/api"
@@ -56,7 +58,7 @@ func (d *dao) List(q *globalvariable.Query) ([]*v1.GlobalVariable, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *globalvariable.Query) ([][]byte, error) {
+func (d *dao) RawList(q *globalvariable.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -70,6 +72,6 @@ func (d *dao) MetadataList(q *globalvariable.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *globalvariable.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *globalvariable.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/globalvariable/service.go
+++ b/internal/api/impl/v1/globalvariable/service.go
@@ -14,7 +14,9 @@
 package globalvariable
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -101,7 +103,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *globalvariable.Query, _ 
 	return s.dao.List(q)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawList(q)
 }
 
@@ -109,6 +111,6 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *globalvariable.Q
 	return s.dao.MetadataList(q)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *globalvariable.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/project/persistence.go
+++ b/internal/api/impl/v1/project/persistence.go
@@ -14,6 +14,8 @@
 package project
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/project"
 	"github.com/perses/perses/pkg/model/api"
@@ -56,7 +58,7 @@ func (d *dao) List(q *project.Query) ([]*v1.Project, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *project.Query) ([][]byte, error) {
+func (d *dao) RawList(q *project.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -70,6 +72,6 @@ func (d *dao) MetadataList(q *project.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *project.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *project.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/project/service.go
+++ b/internal/api/impl/v1/project/service.go
@@ -14,7 +14,9 @@
 package project
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -180,7 +182,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *project.Query, _ apiInte
 	return s.dao.List(q)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawList(q)
 }
 
@@ -188,6 +190,6 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *project.Query, _
 	return s.dao.MetadataList(q)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *project.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/role/persistence.go
+++ b/internal/api/impl/v1/role/persistence.go
@@ -14,6 +14,8 @@
 package role
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/role"
 	"github.com/perses/perses/pkg/model/api"
@@ -60,7 +62,7 @@ func (d *dao) List(q *role.Query) ([]*v1.Role, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *role.Query) ([][]byte, error) {
+func (d *dao) RawList(q *role.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -74,6 +76,6 @@ func (d *dao) MetadataList(q *role.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *role.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *role.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/role/service.go
+++ b/internal/api/impl/v1/role/service.go
@@ -14,7 +14,9 @@
 package role
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -123,7 +125,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *role.Query, params apiIn
 	return s.dao.List(query)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
@@ -139,7 +141,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *role.Query, para
 	return s.dao.MetadataList(query)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *role.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/rolebinding/persistence.go
+++ b/internal/api/impl/v1/rolebinding/persistence.go
@@ -14,6 +14,8 @@
 package rolebinding
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/rolebinding"
 	"github.com/perses/perses/pkg/model/api"
@@ -60,7 +62,7 @@ func (d *dao) List(q *rolebinding.Query) ([]*v1.RoleBinding, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *rolebinding.Query) ([][]byte, error) {
+func (d *dao) RawList(q *rolebinding.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -74,6 +76,6 @@ func (d *dao) MetadataList(q *rolebinding.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *rolebinding.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *rolebinding.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/rolebinding/service.go
+++ b/internal/api/impl/v1/rolebinding/service.go
@@ -14,7 +14,9 @@
 package rolebinding
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -144,7 +146,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *rolebinding.Query, param
 	return s.dao.List(query)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
@@ -160,7 +162,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *rolebinding.Quer
 	return s.dao.MetadataList(query)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *rolebinding.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/secret/persistence.go
+++ b/internal/api/impl/v1/secret/persistence.go
@@ -14,6 +14,8 @@
 package secret
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/secret"
 	"github.com/perses/perses/pkg/model/api"
@@ -73,6 +75,6 @@ func (d *dao) MetadataList(q *secret.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *secret.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *secret.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/secret/service.go
+++ b/internal/api/impl/v1/secret/service.go
@@ -14,7 +14,9 @@
 package secret
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/brunoga/deep"
 	"github.com/perses/perses/internal/api/crypto"
 	apiInterface "github.com/perses/perses/internal/api/interface"
@@ -123,7 +125,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *secret.Query, params api
 	return result, nil
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, _ *secret.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, _ *secret.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -135,7 +137,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *secret.Query, pa
 	return s.dao.MetadataList(query)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *secret.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *secret.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/user/persistence.go
+++ b/internal/api/impl/v1/user/persistence.go
@@ -14,6 +14,8 @@
 package user
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/user"
 	"github.com/perses/perses/pkg/model/api"
@@ -69,6 +71,6 @@ func (d *dao) MetadataList(q *user.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *user.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *user.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -14,7 +14,9 @@
 package user
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -133,7 +135,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *user.Query, _ apiInterfa
 	return result, nil
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, _ *user.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, _ *user.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -141,6 +143,6 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *user.Query, _ ap
 	return s.dao.MetadataList(q)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *user.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *user.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	return s.dao.RawMetadataList(q)
 }

--- a/internal/api/impl/v1/variable/persistence.go
+++ b/internal/api/impl/v1/variable/persistence.go
@@ -14,6 +14,8 @@
 package variable
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/pkg/model/api"
@@ -60,7 +62,7 @@ func (d *dao) List(q *variable.Query) ([]*v1.Variable, error) {
 	return result, err
 }
 
-func (d *dao) RawList(q *variable.Query) ([][]byte, error) {
+func (d *dao) RawList(q *variable.Query) ([]json.RawMessage, error) {
 	return d.client.RawQuery(q)
 }
 
@@ -74,6 +76,6 @@ func (d *dao) MetadataList(q *variable.Query) ([]api.Entity, error) {
 	return result, err
 }
 
-func (d *dao) RawMetadataList(q *variable.Query) ([][]byte, error) {
+func (d *dao) RawMetadataList(q *variable.Query) ([]json.RawMessage, error) {
 	return d.client.RawMetadataQuery(q, d.kind)
 }

--- a/internal/api/impl/v1/variable/service.go
+++ b/internal/api/impl/v1/variable/service.go
@@ -14,7 +14,9 @@
 package variable
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/brunoga/deep"
@@ -113,7 +115,7 @@ func (s *service) List(_ apiInterface.PersesContext, q *variable.Query, params a
 	return s.dao.List(query)
 }
 
-func (s *service) RawList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err
@@ -129,7 +131,7 @@ func (s *service) MetadataList(_ apiInterface.PersesContext, q *variable.Query, 
 	return s.dao.MetadataList(query)
 }
 
-func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([][]byte, error) {
+func (s *service) RawMetadataList(_ apiInterface.PersesContext, q *variable.Query, params apiInterface.Parameters) ([]json.RawMessage, error) {
 	query, err := manageQuery(q, params)
 	if err != nil {
 		return nil, err

--- a/internal/api/impl/v1/view/endpoint_test.go
+++ b/internal/api/impl/v1/view/endpoint_test.go
@@ -14,12 +14,14 @@
 package view
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/perses/perses/pkg/model/api"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/perses/perses/pkg/model/api"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
@@ -88,7 +90,7 @@ func (*mockDashboardService) List(_ apiInterface.PersesContext, _ *dashboard.Que
 	panic("unimplemented")
 }
 
-func (*mockDashboardService) RawList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (*mockDashboardService) RawList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	panic("unimplemented")
 }
 
@@ -96,7 +98,7 @@ func (*mockDashboardService) MetadataList(_ apiInterface.PersesContext, _ *dashb
 	panic("unimplemented")
 }
 
-func (*mockDashboardService) RawMetadataList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([][]byte, error) {
+func (*mockDashboardService) RawMetadataList(_ apiInterface.PersesContext, _ *dashboard.Query, _ apiInterface.Parameters) ([]json.RawMessage, error) {
 	panic("unimplemented")
 }
 

--- a/internal/api/interface/service.go
+++ b/internal/api/interface/service.go
@@ -14,6 +14,8 @@
 package apiinterface
 
 import (
+	"encoding/json"
+
 	"github.com/labstack/echo/v4"
 	"github.com/perses/perses/internal/api/crypto"
 	databaseModel "github.com/perses/perses/internal/api/database/model"
@@ -61,7 +63,7 @@ type Service[T api.Entity, K api.Entity, V databaseModel.Query] interface {
 	Delete(ctx PersesContext, parameters Parameters) error
 	Get(ctx PersesContext, parameters Parameters) (K, error)
 	List(ctx PersesContext, query V, parameters Parameters) ([]K, error)
-	RawList(ctx PersesContext, query V, parameters Parameters) ([][]byte, error)
+	RawList(ctx PersesContext, query V, parameters Parameters) ([]json.RawMessage, error)
 	MetadataList(ctx PersesContext, query V, parameters Parameters) ([]api.Entity, error)
-	RawMetadataList(ctx PersesContext, query V, parameters Parameters) ([][]byte, error)
+	RawMetadataList(ctx PersesContext, query V, parameters Parameters) ([]json.RawMessage, error)
 }

--- a/internal/api/interface/v1/dashboard/interface.go
+++ b/internal/api/interface/v1/dashboard/interface.go
@@ -14,6 +14,8 @@
 package dashboard
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -50,9 +52,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Dashboard, error)
 	List(q *Query) ([]*v1.Dashboard, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/ephemeraldashboard/interface.go
+++ b/internal/api/interface/v1/ephemeraldashboard/interface.go
@@ -14,6 +14,8 @@
 package ephemeraldashboard
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -50,9 +52,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.EphemeralDashboard, error)
 	List(q *Query) ([]*v1.EphemeralDashboard, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/folder/interface.go
+++ b/internal/api/interface/v1/folder/interface.go
@@ -14,6 +14,8 @@
 package folder
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -50,9 +52,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Folder, error)
 	List(q *Query) ([]*v1.Folder, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalrole/interface.go
+++ b/internal/api/interface/v1/globalrole/interface.go
@@ -14,6 +14,8 @@
 package globalrole
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -46,9 +48,9 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRole, error)
 	List(q *Query) ([]*v1.GlobalRole, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalrolebinding/interface.go
+++ b/internal/api/interface/v1/globalrolebinding/interface.go
@@ -14,6 +14,8 @@
 package globalrolebinding
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -46,9 +48,9 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.GlobalRoleBinding, error)
 	List(q *Query) ([]*v1.GlobalRoleBinding, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalsecret/interface.go
+++ b/internal/api/interface/v1/globalsecret/interface.go
@@ -14,6 +14,8 @@
 package globalsecret
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -47,7 +49,7 @@ type DAO interface {
 	Get(name string) (*v1.GlobalSecret, error)
 	List(q *Query) ([]*v1.GlobalSecret, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/globalvariable/interface.go
+++ b/internal/api/interface/v1/globalvariable/interface.go
@@ -14,6 +14,8 @@
 package globalvariable
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -46,9 +48,9 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.GlobalVariable, error)
 	List(q *Query) ([]*v1.GlobalVariable, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/project/interface.go
+++ b/internal/api/interface/v1/project/interface.go
@@ -14,6 +14,8 @@
 package project
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -46,9 +48,9 @@ type DAO interface {
 	Delete(name string) error
 	Get(name string) (*v1.Project, error)
 	List(q *Query) ([]*v1.Project, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/role/interface.go
+++ b/internal/api/interface/v1/role/interface.go
@@ -14,6 +14,8 @@
 package role
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -50,9 +52,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Role, error)
 	List(q *Query) ([]*v1.Role, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/rolebinding/interface.go
+++ b/internal/api/interface/v1/rolebinding/interface.go
@@ -14,6 +14,8 @@
 package rolebinding
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -50,9 +52,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.RoleBinding, error)
 	List(q *Query) ([]*v1.RoleBinding, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/secret/interface.go
+++ b/internal/api/interface/v1/secret/interface.go
@@ -14,6 +14,8 @@
 package secret
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -51,7 +53,7 @@ type DAO interface {
 	Get(project string, name string) (*v1.Secret, error)
 	List(q *Query) ([]*v1.Secret, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/user/interface.go
+++ b/internal/api/interface/v1/user/interface.go
@@ -14,6 +14,8 @@
 package user
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -47,7 +49,7 @@ type DAO interface {
 	Get(name string) (*v1.User, error)
 	List(q *Query) ([]*v1.User, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/interface/v1/variable/interface.go
+++ b/internal/api/interface/v1/variable/interface.go
@@ -14,6 +14,8 @@
 package variable
 
 import (
+	"encoding/json"
+
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/model/api"
@@ -50,9 +52,9 @@ type DAO interface {
 	DeleteAll(project string) error
 	Get(project string, name string) (*v1.Variable, error)
 	List(q *Query) ([]*v1.Variable, error)
-	RawList(q *Query) ([][]byte, error)
+	RawList(q *Query) ([]json.RawMessage, error)
 	MetadataList(q *Query) ([]api.Entity, error)
-	RawMetadataList(q *Query) ([][]byte, error)
+	RawMetadataList(q *Query) ([]json.RawMessage, error)
 }
 
 type Service interface {

--- a/internal/api/toolbox/list.go
+++ b/internal/api/toolbox/list.go
@@ -35,8 +35,8 @@ func buildMapFromList[T api.Entity](list []T) map[string]T {
 	return result
 }
 
-func buildRawMapFromList(rows [][]byte) map[string][]byte {
-	result := make(map[string][]byte)
+func buildRawMapFromList(rows []json.RawMessage) map[string]json.RawMessage {
+	result := make(map[string]json.RawMessage)
 	for _, item := range rows {
 		result[gjson.GetBytes(item, "metadata.name").String()] = item
 	}
@@ -105,9 +105,9 @@ func (t *toolbox[T, K, V]) listWhenPermissionIsActivated(ctx echo.Context, param
 			for _, entity := range typedList {
 				result = append(result, entity)
 			}
-		case [][]byte:
+		case []json.RawMessage:
 			for _, entity := range typedList {
-				result = append(result, json.RawMessage(entity))
+				result = append(result, entity)
 			}
 		}
 	}
@@ -143,8 +143,8 @@ func (t *toolbox[T, K, V]) listProjectWhenPermissionIsActivated(persesContext ap
 			result = append(result, buildMap[project])
 		}
 		return result, nil
-	case [][]byte:
-		result := make([][]byte, 0, len(typedList))
+	case []json.RawMessage:
+		result := make([]json.RawMessage, 0, len(typedList))
 		buildMap := buildRawMapFromList(typedList)
 		for _, project := range projects {
 			result = append(result, buildMap[project])

--- a/internal/api/toolbox/toolbox.go
+++ b/internal/api/toolbox/toolbox.go
@@ -43,22 +43,6 @@ func ExtractParameters(ctx echo.Context, caseSensitive bool) apiInterface.Parame
 	}
 }
 
-func buildJSONBlob(raws [][]byte) []byte {
-	var result []byte
-	if len(raws) == 0 {
-		return []byte(`[]`)
-	}
-	result = append(result, '[')
-	i := 0
-	for i < len(raws)-1 {
-		result = append(result, raws[i]...)
-		result = append(result, ',')
-		i++
-	}
-	result = append(result, raws[len(raws)-1]...)
-	return append(result, ']')
-}
-
 // Toolbox is an interface that defines the different methods that can be used in the different endpoint of the API.
 // This is a way to align the code of the different endpoint.
 type Toolbox[T api.Entity, K databaseModel.Query] interface {
@@ -218,9 +202,6 @@ func (t *toolbox[T, K, V]) List(ctx echo.Context, query V) error {
 		return listErr
 	}
 
-	if blob, ok := list.([][]byte); ok {
-		return ctx.JSONBlob(http.StatusOK, buildJSONBlob(blob))
-	}
 	return ctx.JSON(http.StatusOK, list)
 }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

* This PR is an internal refactoring and does not include any functional changes.
* It prevents bugs caused by holding JSON as `[]byte` (such as in #2122).
  * No need to manually assemble JSON strings when marshaling to JSON. (buildJSONBlob function is removed)
  * No need to write complex type-switch statements.
* Go programmers can understand the meaning of `json.RawMessage` better compared to `[]byte`.
  * They will likely understand the variable's content more quickly.


# Screenshots

There are no UI changes.

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
