### PR TITLE
[DOC] Table: Add datamodel documentation

### DIFF
--- a/docs/plugins/panels.md
+++ b/docs/plugins/panels.md
@@ -32,6 +32,13 @@ spec:
   text: <string>
 ```
 
+## PieChart
+
+```yaml
+kind: "PieChart"
+# TODO document the spec of PieChart
+```
+
 ## StatChart
 
 ```yaml
@@ -56,6 +63,28 @@ spec:
 ```yaml
 kind: "ScatterChart"
 spec: # TODO document the spec of ScatterChart
+```
+
+## Table
+
+```yaml
+kind: "Table"
+spec:
+  [ density: <enum = "compact" | "standard" | "comfortable"> ]
+  [ columnSettings: <Column Settings specification> ]
+```
+
+### Column Settings specification
+
+```yaml
+name:  <string>
+[ header:  <string> ]
+[ headerDescription:  <string> ]
+[ cellDescription: <string> ]
+[ align: <enum = "left" | "center" | "right"> ]
+[ enableSorting: <boolean> ]
+[ width: <number | "auto"> ]
+[ hide: <boolean> ]
 ```
 
 ## TimeSeriesChart
@@ -131,6 +160,27 @@ queryIndex: <number>
 colorMode: <enum = "fixed" | "fixed-single">
 # colorValue is an hexadecimal color code
 colorValue: <string>
+```
+
+## TimeSeriesTable
+
+```yaml
+kind: "TimeSeriesTable"
+# TODO document the spec of TimeSeriesTable
+```
+
+## TraceTable
+
+```yaml
+kind: "TraceTable"
+# TODO document the spec of TraceTable
+```
+
+## TracingGanttChart
+
+```yaml
+kind: "TracingGanttChart"
+# TODO document the spec of TracingGanttChart
 ```
 
 ## Common definitions


### PR DESCRIPTION
NB: I wonder if we could just somehow include/redirect to the cuelang files instead of maintaining this doc on the side, I think the CUE syntax is a bit clearer than the one we use in this doc, it basically describes the same thing & it would avoid misalignment between code & doc. 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).