### PR TITLE
[BUGFIX] Disable mounting native echats tooltip to body for timeseries chart except stacked

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -226,7 +226,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
         // Stacked bar uses ECharts tooltip so subgroup data shows correctly.
         showContent: isStackedBar,
         trigger: isStackedBar ? 'item' : 'axis',
-        appendToBody: true,
+        appendToBody: isStackedBar,
       },
       // https://echarts.apache.org/en/option.html#axisPointer
       axisPointer: {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Closes #2217 

This PR addresses a bug that caused an increase in vertical page size and redundant scrolling. The issue was traced back to the native ECharts tooltip, which was attached to the body element, causing unexpected layout shifts.


# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
