### PR TITLE
[ENHANCEMENT] Table panel migration: rename Time to timestamp

### DIFF
--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -443,7 +443,7 @@
                 {
                   "header": "",
                   "hide": true,
-                  "name": "Time"
+                  "name": "timestamp"
                 },
                 {
                   "hide": true,

--- a/internal/api/migrate/testdata/tables_perses_dashboard.json
+++ b/internal/api/migrate/testdata/tables_perses_dashboard.json
@@ -168,7 +168,7 @@
               "columnSettings": [
                 {
                   "hide": true,
-                  "name": "Time"
+                  "name": "timestamp"
                 },
                 {
                   "header": "hello",
@@ -339,7 +339,7 @@
                 },
                 {
                   "header": "Timestamp",
-                  "name": "Time"
+                  "name": "timestamp"
                 },
                 {
                   "header": "group",
@@ -388,7 +388,7 @@
                 },
                 {
                   "header": "Timestamp",
-                  "name": "Time"
+                  "name": "timestamp"
                 },
                 {
                   "header": "group",


### PR DESCRIPTION
# Description

Same as for the `Value` case tackled in https://github.com/perses/perses/pull/2259, the `Time` column in Grafana should map to `timestamp` in Perses.

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).