### PR TITLE
[BUGFIX] migrate: ignore adhoc variables

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -70,7 +70,7 @@ spec: {
     display: {
         name: #grafanaDashboard.title
     }
-    variables: [ for _, grafanaVar in #grafanaDashboard.templating.list {
+    variables: [ for _, grafanaVar in #grafanaDashboard.templating.list if grafanaVar.type != "adhoc" {
         _displayConversion: {
             #var: _
 


### PR DESCRIPTION

# Description

migrate: ignore [adhoc](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#add-ad-hoc-filters) variables not supported by Perses:

Error without ignoring it :

```
percli migrate -f dash.json -o yaml --online
Error: something wrong happened with the request to the API.  Message: bad request: unable to convert to Perses dashboard: spec.variables.2.spec: undefined field: hide StatusCode: 400
```
Example variable in grafana:

```
...
            {
                "datasource": {
                    "type": "prometheus",
                    "uid": "PC7A11E9A55DE2B10"
                },
                "description": "Metrics filter.",
                "label": "mfilter",
                "name": "mfilter",
                "type": "adhoc"
            },
...
```

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

