### PR TITLE
[ENHANCEMENT] DaC CUE SDK: new utility to generate query params from labels

### DIFF
--- a/cue/dac-utils/variable/group/group.cue
+++ b/cue/dac-utils/variable/group/group.cue
@@ -14,6 +14,7 @@
 package group
 
 import (
+	"strings"
 	varBuilder "github.com/perses/perses/cue/dac-utils/variable"
 )
 
@@ -24,3 +25,7 @@ import (
 }]
 
 variables: [for i in #input {i.variable}]
+
+// generate a query param string to be used in urls
+_varNames: [for v in variables {"var-\(v.spec.name)=$\(v.spec.name)"}]
+queryParams: strings.Join(_varNames, "&")

--- a/docs/dac/cue/variable/group.md
+++ b/docs/dac/cue/variable/group.md
@@ -23,11 +23,12 @@ varGroupBuilder & {} // input parameters expected
 Technically the array could contain any kind of object, still it is meant to receive variables builder entries that are going to do something with the dependencies appended by the Variable Group builder.
 You can also pass to it variables for which the notion of dependencies don't/can't apply (like text variables or static lists) but that will still be used as dependencies for the following variables.
 
-## Output
+## Outputs
 
-| Field       | Type                                                             | Description                                                         |
-|-------------|------------------------------------------------------------------|---------------------------------------------------------------------|
-| `variables` | [...[Variable](../../../api/variable.md#variable-specification)] | The final list of variables objects, to be passed to the dashboard. |
+| Field         | Type                                                             | Description                                                                |
+|---------------|------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `variables`   | [...[Variable](../../../api/variable.md#variable-specification)] | The final list of variables objects, to be passed to the dashboard.        |
+| `queryParams` | string                                                           | A query string including all variables from the group, to be used in urls. |
 
 ## Example
 

--- a/go-sdk/dashboard/dashboard_test.go
+++ b/go-sdk/dashboard/dashboard_test.go
@@ -69,6 +69,7 @@ func buildCPUPanel(grouping string) panelgroup.Option {
 		panel.AddQuery(
 			query.PromQL(fmt.Sprintf("sum %s (%s{%s})", grouping, cpuMetric, filter)),
 		),
+		panel.AddLink("http://localhost:3000/projects/perses/dashboards/hello?var-stack=$stack&var-prometheus=$prometheus&var-prometheus_namespace=$prometheus_namespace&var-namespace=$namespace&var-namespaceLabels=$namespaceLabels&var-pod=$pod&var-container=$container&var-containerLabels=$containerLabels"),
 	)
 }
 

--- a/internal/test/dac/expected_output.json
+++ b/internal/test/dac/expected_output.json
@@ -218,6 +218,11 @@
                 }
               }
             }
+          ],
+          "links": [
+            {
+              "url": "http://localhost:3000/projects/perses/dashboards/hello?var-stack=$stack&var-prometheus=$prometheus&var-prometheus_namespace=$prometheus_namespace&var-namespace=$namespace&var-namespaceLabels=$namespaceLabels&var-pod=$pod&var-container=$container&var-containerLabels=$containerLabels"
+            }
           ]
         }
       },
@@ -250,6 +255,11 @@
                   }
                 }
               }
+            }
+          ],
+          "links": [
+            {
+              "url": "http://localhost:3000/projects/perses/dashboards/hello?var-stack=$stack&var-prometheus=$prometheus&var-prometheus_namespace=$prometheus_namespace&var-namespace=$namespace&var-namespaceLabels=$namespaceLabels&var-pod=$pod&var-container=$container&var-containerLabels=$containerLabels"
             }
           ]
         }

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -112,6 +112,11 @@ import (
 				}
 			},
 		]
+		links: [
+			{
+				url: "http://localhost:3000/projects/perses/dashboards/hello?" + #myVarsBuilder.queryParams
+			},
+		]
 	}
 }
 


### PR DESCRIPTION
# Description

Adding a new output to the existing variable-group lib to generate a query param expression from the list of variables passed. This can come in handy when you want to add links to a panel.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).