### PR TITLE
[ENHANCEMENT] Avoid failing grafana migration on `hide` absence

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -74,22 +74,14 @@ spec: {
         _displayConversion: {
             #var: _
 
-            name: [ // switch
-                if #var.label != _|_ if #var.label != "" {
-                    #var.label
-                },
-                #var.name
-            ][0]
-            if #var.description != _|_ {
-                description: #var.description
+            if #var.label != _|_ if #var.label != "" {
+                display: name: #var.label
             }
-            if #var.hide != _|_ {
-                hidden: [ // switch
-                    if #var.hide > 0 {
-                        true
-                    },
-                    false
-                ][0]
+            if #var.description != _|_ {
+                display: description: #var.description
+            }
+            if #var.hide != _|_ if #var.hide > 0 {
+                display: hidden: true
             }
         }
         _singleVarConversion: this={
@@ -99,7 +91,7 @@ spec: {
             kind: "TextVariable"
             spec: {
                 name: #var.name
-                display: _displayConversion & {#var: this.#var}
+                _displayConversion & {#var: this.#var}
                 constant: #constant
                 value: #var.query
             }
@@ -114,9 +106,7 @@ spec: {
             kind: "ListVariable"
             spec: {
                 name: grafanaVar.name
-                if grafanaVar.label != _|_ || grafanaVar.description != _|_ || grafanaVar.hide > 0 {
-                    display: _displayConversion & {#var: grafanaVar}
-                }
+                _displayConversion & {#var: grafanaVar}
                 allowAllValue: *grafanaVar.includeAll | false // the default value tackles the case of variables of type `interval` that don't have such field
                 allowMultiple: *grafanaVar.multi | false      // the default value tackles the case of variables of type `interval` that don't have such field
                 if allowAllValue if grafanaVar.allValue != _|_ {

--- a/internal/api/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/simple_grafana_dashboard.json
@@ -901,7 +901,6 @@
         },
         "definition": "query_result(group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range])))",
         "description": "query result var for volatile series (relies $__range global var)",
-        "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "queryResVarVolatile",

--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -146,7 +146,6 @@
         "kind": "ListVariable",
         "spec": {
           "display": {
-            "name": "interval",
             "description": "ad hoc filter",
             "hidden": false
           },
@@ -236,7 +235,6 @@
         "kind": "ListVariable",
         "spec": {
           "display": {
-            "name": "queryResVarVolatile",
             "description": "query result var for volatile series (relies $__range global var)",
             "hidden": false
           },
@@ -257,7 +255,6 @@
         "kind": "ListVariable",
         "spec": {
           "display": {
-            "name": "queryResVarOther",
             "description": "query result var with no <aggr> by clause",
             "hidden": false
           },


### PR DESCRIPTION
# Description

Follow-up on the issue reported in https://github.com/perses/perses/pull/2218. The migration logic is now resilient to the absence of the `hide` property for variables.

This PR also changes the migration code to stop populating the variable display name with its "technical" name. This was done at the time because of a model constraint that https://github.com/perses/perses/pull/1414 got rid of.

It also simplifies the code responsible of migrating variable's display attributes as a whole.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
