### PR TITLE
[ENHANCEMENT] Table panel migration: support column rename from field overrides

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -3,7 +3,8 @@
 
 import (
     "regexp"
-    "strings" 
+    "strconv"
+    "strings"
     "math"
 )
 

--- a/internal/api/migrate/migrate_test.go
+++ b/internal/api/migrate/migrate_test.go
@@ -64,6 +64,12 @@ func TestMigrate(t *testing.T) {
 			expectedPersesDashboardFile: "empty_panels_list_perses_dashboard.json",
 			expectedErrorStr:            "",
 		},
+		{
+			title:                       "dashboard with simple table panels, focused on validating the migration of column settings",
+			inputGrafanaDashboardFile:   "tables_grafana_dashboard.json",
+			expectedPersesDashboardFile: "tables_perses_dashboard.json",
+			expectedErrorStr:            "",
+		},
 	}
 
 	for _, test := range testSuite {

--- a/internal/api/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/simple_grafana_dashboard.json
@@ -1,4 +1,72 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROM",
+      "label": "PROM",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_MYCONST",
+      "type": "constant",
+      "label": "My Constant Variable",
+      "value": "const_val",
+      "description": ""
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.1.8"
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -25,14 +93,14 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 40381,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "argos-world"
+        "uid": "${DS_PROM}"
       },
       "description": "a stat chart that is basically showing stats as a chart",
       "fieldConfig": {
@@ -86,7 +154,11 @@
           "expr": "vector(4)",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          }
         }
       ],
       "title": "My Stat chart",
@@ -95,7 +167,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "argos-world"
+        "uid": "${DS_PROM}"
       },
       "description": "my second panel is a gauge",
       "fieldConfig": {
@@ -145,7 +217,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "argos-world"
+            "uid": "${DS_PROM}"
           },
           "editorMode": "code",
           "expr": "vector(2)",
@@ -160,7 +232,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "argos-world"
+        "uid": "${DS_PROM}"
       },
       "description": "my first panel is a timeseries",
       "fieldConfig": {
@@ -200,8 +272,6 @@
             }
           },
           "mappings": [],
-          "max": 100,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -250,7 +320,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "argos-world"
+            "uid": "${DS_PROM}"
           },
           "editorMode": "code",
           "expr": "vector(1)",
@@ -265,7 +335,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "argos-world"
+        "uid": "${DS_PROM}"
       },
       "fieldConfig": {
         "defaults": {
@@ -345,7 +415,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "argos-world"
+            "uid": "${DS_PROM}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -399,7 +469,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "argos-world"
+            "uid": "${DS_PROM}"
           },
           "description": "my third panel is a timeseries",
           "fieldConfig": {
@@ -443,8 +513,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -477,7 +546,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "argos-world"
+                "type": "prometheus",
+                "uid": "${DS_PROM}"
               },
               "editorMode": "code",
               "expr": "vector(3)",
@@ -492,7 +562,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "argos-world"
+            "uid": "${DS_PROM}"
           },
           "fieldConfig": {
             "defaults": {
@@ -556,7 +626,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "argos-world"
+            "uid": "${DS_PROM}"
           },
           "description": "",
           "gridPos": {
@@ -584,7 +654,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "argos-world"
+            "uid": "PROM"
           },
           "refId": "A"
         }
@@ -638,20 +708,28 @@
         "hide": 2,
         "label": "My Constant Variable",
         "name": "MyConst",
-        "query": "const_val",
+        "query": "${VAR_MYCONST}",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "constant",
+        "current": {
+          "value": "${VAR_MYCONST}",
+          "text": "${VAR_MYCONST}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_MYCONST}",
+            "text": "${VAR_MYCONST}",
+            "selected": false
+          }
+        ]
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "${DS_PROM}"
         },
         "definition": "label_values(stack)",
         "description": "Label values, 1rst flavor",
@@ -672,13 +750,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
-          "uid": "argos-world"
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
         },
         "definition": "label_values(thanos_build_info, stack)",
         "description": "Label values, 2nd flavor",
@@ -699,14 +774,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "${DS_PROM}"
         },
         "definition": "label_values(thanos_build_info{stack=~\"erd.+\"}, stack)",
         "description": "Label values, 3rd flavor",
