### PR TITLE
[IGNORE] DaC CUE SDK: refactor/simplify dac-utils code for variables (part 2)

### DIFF
--- a/cue/dac-utils/variable/staticlist/staticlist.cue
+++ b/cue/dac-utils/variable/staticlist/staticlist.cue
@@ -16,26 +16,19 @@ package staticlist
 import (
 	staticListVar "github.com/perses/perses/cue/schemas/variables/static-list:model"
 	listVarBuilder "github.com/perses/perses/cue/dac-utils/variable/list"
-	v1Variable "github.com/perses/perses/cue/model/api/v1/variable"
 )
 
-_kind=#kind: listVarBuilder.#kind & "ListVariable"
-_name=#name: listVarBuilder.#name
-_display=#display?: v1Variable.#Display & {
-	hidden: bool | *false
-}
-_allowAllValue=#allowAllValue:      listVarBuilder.#allowAllValue
-_allowMultiple=#allowMultiple:      listVarBuilder.#allowMultiple
-_customAllValue=#customAllValue?:   string
-_capturingRegexp=#capturingRegexp?: string
-_sort=#sort?:                       v1Variable.#Sort
-#pluginKind:                        listVarBuilder.#pluginKind & staticListVar.kind
+// include the definitions of listVarBuilder at the root
+listVarBuilder
+
+// specify the constraints for this variable
+#pluginKind: staticListVar.kind
 #values: [...(string | {
 	value:  string
 	label?: string
 })]
 
-variable: {listVarBuilder & {#kind: _kind, #name: _name, #display: _display, #allowAllValue: _allowAllValue, #allowMultiple: _allowMultiple, #customAllValue: _customAllValue, #capturingRegexp: _capturingRegexp, #sort: _sort}}.variable & {
+variable: listVarBuilder.variable & {
 	spec: {
 		plugin: staticListVar & {
 			spec: {

--- a/cue/dac-utils/variable/text/text.cue
+++ b/cue/dac-utils/variable/text/text.cue
@@ -16,14 +16,17 @@ package text
 import (
 	v1Dashboard "github.com/perses/perses/cue/model/api/v1/dashboard"
 	varBuilder "github.com/perses/perses/cue/dac-utils/variable"
-	v1Variable "github.com/perses/perses/cue/model/api/v1/variable"
 )
 
-#kind: varBuilder.#kind & "TextVariable"
-#name: varBuilder.#name
-#display?: v1Variable.#Display & {
-	hidden: bool | *false
-}
+// include the definitions of varBuilder at the root
+varBuilder
+
+#name: _ // this is needed for below reference
+
+#display?: _ // this is needed for below reference
+
+// specify the constraints for this variable
+#kind:     "TextVariable"
 #value:    string
 #constant: bool | *false
 

--- a/cue/schemas/variables/static-list/static-list.cue
+++ b/cue/schemas/variables/static-list/static-list.cue
@@ -15,7 +15,8 @@ package model
 
 kind: "StaticListVariable"
 spec: close({
-	values: [...(string | {value: string
+	values: [...(string | {
+		value:  string
 		label?: string
 	})]
 })

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -32,6 +32,7 @@ import (
 	promqlVar "github.com/perses/perses/go-sdk/prometheus/variable/promql"
 	variablegroup "github.com/perses/perses/go-sdk/variable-group"
 	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	staticlist "github.com/perses/perses/go-sdk/variable/plugin/static-list"
 	txtVar "github.com/perses/perses/go-sdk/variable/text-variable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,9 +93,9 @@ func TestDashboardBuilder(t *testing.T) {
 			txtVar.Text("platform", txtVar.Constant(true)),
 		),
 		AddVariable("prometheus_namespace",
-			txtVar.Text("observability",
-				txtVar.Constant(true),
-				txtVar.Description("constant to reduce the query scope thus improve performances"),
+			listVar.List(
+				staticlist.StaticList(staticlist.Values("observability", "monitoring")),
+				listVar.Description("to reduce the query scope thus improve performances"),
 			),
 		),
 		AddVariable("namespace", listVar.List(
@@ -192,9 +193,9 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 				txtVar.Text("platform", txtVar.Constant(true)),
 			),
 			variablegroup.AddVariable("prometheus_namespace",
-				txtVar.Text("observability",
-					txtVar.Constant(true),
-					txtVar.Description("constant to reduce the query scope thus improve performances"),
+				listVar.List(
+					staticlist.StaticList(staticlist.Values("observability", "monitoring")),
+					listVar.Description("to reduce the query scope thus improve performances"),
 				),
 			),
 			variablegroup.AddVariable("namespace", listVar.List(

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -47,15 +47,21 @@
         }
       },
       {
-        "kind": "TextVariable",
+        "kind": "ListVariable",
         "spec": {
           "name": "prometheus_namespace",
           "display": {
-            "description": "constant to reduce the query scope thus improve performances",
+            "description": "to reduce the query scope thus improve performances",
             "hidden": false
           },
-          "value": "observability",
-          "constant": true
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [ "observability", "monitoring" ]
+            }
+          }
         }
       },
       {

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -22,6 +22,7 @@ import (
 	labelValuesVarBuilder "github.com/perses/perses/cue/dac-utils/prometheus/variable/labelvalues"
 	labelNamesVarBuilder "github.com/perses/perses/cue/dac-utils/prometheus/variable/labelnames"
 	textVarBuilder "github.com/perses/perses/cue/dac-utils/variable/text"
+	staticListVarBuilder "github.com/perses/perses/cue/dac-utils/variable/staticlist"
 	promFilterBuilder "github.com/perses/perses/cue/dac-utils/prometheus/filter"
 	timeseriesChart "github.com/perses/perses/cue/schemas/panels/time-series:model"
 	promQuery "github.com/perses/perses/cue/schemas/queries/prometheus:model"
@@ -43,11 +44,10 @@ import (
 			#value:    "platform"
 			#constant: true
 		},
-		textVarBuilder & {
+		staticListVarBuilder & {
 			#name: "prometheus_namespace"
-			#display: description: "constant to reduce the query scope thus improve performances"
-			#value:    "observability"
-			#constant: true
+			#display: description: "to reduce the query scope thus improve performances"
+			#values: ["observability", "monitoring"]
 		},
 		promQLVarBuilder & {
 			#name:           "namespace"


### PR DESCRIPTION
# Description

Same refactor as done in https://github.com/perses/perses/pull/2289 but for TextVariable & StaticListVariable.
Also took the opportunity to cover StaticListVariable in the DaC unit tests.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).