### PR TITLE
[ENHANCEMENT] Ignore Not Found errors in percli delete command

### DIFF
--- a/internal/cli/cmd/remove/remove.go
+++ b/internal/cli/cmd/remove/remove.go
@@ -14,6 +14,7 @@
 package remove
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -25,6 +26,7 @@ import (
 	"github.com/perses/perses/internal/cli/resource"
 	"github.com/perses/perses/internal/cli/service"
 	"github.com/perses/perses/pkg/client/api"
+	"github.com/perses/perses/pkg/client/perseshttp"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/spf13/cobra"
@@ -98,6 +100,12 @@ func (o *option) Execute() error {
 			return svcErr
 		}
 		if err := svc.DeleteResource(name); err != nil {
+			if errors.Is(err, perseshttp.RequestNotFoundError) {
+				if outputError := resource.HandleSuccessMessage(o.writer, kind, project, fmt.Sprintf("object %q %q is not found", kind, name)); outputError != nil {
+					return outputError
+				}
+				continue
+			}
 			return err
 		}
 		if outputError := resource.HandleSuccessMessage(o.writer, kind, project, fmt.Sprintf("object %q %q has been deleted", kind, name)); outputError != nil {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

The current `percli delete` command outputs a Not Found error when a resource is not found. This is inconvenient when using a definition file that includes multiple existing resources for deletion.

For example, the command would result in the following output.

```
$ # add new resources
$ percli apply -f sandbox.json
object "Project" "project-1" has been applied
object "Role" "defaultrole" has been applied in the project "project-1"
object "User" "user1" has been applied
object "RoleBinding" "projectrolebinding" has been applied in the project "project-1"

$ # delete resources
$ percli delete -f sandbox.json
object "Project" "project-1" has been deleted
Error: something wrong happened with the request to the API.  Message: document not found StatusCode: 404
```

In this PR, I will make changes to ignore Not found errors.

This is an implementation idea. Feedback and discussion are welcome.

# Screenshots

not ui changes

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