@@ -727,14 +798,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "${DS_PROM}"
         },
         "definition": "label_values(thanos_build_info{stack=~\"$lv1\"}, stack)",
         "description": "Label values, 4th flavor",
@@ -826,7 +893,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "PROM"
         },
         "description": "This ad-hoc filter should be replaced by a placeholder in the migration since it's not supported in Perses yet",
         "filters": [],
@@ -837,14 +904,10 @@
         "type": "adhoc"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "API",
-          "value": "API"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "${DS_PROM}"
         },
         "definition": "label_names()",
         "hide": 0,
@@ -863,14 +926,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "Azure",
-          "value": "Azure"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "${DS_PROM}"
         },
         "definition": "query_result(group by(type) (up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}))",
         "description": "variable using query_result clause",
@@ -891,17 +950,14 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "{type=\"TSL\"} 1 1722509708000",
-          "value": "{type=\"TSL\"} 1 1722509708000"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "${DS_PROM}"
         },
         "definition": "query_result(group by(type) (present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range])))",
         "description": "query result var for volatile series (relies $__range global var)",
+        "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "queryResVarVolatile",
@@ -917,14 +973,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "cmdbrtu-custom-sd",
-          "value": "cmdbrtu-custom-sd"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "argos-world"
+          "uid": "${DS_PROM}"
         },
         "definition": "query_result(present_over_time(up{osname=~\".*Linux.*\", job=~\"cmdbrtu-custom-sd.*\", prometheus=~\"system\"}[$__range]))",
         "description": "query result var with no <aggr> by clause",

--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -46,7 +46,7 @@
             "description": "This Custom variable should be translated into a TextVariable in Perses, with constant flag set to true",
             "hidden": true
           },
-          "value": "const_val",
+          "value": "${VAR_MYCONST}",
           "constant": true,
           "name": "MyConst"
         }
@@ -320,6 +320,10 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DS_PROM}"
+                    },
                     "query": "vector(4)"
                   }
                 }
@@ -365,7 +369,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "argos-world"
+                      "name": "${DS_PROM}"
                     },
                     "query": "vector(2)"
                   }
@@ -404,10 +408,6 @@
                 "connectNulls": true,
                 "display": "line",
                 "lineWidth": 1
-              },
-              "yAxis": {
-                "max": 100,
-                "min": 0
               }
             }
           },
@@ -420,7 +420,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "argos-world"
+                      "name": "${DS_PROM}"
                     },
                     "query": "vector(1)"
                   }
@@ -441,6 +441,7 @@
             "spec": {
               "columnSettings": [
                 {
+                  "header": "",
                   "hide": true,
                   "name": "Time"
                 },
@@ -449,16 +450,16 @@
                   "name": "__name__"
                 },
                 {
-                  "header": "",
-                  "name": "Time"
-                },
-                {
-                    "header": "ValueCustomHeader",
-                    "name": "value"
+                  "header": "ValueCustomHeader",
+                  "name": "value"
                 },
                 {
                   "header": "API server",
                   "name": "apiserver",
+                  "width": 300
+                },
+                {
+                  "name": "API server",
                   "width": 300
                 },
                 {
@@ -478,7 +479,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "argos-world"
+                      "name": "${DS_PROM}"
                     },
                     "query": "up{stack=\"ccp-ne-ogob01a\", prometheus=\"platform\"}"
                   }
@@ -515,7 +516,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "argos-world"
+                      "name": "${DS_PROM}"
                     },
                     "query": "vector(3)"
                   }

