### PR TITLE
[IGNORE] TraceTable: expose service-color as CSS var

### DIFF
--- a/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
@@ -131,7 +131,7 @@ function buildRow(
         <Typography display="inline">{totalSpanCount} spans</Typography>
         {totalErrorCount > 0 && (
           <Chip
-            label={`${totalErrorCount} errors`}
+            label={`${totalErrorCount} error${totalErrorCount === 1 ? '' : 's'}`}
             sx={{ marginLeft: '5px' }}
             icon={<InformationIcon />}
             variant="outlined"
@@ -181,14 +181,18 @@ function buildServiceStatsChips(
     <Chip
       key={serviceName}
       label={serviceName}
-      sx={{ marginTop: '5px', marginRight: '5px' }}
       variant="outlined"
       size="small"
-      style={{ borderColor: serviceColorGenerator(serviceName) }}
+      style={{ ['--service-color' as string]: serviceColorGenerator(serviceName) }}
+      sx={{ marginTop: '5px', marginRight: '5px', borderColor: 'var(--service-color)' }}
       avatar={
         <Avatar
-          sx={{ fontSize: '0.65rem', fontWeight: 'bold', textShadow: '0 0 5px #fff' }}
-          style={{ backgroundColor: serviceColorGenerator(serviceName) }}
+          sx={{
+            backgroundColor: 'var(--service-color)',
+            fontSize: '0.65rem',
+            fontWeight: 'bold',
+            textShadow: '0 0 5px #fff',
+          }}
         >
           {stats.spanCount}
         </Avatar>


### PR DESCRIPTION
# Description

TraceTable: expose service-color as CSS var

This helps with customizations when embedding this panel, for example:
```
.MuiChip-root {
  background-color: var(--service-color);
}
```

Also, fix spelling of `error` chip if `count==1`.

# Screenshots

no mentionable UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
