### PR TITLE
[ENHANCEMENT] Improve the query editor's look

### DIFF
--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -32,7 +32,7 @@ export function PluginEditor(props: PluginEditorProps) {
     <Box {...others}>
       <PluginKindSelect
         fullWidth={false}
-        sx={{ mb: 1, minWidth: 120 }}
+        sx={{ mb: 2, minWidth: 120 }}
         margin="dense"
         label={pluginKindLabel}
         pluginTypes={pluginTypes}

--- a/ui/prometheus-plugin/src/components/PromQL.tsx
+++ b/ui/prometheus-plugin/src/components/PromQL.tsx
@@ -47,6 +47,7 @@ export function PromQLEditor({ completeConfig, ...rest }: PromQLEditorProps) {
       </InputLabel>
       <CodeMirror
         {...rest}
+        style={{ border: `1px solid ${theme.palette.divider}` }}
         theme={isDarkMode ? 'dark' : 'light'}
         basicSetup={{
           highlightActiveLine: false,
@@ -61,12 +62,7 @@ export function PromQLEditor({ completeConfig, ...rest }: PromQLEditorProps) {
               paddingTop: '8px',
               paddingBottom: '8px',
             },
-            '.cm-scroller': {
-              border: `1px solid ${theme.palette.divider}`,
-              borderRadius: '4px',
-            },
           }),
-          EditorView.editorAttributes.of({ style: 'border-radius: 4px' }),
         ]}
         placeholder="sum(rate(http_requests_total[5m]))"
       />

--- a/ui/prometheus-plugin/src/components/PromQL.tsx
+++ b/ui/prometheus-plugin/src/components/PromQL.tsx
@@ -14,7 +14,7 @@
 import CodeMirror, { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import { PromQLExtension, CompleteConfiguration } from '@prometheus-io/codemirror-promql';
 import { EditorView } from '@codemirror/view';
-import { useTheme } from '@mui/material';
+import { useTheme, InputLabel, Stack } from '@mui/material';
 import { useMemo } from 'react';
 
 export type PromQLEditorProps = { completeConfig: CompleteConfiguration } & Omit<
@@ -31,16 +31,45 @@ export function PromQLEditor({ completeConfig, ...rest }: PromQLEditorProps) {
   }, [completeConfig]);
 
   return (
-    <CodeMirror
-      {...rest}
-      style={{ border: `1px solid ${theme.palette.divider}` }}
-      theme={isDarkMode ? 'dark' : 'light'}
-      basicSetup={{
-        highlightActiveLine: false,
-        highlightActiveLineGutter: false,
-        foldGutter: false,
-      }}
-      extensions={[EditorView.lineWrapping, promQLExtension]}
-    />
+    <Stack position="relative">
+      <InputLabel // reproduce the same kind of input label that regular MUI TextFields have
+        shrink
+        sx={{
+          position: 'absolute',
+          top: '-8px',
+          left: '10px',
+          padding: '0 4px',
+          color: theme.palette.text.primary,
+          zIndex: 1,
+        }}
+      >
+        PromQL expression
+      </InputLabel>
+      <CodeMirror
+        {...rest}
+        theme={isDarkMode ? 'dark' : 'light'}
+        basicSetup={{
+          highlightActiveLine: false,
+          highlightActiveLineGutter: false,
+          foldGutter: false,
+        }}
+        extensions={[
+          EditorView.lineWrapping,
+          promQLExtension,
+          EditorView.theme({
+            '.cm-content': {
+              paddingTop: '8px',
+              paddingBottom: '8px',
+            },
+            '.cm-scroller': {
+              border: `1px solid ${theme.palette.divider}`,
+              borderRadius: '4px',
+            },
+          }),
+          EditorView.editorAttributes.of({ style: 'border-radius: 4px' }),
+        ]}
+        placeholder="sum(rate(http_requests_total[5m]))"
+      />
+    </Stack>
   );
 }

--- a/ui/prometheus-plugin/src/components/PromQL.tsx
+++ b/ui/prometheus-plugin/src/components/PromQL.tsx
@@ -43,7 +43,7 @@ export function PromQLEditor({ completeConfig, ...rest }: PromQLEditorProps) {
           zIndex: 1,
         }}
       >
-        PromQL expression
+        PromQL Expression
       </InputLabel>
       <CodeMirror
         {...rest}
@@ -64,7 +64,7 @@ export function PromQLEditor({ completeConfig, ...rest }: PromQLEditorProps) {
             },
           }),
         ]}
-        placeholder="sum(rate(http_requests_total[5m]))"
+        placeholder="Example: sum(rate(http_requests_total[5m]))"
       />
     </Stack>
   );

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -88,9 +88,9 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
       <Stack direction="row" spacing={2}>
         <TextField
           fullWidth
-          label="Legend Name"
-          placeholder="Tip: Use {{label_name}}. Example: {{instance}} will be replaced with values such as 'webserver-123' and 'webserver-456'."
-          helperText="Name for each series in the legend and the tooltip."
+          label="Legend"
+          placeholder="Example: '{{instance}}' will generate series names like 'webserver-123', 'webserver-456'..."
+          helperText="Text to be displayed in the legend and the tooltip. Use {{label_name}} to interpolate label values."
           value={format ?? ''}
           onChange={(e) => handleFormatChange(e.target.value)}
           onBlur={handleFormatBlur}


### PR DESCRIPTION
# Description

- Added a textfield-like like label for the promQL input + placeholder text
- Consistent spacing between elements
- Rework Legend's texts

There's still room for improvements (e.g label's background)

# Screenshots

_EDIT: gave up on rounded corner for the CodeMirror component since, for maintainability reasons._

| Before | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/bd1d9224-abc5-463c-a9d5-e3ff3eacef1c) | ![2024-10-03_13h05_07](https://github.com/user-attachments/assets/e0ffebb0-a8c5-419c-b449-92be99cd5059) |
| ![2024-10-03_13h07_17](https://github.com/user-attachments/assets/c847f702-6c5b-4a90-bc3b-a013385405f5) | ![2024-10-03_13h08_10](https://github.com/user-attachments/assets/e2ebbaf2-b711-4a23-910a-c416a41a49cc) |

EDIT: with latest changes:
![image](https://github.com/user-attachments/assets/0d6606d6-c342-4168-8350-82208ba0e088)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
