### PR TITLE
[BREAKINGCHANGE] Refactor package pkg/client to handle native/oauth auth natively

### DIFF
--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -494,17 +494,38 @@ discovery_name: <string>
 # URL of the HTTP server exposing the global datasource list to retrieve.
 url: <url>
 
-[ basicAuth: <Basic Auth specification> ]
+[ auth: <Auth specification> ]
 
 # The HTTP authorization credentials for the targets.
 # Basic Auth and authorization are mutually exclusive. Use one or the other not both at the same time.
 [ authorization: <Authorization specification> ]
 
 # Config used to connect to the targets.
-[ tlsConfig: <TLS Config specification> ]
+[ tls_config: <TLS Config specification> ]
 
 headers:
   [<string>:<string>]
+```
+
+##### Auth
+
+```yaml
+[ basic_auth: <Basic Auth specification> ]
+
+[ oauth_config: <Oauth specification> ]
+```
+
+##### Oauth specification
+
+```yaml
+# ClientID is the application's ID.
+client_id: <string>
+
+# ClientSecret is the application's secret.
+client_secret: <string>
+
+# TokenURL is the resource server's token endpoint URL. This is a constant specific to each server.
+token_url: <string>
 ```
 
 ##### Basic Auth specification

--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -512,7 +512,7 @@ headers:
 ```yaml
 [ basic_auth: <Basic Auth specification> ]
 
