### PR TITLE
[ENHANCEMENT] TraceQL query editor: add auto-complete support

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -32601,6 +32601,7 @@
       "version": "0.47.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.17.0",
         "@grafana/lezer-traceql": "^0.0.18",
         "@lezer/highlight": "^1.0.0",
         "@perses-dev/components": "0.47.1",

--- a/ui/tempo-plugin/package.json
+++ b/ui/tempo-plugin/package.json
@@ -29,6 +29,7 @@
         "lint:fix": "eslint --fix src --ext .ts,.tsx"
     },
     "dependencies": {
+        "@codemirror/autocomplete": "^6.17.0",
         "@lezer/highlight": "^1.0.0",
         "@grafana/lezer-traceql": "^0.0.18",
         "@perses-dev/components": "0.47.1",

--- a/ui/tempo-plugin/src/components/TraceQLExtension.ts
+++ b/ui/tempo-plugin/src/components/TraceQLExtension.ts
@@ -13,8 +13,10 @@
 
 import { LRLanguage } from '@codemirror/language';
 import { parser } from '@grafana/lezer-traceql';
+import { CompletionContext } from '@codemirror/autocomplete';
 import { TempoClient } from '../model/tempo-client';
 import { traceQLHighlight } from './highlight';
+import { complete } from './complete';
 
 export function traceQLLanguage(): LRLanguage {
   return LRLanguage.define({
@@ -32,7 +34,11 @@ export interface CompletionConfig {
   client?: TempoClient;
 }
 
-export function TraceQLExtension({ client: _client }: CompletionConfig) {
+export function TraceQLExtension({ client }: CompletionConfig) {
   const language = traceQLLanguage();
-  return [language];
+  const completion = language.data.of({
+    autocomplete: (ctx: CompletionContext) =>
+      complete(ctx, client).catch((e) => console.error('error during TraceQL auto-complete', e)),
+  });
+  return [language, completion];
 }

--- a/ui/tempo-plugin/src/components/complete.test.ts
+++ b/ui/tempo-plugin/src/components/complete.test.ts
@@ -1,0 +1,168 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EditorState } from '@uiw/react-codemirror';
+import { parser } from '@grafana/lezer-traceql';
+import { LRLanguage } from '@codemirror/language';
+import { CompletionContext } from '@codemirror/autocomplete';
+import { Completions, identifyCompletions } from './complete';
+
+const traceQLExtension = LRLanguage.define({ parser: parser });
+
+describe('complete', () => {
+  const tests: Array<{ expr: string; pos?: number; expected: Completions | undefined }> = [
+    // start
+    {
+      expr: '',
+      expected: undefined,
+    },
+    {
+      expr: '{ ',
+      expected: {
+        scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }],
+        from: 2,
+      },
+    },
+    {
+      expr: '{}',
+      pos: 1,
+      expected: {
+        scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }],
+        from: 1,
+      },
+    },
+    {
+      expr: '{}',
+      expected: undefined,
+    },
+    {
+      expr: '{ status=ok ',
+      expected: undefined,
+    },
+    {
+      expr: '{ status=ok }',
+      pos: -1,
+      expected: undefined,
+    },
+    {
+      expr: '{ status=ok && ',
+      expected: {
+        scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }],
+        from: 15,
+      },
+    },
+    {
+      expr: '{ status=ok && }',
+      pos: -1,
+      expected: {
+        scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }],
+        from: 15,
+      },
+    },
+
+    // tag names
+    {
+      expr: '{ resource.',
+      expected: { scopes: [{ kind: 'TagName', scope: 'resource' }], from: 11 },
+    },
+    {
+      expr: '{ span.',
+      expected: { scopes: [{ kind: 'TagName', scope: 'span' }], from: 7 },
+    },
+    {
+      expr: '{ .', // unscoped attributes
+      expected: {
+        scopes: [
+          { kind: 'TagName', scope: 'resource' },
+          { kind: 'TagName', scope: 'span' },
+        ],
+        from: 3,
+      },
+    },
+    {
+      expr: '{ resource.s',
+      expected: { scopes: [{ kind: 'TagName', scope: 'resource' }], from: 11 },
+    },
+    {
+      expr: '{ span.s',
+      expected: { scopes: [{ kind: 'TagName', scope: 'span' }], from: 7 },
+    },
+    {
+      expr: '{ .s',
+      expected: {
+        scopes: [
+          { kind: 'TagName', scope: 'resource' },
+          { kind: 'TagName', scope: 'span' },
+        ],
+        from: 3,
+      },
+    },
+
+    // intrinsic fields
+    {
+      expr: '{ s',
+      expected: { scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }], from: 2 },
+    },
+    {
+      expr: '{ span:s',
+      expected: { scopes: [{ kind: 'TagName', scope: 'intrinsic' }], from: 2 },
+    },
+    {
+      expr: '{ status=ok && s',
+      expected: { scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }], from: 15 },
+    },
+
+    // tag values
+    {
+      expr: '{ resource.service.name=',
+      expected: { scopes: [{ kind: 'TagValue', tag: 'resource.service.name', quotes: true }], from: 24 },
+    },
+    {
+      expr: '{ resource.service.name=""',
+      pos: -1,
+      expected: { scopes: [{ kind: 'TagValue', tag: 'resource.service.name' }], from: 25 },
+    },
+    {
+      expr: '{ span.http.method=""',
+      pos: -1,
+      expected: { scopes: [{ kind: 'TagValue', tag: 'span.http.method' }], from: 20 },
+    },
+    {
+      expr: '{ .service.name=""',
+      pos: -1,
+      expected: { scopes: [{ kind: 'TagValue', tag: '.service.name' }], from: 17 },
+    },
+    {
+      expr: '{ .service.name="article-" && status=error }',
+      pos: 25,
+      expected: { scopes: [{ kind: 'TagValue', tag: '.service.name' }], from: 17 },
+    },
+    {
+      expr: '{ status=',
+      expected: { scopes: [{ kind: 'TagValue', tag: 'status', quotes: true }], from: 9 },
+    },
+    {
+      expr: '{ status=e',
+      expected: { scopes: [{ kind: 'TagValue', tag: 'status' }], from: 9 },
+    },
+  ];
+
+  it.each(tests)('retrive completions for $expr', ({ expr, pos, expected }) => {
+    if (pos === undefined) pos = expr.length;
+    if (pos < 0) pos = expr.length + pos;
+
+    const state = EditorState.create({ doc: expr, extensions: traceQLExtension });
+    const completions = identifyCompletions({ state, pos } as CompletionContext);
+    expect(completions).toEqual(expected);
+  });
+});

