### PR TITLE
[BUGFIX] tempo: support search results with mixed vParquet3 and vParquet4 blocks

### DIFF
--- a/ui/tempo-plugin/src/model/api-types.ts
+++ b/ui/tempo-plugin/src/model/api-types.ts
@@ -65,10 +65,10 @@ export interface TraceSearchResponse {
 
 export interface SpanSearchResponse {
   spanID: string;
-  name: string;
+  name?: string;
   startTimeUnixNano: string;
   durationNanos: string;
-  attributes: Attribute[];
+  attributes?: Attribute[];
 }
 
 export interface ServiceStats {

--- a/ui/tempo-plugin/src/model/tempo-client.ts
+++ b/ui/tempo-plugin/src/model/tempo-client.ts
@@ -101,7 +101,7 @@ export async function searchWithFallback(
   }
 
   // exit early if fallback is not required (serviceStats are contained in the response)
-  if (searchResponse.traces[0]?.serviceStats) {
+  if (searchResponse.traces.every((t) => t.serviceStats)) {
     return searchResponse;
   }
 
@@ -109,6 +109,11 @@ export async function searchWithFallback(
   return {
     traces: await Promise.all(
       searchResponse.traces.map(async (trace) => {
+        if (trace.serviceStats) {
+          // fallback not required, serviceStats are contained in the response
+          return trace;
+        }
+
         const serviceStats: Record<string, ServiceStats> = {};
         const searchTraceIDResponse = await query({ traceId: trace.traceID }, queryOptions);
 

--- a/ui/tempo-plugin/src/test/mock-data.ts
+++ b/ui/tempo-plugin/src/test/mock-data.ts
@@ -2341,6 +2341,62 @@ export const MOCK_SEARCH_RESPONSE_VPARQUET4: SearchResponse = {
   ],
 };
 
+export const MOCK_SEARCH_RESPONSE_MIXED_VPARQUET3_AND_4: SearchResponse = {
+  traces: [
+    {
+      traceID: '224a0e75a0d244f1a3dab3af233e6cf3',
+      rootServiceName: 'telemetrygen',
+      rootTraceName: 'lets-go',
+      startTimeUnixNano: '1727969811138427469',
+      spanSets: [
+        {
+          spans: [
+            {
+              spanID: '237f68dfbed2f473',
+              startTimeUnixNano: '1727969811138427469',
+              durationNanos: '123000',
+            },
+            {
+              spanID: 'a8eefdaad116a872',
+              startTimeUnixNano: '1727969811138427469',
+              durationNanos: '123000',
+            },
+          ],
+          matched: 2,
+        },
+      ],
+      serviceStats: {
+        telemetrygen: {
+          spanCount: 2,
+        },
+      },
+    },
+    {
+      traceID: '71bd40553a881d98dc52f2a27fd53fe3',
+      rootServiceName: 'telemetrygen',
+      rootTraceName: 'lets-go',
+      startTimeUnixNano: '1727969665041183110',
+      spanSets: [
+        {
+          spans: [
+            {
+              spanID: '968a78f0ffbc6570',
+              startTimeUnixNano: '1727969665041183110',
+              durationNanos: '123000',
+            },
+            {
+              spanID: 'bb8ab44ffd46ca07',
+              startTimeUnixNano: '1727969665041183110',
+              durationNanos: '123000',
+            },
+          ],
+          matched: 2,
+        },
+      ],
+    },
+  ],
+};
+
 export const MOCK_TRACE_DATA_SEARCHRESULT: TraceData = {
   searchResult: [
     {


### PR DESCRIPTION
# Description

When upgrading to Tempo v2.6.0, the vParquet4 block format is the default, which includes the `serviceStats` field in the search API response.

The previously stored blocks (using vParquet3 format or older) do not contain this field yet, therefore it's possible to receive a search API response where some traces contain the `serviceStats` field and some traces don't contain this field.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
