### PR TITLE
[BUGFIX] Fix database folder in default config file for the archives

### DIFF
--- a/docs/examples/config.archive.yaml
+++ b/docs/examples/config.archive.yaml
@@ -1,6 +1,6 @@
 database:
   file:
-    folder: "./perses"
+    folder: "./data"
     extension: "json"
 
 schemas:


### PR DESCRIPTION
in the archive the database folder cannot be `perses` since it's the name of the executable.