### PR TITLE
[FEATURE] TracingGanttChart: support categorical color palette

### DIFF
--- a/cue/schemas/panels/tracing-gantt-chart/tracing-gantt-chart.cue
+++ b/cue/schemas/panels/tracing-gantt-chart/tracing-gantt-chart.cue
@@ -13,5 +13,15 @@
 
 package model
 
+#palette: {
+	mode: "auto" | "categorical"
+}
+
+#visual: {
+	palette?: #palette
+}
+
 kind: "TracingGanttChart"
-spec: close({})
+spec: close({
+	visual?: #visual
+})

--- a/ui/panels-plugin/src/model/palette.test.ts
+++ b/ui/panels-plugin/src/model/palette.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getConsistentColor } from './palette';
+import { getConsistentCategoricalColor, getConsistentColor } from './palette';
 
 describe('getConsistentColor', () => {
   it('should generate a consistent custom hsla color', () => {
@@ -33,5 +33,22 @@ describe('getConsistentColor', () => {
     expect(colorErr).toEqual(colorErr2);
     // expect colors to be different
     expect(color).not.toEqual(colorErr);
+  });
+
+  it('should generate a consistent categorical color, depending on the error state', () => {
+    const categoricalPalette = ['#aaa', '#aab', '#aac'];
+    const errorPalette = ['#baa', '#bab', '#bac'];
+    const color = getConsistentCategoricalColor('test', false, categoricalPalette, errorPalette);
+    const color2 = getConsistentCategoricalColor('test', false, categoricalPalette, errorPalette);
+    const colorErr = getConsistentCategoricalColor('test', true, categoricalPalette, errorPalette);
+    const colorErr2 = getConsistentCategoricalColor('test', true, categoricalPalette, errorPalette);
+    // ensures generated color does not change on subsequent calls
+    expect(color).toEqual(color2);
+    expect(colorErr).toEqual(colorErr2);
+    // expect colors to be different
+    expect(color).not.toEqual(colorErr);
+    // hash doesn't change, so we can statically verify the expected color
+    expect(color).toEqual('#aab');
+    expect(colorErr).toEqual('#bab');
   });
 });

--- a/ui/panels-plugin/src/model/palette.ts
+++ b/ui/panels-plugin/src/model/palette.ts
@@ -44,3 +44,23 @@ export function getConsistentColor(name: string, error: boolean) {
   }
   return value;
 }
+
+export function getConsistentCategoricalColor(
+  name: string,
+  error: boolean,
+  categoricalPalette: string[],
+  errorPalette: string[]
+) {
+  const palette = error ? errorPalette : categoricalPalette;
+  if (palette.length === 0) {
+    console.warn('getConsistentCategoricalColor() called with empty color palette, fallback to #000');
+    return '#000';
+  }
+
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  return palette[Math.abs(hash) % palette.length] ?? '#000';
+}

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.test.tsx
@@ -14,6 +14,7 @@
 import { render } from '@testing-library/react';
 import { fireEvent, screen } from '@testing-library/dom';
 import { VirtuosoMockContext } from 'react-virtuoso';
+import { ChartsProvider, testChartsTheme } from '@perses-dev/components';
 import { trace1_root } from '../../../../test';
 import { GanttTableProvider } from './GanttTableProvider';
 import { GanttTable, GanttTableProps } from './GanttTable';
@@ -22,16 +23,19 @@ describe('GanttTable', () => {
   const renderComponent = (props: Omit<GanttTableProps, 'onSpanClick'>) => {
     const onSpanClick = jest.fn();
     return render(
-      <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 20 }}>
-        <GanttTableProvider>
-          <GanttTable {...props} onSpanClick={onSpanClick} />
-        </GanttTableProvider>
-      </VirtuosoMockContext.Provider>
+      <ChartsProvider chartsTheme={testChartsTheme}>
+        <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 20 }}>
+          <GanttTableProvider>
+            <GanttTable {...props} onSpanClick={onSpanClick} />
+          </GanttTableProvider>
+        </VirtuosoMockContext.Provider>
+      </ChartsProvider>
     );
   };
 
   it('render table', () => {
     renderComponent({
+      options: {},
       rootSpan: trace1_root,
       viewport: { startTimeUnixMs: trace1_root.startTimeUnixMs, endTimeUnixMs: trace1_root.endTimeUnixMs },
     });
@@ -42,6 +46,7 @@ describe('GanttTable', () => {
 
   it('collapses a span on click', () => {
     renderComponent({
+      options: {},
       rootSpan: trace1_root,
       viewport: { startTimeUnixMs: trace1_root.startTimeUnixMs, endTimeUnixMs: trace1_root.endTimeUnixMs },
     });

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.tsx
@@ -16,19 +16,21 @@ import { Span } from '@perses-dev/core';
 import { useMemo, useRef, useState } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { Viewport } from '../utils';
+import { TracingGanttChartOptions } from '../../gantt-chart-model';
 import { useGanttTableContext } from './GanttTableProvider';
 import { GanttTableRow } from './GanttTableRow';
 import { GanttTableHeader } from './GanttTableHeader';
 import { ResizableDivider } from './ResizableDivider';
 
 export interface GanttTableProps {
+  options: TracingGanttChartOptions;
   rootSpan: Span;
   viewport: Viewport;
   onSpanClick: (span: Span) => void;
 }
 
 export function GanttTable(props: GanttTableProps) {
-  const { rootSpan, viewport, onSpanClick } = props;
+  const { options, rootSpan, viewport, onSpanClick } = props;
   const { collapsedSpans, setVisibleSpans } = useGanttTableContext();
   const [nameColumnWidth, setNameColumnWidth] = useState<number>(0.25);
   const tableRef = useRef<HTMLDivElement>(null);
@@ -67,6 +69,7 @@ export function GanttTable(props: GanttTableProps) {
         data={rows}
         itemContent={(_, span) => (
           <GanttTableRow
+            options={options}
             span={span}
             viewport={viewport}
             nameColumnWidth={nameColumnWidth}

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTableRow.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTableRow.tsx
@@ -15,10 +15,12 @@ import { Stack, styled } from '@mui/material';
 import { Span } from '@perses-dev/core';
 import { memo } from 'react';
 import { Viewport, rowHeight } from '../utils';
+import { TracingGanttChartOptions } from '../../gantt-chart-model';
 import { SpanName } from './SpanName';
 import { SpanDuration } from './SpanDuration';
 
 interface GanttTableRowProps {
+  options: TracingGanttChartOptions;
   span: Span;
   viewport: Viewport;
   nameColumnWidth: number;
@@ -27,7 +29,7 @@ interface GanttTableRowProps {
 }
 
 export const GanttTableRow = memo(function GanttTableRow(props: GanttTableRowProps) {
-  const { span, viewport, nameColumnWidth, divider, onClick } = props;
+  const { options, span, viewport, nameColumnWidth, divider, onClick } = props;
 
   const handleOnClick = () => {
     // ignore event if triggered by selecting text
@@ -40,7 +42,7 @@ export const GanttTableRow = memo(function GanttTableRow(props: GanttTableRowPro
     <RowContainer direction="row" onClick={handleOnClick}>
       <SpanName span={span} nameColumnWidth={nameColumnWidth} />
       {divider}
-      <SpanDuration span={span} viewport={viewport} />
+      <SpanDuration options={options} span={span} viewport={viewport} />
     </RowContainer>
   );
 });

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.test.tsx
@@ -13,6 +13,7 @@
 
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
+import { ChartsProvider, testChartsTheme } from '@perses-dev/components';
 import { trace1_root, trace1_root_child1_child1 } from '../../../../test';
 import { GanttTableProvider } from './GanttTableProvider';
 import { SpanDuration, SpanDurationProps } from './SpanDuration';
@@ -20,17 +21,31 @@ import { SpanDuration, SpanDurationProps } from './SpanDuration';
 describe('SpanDuration', () => {
   const renderComponent = (props: SpanDurationProps) => {
     return render(
-      <GanttTableProvider>
-        <SpanDuration {...props} />
-      </GanttTableProvider>
+      <ChartsProvider chartsTheme={testChartsTheme}>
+        <GanttTableProvider>
+          <SpanDuration {...props} />
+        </GanttTableProvider>
+      </ChartsProvider>
     );
   };
 
   it('render span bar', () => {
     renderComponent({
+      options: {},
       span: trace1_root_child1_child1,
       viewport: { startTimeUnixMs: trace1_root.startTimeUnixMs, endTimeUnixMs: trace1_root.endTimeUnixMs },
     });
     expect(screen.getByText('150ms')).toBeInTheDocument();
+    expect(screen.getByTestId('span-duration-bar').style.backgroundColor).toEqual('rgba(83, 83, 83, 0.9)');
+  });
+
+  it('render span bar with colors from eCharts theme', () => {
+    renderComponent({
+      options: { visual: { palette: { mode: 'categorical' } } },
+      span: trace1_root_child1_child1,
+      viewport: { startTimeUnixMs: trace1_root.startTimeUnixMs, endTimeUnixMs: trace1_root.endTimeUnixMs },
+    });
+    expect(screen.getByText('150ms')).toBeInTheDocument();
+    expect(screen.getByTestId('span-duration-bar').style.backgroundColor).toEqual('rgb(0, 114, 178)'); // #0072B2 from Perses color palette (theme-gen.ts)
   });
 });

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.tsx
@@ -13,10 +13,13 @@
 
 import { Box, useTheme } from '@mui/material';
 import { Span } from '@perses-dev/core';
-import { Viewport, formatDuration, getConsistentSpanColor } from '../utils';
+import { useChartsTheme } from '@perses-dev/components';
+import { Viewport, formatDuration, getSpanColor } from '../utils';
 import { Ticks } from '../Ticks';
+import { TracingGanttChartOptions } from '../../gantt-chart-model';
 
 export interface SpanDurationProps {
+  options: TracingGanttChartOptions;
   span: Span;
   viewport: Viewport;
 }
@@ -25,8 +28,9 @@ export interface SpanDurationProps {
  * SpanDuration renders the right column of a SpanRow, i.e. the span bar and span duration
  */
 export function SpanDuration(props: SpanDurationProps) {
-  const { span, viewport } = props;
-  const theme = useTheme();
+  const { options, span, viewport } = props;
+  const muiTheme = useTheme();
+  const chartsTheme = useChartsTheme();
 
   const spanDuration = span.endTimeUnixMs - span.startTimeUnixMs;
   const viewportDuration = viewport.endTimeUnixMs - viewport.startTimeUnixMs;
@@ -37,18 +41,19 @@ export function SpanDuration(props: SpanDurationProps) {
     <Box sx={{ position: 'relative', height: '100%', flexGrow: 1, overflow: 'hidden' }}>
       <Ticks />
       <Box
+        data-testid="span-duration-bar"
         sx={{
           position: 'absolute',
           top: 0,
           bottom: 0,
           margin: 'auto',
           height: '8px',
-          borderRadius: theme.shape.borderRadius,
+          borderRadius: muiTheme.shape.borderRadius,
         }}
         style={{
           left: `${relativeStart * 100}%`,
           width: `${relativeDuration * 100}%`,
-          backgroundColor: getConsistentSpanColor(span),
+          backgroundColor: getSpanColor(muiTheme, chartsTheme, options.visual?.palette?.mode, span),
         }}
       />
       <Box
@@ -57,7 +62,7 @@ export function SpanDuration(props: SpanDurationProps) {
           top: '50%',
           transform: 'translateY(-50%)',
           marginLeft: '8px',
-          color: theme.palette.grey[700],
+          color: muiTheme.palette.grey[700],
           fontSize: '.7rem',
         }}
         style={{

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/MiniGanttChart.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/MiniGanttChart.tsx
@@ -15,16 +15,18 @@ import { Box, useTheme } from '@mui/material';
 import { Span } from '@perses-dev/core';
 import { TicksHeader } from '../Ticks';
 import { Viewport, rowHeight } from '../utils';
+import { TracingGanttChartOptions } from '../../gantt-chart-model';
 import { Canvas } from './Canvas';
 
 interface MiniGanttChartProps {
+  options: TracingGanttChartOptions;
   rootSpan: Span;
   viewport: Viewport;
   setViewport: (v: Viewport) => void;
 }
 
 export function MiniGanttChart(props: MiniGanttChartProps) {
-  const { rootSpan, viewport, setViewport } = props;
+  const { options, rootSpan, viewport, setViewport } = props;
   const theme = useTheme();
 
   return (
@@ -37,7 +39,7 @@ export function MiniGanttChart(props: MiniGanttChartProps) {
       <Box sx={{ position: 'relative', height: rowHeight, borderBottom: `1px solid ${theme.palette.divider}` }}>
         <TicksHeader rootSpan={rootSpan} viewport={rootSpan} />
       </Box>
-      <Canvas rootSpan={rootSpan} viewport={viewport} setViewport={setViewport} />
+      <Canvas options={options} rootSpan={rootSpan} viewport={viewport} setViewport={setViewport} />
     </Box>
   );
 }

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/draw.ts
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/draw.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { Span } from '@perses-dev/core';
-import { getConsistentSpanColor } from '../utils';
 
 const MIN_BAR_HEIGHT = 1;
 const MAX_BAR_HEIGHT = 7;
@@ -25,7 +24,13 @@ function countSpans(span: Span) {
   return n;
 }
 
-export function drawSpans(ctx: CanvasRenderingContext2D, width: number, height: number, rootSpan: Span) {
+export function drawSpans(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  rootSpan: Span,
+  spanColorGenerator: (span: Span) => string
+) {
   // calculate optimal height, enforce min and max bar height and finally round to an integer
   const numSpans = countSpans(rootSpan);
   const barHeight = Math.round(Math.min(Math.max(height / numSpans, MIN_BAR_HEIGHT), MAX_BAR_HEIGHT));
@@ -39,7 +44,7 @@ export function drawSpans(ctx: CanvasRenderingContext2D, width: number, height: 
     const relativeDuration = spanDuration / traceDuration;
     const relativeStart = (span.startTimeUnixMs - rootSpan.startTimeUnixMs) / traceDuration;
 
-    ctx.fillStyle = getConsistentSpanColor(span);
+    ctx.fillStyle = spanColorGenerator(span);
     ctx.beginPath();
     ctx.rect(Math.round(relativeStart * width), Math.round(y), Math.round(relativeDuration * width), barHeight);
     ctx.fill();

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.stories.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.stories.tsx
@@ -35,6 +35,13 @@ type Story = StoryObj<typeof TracingGanttChart>;
 
 export const Primary: Story = {
   args: {
+    options: {
+      visual: {
+        palette: {
+          mode: 'auto',
+        },
+      },
+    },
     rootSpan: trace1_root,
   },
 };

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.tsx
@@ -14,6 +14,7 @@
 import { useRef, useState } from 'react';
 import { Box, Stack, useTheme } from '@mui/material';
 import { Span } from '@perses-dev/core';
+import { TracingGanttChartOptions } from '../gantt-chart-model';
 import { MiniGanttChart } from './MiniGanttChart/MiniGanttChart';
 import { DetailPane } from './DetailPane/DetailPane';
 import { Viewport } from './utils';
@@ -22,6 +23,7 @@ import { GanttTableProvider } from './GanttTable/GanttTableProvider';
 import { ResizableDivider } from './GanttTable/ResizableDivider';
 
 export interface TracingGanttChartProps {
+  options: TracingGanttChartOptions;
   rootSpan: Span;
 }
 
@@ -32,7 +34,7 @@ export interface TracingGanttChartProps {
  * https://github.com/jaegertracing/jaeger-ui
  */
 export function TracingGanttChart(props: TracingGanttChartProps) {
-  const { rootSpan } = props;
+  const { options, rootSpan } = props;
 
   const theme = useTheme();
   const [selectedSpan, setSelectedSpan] = useState<Span | undefined>(undefined);
@@ -50,9 +52,9 @@ export function TracingGanttChart(props: TracingGanttChartProps) {
   return (
     <Stack ref={ganttChart} direction="row" sx={{ height: '100%', minHeight: '240px', gap }}>
       <Stack sx={{ flexGrow: 1, gap }}>
-        <MiniGanttChart rootSpan={rootSpan} viewport={viewport} setViewport={setViewport} />
+        <MiniGanttChart options={options} rootSpan={rootSpan} viewport={viewport} setViewport={setViewport} />
         <GanttTableProvider>
-          <GanttTable rootSpan={rootSpan} viewport={viewport} onSpanClick={setSelectedSpan} />
+          <GanttTable options={options} rootSpan={rootSpan} viewport={viewport} onSpanClick={setSelectedSpan} />
         </GanttTableProvider>
       </Stack>
       {selectedSpan && (

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/utils.ts
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/utils.ts
@@ -12,7 +12,9 @@
 // limitations under the License.
 
 import { Span, SpanStatusError } from '@perses-dev/core';
-import { getConsistentColor } from '../../../model/palette';
+import { PersesChartsTheme } from '@perses-dev/components';
+import { Theme } from '@mui/material';
+import { getConsistentCategoricalColor, getConsistentColor } from '../../../model/palette';
 
 /**
  * Viewport contains the current zoom, i.e. which timeframe of the trace should be visible
@@ -24,8 +26,35 @@ export interface Viewport {
 
 export const rowHeight = '2rem';
 export const spanHasError = (span: Span) => span.status?.code === SpanStatusError;
-export const getConsistentServiceColor = (serviceName: string) => getConsistentColor(serviceName, false);
-export const getConsistentSpanColor = (span: Span) => getConsistentColor(span.resource.serviceName, spanHasError(span));
+
+export function getServiceColor(
+  muiTheme: Theme,
+  chartsTheme: PersesChartsTheme,
+  paletteMode: 'auto' | 'categorical' | undefined,
+  serviceName: string,
+  error = false
+) {
+  switch (paletteMode) {
+    case 'categorical': {
+      // ECharts type for color is not always an array but it is always an array in ChartsProvider
+      const categoricalPalette = chartsTheme.echartsTheme.color as string[];
+      const errorPalette = [muiTheme.palette.error.light, muiTheme.palette.error.main, muiTheme.palette.error.dark];
+      return getConsistentCategoricalColor(serviceName, error, categoricalPalette, errorPalette);
+    }
+
+    default:
+      return getConsistentColor(serviceName, error);
+  }
+}
+
+export function getSpanColor(
+  muiTheme: Theme,
+  chartsTheme: PersesChartsTheme,
+  paletteMode: 'auto' | 'categorical' | undefined,
+  span: Span
+) {
+  return getServiceColor(muiTheme, chartsTheme, paletteMode, span.resource.serviceName, spanHasError(span));
+}
 
 export function formatDuration(timeMs: number) {
   if (timeMs < 1) {

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChartPanel.tsx
@@ -19,7 +19,7 @@ import { TracingGanttChart } from './TracingGanttChart/TracingGanttChart';
 
 export type TracingGanttChartPanelProps = PanelProps<TracingGanttChartOptions>;
 
-export function TracingGanttChartPanel() {
+export function TracingGanttChartPanel({ spec }: TracingGanttChartPanelProps) {
   const chartsTheme = useChartsTheme();
   const contentPadding = chartsTheme.container.padding.default;
   const { isFetching, isLoading, queryResults } = useDataQueries('TraceQuery');
@@ -44,7 +44,7 @@ export function TracingGanttChartPanel() {
 
   return (
     <Box sx={{ height: '100%', padding: `${contentPadding}px` }}>
-      <TracingGanttChart rootSpan={trace.rootSpan} />
+      <TracingGanttChart options={spec} rootSpan={trace.rootSpan} />
     </Box>
   );
 }

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/gantt-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/gantt-chart-model.ts
@@ -15,7 +15,17 @@
  * The Options object type supported by the TracingGanttChart panel plugin.
  */
 // Note: The interface attributes must match cue/schemas/panels/tracing-gantt-chart/tracing-gantt-chart.cue
-export interface TracingGanttChartOptions {}
+export interface TracingGanttChartOptions {
+  visual?: TracingGanttChartVisualOptions;
+}
+
+export interface TracingGanttChartVisualOptions {
+  palette?: TracingGanttChartPaletteOptions;
+}
+
+export interface TracingGanttChartPaletteOptions {
+  mode: 'auto' | 'categorical';
+}
 
 /**
  * Creates the initial/empty options for a TracingGanttChart panel.


### PR DESCRIPTION
# Description
Currently, the TracingGanttChart always generates consistent colors with the `ColorHash` library (same as the TimeSeriesChart): https://github.com/perses/perses/blob/0e5663c6c2111eb94bf207b512c1d20d7264ab59/ui/panels-plugin/src/model/palette.ts#L24-L29

To improve the UI when embedding the panel into other pages, it's beneficial to use a fixed color palette, i.e. from the eCharts theme: `chartsTheme.echartsTheme.color`.

# Screenshots
Colors from MUI theme:
![image](https://github.com/user-attachments/assets/5fe84795-71d1-4075-8a3f-c9052ca65acc)

Default, generated colors:
![image](https://github.com/user-attachments/assets/a79642da-f1f8-45d8-8b7e-53c59a45d535)

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
