### PR TITLE
[IGNORE] Update golang,cue and github actions version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true

--- a/.github/workflows/delete-snapshot.yml
+++ b/.github/workflows/delete-snapshot.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -43,12 +43,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.9.1"
+          cue_version: "v0.10.0"
       - name: check format
         run: make checkformat
       - name: check go.mod
@@ -59,12 +59,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
-          cue_version: "v0.9.1"
+          cue_version: "v0.10.0"
       - name: test
         run: make integration-test
   test-mysql:
@@ -83,12 +83,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
-          cue_version: "v0.9.1"
+          cue_version: "v0.10.0"
       - name: test
         run: make mysql-integration-test
   golangci:
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
@@ -117,12 +117,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.9.1"
+          cue_version: "v0.10.0"
       - name: eval cue schema
         run: make cue-eval
       - name: test cue schema
@@ -133,12 +133,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.9.1"
+          cue_version: "v0.10.0"
       - name: generate cue files
         run: make cue-gen
       - name: check for changes

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.5.2
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_npm: true


### PR DESCRIPTION
Moving go version to v1.23.X through the upgrade of the github action.
I am also upgrading the cuelang version used in the CI