### PR TITLE
[BUGFIX] Default panel spec not saved

### DIFF
--- a/ui/components/src/FormatControls/FormatControls.tsx
+++ b/ui/components/src/FormatControls/FormatControls.tsx
@@ -104,7 +104,7 @@ export function FormatControls({ value, onChange, disabled = false }: FormatCont
             onChange={handleKindChange}
             disableClearable
             disabled={disabled}
-          ></SettingsAutocomplete>
+          />
         }
       />
       <OptionsEditorControl

--- a/ui/core/src/model/calculations.ts
+++ b/ui/core/src/model/calculations.ts
@@ -13,7 +13,7 @@
 
 import { TimeSeriesValueTuple } from './time-series-queries';
 
-export const DEFAULT_CALCULATION: CalculationType = 'last-number';
+export const DEFAULT_CALCULATION: CalculationType = 'last'; // aligned with cue
 
 export const CalculationsMap = {
   first: first,

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -49,6 +49,7 @@ export function PanelEditorForm(props: PanelEditorFormProps) {
     pluginTypes: ['Panel'],
     value: { selection: { kind: plugin.kind, type: 'Panel' }, spec: plugin.spec },
     onChange: (plugin) => {
+      form.setValue('panelDefinition.spec.plugin', { kind: plugin.selection.kind, spec: plugin.spec });
       setPlugin({
         kind: plugin.selection.kind,
         spec: plugin.spec,

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.test.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.test.tsx
@@ -155,7 +155,7 @@ describe('BarChartOptionsEditorSettings', () => {
           unit: 'decimal',
           shortValues: true,
         },
-        calculation: 'last-number',
+        calculation: 'last',
         sort: 'desc',
         mode: 'value',
       })

--- a/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/bar-chart/BarChartOptionsEditorSettings.tsx
@@ -29,6 +29,7 @@ import {
 } from '@perses-dev/components';
 import { CalculationType, DEFAULT_CALCULATION, isPercentUnit, FormatOptions } from '@perses-dev/core';
 import { Button } from '@mui/material';
+import { MouseEventHandler } from 'react';
 import {
   BarChartOptions,
   BarChartOptionsEditorProps,
@@ -72,7 +73,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
     );
   };
 
-  const handleResetSettings: React.MouseEventHandler<HTMLButtonElement> = () => {
+  const handleResetSettings: MouseEventHandler<HTMLButtonElement> = () => {
     onChange(
       produce(value, (draft: BarChartOptions) => {
         draft.calculation = DEFAULT_CALCULATION;

--- a/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.tsx
+++ b/ui/plugin-system/src/components/CalculationSelector/CalculationSelector.tsx
@@ -46,7 +46,7 @@ export function CalculationSelector({ value, onChange }: CalculationSelectorProp
           options={CALC_OPTIONS}
           onChange={handleCalculationChange}
           disableClearable
-        ></SettingsAutocomplete>
+        />
       }
     />
   );

--- a/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
@@ -58,7 +58,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
           render={({ field }) => (
             <MultiQueryEditor
               queryTypes={plugin.supportedQueryTypes ?? []}
-              queries={panelDefinition.spec.queries ?? []}
+              queries={field.value ?? []}
               onChange={(queries) => {
                 field.onChange(queries);
                 onQueriesChange(queries);
@@ -80,7 +80,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
             name="panelDefinition.spec.plugin.spec"
             render={({ field }) => (
               <OptionsEditorComponent
-                value={panelDefinition.spec.plugin.spec}
+                value={field.value}
                 onChange={(spec) => {
                   field.onChange(spec);
                   onPluginSpecChange(spec);
@@ -103,11 +103,11 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
     content: (
       <Controller
         control={control}
-        name="panelDefinition.spec.plugin.spec"
+        name="panelDefinition"
         render={({ field }) => (
           <JSONEditor
             maxHeight="80vh"
-            value={panelDefinition}
+            value={field.value}
             onChange={(json) => {
               field.onChange(json);
               onJSONChange(json);

--- a/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PanelSpecEditor/PanelSpecEditor.tsx
@@ -58,7 +58,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
           render={({ field }) => (
             <MultiQueryEditor
               queryTypes={plugin.supportedQueryTypes ?? []}
-              queries={field.value ?? []}
+              queries={panelDefinition.spec.queries ?? []}
               onChange={(queries) => {
                 field.onChange(queries);
                 onQueriesChange(queries);
@@ -80,7 +80,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
             name="panelDefinition.spec.plugin.spec"
             render={({ field }) => (
               <OptionsEditorComponent
-                value={field.value}
+                value={panelDefinition.spec.plugin.spec}
                 onChange={(spec) => {
                   field.onChange(spec);
                   onPluginSpecChange(spec);
@@ -107,7 +107,7 @@ export function PanelSpecEditor(props: PanelSpecEditorProps) {
         render={({ field }) => (
           <JSONEditor
             maxHeight="80vh"
-            value={field.value}
+            value={panelDefinition}
             onChange={(json) => {
               field.onChange(json);
               onJSONChange(json);


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixes #2256. When creating a panel, when the kind is changed, the initial/default spec are changed visually but not spread to react-hook-form. So when you save the panel (!= saving dashboard), default values are not applied (returning empty spec), breaking the panel display if a field is mandatory. It could occur to any panel types, not limited to Bar panel.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
