### PR TITLE
[BUGFIX] tempo query: disable syntax highlighting if query is a trace id

### DIFF
--- a/ui/tempo-plugin/src/components/TraceQLEditor.tsx
+++ b/ui/tempo-plugin/src/components/TraceQLEditor.tsx
@@ -14,6 +14,7 @@
 import { useMemo } from 'react';
 import { useTheme } from '@mui/material';
 import CodeMirror, { EditorView, ReactCodeMirrorProps } from '@uiw/react-codemirror';
+import { isValidTraceId } from '@perses-dev/core';
 import { CompletionConfig, TraceQLExtension } from './TraceQLExtension';
 
 export interface TraceQLEditorProps extends Omit<ReactCodeMirrorProps, 'theme' | 'extensions'> {
@@ -37,6 +38,9 @@ export function TraceQLEditor({ completeConfig, ...rest }: TraceQLEditorProps) {
         highlightActiveLine: false,
         highlightActiveLineGutter: false,
         foldGutter: false,
+        // The explore view accepts either a TraceQL query or a Trace ID as input. The lezer grammar marks Trace IDs as invalid,
+        // therefore let's disable syntax highlighting if the input is a Trace ID.
+        syntaxHighlighting: !isValidTraceId(rest.value ?? ''),
       }}
       extensions={[EditorView.lineWrapping, traceQLExtension]}
     />


### PR DESCRIPTION
# Description

In the explore view, the input field accept either a TraceQL query or a Trace ID, and displays the trace table or the Gantt chart based on the value. Unfortunately, the lezer grammar (correctly) marks Trace IDs as invalid TraceQL queries. Therefore, let's disable syntax highlighting if the input is a Trace ID.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
