### PR TITLE
[IGNORE] align TempoClient with PrometheusClient, add searchTags and searchTagsValues()

### DIFF
--- a/ui/tempo-plugin/src/model/api-types.ts
+++ b/ui/tempo-plugin/src/model/api-types.ts
@@ -26,7 +26,8 @@ export type AttributeValue =
   | { arrayValue: { values: AttributeValue[] } };
 
 /**
- * Parameters of Tempo HTTP API endpoint GET /api/search
+ * Request parameters of Tempo HTTP API endpoint GET /api/search
+ * https://grafana.com/docs/tempo/latest/api_docs/#search
  */
 export interface SearchRequestParameters {
   q: string;
@@ -35,13 +36,14 @@ export interface SearchRequestParameters {
 }
 
 /**
- * Response of Tempo HTTP API endpoint GET /api/search/<query>
+ * Response of Tempo HTTP API endpoint GET /api/search
+ * https://grafana.com/docs/tempo/latest/api_docs/#search
  */
-export interface SearchTraceQueryResponse {
-  traces: TraceSearchResult[];
+export interface SearchResponse {
+  traces: TraceSearchResponse[];
 }
 
-export interface TraceSearchResult {
+export interface TraceSearchResponse {
   traceID: string;
   rootServiceName: string;
   rootTraceName: string;
@@ -50,18 +52,18 @@ export interface TraceSearchResult {
   durationMs?: number;
   /** @deprecated spanSet is deprecated in favor of spanSets */
   spanSet?: {
-    spans: SpanSearchResult[];
+    spans: SpanSearchResponse[];
     matched: number;
   };
   spanSets?: Array<{
-    spans: SpanSearchResult[];
+    spans: SpanSearchResponse[];
     matched: number;
   }>;
   /** ServiceStats are only available in Tempo vParquet4+ blocks */
   serviceStats?: Record<string, ServiceStats>;
 }
 
-export interface SpanSearchResult {
+export interface SpanSearchResponse {
   spanID: string;
   name: string;
   startTimeUnixNano: string;
@@ -76,10 +78,18 @@ export interface ServiceStats {
 }
 
 /**
+ * Request parameters of Tempo HTTP API endpoint GET /api/traces/<traceID>
+ * https://grafana.com/docs/tempo/latest/api_docs/#query
+ */
+export interface QueryRequestParameters {
+  traceId: string;
+}
+
+/**
  * Response of Tempo HTTP API endpoint GET /api/traces/<traceID>
  * OTEL trace proto: https://github.com/open-telemetry/opentelemetry-proto-go/blob/main/otlp/trace/v1/trace.pb.go
  */
-export interface SearchTraceIDResponse {
+export interface QueryResponse {
   batches: Batch[];
 }
 
@@ -128,3 +138,51 @@ export interface SpanStatus {
 export const SpanStatusUnset = 'STATUS_CODE_UNSET';
 export const SpanStatusOk = 'STATUS_CODE_OK';
 export const SpanStatusError = 'STATUS_CODE_ERROR';
+
+/**
+ * Request parameters of Tempo HTTP API endpoint GET /api/v2/search/tags
+ * https://grafana.com/docs/tempo/latest/api_docs/#search-tags-v2
+ */
+export interface SearchTagsRequestParameters {
+  scope?: 'resource' | 'span' | 'intrinsic';
+  q?: string;
+  start?: number;
+  end?: number;
+}
+
+/**
+ * Response of Tempo HTTP API endpoint GET /api/v2/search/tags
+ * https://grafana.com/docs/tempo/latest/api_docs/#search-tags-v2
+ */
+export interface SearchTagsResponse {
+  scopes: SearchTagsScope[];
+}
+
+export interface SearchTagsScope {
+  name: 'resource' | 'span' | 'intrinsic';
+  tags: string[];
+}
+
+/**
+ * Request parameters of Tempo HTTP API endpoint GET /api/v2/search/tag/<tag>/values
+ * https://grafana.com/docs/tempo/latest/api_docs/#search-tag-values-v2
+ */
+export interface SearchTagValuesRequestParameters {
+  tag: string;
+  q?: string;
+  start?: number;
+  end?: number;
+}
+
+/**
+ * Response of Tempo HTTP API endpoint GET /api/v2/search/tag/<tag>/values
+ * https://grafana.com/docs/tempo/latest/api_docs/#search-tag-values-v2
+ */
+export interface SearchTagValuesResponse {
+  tagValues: SearchTagValue[];
+}
+
+export interface SearchTagValue {
+  type: string;
+  value: string;
+}

--- a/ui/tempo-plugin/src/model/tempo-client.test.ts
+++ b/ui/tempo-plugin/src/model/tempo-client.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { MOCK_SEARCH_RESPONSE_VPARQUET3, MOCK_SEARCH_RESPONSE_VPARQUET4, MOCK_TRACE_RESPONSE } from '../test';
-import { searchTraceQueryFallback } from './tempo-client';
+import { searchWithFallback } from './tempo-client';
 
 const fetchMock = (global.fetch = jest.fn());
 
@@ -20,7 +20,7 @@ describe('tempo-client', () => {
   it('should return query results as-is when serviceStats are present', async () => {
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(MOCK_SEARCH_RESPONSE_VPARQUET4) });
 
-    const results = await searchTraceQueryFallback({ q: '{}' }, { datasourceUrl: '' });
+    const results = await searchWithFallback({ q: '{}' }, { datasourceUrl: '' });
     expect(results).toEqual(MOCK_SEARCH_RESPONSE_VPARQUET4);
   });
 
@@ -28,7 +28,7 @@ describe('tempo-client', () => {
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(MOCK_SEARCH_RESPONSE_VPARQUET3) });
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(MOCK_TRACE_RESPONSE) });
 
-    const results = await searchTraceQueryFallback({ q: '{}' }, { datasourceUrl: '' });
+    const results = await searchWithFallback({ q: '{}' }, { datasourceUrl: '' });
     expect(results).toEqual(MOCK_SEARCH_RESPONSE_VPARQUET4);
   });
 });

--- a/ui/tempo-plugin/src/plugins/plugin.test.ts
+++ b/ui/tempo-plugin/src/plugins/plugin.test.ts
@@ -30,8 +30,8 @@ const datasource: TempoDatasourceSpec = {
 };
 
 const tempoStubClient = TempoDatasource.createClient(datasource, {});
-tempoStubClient.searchTraceID = jest.fn(async () => MOCK_TRACE_RESPONSE_SMALL);
-tempoStubClient.searchTraceQueryFallback = jest.fn(async () => MOCK_SEARCH_RESPONSE_VPARQUET4);
+tempoStubClient.query = jest.fn(async () => MOCK_TRACE_RESPONSE_SMALL);
+tempoStubClient.searchWithFallback = jest.fn(async () => MOCK_SEARCH_RESPONSE_VPARQUET4);
 
 const getDatasourceClient: jest.Mock = jest.fn(() => {
   return tempoStubClient;

--- a/ui/tempo-plugin/src/plugins/tempo-datasource.tsx
+++ b/ui/tempo-plugin/src/plugins/tempo-datasource.tsx
@@ -12,14 +12,14 @@
 // limitations under the License.
 
 import { DatasourcePlugin } from '@perses-dev/plugin-system';
-import { searchTraceQuery, searchTraceID, searchTraceQueryFallback, TempoClient } from '../model/tempo-client';
+import { TempoClient, query, search, searchTagValues, searchTags, searchWithFallback } from '../model/tempo-client';
 import { TempoDatasourceSpec } from './tempo-datasource-types';
 
 /**
  * Creates a TempoClient for a specific datasource spec.
  */
 const createClient: DatasourcePlugin<TempoDatasourceSpec, TempoClient>['createClient'] = (spec, options) => {
-  const { directUrl } = spec;
+  const { directUrl, proxy } = spec;
   const { proxyUrl } = options;
 
   // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
@@ -28,13 +28,18 @@ const createClient: DatasourcePlugin<TempoDatasourceSpec, TempoClient>['createCl
     throw new Error('No URL specified for Tempo client. You can use directUrl in the spec to configure it.');
   }
 
+  const specHeaders = proxy?.spec.headers;
+
   return {
     options: {
       datasourceUrl,
     },
-    searchTraceQuery: (params, queryOptions) => searchTraceQuery(params, queryOptions),
-    searchTraceQueryFallback: (params, queryOptions) => searchTraceQueryFallback(params, queryOptions),
-    searchTraceID: (traceID, queryOptions) => searchTraceID(traceID, queryOptions),
+    query: (params, headers) => query(params, { datasourceUrl, headers: headers ?? specHeaders }),
+    search: (params, headers) => search(params, { datasourceUrl, headers: headers ?? specHeaders }),
+    searchWithFallback: (params, headers) =>
+      searchWithFallback(params, { datasourceUrl, headers: headers ?? specHeaders }),
+    searchTags: (params, headers) => searchTags(params, { datasourceUrl, headers: headers ?? specHeaders }),
+    searchTagValues: (params, headers) => searchTagValues(params, { datasourceUrl, headers: headers ?? specHeaders }),
   };
 };
 

--- a/ui/tempo-plugin/src/plugins/tempo-trace-query/get-trace-data.ts
+++ b/ui/tempo-plugin/src/plugins/tempo-trace-query/get-trace-data.ts
@@ -28,8 +28,8 @@ import { TEMPO_DATASOURCE_KIND, TempoDatasourceSelector } from '../../model/temp
 import { TempoClient } from '../../model/tempo-client';
 import {
   SearchRequestParameters,
-  SearchTraceIDResponse,
-  SearchTraceQueryResponse,
+  QueryResponse,
+  SearchResponse,
   Resource as TempoResource,
   Span as TempoSpan,
   SpanEvent as TempoSpanEvent,
@@ -58,12 +58,6 @@ export const getTraceData: TraceQueryPlugin<TempoTraceQuerySpec>['getTraceData']
     spec.datasource ?? defaultTempoDatasource
   );
 
-  const datasourceUrl = client?.options?.datasourceUrl;
-  if (datasourceUrl === undefined || datasourceUrl === null || datasourceUrl === '') {
-    console.error('TempoDatasource is undefined, null, or an empty string.');
-    return { searchResult: [] };
-  }
-
   const getQuery = (): SearchRequestParameters => {
     // if time range not defined -- only return the query from the spec
     if (context.absoluteTimeRange === undefined) {
@@ -84,7 +78,7 @@ export const getTraceData: TraceQueryPlugin<TempoTraceQuerySpec>['getTraceData']
    * otherwise, execute a TraceQL query
    */
   if (isValidTraceId(spec.query)) {
-    const response = await client.searchTraceID(spec.query, { datasourceUrl });
+    const response = await client.query({ traceId: spec.query });
     return {
       trace: parseTraceResponse(response),
       metadata: {
@@ -92,7 +86,7 @@ export const getTraceData: TraceQueryPlugin<TempoTraceQuerySpec>['getTraceData']
       },
     };
   } else {
-    const response = await client.searchTraceQueryFallback(getQuery(), { datasourceUrl });
+    const response = await client.searchWithFallback(getQuery());
     return {
       searchResult: parseSearchResponse(response),
       metadata: {
@@ -148,7 +142,7 @@ function parseSpan(span: TempoSpan) {
  * parseTraceResponse builds a tree of spans from the Tempo API response
  * time complexity: O(2n)
  */
-function parseTraceResponse(response: SearchTraceIDResponse): Trace {
+function parseTraceResponse(response: QueryResponse): Trace {
   // first pass: build lookup table <spanId, Span>
   const lookup = new Map<string, Span>();
   for (const batch of response.batches) {
@@ -196,7 +190,7 @@ function parseTraceResponse(response: SearchTraceIDResponse): Trace {
   };
 }
 
-function parseSearchResponse(response: SearchTraceQueryResponse): TraceSearchResult[] {
+function parseSearchResponse(response: SearchResponse): TraceSearchResult[] {
   return response.traces.map((trace) => ({
     startTimeUnixMs: parseInt(trace.startTimeUnixNano) * 1e-6, // convert to millisecond for eChart time format,
     durationMs: trace.durationMs ?? 0, // Tempo API doesn't return 0 values

--- a/ui/tempo-plugin/src/test/mock-data.ts
+++ b/ui/tempo-plugin/src/test/mock-data.ts
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 import { Span, TraceData } from '@perses-dev/core';
-import { SearchTraceIDResponse, SearchTraceQueryResponse } from '../model/api-types';
+import { QueryResponse, SearchResponse } from '../model/api-types';
 
-export const MOCK_TRACE_RESPONSE: SearchTraceIDResponse = {
+export const MOCK_TRACE_RESPONSE: QueryResponse = {
   batches: [
     {
       resource: {
@@ -2075,7 +2075,7 @@ export const MOCK_TRACE_RESPONSE: SearchTraceIDResponse = {
   ],
 };
 
-export const MOCK_TRACE_RESPONSE_SMALL: SearchTraceIDResponse = {
+export const MOCK_TRACE_RESPONSE_SMALL: QueryResponse = {
   batches: [
     {
       resource: {
@@ -2220,7 +2220,7 @@ export const MOCK_TRACE_RESPONSE_SMALL: SearchTraceIDResponse = {
   ],
 };
 
-export const MOCK_SEARCH_RESPONSE_VPARQUET3: SearchTraceQueryResponse = {
+export const MOCK_SEARCH_RESPONSE_VPARQUET3: SearchResponse = {
   traces: [
     {
       traceID: 'fbd37845209d43cdccd418dc5f9ff021',
@@ -2272,7 +2272,7 @@ export const MOCK_SEARCH_RESPONSE_VPARQUET3: SearchTraceQueryResponse = {
   ],
 };
 
-export const MOCK_SEARCH_RESPONSE_VPARQUET4: SearchTraceQueryResponse = {
+export const MOCK_SEARCH_RESPONSE_VPARQUET4: SearchResponse = {
   traces: [
     {
       traceID: 'fbd37845209d43cdccd418dc5f9ff021',


### PR DESCRIPTION
# Description

* name API functions after Tempo API functions
* use params dict for every API functions
* store datasourceUrl in closure
* support custom headers
* add searchTags() and searchTagsValues() API functions

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