-[ oauth_config: <Oauth specification> ]
+[ oauthg: <Oauth specification> ]
 ```
 
 ##### Oauth specification

--- a/internal/api/discovery/http/http.go
+++ b/internal/api/discovery/http/http.go
@@ -20,6 +20,7 @@ import (
 	"github.com/perses/common/async"
 	"github.com/perses/common/async/taskhelper"
 	"github.com/perses/perses/internal/api/discovery/service"
+	clientConfig "github.com/perses/perses/pkg/client/config"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	"github.com/perses/perses/pkg/model/api/config"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
@@ -28,7 +29,7 @@ import (
 )
 
 func NewDiscovery(Name string, refreshInterval model.Duration, cfg *config.HTTPDiscovery, svc *service.ApplyService) (taskhelper.Helper, error) {
-	client, err := perseshttp.NewFromConfig(cfg.RestConfigClient)
+	client, err := clientConfig.NewFromConfig(cfg.RestConfigClient)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/discovery/http/http.go
+++ b/internal/api/discovery/http/http.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewDiscovery(Name string, refreshInterval model.Duration, cfg *config.HTTPDiscovery, svc *service.ApplyService) (taskhelper.Helper, error) {
-	client, err := clientConfig.NewFromConfig(cfg.RestConfigClient)
+	client, err := clientConfig.NewRESTClient(cfg.RestConfigClient)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -16,7 +16,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/clientcredentials"
 )
 
 func TestAuth(t *testing.T) {
@@ -243,7 +241,7 @@ func TestAuth_OAuthProvider_Token_FromDeviceCode(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doe", "password"),
+			e2eframework.NewUser("john.doe", ""),
 		}
 
 		jsonToken := expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)).
@@ -271,7 +269,7 @@ func TestAuth_OIDCProvider_Token_FromDeviceCode(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doeOIDC", "password"),
+			e2eframework.NewUser("john.doeOIDC", ""),
 		}
 
 		jsonToken := expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOIDC, providerConfig.SlugID, utils.PathToken)).
@@ -299,7 +297,7 @@ func TestAuth_OAuthProvider_Token_FromClientCredentials(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doe", "password"),
+			e2eframework.NewUser("john.doe", ""),
 		}
 
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)).
@@ -332,7 +330,7 @@ func TestAuth_OIDCProvider_Token_FromClientCredentials(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("client-id-oidc", "password"),
+			e2eframework.NewUser("client-id-oidc", ""),
 		}
 
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOIDC, providerConfig.SlugID, utils.PathToken)).
@@ -364,28 +362,29 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 	// Server with oauth provider configured.
 	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doe", "password"),
+			e2eframework.NewUser("john.doe", ""),
 		}
 
 		persesBaseURL := common.MustParseURL(server.URL)
-		unauthenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
-			URL: persesBaseURL,
-		})
-		assert.NoError(t, err)
-
-		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
+		unauthenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
 		persesTokenURL := common.MustParseURL(server.URL)
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
-		oauthConfig := &clientcredentials.Config{
-			ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-			ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-			TokenURL:     persesTokenURL.String(),
-			AuthStyle:    oauth2.AuthStyleInHeader,
-		}
-		authenticatedClient.Client = oauthConfig.Client(context.Background())
+
+		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
+			URL: persesBaseURL,
+			Auth: &config.Auth{
+				Oauth: &config.Oauth{
+					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+					TokenURL:     persesTokenURL.String(),
+					AuthStyle:    oauth2.AuthStyleInHeader,
+				},
+			},
+		})
+		assert.NoError(t, err)
 
 		// => Nominal case: The perses backend has the /token endpoint and the client have the client credentials.
 		_, err = v1.NewWithClient(authenticatedClient).Project().List("")
@@ -401,19 +400,20 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 	// Server without oauth provider configured.
 	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		persesBaseURL := common.MustParseURL(server.URL)
-		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
-			URL: persesBaseURL,
-		})
-		assert.NoError(t, err)
 		persesTokenURL := common.MustParseURL(server.URL)
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
-		oauthConfig := &clientcredentials.Config{
-			ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-			ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-			TokenURL:     persesTokenURL.String(),
-			AuthStyle:    oauth2.AuthStyleInHeader,
-		}
-		authenticatedClient.Client = oauthConfig.Client(context.Background())
+		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
+			URL: persesBaseURL,
+			Auth: &config.Auth{
+				Oauth: &config.Oauth{
+					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+					TokenURL:     persesTokenURL.String(),
+					AuthStyle:    oauth2.AuthStyleInHeader,
+				},
+			},
+		})
+		assert.NoError(t, err)
 
 		_, err = v1.NewWithClient(authenticatedClient).Project().List("")
 
@@ -436,28 +436,29 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 	// Server with OIDC provider configured.
 	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("MyClientID", "password"),
+			e2eframework.NewUser("MyClientID", ""),
 		}
 
 		persesBaseURL := common.MustParseURL(server.URL)
-		unauthenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
+		unauthenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
 
-		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
-			URL: persesBaseURL,
-		})
-		assert.NoError(t, err)
 		persesTokenURL := common.MustParseURL(server.URL)
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOIDC, providerConfig.SlugID, utils.PathToken)
-		oauthConfig := &clientcredentials.Config{
-			ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-			ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-			TokenURL:     persesTokenURL.String(),
-			AuthStyle:    oauth2.AuthStyleInHeader,
-		}
-		authenticatedClient.Client = oauthConfig.Client(context.Background())
+		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
+			URL: persesBaseURL,
+			Auth: &config.Auth{
+				Oauth: &config.Oauth{
+					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+					TokenURL:     persesTokenURL.String(),
+					AuthStyle:    oauth2.AuthStyleInHeader,
+				},
+			},
+		})
+		assert.NoError(t, err)
 
 		// => Nominal case: The perses backend has the /token endpoint and the client have the client credentials.
 		_, err = v1.NewWithClient(authenticatedClient).Project().List("")
@@ -473,19 +474,20 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 	// Server without OIDC provider configured.
 	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		persesBaseURL := common.MustParseURL(server.URL)
-		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
+		persesTokenURL := common.MustParseURL(server.URL)
+		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
+		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
+			Auth: &config.Auth{
+				Oauth: &config.Oauth{
+					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+					TokenURL:     persesTokenURL.String(),
+					AuthStyle:    oauth2.AuthStyleInHeader,
+				},
+			},
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
-		persesTokenURL := common.MustParseURL(server.URL)
-		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
-		oauthConfig := &clientcredentials.Config{
-			ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-			ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-			TokenURL:     persesTokenURL.String(),
-			AuthStyle:    oauth2.AuthStyleInHeader,
-		}
-		authenticatedClient.Client = oauthConfig.Client(context.Background())
 
 		_, err = v1.NewWithClient(authenticatedClient).Project().List("")
 

--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -27,7 +27,7 @@ import (
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	"github.com/perses/perses/internal/api/utils"
 	v1 "github.com/perses/perses/pkg/client/api/v1"
-	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/client/config"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +38,7 @@ import (
 
 func TestAuth(t *testing.T) {
 	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
-		usrEntity := e2eframework.NewUser("foo")
+		usrEntity := e2eframework.NewUser("foo", "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
 			Expect().
@@ -62,7 +62,7 @@ func TestAuth(t *testing.T) {
 
 func TestAuth_EmptyPassword(t *testing.T) {
 	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
-		usrEntity := e2eframework.NewUser("foo")
+		usrEntity := e2eframework.NewUser("foo", "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
 			Expect().
@@ -243,7 +243,7 @@ func TestAuth_OAuthProvider_Token_FromDeviceCode(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doe"),
+			e2eframework.NewUser("john.doe", "password"),
 		}
 
 		jsonToken := expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)).
@@ -271,7 +271,7 @@ func TestAuth_OIDCProvider_Token_FromDeviceCode(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doeOIDC"),
+			e2eframework.NewUser("john.doeOIDC", "password"),
 		}
 
 		jsonToken := expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOIDC, providerConfig.SlugID, utils.PathToken)).
@@ -299,7 +299,7 @@ func TestAuth_OAuthProvider_Token_FromClientCredentials(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doe"),
+			e2eframework.NewUser("john.doe", "password"),
 		}
 
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)).
@@ -332,7 +332,7 @@ func TestAuth_OIDCProvider_Token_FromClientCredentials(t *testing.T) {
 
 	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("client-id-oidc"),
+			e2eframework.NewUser("client-id-oidc", "password"),
 		}
 
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOIDC, providerConfig.SlugID, utils.PathToken)).
@@ -364,16 +364,16 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 	// Server with oauth provider configured.
 	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("john.doe"),
+			e2eframework.NewUser("john.doe", "password"),
 		}
 
 		persesBaseURL := common.MustParseURL(server.URL)
-		unauthenticatedClient, err := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+		unauthenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
 
-		authenticatedClient, err := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
@@ -401,7 +401,7 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 	// Server without oauth provider configured.
 	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		persesBaseURL := common.MustParseURL(server.URL)
-		authenticatedClient, err := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
@@ -436,16 +436,16 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 	// Server with OIDC provider configured.
 	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("MyClientID"),
+			e2eframework.NewUser("MyClientID", "password"),
 		}
 
 		persesBaseURL := common.MustParseURL(server.URL)
-		unauthenticatedClient, err := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+		unauthenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
 
-		authenticatedClient, err := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)
@@ -473,7 +473,7 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 	// Server without OIDC provider configured.
 	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		persesBaseURL := common.MustParseURL(server.URL)
-		authenticatedClient, err := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+		authenticatedClient, err := config.NewFromConfig(config.RestConfigClient{
 			URL: persesBaseURL,
 		})
 		assert.NoError(t, err)

--- a/internal/api/e2e/api/dashboard_test.go
+++ b/internal/api/e2e/api/dashboard_test.go
@@ -136,7 +136,7 @@ func extractDashboardFromHTTPBody(body interface{}, t *testing.T) *modelV1.Dashb
 func TestAuthListDashboardInProject(t *testing.T) {
 	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
 
-		usrEntity := e2eframework.NewUser("creator")
+		usrEntity := e2eframework.NewUser("creator", "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
 			Expect().

--- a/internal/api/e2e/api/globalrolebinding_test.go
+++ b/internal/api/e2e/api/globalrolebinding_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestMainScenarioGlobalRoleBinding(t *testing.T) {
 	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice")
+		user := e2eframework.NewUser("alice", "password")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
 		globalRole := e2eframework.NewGlobalRole("admin")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, globalRole)
@@ -45,7 +45,7 @@ func TestMainScenarioGlobalRoleBinding(t *testing.T) {
 
 func TestUpdateScenarioGlobalRoleBindingRole(t *testing.T) {
 	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice")
+		user := e2eframework.NewUser("alice", "password")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
 		globalRole := e2eframework.NewGlobalRole("admin")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, globalRole)

--- a/internal/api/e2e/api/rbac_test.go
+++ b/internal/api/e2e/api/rbac_test.go
@@ -33,7 +33,7 @@ import (
 func TestNewProjectEndpoints(t *testing.T) {
 	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		creator := "foo"
-		usrEntity := e2eframework.NewUser(creator)
+		usrEntity := e2eframework.NewUser(creator, "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
 			Expect().
@@ -74,7 +74,7 @@ func TestNewProjectEndpoints(t *testing.T) {
 func TestAnonymousEndpoints(t *testing.T) {
 	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		creator := "foo"
-		usrEntity := e2eframework.NewUser(creator)
+		usrEntity := e2eframework.NewUser(creator, "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
 			Expect().
@@ -89,7 +89,7 @@ func TestAnonymousEndpoints(t *testing.T) {
 			Expect().
 			Status(http.StatusOK)
 
-		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token")
+		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token", "expiry", "token_type")
 		token := authResponse.JSON().Object().Value("access_token").String().Raw()
 
 		expect.GET("/api/config").WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).Expect().Status(http.StatusOK)
@@ -104,7 +104,7 @@ func TestAnonymousEndpoints(t *testing.T) {
 func TestUnauthorizedEndpoints(t *testing.T) {
 	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		creator := "foo"
-		usrEntity := e2eframework.NewUser(creator)
+		usrEntity := e2eframework.NewUser(creator, "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
 			Expect().
@@ -119,7 +119,7 @@ func TestUnauthorizedEndpoints(t *testing.T) {
 			Expect().
 			Status(http.StatusOK)
 
-		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token")
+		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token", "expiry", "token_type")
 		token := authResponse.JSON().Object().Value("access_token").String().Raw()
 
 		glRole := e2eframework.NewGlobalRole("test")

--- a/internal/api/e2e/api/rolebinding_test.go
+++ b/internal/api/e2e/api/rolebinding_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestMainScenarioRoleBinding(t *testing.T) {
 	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice")
+		user := e2eframework.NewUser("alice", "password")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
 		project := e2eframework.NewProject("mysuperproject")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
@@ -47,7 +47,7 @@ func TestMainScenarioRoleBinding(t *testing.T) {
 
 func TestUpdateScenarioRoleBindingRole(t *testing.T) {
 	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice")
+		user := e2eframework.NewUser("alice", "password")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
 		project := e2eframework.NewProject("mysuperproject")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)

--- a/internal/api/e2e/api/user_test.go
+++ b/internal/api/e2e/api/user_test.go
@@ -49,7 +49,7 @@ func decodePublicUser(t *testing.T, object interface{}) *modelV1.PublicUser {
 func TestMainScenarioUser(t *testing.T) {
 	path := utils.PathUser
 	creator := func(name string) modelAPI.Entity {
-		return e2eframework.NewUser(name)
+		return e2eframework.NewUser(name, "password")
 	}
 	e2eframework.CreateTestScenario(t, path, creator)
 	// Update test

--- a/internal/api/e2e/client/auth_test.go
+++ b/internal/api/e2e/client/auth_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package client
+
+import (
+	"testing"
+
+	"github.com/perses/perses/internal/api/dependency"
+	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// This test is mainly here to test that when auth is configured in the perseshttp.client, then it will automatically handle the auth and refresh the token as well.
+func TestGetProtectedDatasource(t *testing.T) {
+	withAuthClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+		projectEntity := e2eframework.NewProject("perses")
+		entity := e2eframework.NewDatasource(t, "perses", "myDTS")
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager, projectEntity)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
+
+		object, err := clientInterface.Datasource(entity.Metadata.Project).Get(entity.Metadata.Name)
+		assert.NoError(t, err)
+		assert.Equal(t, entity.Metadata.Name, object.Metadata.Name)
+		assert.Equal(t, entity.Spec, object.Spec)
+		return []modelAPI.Entity{projectEntity, entity}
+	})
+}

--- a/internal/api/e2e/client/auth_test.go
+++ b/internal/api/e2e/client/auth_test.go
@@ -16,27 +16,40 @@
 package client
 
 import (
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gavv/httpexpect/v2"
 	"github.com/perses/perses/internal/api/dependency"
 	e2eframework "github.com/perses/perses/internal/api/e2e/framework"
 	v1 "github.com/perses/perses/pkg/client/api/v1"
+	"github.com/perses/perses/pkg/client/config"
 	modelAPI "github.com/perses/perses/pkg/model/api"
+	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/stretchr/testify/assert"
 )
 
 // This test is mainly here to test that when auth is configured in the perseshttp.client, then it will automatically handle the auth and refresh the token as well.
 func TestGetProtectedDatasource(t *testing.T) {
-	withAuthClient(t, func(clientInterface v1.ClientInterface, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		projectEntity := e2eframework.NewProject("perses")
 		entity := e2eframework.NewDatasource(t, "perses", "myDTS")
+		usrEntity := e2eframework.NewUser("foo", "$2a$10$iCemKjvjN.ieqJOPlEL5keGRLAGKRGBNjph2N8uY.4XFPZYwcBT8K") // the encrypted value for password
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager, usrEntity)
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, projectEntity)
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
-
-		object, err := clientInterface.Datasource(entity.Metadata.Project).Get(entity.Metadata.Name)
+		restClient, err := config.NewRESTClient(config.RestConfigClient{
+			URL: common.MustParseURL(server.URL),
+			Auth: &config.Auth{NativeAuth: &modelAPI.Auth{
+				Login:    "foo",
+				Password: "password",
+			}},
+		})
+		assert.NoError(t, err)
+		object, err := v1.NewWithClient(restClient).Datasource(entity.Metadata.Project).Get(entity.Metadata.Name)
 		assert.NoError(t, err)
 		assert.Equal(t, entity.Metadata.Name, object.Metadata.Name)
 		assert.Equal(t, entity.Spec, object.Spec)
-		return []modelAPI.Entity{projectEntity, entity}
+		return []modelAPI.Entity{projectEntity, entity, usrEntity}
 	})
 }

--- a/internal/api/e2e/client/test_utils.go
+++ b/internal/api/e2e/client/test_utils.go
@@ -27,16 +27,6 @@ import (
 	"github.com/perses/perses/pkg/model/api/v1/common"
 )
 
-func withAuthClient(t *testing.T, testFunc func(v1.ClientInterface, dependency.PersistenceManager) []api.Entity) {
-	server, _, persistenceManager := e2eframework.CreateServer(t, e2eframework.DefaultAuthConfig())
-	defer server.Close()
-	persesClient := createAuthClient(t, server)
-	usrEntity := e2eframework.NewUser("foo", "$2a$10$iCemKjvjN.ieqJOPlEL5keGRLAGKRGBNjph2N8uY.4XFPZYwcBT8K") // the encrypted value for password
-	e2eframework.CreateAndWaitUntilEntityExists(t, persistenceManager, usrEntity)
-	entities := testFunc(persesClient, persistenceManager)
-	e2eframework.ClearAllKeys(t, persistenceManager.GetPersesDAO(), append(entities, usrEntity)...)
-}
-
 func withClient(t *testing.T, testFunc func(v1.ClientInterface, dependency.PersistenceManager) []api.Entity) {
 	server, _, persistenceManager := e2eframework.CreateServer(t, e2eframework.DefaultConfig())
 	defer server.Close()
@@ -46,22 +36,8 @@ func withClient(t *testing.T, testFunc func(v1.ClientInterface, dependency.Persi
 
 }
 
-func createAuthClient(t *testing.T, server *httptest.Server) v1.ClientInterface {
-	restClient, err := config.NewFromConfig(config.RestConfigClient{
-		URL: common.MustParseURL(server.URL),
-		Auth: &config.AuthConfig{NativeAuth: &api.Auth{
-			Login:    "foo",
-			Password: "password",
-		}},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return v1.NewWithClient(restClient)
-}
-
 func createClient(t *testing.T, server *httptest.Server) v1.ClientInterface {
-	restClient, err := config.NewFromConfig(config.RestConfigClient{
+	restClient, err := config.NewRESTClient(config.RestConfigClient{
 		URL: common.MustParseURL(server.URL),
 	})
 	if err != nil {

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -154,10 +154,11 @@ func CreateAndWaitUntilEntitiesExist(t *testing.T, persistenceManager dependency
 func CreateAndWaitUntilEntityExists(t *testing.T, persistenceManager dependency.PersistenceManager, object interface{}) {
 	getFunc, upsertFunc := CreateGetFunc(t, persistenceManager, object)
 
-	// it appears that (maybe because of the tiny short between a deletion order and a creation order),
+	// It appears that (maybe because of the tiny short between a deletion order and a creation order),
 	// an entity actually created in database could be removed by a previous delete order.
-	// In order to avoid that we will upsert the entity multiple times.
-	// Also, we can have some delay between the order to create the document and the actual creation. so let's wait sometimes
+	// To avoid that we will upsert the entity multiple times.
+	// Also, we can have some delay between the order to create the document and the actual creation.
+	// So let's wait sometimes
 	nbTimeToCreate := 3
 	var err error
 	for i := 0; i < nbTimeToCreate; i++ {
@@ -466,13 +467,13 @@ func NewPublicGlobalSecret(name string) *v1.PublicGlobalSecret {
 	return entity
 }
 
-func NewUser(name string) *v1.User {
+func NewUser(name string, password string) *v1.User {
 	entity := &v1.User{
 		Kind:     v1.KindUser,
 		Metadata: newMetadata(name),
 		Spec: v1.UserSpec{
 			NativeProvider: v1.NativeProvider{
-				Password: "password",
+				Password: password,
 			},
 		},
 	}

--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -130,8 +130,10 @@ func (e *endpoint) refresh(ctx echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return ctx.JSON(http.StatusOK, api.AuthResponse{
-		AccessToken: accessToken,
+	return ctx.JSON(http.StatusOK, oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    oidc.BearerToken,
 	})
 }
 

--- a/internal/api/impl/auth/native.go
+++ b/internal/api/impl/auth/native.go
@@ -25,6 +25,8 @@ import (
 	"github.com/perses/perses/internal/api/route"
 	"github.com/perses/perses/internal/api/utils"
 	"github.com/perses/perses/pkg/model/api"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"golang.org/x/oauth2"
 )
 
 type nativeEndpoint struct {
@@ -71,8 +73,9 @@ func (e *nativeEndpoint) auth(ctx echo.Context) error {
 		return err
 	}
 
-	return ctx.JSON(http.StatusOK, api.AuthResponse{
+	return ctx.JSON(http.StatusOK, oauth2.Token{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		TokenType:    oidc.BearerToken,
 	})
 }

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -414,7 +414,7 @@ func (e *oAuthEndpoint) tokenHandler(ctx echo.Context) error {
 }
 
 // performUserSync performs user synchronization and generates access and refresh tokens.
-func (e *oAuthEndpoint) performUserSync(userInfo externalUserInfo, setCookie func(cookie *http.Cookie)) (*api.AuthResponse, error) {
+func (e *oAuthEndpoint) performUserSync(userInfo externalUserInfo, setCookie func(cookie *http.Cookie)) (*oauth2.Token, error) {
 	usr, err := e.svc.syncUser(userInfo)
 	if err != nil {
 		e.logWithError(err).Error("Failed to sync user in database.")
@@ -434,9 +434,10 @@ func (e *oAuthEndpoint) performUserSync(userInfo externalUserInfo, setCookie fun
 		return nil, err
 	}
 
-	return &api.AuthResponse{
+	return &oauth2.Token{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		TokenType:    oidc.BearerToken,
 	}, nil
 }
 

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -333,7 +333,7 @@ func (e *oIDCEndpoint) token(ctx echo.Context) error {
 }
 
 // performUserSync performs user synchronization and generates access and refresh tokens.
-func (e *oIDCEndpoint) performUserSync(userInfo *oidcUserInfo, setCookie func(cookie *http.Cookie)) (*api.AuthResponse, error) {
+func (e *oIDCEndpoint) performUserSync(userInfo *oidcUserInfo, setCookie func(cookie *http.Cookie)) (*oauth2.Token, error) {
 	// We don´t forget to set the issuer before making any sync in the database.
 	userInfo.issuer = e.issuer
 
@@ -356,9 +356,10 @@ func (e *oIDCEndpoint) performUserSync(userInfo *oidcUserInfo, setCookie func(co
 		return nil, err
 	}
 
-	return &api.AuthResponse{
+	return &oauth2.Token{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		TokenType:    oidc.BearerToken,
 	}, nil
 }
 

--- a/internal/cli/cmd/login/device_code.go
+++ b/internal/cli/cmd/login/device_code.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/perses/perses/internal/cli/output"
 	"github.com/perses/perses/pkg/client/api"
-	modelAPI "github.com/perses/perses/pkg/model/api"
+	"golang.org/x/oauth2"
 )
 
 type deviceCodeLogin struct {
@@ -29,7 +29,7 @@ type deviceCodeLogin struct {
 	apiClient            api.ClientInterface
 }
 
-func (l *deviceCodeLogin) Login() (*modelAPI.AuthResponse, error) {
+func (l *deviceCodeLogin) Login() (*oauth2.Token, error) {
 	deviceCodeResponse, err := l.apiClient.Auth().DeviceCode(string(l.externalAuthKind), l.externalAuthProvider)
 	if err != nil {
 		return nil, err

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -23,12 +23,12 @@ import (
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/output"
 	"github.com/perses/perses/pkg/client/api"
-	"github.com/perses/perses/pkg/client/perseshttp"
-	modelAPI "github.com/perses/perses/pkg/model/api"
+	clientConfig "github.com/perses/perses/pkg/client/config"
 	backendConfig "github.com/perses/perses/pkg/model/api/config"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
 )
 
 type externalAuthKind string
@@ -47,7 +47,7 @@ const (
 )
 
 type loginOption interface {
-	Login() (*modelAPI.AuthResponse, error)
+	Login() (*oauth2.Token, error)
 	SetMissingInput() error
 }
 
@@ -67,7 +67,7 @@ type option struct {
 	refreshToken         string
 	insecureTLS          bool
 	apiClient            api.ClientInterface
-	restConfig           perseshttp.RestConfigClient
+	restConfig           clientConfig.RestConfigClient
 	remoteConfig         *backendConfig.Config
 }
 
@@ -97,7 +97,7 @@ func (o *option) Complete(args []string) error {
 		o.restConfig.TLSConfig = &secret.TLSConfig{}
 	}
 	o.restConfig.TLSConfig.InsecureSkipVerify = o.insecureTLS
-	restClient, err := perseshttp.NewFromConfig(o.restConfig)
+	restClient, err := clientConfig.NewFromConfig(o.restConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -97,7 +97,7 @@ func (o *option) Complete(args []string) error {
 		o.restConfig.TLSConfig = &secret.TLSConfig{}
 	}
 	o.restConfig.TLSConfig.InsecureSkipVerify = o.insecureTLS
-	restClient, err := clientConfig.NewFromConfig(o.restConfig)
+	restClient, err := clientConfig.NewRESTClient(o.restConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/login/login_int_test.go
+++ b/internal/cli/cmd/login/login_int_test.go
@@ -44,7 +44,7 @@ func TestLoginOAuth(t *testing.T) {
 			//  - On the other hand, putting client id as username can be misleading(/unsecure?) for some providers.
 			//    For example azure advise to use object id to identify a Azure Application in a relying party tool like Perses.
 			//e2eframework.NewUser("anything"),
-			e2eframework.NewUser("john.doe"),
+			e2eframework.NewUser("john.doe", "password"),
 		}
 		testSuite := []cmdTest.Suite{{
 			Title: "Nominal Device Code flow",
@@ -78,8 +78,8 @@ func TestLoginOIDC(t *testing.T) {
 	// Server with oauth provider configured.
 	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
-			e2eframework.NewUser("anything"),
-			e2eframework.NewUser("john.doeOIDC"),
+			e2eframework.NewUser("anything", "password"),
+			e2eframework.NewUser("john.doeOIDC", "password"),
 		}
 		testSuite := []cmdTest.Suite{{
 			Title: "Nominal Device Code flow",

--- a/internal/cli/cmd/login/native.go
+++ b/internal/cli/cmd/login/native.go
@@ -19,7 +19,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/perses/perses/internal/cli/output"
 	"github.com/perses/perses/pkg/client/api"
-	modelAPI "github.com/perses/perses/pkg/model/api"
+	"golang.org/x/oauth2"
 )
 
 type nativeLogin struct {
@@ -29,7 +29,7 @@ type nativeLogin struct {
 	apiClient api.ClientInterface
 }
 
-func (l *nativeLogin) Login() (*modelAPI.AuthResponse, error) {
+func (l *nativeLogin) Login() (*oauth2.Token, error) {
 	return l.apiClient.Auth().Login(l.username, l.password)
 }
 

--- a/internal/cli/cmd/login/robotic.go
+++ b/internal/cli/cmd/login/robotic.go
@@ -19,7 +19,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/perses/perses/internal/cli/output"
 	"github.com/perses/perses/pkg/client/api"
-	modelAPI "github.com/perses/perses/pkg/model/api"
+	"golang.org/x/oauth2"
 )
 
 type roboticLogin struct {
@@ -31,7 +31,7 @@ type roboticLogin struct {
 	apiClient            api.ClientInterface
 }
 
-func (l *roboticLogin) Login() (*modelAPI.AuthResponse, error) {
+func (l *roboticLogin) Login() (*oauth2.Token, error) {
 	return l.apiClient.Auth().ClientCredentialsToken(string(l.externalAuthKind), l.externalAuthProvider, l.clientID, l.clientSecret)
 }
 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -89,7 +89,7 @@ type Config struct {
 }
 
 func (c *Config) init() error {
-	restClient, err := config.NewFromConfig(c.RestClientConfig)
+	restClient, err := config.NewRESTClient(c.RestClientConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 
 	"github.com/perses/perses/pkg/client/api"
-	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/client/config"
 	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/sirupsen/logrus"
 )
@@ -55,10 +55,10 @@ func Init(configPath string) {
 
 // PublicConfig should be only used when displaying the config to the client
 type PublicConfig struct {
-	RestClientConfig perseshttp.PublicRestConfigClient `json:"rest_client_config,omitempty" yaml:"rest_client_config,omitempty"`
-	Project          string                            `json:"project,omitempty" yaml:"project,omitempty"`
-	RefreshToken     secret.Hidden                     `json:"refresh_token,omitempty" yaml:"refresh_token,omitempty"`
-	Dac              Dac                               `json:"dac,omitempty" yaml:"dac,omitempty"`
+	RestClientConfig config.PublicRestConfigClient `json:"rest_client_config,omitempty" yaml:"rest_client_config,omitempty"`
+	Project          string                        `json:"project,omitempty" yaml:"project,omitempty"`
+	RefreshToken     secret.Hidden                 `json:"refresh_token,omitempty" yaml:"refresh_token,omitempty"`
+	Dac              Dac                           `json:"dac,omitempty" yaml:"dac,omitempty"`
 }
 
 func NewPublicConfig(cfg *Config) *PublicConfig {
@@ -66,7 +66,7 @@ func NewPublicConfig(cfg *Config) *PublicConfig {
 		return nil
 	}
 	return &PublicConfig{
-		RestClientConfig: *perseshttp.NewPublicRestConfigClient(&cfg.RestClientConfig),
+		RestClientConfig: *config.NewPublicRestConfigClient(&cfg.RestClientConfig),
 		Project:          cfg.Project,
 		RefreshToken:     secret.Hidden(cfg.RefreshToken),
 		Dac:              cfg.Dac,
@@ -80,16 +80,16 @@ type Dac struct {
 }
 
 type Config struct {
-	RestClientConfig perseshttp.RestConfigClient `json:"rest_client_config,omitempty" yaml:"rest_client_config,omitempty"`
-	Project          string                      `json:"project,omitempty" yaml:"project,omitempty"`
-	RefreshToken     string                      `json:"refresh_token,omitempty" yaml:"refresh_token,omitempty"`
-	Dac              Dac                         `json:"dac,omitempty" yaml:"dac,omitempty"`
+	RestClientConfig config.RestConfigClient `json:"rest_client_config,omitempty" yaml:"rest_client_config,omitempty"`
+	Project          string                  `json:"project,omitempty" yaml:"project,omitempty"`
+	RefreshToken     string                  `json:"refresh_token,omitempty" yaml:"refresh_token,omitempty"`
+	Dac              Dac                     `json:"dac,omitempty" yaml:"dac,omitempty"`
 	filePath         string
 	apiClient        api.ClientInterface
 }
 
 func (c *Config) init() error {
-	restClient, err := perseshttp.NewFromConfig(c.RestClientConfig)
+	restClient, err := config.NewFromConfig(c.RestClientConfig)
 	if err != nil {
 		return err
 	}
@@ -153,13 +153,13 @@ func SetProject(project string) error {
 
 func SetAccessToken(token string) error {
 	return Write(&Config{
-		RestClientConfig: perseshttp.RestConfigClient{Authorization: secret.NewBearerToken(token)},
+		RestClientConfig: config.RestConfigClient{Authorization: secret.NewBearerToken(token)},
 	})
 }
 
 // Write writes the configuration file in the path {USER_HOME}/.perses/config
 // if the directory doesn't exist, the function will create it
-func Write(config *Config) error {
+func Write(cfg *Config) error {
 	// this value has been set by the root command, and that will be the path where the config must be saved
 	filePath := Global.filePath
 	directory := filepath.Dir(filePath)
@@ -176,9 +176,9 @@ func Write(config *Config) error {
 	previousConf, err := readConfig(filePath)
 	if err == nil {
 		// the config already exists, so we should update it with the one provided in the parameter.
-		if config != nil {
-			restConfig := config.RestClientConfig
-			if !reflect.DeepEqual(restConfig, perseshttp.RestConfigClient{}) {
+		if cfg != nil {
+			restConfig := cfg.RestClientConfig
+			if !reflect.DeepEqual(restConfig, config.RestConfigClient{}) {
 				if restConfig.TLSConfig != nil {
 					previousConf.RestClientConfig.TLSConfig = restConfig.TLSConfig
 				}
@@ -191,16 +191,19 @@ func Write(config *Config) error {
 				if len(restConfig.Headers) > 0 {
 					previousConf.RestClientConfig.Headers = restConfig.Headers
 				}
+				if restConfig.Auth != nil {
+					previousConf.RestClientConfig.Auth = restConfig.Auth
+				}
 			}
-			if len(config.Project) > 0 {
-				previousConf.Project = config.Project
+			if len(cfg.Project) > 0 {
+				previousConf.Project = cfg.Project
 			}
-			if len(config.RefreshToken) > 0 {
-				previousConf.RefreshToken = config.RefreshToken
+			if len(cfg.RefreshToken) > 0 {
+				previousConf.RefreshToken = cfg.RefreshToken
 			}
 		}
 	} else {
-		previousConf = config
+		previousConf = cfg
 	}
 
 	data, err := json.Marshal(previousConf)

--- a/pkg/client/api/client.go
+++ b/pkg/client/api/client.go
@@ -14,7 +14,9 @@
 package api
 
 import (
+	"github.com/perses/perses/pkg/client/api/auth"
 	v1 "github.com/perses/perses/pkg/client/api/v1"
+	"github.com/perses/perses/pkg/client/api/validate"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	"github.com/perses/perses/pkg/model/api"
 	apiConfig "github.com/perses/perses/pkg/model/api/config"
@@ -25,8 +27,8 @@ type ClientInterface interface {
 	RESTClient() *perseshttp.RESTClient
 	V1() v1.ClientInterface
 	Migrate(body *api.Migrate) (*modelV1.Dashboard, error)
-	Validate() ValidateInterface
-	Auth() AuthInterface
+	Validate() validate.Interface
+	Auth() auth.Interface
 	Config() (*apiConfig.Config, error)
 }
 
@@ -60,12 +62,12 @@ func (c *client) Migrate(body *api.Migrate) (*modelV1.Dashboard, error) {
 	return result, err
 }
 
-func (c *client) Validate() ValidateInterface {
-	return newValidate(c.restClient)
+func (c *client) Validate() validate.Interface {
+	return validate.New(c.restClient)
 }
 
-func (c *client) Auth() AuthInterface {
-	return newAuth(c.restClient)
+func (c *client) Auth() auth.Interface {
+	return auth.New(c.restClient)
 }
 
 func (c *client) Config() (*apiConfig.Config, error) {

--- a/pkg/client/api/validate/validate.go
+++ b/pkg/client/api/validate/validate.go
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package validate
 
 import (
 	"github.com/perses/perses/pkg/client/perseshttp"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
-type ValidateInterface interface {
+type Interface interface {
 	Dashboard(entity *v1.Dashboard) error
 	Datasource(entity *v1.Datasource) error
 	GlobalDatasource(entity *v1.GlobalDatasource) error
@@ -27,11 +27,11 @@ type ValidateInterface interface {
 }
 
 type validate struct {
-	ValidateInterface
+	Interface
 	client *perseshttp.RESTClient
 }
 
-func newValidate(client *perseshttp.RESTClient) ValidateInterface {
+func New(client *perseshttp.RESTClient) Interface {
 	return &validate{client: client}
 }
 

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -1,0 +1,189 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/client/transport"
+	"github.com/perses/perses/pkg/model/api"
+	"github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const connectionTimeout = 30 * time.Second
+
+type PublicOauthConfig struct {
+	ClientID       secret.Hidden    `json:"client_id" yaml:"client_id"`
+	ClientSecret   secret.Hidden    `json:"client_secret" yaml:"client_secret"`
+	TokenURL       string           `json:"token_url" yaml:"token_url"`
+	Scopes         []string         `json:"scopes" yaml:"scopes"`
+	EndpointParams url.Values       `json:"endpoint_params" yaml:"endpoint_params"`
+	AuthStyle      oauth2.AuthStyle `json:"auth_style" yaml:"auth_style"`
+}
+
+func newPublicOauthConfig(oauthConfig *OauthConfig) *PublicOauthConfig {
+	if oauthConfig == nil {
+		return nil
+	}
+	return &PublicOauthConfig{
+		ClientID:       secret.Hidden(oauthConfig.ClientID),
+		ClientSecret:   secret.Hidden(oauthConfig.ClientSecret),
+		TokenURL:       oauthConfig.TokenURL,
+		Scopes:         oauthConfig.Scopes,
+		EndpointParams: oauthConfig.EndpointParams,
+		AuthStyle:      oauthConfig.AuthStyle,
+	}
+}
+
+type PublicAuthConfig struct {
+	NativeAuth  *api.PublicAuth         `json:"native_auth,omitempty" yaml:"native_auth,omitempty"`
+	OauthConfig *PublicOauthConfig      `json:"oauth_config,omitempty" yaml:"oauth_config,omitempty"`
+	BasicAuth   *secret.PublicBasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`
+}
+
+func newPublicAuthConfig(auth *AuthConfig) *PublicAuthConfig {
+	if auth == nil {
+		return nil
+	}
+	return &PublicAuthConfig{
+		OauthConfig: newPublicOauthConfig(auth.OauthConfig),
+		BasicAuth:   secret.NewPublicBasicAuth(auth.BasicAuth),
+		NativeAuth:  api.NewPublicAuth(auth.NativeAuth),
+	}
+}
+
+// PublicRestConfigClient is the struct that should be used when printing the config
+type PublicRestConfigClient struct {
+	URL  *common.URL       `json:"url" yaml:"url"`
+	Auth *PublicAuthConfig `json:"auth,omitempty" yaml:"auth,omitempty"`
+	// The HTTP authorization credentials for the targets.
+	Authorization *secret.PublicAuthorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
+	// TLSConfig to use to connect to the targets.
+	TLSConfig *secret.PublicTLSConfig `json:"tls_config,omitempty" yaml:"tls_config,omitempty"`
+	Headers   map[string]string       `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+func NewPublicRestConfigClient(config *RestConfigClient) *PublicRestConfigClient {
+	if config == nil {
+		return nil
+	}
+	return &PublicRestConfigClient{
+		URL:           config.URL,
+		Auth:          newPublicAuthConfig(config.Auth),
+		Authorization: secret.NewPublicAuthorization(config.Authorization),
+		TLSConfig:     secret.NewPublicTLSConfig(config.TLSConfig),
+		Headers:       config.Headers,
+	}
+}
+
+type OauthConfig struct {
+	// ClientID is the application's ID.
+	ClientID string `json:"client_id" yaml:"client_id"`
+	// ClientSecret is the application's secret.
+	ClientSecret string `json:"client_secret" yaml:"client_secret"`
+	// TokenURL is the resource server's token endpoint
+	// URL. This is a constant specific to each server.
+	TokenURL string `json:"token_url" yaml:"token_url"`
+	// Scope specifies optional requested permissions.
+	Scopes []string `json:"scopes" yaml:"scopes"`
+	// EndpointParams specifies additional parameters for requests to the token endpoint.
+	EndpointParams url.Values `json:"endpoint_params" yaml:"endpoint_params"`
+	// AuthStyle optionally specifies how the endpoint wants the
+	// client ID & client secret sent. The zero value means to
+	// auto-detect.
+	AuthStyle oauth2.AuthStyle `json:"auth_style" yaml:"auth_style"`
+}
+
+type AuthConfig struct {
+	NativeAuth  *api.Auth         `json:"native_auth,omitempty" yaml:"native_auth,omitempty"`
+	OauthConfig *OauthConfig      `json:"oauth_config,omitempty" yaml:"oauth_config,omitempty"`
+	BasicAuth   *secret.BasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`
+}
+
+// RestConfigClient defines all parameters that can be set to customize the RESTClient
+type RestConfigClient struct {
+	URL  *common.URL `json:"url" yaml:"url"`
+	Auth *AuthConfig `json:"auth,omitempty" yaml:"auth,omitempty"`
+	// The HTTP authorization credentials for the targets.
+	Authorization *secret.Authorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
+	// TLSConfig to use to connect to the targets.
+	TLSConfig *secret.TLSConfig `json:"tls_config,omitempty" yaml:"tls_config,omitempty"`
+	Headers   map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+// NewFromConfig create an instance of RESTClient using the config passed as parameter
+func NewFromConfig(config RestConfigClient) (*perseshttp.RESTClient, error) {
+	if config.Auth != nil && config.Auth.OauthConfig != nil {
+		// In case oauth is configured, then TLS parameters are ignored.
+		// Everything is handled by the custom http client from Oauth2 (including the refresh of the token).
+		oauthConfig := &clientcredentials.Config{
+			ClientID:     config.Auth.OauthConfig.ClientID,
+			ClientSecret: config.Auth.OauthConfig.ClientSecret,
+			TokenURL:     config.Auth.OauthConfig.TokenURL,
+			Scopes:       config.Auth.OauthConfig.Scopes,
+			AuthStyle:    config.Auth.OauthConfig.AuthStyle,
+		}
+		httpClient := oauthConfig.Client(context.Background())
+		return &perseshttp.RESTClient{
+			Headers: config.Headers,
+			BaseURL: config.URL.URL,
+			Client:  httpClient,
+		}, nil
+	}
+
+	tlsCfg, err := secret.BuildTLSConfig(config.TLSConfig)
+	if err != nil {
+		return nil, err
+	}
+	var roundTripper http.RoundTripper = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   connectionTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsCfg, // nolint: gas, gosec
+	}
+	var basicAuth *secret.BasicAuth
+
+	if config.Auth != nil {
+		if config.Auth.BasicAuth != nil {
+			basicAuth = config.Auth.BasicAuth
+		}
+		if config.Auth.NativeAuth != nil {
+			roundTripper = transport.New(config.URL.URL, roundTripper, *config.Auth.NativeAuth)
+		}
+	}
+
+	httpClient := &http.Client{
+		Transport: roundTripper,
+		Timeout:   connectionTimeout,
+	}
+
+	return &perseshttp.RESTClient{
+		BaseURL:       config.URL.URL,
+		Authorization: config.Authorization,
+		BasicAuth:     basicAuth,
+		Client:        httpClient,
+		Headers:       config.Headers,
+	}, nil
+}

