### PR TITLE
[IGNORE] Allow passing custom parameters to the MUI `createTheme()` function

### DIFF
--- a/ui/components/src/theme/index.ts
+++ b/ui/components/src/theme/index.ts
@@ -15,6 +15,7 @@ import type {} from './types/ThemeExtension';
 import { PersesColor } from './palette';
 
 export * from './theme';
+export * from './typography';
 
 //Use Typescript interface augmentation to extend the MUI type definition
 declare module '@mui/material/styles/createPalette' {

--- a/ui/components/src/theme/theme.ts
+++ b/ui/components/src/theme/theme.ts
@@ -40,12 +40,13 @@ const getModalBackgroundStyle = ({ theme }: { theme: Omit<Theme, 'components'> }
  * Need to reinstantiate the theme everytime to support switching between light and dark themes
  * https://github.com/mui-org/material-ui/issues/18831
  */
-export function getTheme(mode: PaletteMode) {
+export function getTheme(mode: PaletteMode, options: ThemeOptions = {}) {
   const theme = createTheme({
     palette: getPaletteOptions(mode),
     typography,
     mixins: {},
     components,
+    ...options,
   });
   return theme;
 }


### PR DESCRIPTION
# Description
Allow passing custom parameters to the MUI `createTheme()` function

Example:
```
const muiTheme = getTheme('light', {
  typography: {
    ...typography,
    fontFamily: 'my-custom-font',
  },
  shape: {
    borderRadius: 0,
  },
});
```

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
