### PR TITLE
[BUGFIX] Fix metric finder list flickering

### DIFF
--- a/ui/explore/src/components/PrometheusMetricsFinder/display/list/MetricList.tsx
+++ b/ui/explore/src/components/PrometheusMetricsFinder/display/list/MetricList.tsx
@@ -42,7 +42,7 @@ export function MetricRow({ metricName, datasource, filters, isMetadataEnabled, 
         <Typography sx={{ fontFamily: 'monospace' }}>{metricName}</Typography>
       </TableCell>
 
-      <TableCell style={{ minWidth: 'fit-content', textAlign: 'center' }}>
+      <TableCell style={{ width: 115, textAlign: 'center' }}>
         {isMetadataEnabled && isLoading ? (
           <Skeleton variant="rounded" width={75} />
         ) : (
@@ -53,12 +53,12 @@ export function MetricRow({ metricName, datasource, filters, isMetadataEnabled, 
         {isMetadataEnabled && isLoading ? (
           <Skeleton variant="text" width={180} />
         ) : (
-          <Typography sx={{ fontStyle: metadata?.help ? 'initial' : 'italic' }}>
+          <Typography sx={{ fontStyle: metadata?.help ? 'initial' : 'italic', minWidth: '30vw' }}>
             {metadata ? metadata.help : 'unknown'}
           </Typography>
         )}
       </TableCell>
-      <TableCell style={{ minWidth: 'fit-content' }}>
+      <TableCell style={{ width: 140 }}>
         <Button
           aria-label={`explore metric ${metricName}`}
           variant="contained"


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Should fix the flickering issue on the metric finder.


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
