### PR TITLE
[ENHANCEMENT] ScatterPlot panel: format time based on next best unit

### DIFF
--- a/ui/panels-plugin/src/plugins/scatterplot/Scatterplot.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/Scatterplot.tsx
@@ -24,6 +24,7 @@ import {
 } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 import { EChartsOption } from 'echarts';
+import { formatValue } from '@perses-dev/core';
 
 use([
   DatasetComponent,
@@ -66,7 +67,7 @@ export function Scatterplot(props: ScatterplotProps) {
       type: 'value',
       name: 'Duration',
       axisLabel: {
-        formatter: '{value} ms',
+        formatter: (durationMs: number) => formatValue(durationMs, { unit: 'milliseconds' }),
       },
     },
     animation: false,


### PR DESCRIPTION
# Description
ScatterPlot panel: format time based on next best unit

# Screenshots
Before:
![image](https://github.com/user-attachments/assets/9e1db925-576c-4e67-afc1-c672eccb86a8)

After:
![image](https://github.com/user-attachments/assets/529e32cf-e15c-479d-bc01-a26502823b34)

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