--- a/internal/api/migrate/testdata/tables_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/tables_grafana_dashboard.json
@@ -1,0 +1,1008 @@
+{
+  "__inputs": [
+    {
+      "name": "DATASOURCE",
+      "label": "prometheusdemo",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_FILTER",
+      "type": "constant",
+      "label": "filter",
+      "value": "placeholder",
+      "description": ""
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.1.8"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "bonjour"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "family"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Rename using field overrides",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Rename using Transform > Organize fields",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "bonjour",
+              "job": "family"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "family"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "group"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bonjour"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "hello"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Both options to rename the same field",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "bonjour",
+              "job": "family"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hello"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Rename+hide using transform, width using overrides",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "hello"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "displayName",
+                "value": "family"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "bonjour"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Rename+width using overrides",
+      "transformations": [],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "bonjour"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "hello"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Duplicated rename using field overrides",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Duplicated width using field overrides",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Duplicated rename using Transform > Organize fields",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "bonjour",
+              "job": "family"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Time": "Timestamp",
+              "family": "group"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "group"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 9,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DATASOURCE}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (up{$filter})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Duplicated rename using Transform > Organize fields + width using overrides",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "bonjour",
+              "job": "family"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Time": "Timestamp",
+              "family": "group"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "description": "",
+        "hide": 2,
+        "name": "filter",
+        "query": "${VAR_FILTER}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_FILTER}",
+          "text": "${VAR_FILTER}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_FILTER}",
+            "text": "${VAR_FILTER}",
+            "selected": false
+          }
+        ]
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Perses testing / table panel column rename - PR#2259",
+  "uid": "ef16b5e1-3587-4892-8ba0-821720cd23b3",
+  "version": 16,
+  "weekStart": ""
+}

--- a/internal/api/migrate/testdata/tables_perses_dashboard.json
+++ b/internal/api/migrate/testdata/tables_perses_dashboard.json
@@ -1,0 +1,518 @@
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ef16b5e1-3587-4892-8ba0-821720cd23b3",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": ""
+  },
+  "spec": {
+    "display": {
+      "name": "Perses testing / table panel column rename - PR#2259"
+    },
+    "variables": [
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "display": {
+            "hidden": true
+          },
+          "value": "${VAR_FILTER}",
+          "constant": true,
+          "name": "filter"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rename using field overrides"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "bonjour",
+                  "name": "value"
+                },
+                {
+                  "header": "family",
+                  "name": "job"
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rename using Transform > Organize fields"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "bonjour",
+                  "name": "value"
+                },
+                {
+                  "header": "family",
+                  "name": "job"
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Both options to rename the same field"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "hello",
+                  "name": "value"
+                },
+                {
+                  "header": "group",
+                  "name": "job"
+                },
+                {
+                  "header": "group",
+                  "name": "family"
+                },
+                {
+                  "header": "hello",
+                  "name": "bonjour"
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rename+hide using transform, width using overrides"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "hide": true,
+                  "name": "Time"
+                },
+                {
+                  "header": "hello",
+                  "name": "value",
+                  "width": 100
+                },
+                {
+                  "name": "hello",
+                  "width": 100
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rename+width using overrides"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "family",
+                  "name": "job",
+                  "width": 100
+                },
+                {
+                  "header": "bonjour",
+                  "name": "value",
+                  "width": 100
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Duplicated rename using field overrides"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "hello",
+                  "name": "value"
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Duplicated width using field overrides"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "name": "value",
+                  "width": 200
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Duplicated rename using Transform > Organize fields"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "bonjour",
+                  "name": "value"
+                },
+                {
+                  "header": "family",
+                  "name": "job"
+                },
+                {
+                  "header": "Timestamp",
+                  "name": "Time"
+                },
+                {
+                  "header": "group",
+                  "name": "family"
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Duplicated rename using Transform > Organize fields + width using overrides"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "bonjour",
+                  "name": "value"
+                },
+                {
+                  "header": "family",
+                  "name": "job"
+                },
+                {
+                  "header": "Timestamp",
+                  "name": "Time"
+                },
+                {
+                  "header": "group",
+                  "name": "family",
+                  "width": 150
+                },
+                {
+                  "name": "group",
+                  "width": 150
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${DATASOURCE}"
+                    },
+                    "query": "sum by (job) (up{$filter})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 12,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 32,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR improves the table migration logic by supporting migrating column renames from both the "Organize" transformation & the "field overrides" options from Grafana.

NB1: this remains a best effort migration. In the new test file added, the 2 last panels are not accurately migrated, but these are tackling some corner cases that's not worth investing on imho.

NB2: the migration logic was quite heavily revamped here, hopefully the new code should allow for easier extension in the future: table panels in Grafana provides many customization capabilities, so we'll most likely have to enrich this code again later..

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
