### PR TITLE
[ENHANCEMENT] Configuration of the HTTP client for oauth/oidc providers

### DIFF
--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -192,6 +192,18 @@ device_code:
   [ client_id: <secret> ]
   # Allow to use a different Client Secret for the device code flow
   [ client_secret: <secret> ]
+  # Allow using different Scopes for the device code flow
+  scopes:
+  - [ <string> ]
+
+client_credentials:
+  # Allow using a different Client ID for the client credentials flow
+  [ client_id: <secret> ]
+  # Allow using a different Client Secret for the client credentials flow
+  [ client_secret: <secret> ]
+  # Allow using different Scopes for the client credentials flow
+  scopes:
+  - [ <string> ]
 
 # The callback URL for authorization code (Have to be <your URL> + /api/auth/providers/oidc/{slug}/callback)
 # If not set it will get it from the request.
@@ -200,6 +212,9 @@ device_code:
 # The needed scopes to authenticate a user in the provider. It's not mandatory because it will depend on the provider
 scopes:
   - [ <string> ]
+
+# Some configuration of the HTTP client used to make the requests to the provider
+http: <Authentication provider HTTP Config>
 
 # The provider issuer URL
 issuer: <string>
@@ -248,12 +263,16 @@ client_credentials:
   scopes:
     - [ <string> ]
 
-# The callback URL for authorization code (Have to be <your URL> + /api/auth/providers/oidc/{slug}/callback)
+# The callback URL for authorization code (Have to be <your URL> + /api/auth/providers/oauth/{slug}/callback)
+# If not set it will get it from the request.
 [ redirect_uri: <string> ]
 
 # The needed scopes to authenticate a user in the provider
 scopes:
   - [ <string> ]
+
+# Some configuration of the HTTP client used to make the requests to the provider
+http: <Authentication provider HTTP Config>
 
 # The provider Authorization URL
 auth_url: <string>
@@ -272,6 +291,16 @@ user_infos_url: <string>
 # Name of the property to get "login" from user infos API (if not in the default list ["login", "username"] )
 # The login is mandatory to store in the database the name of the user.
 [ custom_login_property: <string>]
