### PR TITLE
[IGNORE] fix TraceTable type

### DIFF
--- a/ui/panels-plugin/src/plugins/trace-table/TraceTable.ts
+++ b/ui/panels-plugin/src/plugins/trace-table/TraceTable.ts
@@ -12,13 +12,13 @@
 // limitations under the License.
 
 import { PanelPlugin } from '@perses-dev/plugin-system';
-import { TraceTablePanel } from './TraceTablePanel';
+import { TraceTablePanel, TraceTableProps } from './TraceTablePanel';
 import { TraceTableOptions, createInitialTraceTableOptions } from './trace-table-model';
 
 /**
  * The core TraceTable panel plugin for Perses.
  */
-export const TraceTable: PanelPlugin<TraceTableOptions> = {
+export const TraceTable: PanelPlugin<TraceTableOptions, TraceTableProps> = {
   PanelComponent: TraceTablePanel,
   supportedQueryTypes: ['TraceQuery'],
   createInitialOptions: createInitialTraceTableOptions,

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -24,8 +24,8 @@ export type PanelOptionsEditorComponent<T> = Pick<OptionsEditorTab, 'label'> & {
 /**
  * Plugin the provides custom visualizations inside a Panel.
  */
-export interface PanelPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
-  PanelComponent: React.ComponentType<PanelProps<Spec>>;
+export interface PanelPlugin<Spec = UnknownSpec, TPanelProps = PanelProps<Spec>> extends Plugin<Spec> {
+  PanelComponent: React.ComponentType<TPanelProps>;
   /**
    * React components for custom tabs
    */


### PR DESCRIPTION
# Description

Fix access to the `traceLink` property when embedding the `TraceTable`:
```
<TraceTable.PanelComponent spec={{}} traceLink={traceDetailLink} />
```

We decided to put the `traceLink` property to the panel properties instead of the `spec`, because it must be a function and cannot be JSON serialized.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
