### PR TITLE
[BUGFIX] tempo client: encode URL parameters in path

### DIFF
--- a/ui/tempo-plugin/src/model/tempo-client.ts
+++ b/ui/tempo-plugin/src/model/tempo-client.ts
@@ -78,7 +78,7 @@ export function search(params: SearchRequestParameters, queryOptions: QueryOptio
  * Returns an entire trace.
  */
 export function query(params: QueryRequestParameters, queryOptions: QueryOptions) {
-  return fetchWithGet<null, QueryResponse>(`/api/traces/${params.traceId}`, null, queryOptions);
+  return fetchWithGet<null, QueryResponse>(`/api/traces/${encodeURIComponent(params.traceId)}`, null, queryOptions);
 }
 
 /**
@@ -156,7 +156,7 @@ export function searchTags(params: SearchTagsRequestParameters, queryOptions: Qu
 export function searchTagValues(params: SearchTagValuesRequestParameters, queryOptions: QueryOptions) {
   const { tag, ...rest } = params;
   return fetchWithGet<Omit<SearchTagValuesRequestParameters, 'tag'>, SearchTagValuesResponse>(
-    `/api/v2/search/tag/${tag}/values`,
+    `/api/v2/search/tag/${encodeURIComponent(tag)}/values`,
     rest,
     queryOptions
   );


### PR DESCRIPTION
# Description

tempo client: encode URL parameters in path

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