+```
+
+###### Authentication provider HTTP Config
+
+```yaml
+# Request timeout
+[ timeout: <duration> | default = 1m]
+
+# TLS configuration.
+[ tls_config: <TLS config> ]
 ```
 
 #### Authorization config

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -129,6 +129,7 @@ type oAuthEndpoint struct {
 	conf            oauth2.Config
 	deviceCodeConf  oauth2.Config
 	clientCredConf  oauth2.Config
+	httpClient      *http.Client
 	secureCookie    *securecookie.SecureCookie
 	jwt             crypto.JWT
 	tokenManagement tokenManagement
@@ -139,7 +140,7 @@ type oAuthEndpoint struct {
 	loginProps      []string
 }
 
-func newOAuthEndpoint(provider config.OAuthProvider, jwt crypto.JWT, dao user.DAO) route.Endpoint {
+func newOAuthEndpoint(provider config.OAuthProvider, jwt crypto.JWT, dao user.DAO) (route.Endpoint, error) {
 	// As the cookie is used only at login time, we don't need a persistent value here.
 	// (same reason as newOIDCEndpoint)
 	key := securecookie.GenerateRandomKey(16)
@@ -160,10 +161,16 @@ func newOAuthEndpoint(provider config.OAuthProvider, jwt crypto.JWT, dao user.DA
 		loginProps = []string{customProp}
 	}
 
+	httpClient, err := newHTTPClient(provider.HTTP)
+	if err != nil {
+		return nil, err
+	}
+
 	return &oAuthEndpoint{
 		conf:            conf,
 		deviceCodeConf:  deviceCodeConf,
 		clientCredConf:  clientCredConf,
+		httpClient:      httpClient,
 		secureCookie:    secureCookie,
 		jwt:             jwt,
 		tokenManagement: tokenManagement{jwt: jwt},
@@ -172,7 +179,7 @@ func newOAuthEndpoint(provider config.OAuthProvider, jwt crypto.JWT, dao user.DA
 		authURL:         *provider.AuthURL.URL,
 		svc:             service{dao: dao},
 		loginProps:      loginProps,
-	}
+	}, nil
 }
 
 func (e *oAuthEndpoint) setCookie(ctx echo.Context, name, value string) error {
@@ -252,6 +259,13 @@ func (e *oAuthEndpoint) readCodeVerifierCookie(ctx echo.Context) (state string, 
 	return state, nil
 }
 
+// newQueryContext build a specific context for the oauth provider.
+// It allows us to set up tls config hacking the http client directly in the given context
+// Ref: https://github.com/golang/oauth2/issues/187
+func (e *oAuthEndpoint) newQueryContext(ctx echo.Context) context.Context {
+	return context.WithValue(ctx.Request().Context(), oauth2.HTTPClient, e.httpClient)
+}
+
 func (e *oAuthEndpoint) CollectRoutes(g *route.Group) {
 	oauthGroup := g.Group(fmt.Sprintf("/%s/%s", utils.AuthKindOAuth, e.slugID), withOAuthErrorMdw)
 
@@ -326,14 +340,16 @@ func (e *oAuthEndpoint) codeExchangeHandler(ctx echo.Context) error {
 		opts = append(opts, oauth2.SetAuthURLParam("redirect_uri", getRedirectURI(ctx.Request(), utils.AuthKindOAuth, e.slugID)))
 	}
 
+	providerCtx := e.newQueryContext(ctx)
+
 	// Exchange the authorization code with a token
-	token, err := e.conf.Exchange(ctx.Request().Context(), code, opts...)
+	token, err := e.conf.Exchange(providerCtx, code, opts...)
 	if err != nil {
 		e.logWithError(err).Error("An error occurred while exchanging code with token")
 		return err
 	}
 
-	uInfo, err := e.requestUserInfo(ctx, token)
+	uInfo, err := e.requestUserInfo(providerCtx, token)
 	if err != nil {
 		e.logWithError(err).Error("An error occurred while requesting user infos. User infos will be ignored.")
 		return err
@@ -358,7 +374,8 @@ func (e *oAuthEndpoint) deviceCodeHandler(ctx echo.Context) error {
 		e.logWithError(errors.New("device code flow is not supported by this provider"))
 		return echo.NewHTTPError(http.StatusNotImplemented, "Device code flow is not supported by this provider")
 	}
-	resp, err := e.deviceCodeConf.DeviceAuth(ctx.Request().Context())
+
+	resp, err := e.deviceCodeConf.DeviceAuth(e.newQueryContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -370,12 +387,14 @@ func (e *oAuthEndpoint) deviceCodeHandler(ctx echo.Context) error {
 func (e *oAuthEndpoint) tokenHandler(ctx echo.Context) error {
 	grantType := ctx.FormValue("grant_type")
 
+	providerCtx := e.newQueryContext(ctx)
+
 	var accessToken *oauth2.Token
 	var err error
 	switch api.GrantType(grantType) {
 	case api.GrantTypeDeviceCode:
 		deviceCode := ctx.FormValue("device_code")
-		accessToken, err = e.retrieveDeviceAccessToken(ctx.Request().Context(), deviceCode)
+		accessToken, err = e.retrieveDeviceAccessToken(providerCtx, deviceCode)
 		if err != nil {
 			// (We log a warning as the failure means most of the time that the user didn't authorize the app yet)
 			e.logWithError(err).Warn("Failed to exchange device code for token")
@@ -389,7 +408,7 @@ func (e *oAuthEndpoint) tokenHandler(ctx echo.Context) error {
 			e.logWithError(err).Error("Invalid or missing Authorization header")
 			return err
 		}
-		accessToken, err = e.retrieveClientCredentialsToken(ctx.Request().Context(), clientID, clientSecret)
+		accessToken, err = e.retrieveClientCredentialsToken(providerCtx, clientID, clientSecret)
 		if err != nil {
 			e.logWithError(err).Error("Failed to exchange client credentials for token")
 			return err
@@ -400,7 +419,7 @@ func (e *oAuthEndpoint) tokenHandler(ctx echo.Context) error {
 		}
 	}
 
-	uInfo, err := e.requestUserInfo(ctx, accessToken)
+	uInfo, err := e.requestUserInfo(providerCtx, accessToken)
 	if err != nil {
 		e.logWithError(err).Error("An error occurred while requesting user infos.")
 		return err
@@ -528,8 +547,8 @@ func (e *oAuthEndpoint) retrieveClientCredentialsToken(ctx context.Context, clie
 }
 
 // requestUserInfo execute an HTTP request on the user infos url if provided.
-func (e *oAuthEndpoint) requestUserInfo(ctx echo.Context, token *oauth2.Token) (externalUserInfo, error) {
-	resp, err := e.conf.Client(ctx.Request().Context(), token).Get(e.userInfoURL)
+func (e *oAuthEndpoint) requestUserInfo(ctx context.Context, token *oauth2.Token) (externalUserInfo, error) {
+	resp, err := e.conf.Client(ctx, token).Get(e.userInfoURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -90,6 +90,7 @@ func newRelyingParty(provider config.OIDCProvider, override *config.OAuthOverrid
 	if !provider.RedirectURI.IsNilOrEmpty() {
 		redirectURI = provider.RedirectURI.String()
 	}
+
 	// As the cookie is used only at login time, we don't need a persistent value here.
 	// The OIDC library will use it this way:
 	// - Right before calling the /authorize provider's endpoint, it set "state" in a cookie and the "PKCE code challenge" in another
@@ -98,12 +99,8 @@ func newRelyingParty(provider config.OIDCProvider, override *config.OAuthOverrid
 	//   from cookie to use them before deleting the cookies.
 	key := securecookie.GenerateRandomKey(16)
 	cookieHandler := httphelper.NewCookieHandler(key, key)
-	httpClient := &http.Client{
-		Timeout: time.Minute,
-	}
 	options := []rp.Option{
 		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),
-		rp.WithHTTPClient(httpClient),
 		rp.WithCookieHandler(cookieHandler),
 	}
 	if !provider.DisablePKCE {
@@ -112,6 +109,12 @@ func newRelyingParty(provider config.OIDCProvider, override *config.OAuthOverrid
 	if !provider.DiscoveryURL.IsNilOrEmpty() {
 		options = append(options, rp.WithCustomDiscoveryUrl(provider.DiscoveryURL.String()))
 	}
+
+	httpClient, err := newHTTPClient(provider.HTTP)
+	if err != nil {
+		return nil, err
+	}
+	options = append(options, rp.WithHTTPClient(httpClient))
 
 	clientID := provider.ClientID
 	clientSecret := provider.ClientSecret

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -16,7 +16,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/prometheus/common/config"
 	"time"
 
 	"github.com/perses/perses/pkg/model/api/v1/common"
@@ -49,7 +48,7 @@ func appendIfMissing[T comparable](slice []T, value T) ([]T, bool) {
 
 type HTTP struct {
 	Timeout   model.Duration    `json:"timeout" yaml:"timeout"`
-	TLSConfig *config.TLSConfig `json:"tls_config" yaml:"tls_config"`
+	TLSConfig *secret.TLSConfig `json:"tls_config" yaml:"tls_config"`
 }
 
 func (h *HTTP) Verify() error {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR allows us to set a timeout and various TLS configurations into the HTTP client that is used to make the various queries to external auth providers.

Hopefully fixes #2302 

It makes a little cleanup as well in the auth config documentation that was missing some elements.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
