### PR TITLE
[FEATURE] Usage Tracking Frontend Work

### DIFF
--- a/internal/api/impl/v1/view/endpoint.go
+++ b/internal/api/impl/v1/view/endpoint.go
@@ -52,13 +52,15 @@ func (e *endpoint) view(ctx echo.Context) error {
 		return apiInterface.HandleBadRequestError(err.Error())
 	}
 
-	claims := crypto.ExtractJWTClaims(ctx)
-	if claims == nil {
-		return apiInterface.HandleUnauthorizedError("missing claims")
-	}
+	if e.rbac.IsEnabled() {
+		claims := crypto.ExtractJWTClaims(ctx)
+		if claims == nil {
+			return apiInterface.HandleUnauthorizedError("missing claims")
+		}
 
-	if ok := e.rbac.HasPermission(claims.Subject, role.ReadAction, view.Project, role.DashboardScope); !ok {
-		return apiInterface.HandleUnauthorizedError(fmt.Sprintf("missing '%s' permission in '%s' project for '%s' kind", role.ReadAction, view.Project, role.DashboardScope))
+		if ok := e.rbac.HasPermission(claims.Subject, role.ReadAction, view.Project, role.DashboardScope); !ok {
+			return apiInterface.HandleUnauthorizedError(fmt.Sprintf("missing '%s' permission in '%s' project for '%s' kind", role.ReadAction, view.Project, role.DashboardScope))
+		}
 	}
 
 	if _, err := e.dashboardService.Get(apiInterface.NewPersesContext(ctx), apiInterface.Parameters{

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -14,7 +14,7 @@
 import { Box, CircularProgress, Stack } from '@mui/material';
 import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard } from '@perses-dev/dashboards';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { PluginRegistry, ValidationProvider } from '@perses-dev/plugin-system';
+import { PluginRegistry, UsageMetricsProvider, ValidationProvider } from '@perses-dev/plugin-system';
 import { DashboardResource, EphemeralDashboardResource, getResourceDisplayName } from '@perses-dev/core';
 import { useEffect, useMemo, useState } from 'react';
 import { bundledPluginLoader } from '../../../model/bundled-plugins';
@@ -89,23 +89,25 @@ export function HelperDashboardView(props: GenericDashboardViewProps) {
         >
           <ValidationProvider>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <ViewDashboard
-                dashboardResource={dashboardResource}
-                datasourceApi={datasourceApi}
-                externalVariableDefinitions={externalVariableDefinitions}
-                dashboardTitleComponent={
-                  <ProjectBreadcrumbs dashboardName={getResourceDisplayName(dashboardResource)} project={project} />
-                }
-                emptyDashboardProps={{
-                  additionalText: 'In order to save this dashboard, you need to add at least one panel!',
-                }}
-                onSave={onSave}
-                onDiscard={onDiscard}
-                initialVariableIsSticky={true}
-                isReadonly={isReadonly}
-                isEditing={isEditing}
-                isCreating={isCreating}
-              />
+              <UsageMetricsProvider project={project.metadata.name} dashboard={dashboardResource.metadata.name}>
+                <ViewDashboard
+                  dashboardResource={dashboardResource}
+                  datasourceApi={datasourceApi}
+                  externalVariableDefinitions={externalVariableDefinitions}
+                  dashboardTitleComponent={
+                    <ProjectBreadcrumbs dashboardName={getResourceDisplayName(dashboardResource)} project={project} />
+                  }
+                  emptyDashboardProps={{
+                    additionalText: 'In order to save this dashboard, you need to add at least one panel!',
+                  }}
+                  onSave={onSave}
+                  onDiscard={onDiscard}
+                  initialVariableIsSticky={true}
+                  isReadonly={isReadonly}
+                  isEditing={isEditing}
+                  isCreating={isCreating}
+                />
+              </UsageMetricsProvider>
             </ErrorBoundary>
           </ValidationProvider>
         </PluginRegistry>

--- a/ui/plugin-system/src/runtime/UsageMetricsProvider.tsx
+++ b/ui/plugin-system/src/runtime/UsageMetricsProvider.tsx
@@ -1,0 +1,101 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fetch, QueryDefinition } from '@perses-dev/core';
+import { createContext, ReactNode, useContext } from 'react';
+
+type QueryState = 'pending' | 'success' | 'error';
+
+interface UsageMetrics {
+  project: string;
+  dashboard: string;
+  startRenderTime: number;
+  renderDurationMs: number;
+  renderErrorCount: number;
+  pendingQueries: Map<string, QueryState>;
+}
+
+interface UsageMetricsProps {
+  project: string;
+  dashboard: string;
+  children: ReactNode;
+}
+
+interface UseUsageMetricsResults {
+  markQuery: (definition: QueryDefinition, state: QueryState) => void;
+}
+
+export const UsageMetricsContext = createContext<UsageMetrics | undefined>(undefined);
+
+export const useUsageMetricsContext = () => {
+  return useContext(UsageMetricsContext);
+};
+
+export const useUsageMetrics = (): UseUsageMetricsResults => {
+  const ctx = useUsageMetricsContext();
+
+  return {
+    markQuery: (definition: QueryDefinition, newState: QueryState) => {
+      if (ctx === undefined) {
+        return;
+      }
+
+      const definitionKey = JSON.stringify(definition);
+      if (ctx.pendingQueries.has(definitionKey) && newState === 'pending') {
+        // Never allow transitions back to pending, to avoid re-sending stats on a re-render.
+        return;
+      }
+
+      if (ctx.pendingQueries.get(definitionKey) !== newState) {
+        ctx.pendingQueries.set(definitionKey, newState);
+        if (newState === 'error') {
+          ctx.renderErrorCount += 1;
+        }
+
+        const allDone = [...ctx.pendingQueries.values()].every((p) => p !== 'pending');
+        if (ctx.renderDurationMs === 0 && allDone) {
+          ctx.renderDurationMs = Date.now() - ctx.startRenderTime;
+          submitMetrics(ctx);
+        }
+      }
+    },
+  };
+};
+
+const submitMetrics = async (stats: UsageMetrics) => {
+  await fetch('/api/v1/view', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      project: stats.project,
+      dashboard: stats.dashboard,
+      render_time: stats.renderDurationMs / 1000,
+      render_errors: stats.renderErrorCount,
+    }),
+  });
+};
+
+export const UsageMetricsProvider = ({ project, dashboard, children }: UsageMetricsProps) => {
+  const ctx = {
+    project: project,
+    dashboard: dashboard,
+    renderErrorCount: 0,
+    startRenderTime: Date.now(),
+    renderDurationMs: 0,
+    pendingQueries: new Map(),
+  };
+
+  return <UsageMetricsContext.Provider value={ctx}>{children}</UsageMetricsContext.Provider>;
+};

--- a/ui/plugin-system/src/runtime/index.ts
+++ b/ui/plugin-system/src/runtime/index.ts
@@ -20,3 +20,4 @@ export * from './time-series-queries';
 export * from './trace-queries';
 export * from './DataQueriesProvider';
 export * from './QueryCountProvider';
+export * from './UsageMetricsProvider';


### PR DESCRIPTION
# Description

This is the other half of https://github.com/perses/perses/issues/1170

This adds in a provider that tracks metrics about a dashboard that is being loaded. Each individual panel uses that provider to store the state of it's queries, and then once all the queries are finished, we
ship the metrics off to the previously created /visit api.

# Screenshots

https://github.com/user-attachments/assets/f693294a-73ef-4dc5-a2a8-9d28ea68fdc7

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
