### PR TITLE
[ENHANCEMENT] TraceTablePanel: support disabling links to the trace

### DIFF
--- a/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
@@ -19,12 +19,18 @@ import { DataTable, TraceLink } from './DataTable';
 import { TraceTableOptions } from './trace-table-model';
 
 export interface TraceTableProps extends PanelProps<TraceTableOptions> {
-  traceLink?: TraceLink;
+  /**
+   * Specify a link for the traces in the table.
+   * If this field is unset or undefined, a link to the Gantt chart on the explore page is configured.
+   * Set this field explicitly to null to disable creating a link.
+   */
+  traceLink?: TraceLink | null;
 }
 
-export function defaultTraceLink({ query, traceId }: { query: QueryDefinition; traceId: string }) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (query.spec.plugin.spec as any).query = traceId;
+export function defaultTraceLink({ query: originalQuery, traceId }: { query: QueryDefinition; traceId: string }) {
+  // clone the original query spec (including the datasource) and replace the query value with the trace id
+  const query: QueryDefinition = JSON.parse(JSON.stringify(originalQuery));
+  query.spec.plugin.spec.query = traceId;
 
   const traceLinkParams = new URLSearchParams({
     explorer: 'traces',
@@ -34,7 +40,7 @@ export function defaultTraceLink({ query, traceId }: { query: QueryDefinition; t
 }
 
 export function TraceTablePanel(props: TraceTableProps) {
-  const { traceLink = defaultTraceLink } = props;
+  const { traceLink } = props;
 
   const chartsTheme = useChartsTheme();
   const { isFetching, isLoading, queryResults } = useDataQueries('TraceQuery');
@@ -56,7 +62,7 @@ export function TraceTablePanel(props: TraceTableProps) {
 
   return (
     <Box sx={{ height: '100%', padding: `${contentPadding}px`, overflowY: 'scroll' }}>
-      <DataTable result={queryResults} traceLink={traceLink} />
+      <DataTable result={queryResults} traceLink={traceLink === null ? undefined : (traceLink ?? defaultTraceLink)} />
     </Box>
   );
 }


### PR DESCRIPTION
# Description
Previously, not setting the `traceLink` property always sets a link to the explore page.
However, there might be cases when developers explicitly don't want to create a link.

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
