### PR TITLE
[ENHANCEMENT] Migrate: rename Value to value in table migrations

### DIFF
--- a/cue/schemas/panels/table/migrate.cue
+++ b/cue/schemas/panels/table/migrate.cue
@@ -18,7 +18,11 @@ if #panel.type != _|_ if #panel.type == "table" {
 		// We use the future 'header' information as a key for both maps here, because this is the common denominator between the two sources
 		// Indeed in grafana the fieldconfig's overrides are matched against the final column name (thus potentially renamed))
 		_renamedMap: {if #panel.transformations != _|_ for transformation in #panel.transformations if transformation.id == "organize" for technicalName, prettyName in transformation.options.renameByName {
-			"\(prettyName)": technicalName
+			"\(prettyName)": [
+				if technicalName != "Value" { technicalName },
+				// Map Grafana special 'Value' to lowercase 'value':
+				if technicalName == "Value" { "value" }
+			][0]
 		}}
 		_customWidthMap: {if #panel.fieldConfig.overrides != _|_ for override in #panel.fieldConfig.overrides if override.matcher.id == "byName" && override.matcher.options != _|_ for property in override.properties if property.id == "custom.width" {
 			"\(override.matcher.options)": property.value

--- a/internal/api/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/simple_grafana_dashboard.json
@@ -378,6 +378,7 @@
             "indexByName": {},
             "renameByName": {
               "Time": "",
+              "Value": "ValueCustomHeader",
               "apiserver": "API server"
             }
           }

--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -453,6 +453,10 @@
                   "name": "Time"
                 },
                 {
+                    "header": "ValueCustomHeader",
+                    "name": "value"
+                },
+                {
                   "header": "API server",
                   "name": "apiserver",
                   "width": 300


### PR DESCRIPTION

# Description

Small improvement to table migrations:
Special 'Value' column from Grafana should be 'value' in order to match Perses 'value' column with actual values.

# Screenshots
old migration:
![image](https://github.com/user-attachments/assets/2b8de730-2b04-4d7d-95b6-6d125295d42e)
after migration:
![image](https://github.com/user-attachments/assets/48d3710f-aa98-4f13-8c34-7c6b12018c9d)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