--- a/pkg/client/fake/api/client.go
+++ b/pkg/client/fake/api/client.go
@@ -33,7 +33,7 @@ type client struct {
 }
 
 func New() api.ClientInterface {
-	restClient, _ := config.NewFromConfig(config.RestConfigClient{
+	restClient, _ := config.NewRESTClient(config.RestConfigClient{
 		URL: common.MustParseURL("http://localhost:8080"),
 	})
 	return &client{

--- a/pkg/client/fake/api/client.go
+++ b/pkg/client/fake/api/client.go
@@ -20,6 +20,7 @@ package fakeapi
 import (
 	"github.com/perses/perses/pkg/client/api"
 	v1 "github.com/perses/perses/pkg/client/api/v1"
+	"github.com/perses/perses/pkg/client/config"
 	"github.com/perses/perses/pkg/client/fake/api/v1"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	apiConfig "github.com/perses/perses/pkg/model/api/config"
@@ -32,7 +33,7 @@ type client struct {
 }
 
 func New() api.ClientInterface {
-	restClient, _ := perseshttp.NewFromConfig(perseshttp.RestConfigClient{
+	restClient, _ := config.NewFromConfig(config.RestConfigClient{
 		URL: common.MustParseURL("http://localhost:8080"),
 	})
 	return &client{

--- a/pkg/client/perseshttp/client.go
+++ b/pkg/client/perseshttp/client.go
@@ -14,117 +14,25 @@
 package perseshttp
 
 import (
-	"net"
 	"net/http"
 	"net/url"
-	"sync"
-	"time"
 
-	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/secret"
 )
-
-const connectionTimeout = 30 * time.Second
-
-// PublicRestConfigClient is the struct that should be used when printing the config
-type PublicRestConfigClient struct {
-	URL       *common.URL             `json:"url" yaml:"url"`
-	BasicAuth *secret.PublicBasicAuth `json:"basicAuth,omitempty" yaml:"basicAuth,omitempty"`
-	// The HTTP authorization credentials for the targets.
-	Authorization *secret.PublicAuthorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
-	// TLSConfig to use to connect to the targets.
-	TLSConfig *secret.PublicTLSConfig `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty"`
-	Headers   map[string]string       `json:"headers,omitempty" yaml:"headers,omitempty"`
-}
-
-func NewPublicRestConfigClient(config *RestConfigClient) *PublicRestConfigClient {
-	if config == nil {
-		return nil
-	}
-	return &PublicRestConfigClient{
-		URL:           config.URL,
-		BasicAuth:     secret.NewPublicBasicAuth(config.BasicAuth),
-		Authorization: secret.NewPublicAuthorization(config.Authorization),
-		TLSConfig:     secret.NewPublicTLSConfig(config.TLSConfig),
-		Headers:       config.Headers,
-	}
-}
-
-// RestConfigClient defines all parameters that can be set to customize the RESTClient
-type RestConfigClient struct {
-	URL       *common.URL       `json:"url" yaml:"url"`
-	BasicAuth *secret.BasicAuth `json:"basicAuth,omitempty" yaml:"basicAuth,omitempty"`
-	// The HTTP authorization credentials for the targets.
-	Authorization *secret.Authorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
-	// TLSConfig to use to connect to the targets.
-	TLSConfig *secret.TLSConfig `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty"`
-	Headers   map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
-}
-
-// NewFromConfig create an instance of RESTClient using the config passed as parameter
-func NewFromConfig(config RestConfigClient) (*RESTClient, error) {
-	tlsCfg, err := secret.BuildTLSConfig(config.TLSConfig)
-	if err != nil {
-		return nil, err
-	}
-	roundTripper := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   connectionTimeout,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:     tlsCfg, // nolint: gas, gosec
-	}
-
-	httpClient := &http.Client{
-		Transport: roundTripper,
-		Timeout:   connectionTimeout,
-	}
-
-	return &RESTClient{
-		authorization: config.Authorization,
-		BaseURL:       config.URL.URL,
-		Client:        httpClient,
-		headers:       config.Headers,
-		basicAuth:     config.BasicAuth,
-	}, nil
-}
 
 // RESTClient defines an HTTP client designed for the HTTP request to a REST API.
 type RESTClient struct {
 	// Usually it contains the bearer token required to contact the remote API.
-	authorization *secret.Authorization
+	Authorization *secret.Authorization
 	// basicAuth to be used for each request (not editable)
 	// Using a basicAuth has the priority other the token
-	basicAuth *secret.BasicAuth
+	BasicAuth *secret.BasicAuth
 	// Default headers for all client requests (not editable)
-	headers map[string]string
+	Headers map[string]string
 	// base is the root URL for all invocations of the client
 	BaseURL *url.URL
-	// Set specific behavior of the client.  If not set http.DefaultClient will be used.
-	Client    *http.Client
-	authMutex sync.RWMutex
-}
-
-func (c *RESTClient) SetBasicAuth(username, password string) {
-	c.authMutex.Lock()
-	c.basicAuth = &secret.BasicAuth{
-		Username: username,
-		Password: password,
-	}
-	c.authMutex.Unlock()
-}
-
-func (c *RESTClient) SetAuthorization(authorization *secret.Authorization) {
-	c.authMutex.Lock()
-	c.authorization = authorization
-	c.authMutex.Unlock()
-}
-
-// GetHeaders gets the headers
-func (c *RESTClient) GetHeaders() map[string]string {
-	return c.headers
+	// Set specific behavior of the client. If not, set http.DefaultClient will be used.
+	Client *http.Client
 }
 
 // Get begins a GET request. Short for c.newRequest("GET")
@@ -153,7 +61,5 @@ func (c *RESTClient) Delete() *Request {
 }
 
 func (c *RESTClient) newRequest(method string) *Request {
-	c.authMutex.RLock()
-	defer c.authMutex.RUnlock()
-	return NewRequest(c.Client, method, c.BaseURL, c.authorization, c.basicAuth, c.headers)
+	return NewRequest(c.Client, method, c.BaseURL, c.Authorization, c.BasicAuth, c.Headers)
 }

--- a/pkg/client/transport/transport.go
+++ b/pkg/client/transport/transport.go
@@ -1,0 +1,111 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/perses/perses/pkg/client/api/auth"
+	"github.com/perses/perses/pkg/client/perseshttp"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	"golang.org/x/oauth2"
+)
+
+type tokenManager struct {
+	authClient auth.Interface
+	mutex      sync.Mutex
+	token      *oauth2.Token
+	auth       modelAPI.Auth
+}
+
+func (t *tokenManager) getToken() (*oauth2.Token, error) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	var err error
+	// if the token is empty, then we need to authenticate
+	if t.token == nil {
+		t.token, err = t.authClient.Login(t.auth.Login, t.auth.Password)
+		return t.token, err
+	}
+
+	if !t.token.Valid() {
+		// Then we need to refresh the token or to authenticate.
+		t.token, err = t.authClient.Refresh(t.token.RefreshToken)
+		if err != nil {
+			if requestErr, ok := err.(*perseshttp.RequestError); ok {
+				if requestErr.StatusCode == http.StatusBadRequest {
+					// Then it means the refresh token doesn't work anymore and we need to authenticate
+					t.token, err = t.authClient.Login(t.auth.Login, t.auth.Password)
+					return t.token, err
+				}
+			}
+			// Otherwise, there is another error that shall be managed at upper level
+			return nil, err
+		}
+	}
+	return t.token, nil
+}
+
+func New(baseURL *url.URL, base http.RoundTripper, nativeAuth modelAPI.Auth) http.RoundTripper {
+	client := auth.New(&perseshttp.RESTClient{
+		BaseURL: baseURL,
+		Client:  &http.Client{Transport: base},
+	})
+	return &transport{
+		tokenManager: &tokenManager{authClient: client, auth: nativeAuth},
+		base:         base,
+	}
+}
+
+type transport struct {
+	tokenManager *tokenManager
+	// base is the base RoundTripper used to make HTTP requests.
+	base http.RoundTripper
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqBodyClosed := false
+	if req.Body != nil {
+		defer func() {
+			if !reqBodyClosed {
+				req.Body.Close()
+			}
+		}()
+	}
+	token, err := t.tokenManager.getToken()
+	if err != nil {
+		return nil, err
+	}
+	req2 := cloneRequest(req) // per RoundTripper contract
+	token.SetAuthHeader(req2)
+	// req.Body is assumed to be closed by the base RoundTripper.
+	reqBodyClosed = true
+	return t.base.RoundTrip(req2)
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+	return r2
+}

--- a/pkg/model/api/auth.go
+++ b/pkg/model/api/auth.go
@@ -17,8 +17,24 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/perses/perses/pkg/model/api/v1/secret"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
+
+type PublicAuth struct {
+	Login    string        `json:"login"`
+	Password secret.Hidden `json:"password"`
+}
+
+func NewPublicAuth(auth *Auth) *PublicAuth {
+	if auth == nil {
+		return nil
+	}
+	return &PublicAuth{
+		Login:    auth.Login,
+		Password: secret.Hidden(auth.Password),
+	}
+}
 
 type Auth struct {
 	Login    string `json:"login"`
@@ -40,14 +56,6 @@ func (u *Auth) UnmarshalJSON(data []byte) error {
 	u.Password = tmp.Password
 	u.Login = tmp.Login
 	return nil
-}
-
-// AuthResponse represents the response of an authentication request.
-// Disclaimer: This is an exception to the general camelCase convention in the project, to respect oauth 2.0 specs.
-// -> https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4
-type AuthResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
 // RefreshRequest represents the request used to refresh an access token from a refresh token.

--- a/pkg/model/api/config/datasourcediscovery.go
+++ b/pkg/model/api/config/datasourcediscovery.go
@@ -17,14 +17,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/client/config"
 	"github.com/prometheus/common/model"
 )
 
 const defaultRefreshInterval = model.Duration(time.Minute * 5)
 
 type HTTPDiscovery struct {
-	perseshttp.RestConfigClient `json:",inline" yaml:",inline"`
+	config.RestConfigClient `json:",inline" yaml:",inline"`
 }
 
 type KubeServiceDiscovery struct {


### PR DESCRIPTION
This PR is changing the http client of Perses. The main goal is to handle the Oauth and native auth easily.

For that I am introducing a custom round tripper in the package `transport`. That's the part that is handling automatically the native authentification.

We are using the package `oauth2` to handle oauth authentication.

As a side effect, the login requests are now returning the object `oauth2.Token`. Doing that help a lot to handle the different cases (i.a, does the token expire, the type of the token ...etc.) 

With this PR handling configuring oauth with the perses client will be like that:

```go
client, err := config.NewFromConfig(config.RestConfigClient {
	URL: "http://localhost:8080",
        Auth: &config.AuthConfig {
		OauthConfig: &config.OauthConfig{
		        ClientID:     "MyClientID",
		        ClientSecret: "MyClientSecret",
		        TokenURL:     "http://localhost:8080/api/v1/auth/providers/oauth/github/token",
		        AuthStyle:    oauth2.AuthStyleInHeader,
		}
	}

})

// Make any classic Perses query 
_, err = v1.NewWithClient(client).Project().List("")