### PR TITLE
[ENHANCEMENT] make circle size configurable in ScatterPlot panel

### DIFF
--- a/cue/schemas/panels/scatter/scatter.cue
+++ b/cue/schemas/panels/scatter/scatter.cue
@@ -14,4 +14,6 @@
 package model
 
 kind: "ScatterChart"
-spec: close({})
+spec: close({
+	sizeRange?: [number, number]
+})

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.test.tsx
@@ -24,7 +24,7 @@ import { screen, render } from '@testing-library/react';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import { ChartsProvider, testChartsTheme } from '@perses-dev/components';
 import { MOCK_TRACE_DATA, MOCK_TRACE_QUERY_RESULT, MOCK_EMPTY_TRACE_QUERY_RESULT } from '../../test/';
-import { ScatterChartPanel, ScatterChartPanelProps } from './ScatterChartPanel';
+import { getSymbolSize, ScatterChartPanel, ScatterChartPanelProps } from './ScatterChartPanel';
 
 jest.mock('@perses-dev/plugin-system', () => {
   return {
@@ -51,19 +51,7 @@ const TEST_SCATTER_PANEL: ScatterChartPanelProps = {
     width: 500,
     height: 500,
   },
-  spec: {
-    query: {
-      kind: 'TraceQuery',
-      spec: {
-        plugin: {
-          kind: 'TempoTraceQuery',
-          spec: {
-            query: '{duration>500ms}',
-          },
-        },
-      },
-    },
-  },
+  spec: {},
 };
 
 const TEST_TIME_RANGE: TimeRangeValue = { pastDuration: '1h' };
@@ -111,5 +99,15 @@ describe('ScatterChartPanel', () => {
     renderPanel();
     // expect it to return a Alert because the query produces no trace results
     expect(await screen.findByText('No traces')).toBeInTheDocument();
+  });
+
+  it('should scale the circles', () => {
+    // apply linear scale from range [1,5] to a value from range [10,20]
+    expect(getSymbolSize(1, [1, 5], [10, 20])).toEqual(10);
+    expect(getSymbolSize(3, [1, 5], [10, 20])).toEqual(15);
+    expect(getSymbolSize(5, [1, 5], [10, 20])).toEqual(20);
+
+    // use max size if all span counts are same
+    expect(getSymbolSize(5, [5, 5], [10, 20])).toEqual(20);
   });
 });

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.tsx
@@ -28,6 +28,9 @@ export interface EChartTraceValue extends Omit<TraceSearchResult, 'startTimeUnix
 
 export type ScatterChartPanelProps = PanelProps<ScatterChartOptions>;
 
