### PR TITLE
[BUGFIX] fix flaky TraceQL auto-completion tests

### DIFF
--- a/ui/tempo-plugin/src/components/complete.test.ts
+++ b/ui/tempo-plugin/src/components/complete.test.ts
@@ -13,8 +13,7 @@
 
 import { EditorState } from '@uiw/react-codemirror';
 import { parser } from '@grafana/lezer-traceql';
-import { LRLanguage } from '@codemirror/language';
-import { CompletionContext } from '@codemirror/autocomplete';
+import { LRLanguage, ensureSyntaxTree } from '@codemirror/language';
 import { Completions, identifyCompletions } from './complete';
 
 const traceQLExtension = LRLanguage.define({ parser: parser });
@@ -157,12 +156,14 @@ describe('complete', () => {
     },
   ];
 
-  it.each(tests)('retrive completions for $expr', ({ expr, pos, expected }) => {
+  it.each(tests)('retrieve completions for $expr', ({ expr, pos, expected }) => {
     if (pos === undefined) pos = expr.length;
     if (pos < 0) pos = expr.length + pos;
 
     const state = EditorState.create({ doc: expr, extensions: traceQLExtension });
-    const completions = identifyCompletions({ state, pos } as CompletionContext);
+    const tree = ensureSyntaxTree(state, expr.length, 1000);
+    expect(tree).not.toBeNull();
+    const completions = identifyCompletions(state, pos, tree!);
     expect(completions).toEqual(expected);
   });
 });

--- a/ui/tempo-plugin/src/components/complete.ts
+++ b/ui/tempo-plugin/src/components/complete.ts
@@ -13,6 +13,8 @@
 
 import { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { syntaxTree } from '@codemirror/language';
+import { EditorState } from '@codemirror/state';
+import { Tree } from '@lezer/common';
 import {
   String as StringType,
   FieldExpression,
@@ -42,11 +44,11 @@ export interface Completions {
 }
 
 export async function complete(
-  completionContext: CompletionContext,
+  { state, pos }: CompletionContext,
   client?: TempoClient
 ): Promise<CompletionResult | null> {
   // First, identify the completion scopes, for example Scopes() and TagName(scope=intrinsic)
-  const completions = identifyCompletions(completionContext);
+  const completions = identifyCompletions(state, pos, syntaxTree(state));
   if (!completions) {
     // No completion scopes found for current cursor position.
     return null;
@@ -65,9 +67,8 @@ export async function complete(
  *
  * Function is exported for tests only.
  */
-export function identifyCompletions(completionContext: CompletionContext): Completions | undefined {
-  const { state, pos } = completionContext;
-  const node = syntaxTree(state).resolveInner(pos, -1);
+export function identifyCompletions(state: EditorState, pos: number, tree: Tree): Completions | undefined {
+  const node = tree.resolveInner(pos, -1);
 
   switch (node.type.id) {
     case SpansetFilter:


### PR DESCRIPTION
# Description

CodeMirror parses the input in the background, and sometimes didn't complete parsing the input before the tree was searched to identify the completions.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