--- a/ui/tempo-plugin/src/components/complete.ts
+++ b/ui/tempo-plugin/src/components/complete.ts
@@ -1,0 +1,229 @@
+import { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+import { syntaxTree } from '@codemirror/language';
+import {
+  String as StringType,
+  FieldExpression,
+  AttributeField,
+  Resource,
+  Identifier,
+  Span,
+  SpansetFilter,
+  FieldOp,
+} from '@grafana/lezer-traceql';
+import { TempoClient } from '../model/tempo-client';
+
+/** CompletionScope specifies the completion kind, e.g. whether to complete tag names or values etc. */
+type CompletionScope =
+  | { kind: 'Scopes' } // 'resource'|'span'
+  | { kind: 'TagName'; scope: 'resource' | 'span' | 'intrinsic' }
+  | { kind: 'TagValue'; tag: string; quotes?: boolean };
+
+/**
+ * Completions specifies the identified scopes and position of the completion in the current editor text.
+ * For example, when entering '{' the following completions are possible: Scopes(), TagName(scope=intrinsic)
+ */
+export interface Completions {
+  scopes: CompletionScope[];
+  from: number;
+  to?: number;
+}
+
+export async function complete(
+  completionContext: CompletionContext,
+  client?: TempoClient
+): Promise<CompletionResult | null> {
+  // First, identify the completion scopes, for example Scopes() and TagName(scope=intrinsic)
+  const completions = identifyCompletions(completionContext);
+  if (!completions) {
+    // No completion scopes found for current cursor position.
+    return null;
+  }
+
+  // Then, retrieve completion options for all identified scopes (from the Tempo API).
+  const options = await retrieveOptions(completions.scopes, client);
+  return { options, from: completions.from, to: completions.to };
+}
+
+/**
+ * Identify completion scopes (e.g. TagValue) and position, based on the current node in the syntax tree.
+ *
+ * For development, you can visualize the tree of a TraceQL query using this tool:
+ * https://github.com/grafana/lezer-traceql/blob/main/tools/tree-viz.html
+ *
+ * Function is exported for tests only.
+ */
+export function identifyCompletions(completionContext: CompletionContext): Completions | undefined {
+  const { state, pos } = completionContext;
+  const node = syntaxTree(state).resolveInner(pos, -1);
+
+  switch (node.type.id) {
+    case SpansetFilter:
+      // autocomplete {
+      // autocomplete {}
+      // do not autocomplete if cursor is after } or { status=ok }
+      if (
+        (node.firstChild === null || node.firstChild?.type.id === 0) &&
+        !state.sliceDoc(node.from, pos).includes('}')
+      ) {
+        return {
+          scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }],
+          from: pos,
+        };
+      }
+      break;
+
+    case FieldExpression:
+      // autocomplete { status=ok &&
+      return {
+        scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }],
+        from: pos,
+      };
+
+    case AttributeField:
+      // autocomplete { resource.
+      if (node.firstChild?.type.id === Resource) {
+        return { scopes: [{ kind: 'TagName', scope: 'resource' }], from: pos };
+      }
+
+      // autocomplete { span.
+      if (node.firstChild?.type.id === Span) {
+        return { scopes: [{ kind: 'TagName', scope: 'span' }], from: pos };
+      }
+
+      // autocomplete { .
+      if (state.sliceDoc(node.from, node.to) === '.') {
+        return {
+          scopes: [
+            { kind: 'TagName', scope: 'resource' },
+            { kind: 'TagName', scope: 'span' },
+          ],
+          from: pos,
+        };
+      }
+      break;
+
+    case Identifier:
+      if (node.parent?.type.id === AttributeField) {
+        const text = state.sliceDoc(node.parent.from, node.parent.to);
+        // autocomplete { span:s
+        // only intrinsic fields can have a : in the name.
+        if (text.includes(':')) {
+          return { scopes: [{ kind: 'TagName', scope: 'intrinsic' }], from: node.parent.from };
+        }
+
+        // autocomplete { resource.s
+        if (node.parent?.firstChild?.type.id === Resource) {
+          return { scopes: [{ kind: 'TagName', scope: 'resource' }], from: node.from };
+        }
+
+        // autocomplete { span.s
+        if (node.parent?.firstChild?.type.id === Span) {
+          return { scopes: [{ kind: 'TagName', scope: 'span' }], from: node.from };
+        }
+
+        // autocomplete { .s
+        if (node.parent?.firstChild?.type.id === Identifier) {
+          return {
+            scopes: [
+              { kind: 'TagName', scope: 'resource' },
+              { kind: 'TagName', scope: 'span' },
+            ],
+            from: node.from,
+          };
+        }
+      }
+      break;
+
+    case FieldOp:
+      // autocomplete { status=
+      // autocomplete { span.http.method=
+      if (node.parent?.firstChild?.type.id === FieldExpression) {
+        const fieldExpr = node.parent.firstChild;
+        const attribute = state.sliceDoc(fieldExpr.from, fieldExpr.to);
+        return { scopes: [{ kind: 'TagValue', tag: attribute, quotes: true }], from: pos };
+      }
+      break;
+
+    case StringType:
+      // autocomplete { resource.service.name="
+      if (node.parent?.parent?.parent?.firstChild?.type.id === FieldExpression) {
+        const fieldExpr = node.parent.parent.parent.firstChild;
+        const attribute = state.sliceDoc(fieldExpr.from, fieldExpr.to);
+        return { scopes: [{ kind: 'TagValue', tag: attribute }], from: node.from + 1 }; // node.from+1 to ignore leading "
+      }
+      break;
+
+    case 0 /* error node */:
+      // autocomplete { status=e
+      if (node.prevSibling?.type.id === FieldOp && node.parent?.firstChild?.type.id === FieldExpression) {
+        const fieldExpr = node.parent.firstChild;
+        const attribute = state.sliceDoc(fieldExpr.from, fieldExpr.to);
+        return { scopes: [{ kind: 'TagValue', tag: attribute }], from: node.from };
+      }
+
+      // autocomplete { s
+      // autocomplete { status=ok && s
+      if (node.parent?.type.id === SpansetFilter || node.parent?.type.id === FieldExpression) {
+        return {
+          scopes: [{ kind: 'Scopes' }, { kind: 'TagName', scope: 'intrinsic' }],
+          from: node.from,
+        };
+      }
+      break;
+  }
+}
+
+/**
+ * Retrieve all completion options based on the previously identified completion scopes.
+ */
+async function retrieveOptions(completions: CompletionScope[], client?: TempoClient): Promise<Completion[]> {
+  const results: Array<Promise<Completion[]>> = [];
+
+  for (const completion of completions) {
+    switch (completion.kind) {
+      case 'Scopes':
+        results.push(Promise.resolve([{ label: 'span' }, { label: 'resource' }]));
+        break;
+
+      case 'TagName':
+        if (client) {
+          results.push(completeTagName(client, completion.scope));
+        }
+        break;
+
+      case 'TagValue':
+        if (client) {
+          results.push(completeTagValue(client, completion.tag, completion.quotes));
+        }
+        break;
+    }
+  }
+
+  // Retrieve options concurrently
+  // e.g. for unscoped attribute fields, retrieve list of span and resource attributes concurrently.
+  const options = await Promise.all(results);
+  return options.flat();
+}
+
+async function completeTagName(client: TempoClient, scope: 'resource' | 'span' | 'intrinsic'): Promise<Completion[]> {
+  const response = await client.searchTags({ scope });
+  return response.scopes.flatMap((scope) => scope.tags).map((tag) => ({ label: tag }));
+}
+
+async function completeTagValue(client: TempoClient, tag: string, quotes?: boolean): Promise<Completion[]> {
+  const response = await client.searchTagValues({ tag });
+  const completions: Completion[] = [];
+  for (const { type, value } of response.tagValues) {
+    switch (type) {
+      case 'string':
+        completions.push({ displayLabel: value, label: quotes ? `"${value}"` : value });
+        break;
+
+      case 'keyword':
+      case 'int':
+        completions.push({ label: value });
+        break;
+    }
+  }
+  return completions;
+}

--- a/ui/tempo-plugin/src/components/complete.ts
+++ b/ui/tempo-plugin/src/components/complete.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { syntaxTree } from '@codemirror/language';
 import {

--- a/ui/tempo-plugin/src/index.ts
+++ b/ui/tempo-plugin/src/index.ts
@@ -20,3 +20,6 @@ export { TempoTraceQuery, TempoDatasource };
 // For consumers to leverage in DatasourceStoreProvider onCreate
 export * from './model/tempo-client';
 export * from './model/tempo-selectors';
+
+// For consumers of TraceQLExtension
+export * from './components/TraceQLExtension';


### PR DESCRIPTION
# Description
TraceQL query editor: add auto-complete support

_Note: This PR requires #2228_

# Screenshots
https://github.com/user-attachments/assets/859a27c1-0b76-4faa-acf9-8f248e96a692

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