+/** default size range of the circles diameter */
+const DEFAULT_SIZE_RANGE: [number, number] = [6, 20];
+
 /**
  * ScatterChartPanel receives data from the DataQueriesProvider and transforms it
  * into a `dataset` object that Apache ECharts can consume. Additionally,
@@ -44,21 +47,23 @@ export type ScatterChartPanelProps = PanelProps<ScatterChartOptions>;
  * visualization of the data.
  */
 export function ScatterChartPanel(props: ScatterChartPanelProps) {
-  const { contentDimensions } = props;
+  const { spec, contentDimensions } = props;
   const { queryResults: traceResults, isLoading: traceIsLoading } = useDataQueries('TraceQuery');
   const chartsTheme = useChartsTheme();
   const defaultColor = chartsTheme.thresholds.defaultColor || 'blue';
+  const sizeRange = spec.sizeRange || DEFAULT_SIZE_RANGE;
 
   // Generate dataset
   // Transform Tempo API response to fit 'dataset' structure from Apache ECharts
   // https://echarts.apache.org/handbook/en/concepts/dataset
-  const { dataset, maxSpanCount } = useMemo(() => {
+  const { dataset, minSpanCount, maxSpanCount } = useMemo(() => {
     if (traceIsLoading) {
-      return { dataset: [], maxSpanCount: 1 };
+      return { dataset: [], minSpanCount: 0, maxSpanCount: 0 };
     }
 
     const dataset = [];
-    let maxSpanCount = 1;
+    let minSpanCount: number | undefined;
+    let maxSpanCount: number | undefined;
     for (const result of traceResults) {
       if (result.isLoading || result.data === undefined || result.data.searchResult === undefined) continue;
       const dataSeries = result.data.searchResult.map((trace) => {
@@ -68,7 +73,11 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
           spanCount += stats.spanCount;
           errorCount += stats.errorCount ?? 0;
         }
-        if (spanCount > maxSpanCount) {
+
+        if (minSpanCount === undefined || spanCount < minSpanCount) {
+          minSpanCount = spanCount;
+        }
+        if (maxSpanCount === undefined || spanCount > maxSpanCount) {
           maxSpanCount = spanCount;
         }
 
@@ -85,7 +94,7 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
         source: dataSeries,
       });
     }
-    return { dataset, maxSpanCount };
+    return { dataset, minSpanCount: minSpanCount ?? 0, maxSpanCount: maxSpanCount ?? 0 };
   }, [traceIsLoading, traceResults]);
 
   // Formatting for the dataset
@@ -102,9 +111,8 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
         y: 'durationMs',
       },
       symbolSize: function (data) {
-        // Changes datapoint to correspond to number of spans in a trace
-        const maxScaleSymbolSize = 80;
-        return (data.spanCount / maxSpanCount) * maxScaleSymbolSize;
+        // returns the diameter of the circles
+        return getSymbolSize(data.spanCount, [minSpanCount, maxSpanCount], sizeRange);
       },
       itemStyle: {
         color: function (params) {
@@ -125,7 +133,7 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
       series.push({ ...seriesTemplate2, datasetIndex: i });
     }
     return series;
-  }, [dataset, defaultColor, maxSpanCount]);
+  }, [dataset, defaultColor, minSpanCount, maxSpanCount, sizeRange]);
 
   if (traceIsLoading) {
     return <LoadingOverlay />;
@@ -153,4 +161,19 @@ export function ScatterChartPanel(props: ScatterChartPanelProps) {
       <Scatterplot width={contentDimensions.width} height={contentDimensions.height} options={options} />
     </div>
   );
+}
+
+// exported for tests
+export function getSymbolSize(spanCount: number, spanCountRange: [number, number], sizeRange: [number, number]) {
+  const [minSize, maxSize] = sizeRange;
+  const [minSpanCount, maxSpanCount] = spanCountRange;
+
+  // catch divison by zero
+  if (maxSpanCount - minSpanCount === 0) {
+    return maxSize;
+  }
+
+  // apply linear scale of spanCount from range [minSpanCount,maxSpanCount] to a value from range [minSize,maxSize]
+  const rel = (spanCount - minSpanCount) / (maxSpanCount - minSpanCount);
+  return minSize + (maxSize - minSize) * rel;
 }

--- a/ui/panels-plugin/src/plugins/scatterplot/scatter-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/scatterplot/scatter-chart-model.ts
@@ -22,8 +22,10 @@ export type TraceQueryDefinition<PluginSpec = UnknownSpec> = QueryDefinition<'Tr
 // Some scaffolding has been done to support formatting options.
 // This includes the interface below which still needs implementation.
 // Note: The interface attributes must match cue/schemas/panels/scatter/scatter.cue
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ScatterChartOptions {}
+export interface ScatterChartOptions {
+  /** range of the circles diameter */
+  sizeRange?: [number, number];
+}
 
 /**
  * Creates the initial/empty options for a ScatterChart panel.


### PR DESCRIPTION
# Description
* make size configurable (min/max size), use a default range from 6-20 px
* apply linear scale of spanCount from range minSpanCount..maxSpanCount to a value from minSize..maxSize

# Screenshots
Before:
![Bildschirmfoto vom 2024-08-26 13-17-33](https://github.com/user-attachments/assets/21432210-d5e3-4ce2-b2d0-188807251ef1)

After:
![Bildschirmfoto vom 2024-08-26 13-17-09](https://github.com/user-attachments/assets/7a09c3f0-bd7c-460f-acd0-49f9d37451f5)

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
