### PR TITLE
[ENHANCEMENT] allow variables to be empty

### DIFF
--- a/ui/core/src/schema/variable.ts
+++ b/ui/core/src/schema/variable.ts
@@ -91,7 +91,7 @@ export function buildVariableListSchema(pluginSchema: PluginSchema): typeof vari
 export const variableTextSpecSchema: z.ZodSchema<TextVariableSpec> = z.object({
   name: z.string().min(1),
   display: variableDisplaySchema.optional(),
-  value: z.string().min(1),
+  value: z.string(),
   constant: z.boolean().optional(),
 });
 

--- a/ui/plugin-system/src/utils/variables.ts
+++ b/ui/plugin-system/src/utils/variables.ts
@@ -24,7 +24,7 @@ export function replaceVariables(text: string, variableState: VariableStateMap):
     .sort((a, b) => b.length - a.length)
     .forEach((v) => {
       const variable = variableState[v];
-      if (variable && variable?.value) {
+      if (variable && variable.value !== undefined) {
         finalText = replaceVariable(finalText, v, variable?.value);
       }
     });


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
fix #2320
![image](https://github.com/user-attachments/assets/f79de2e5-6f38-4d0f-b4d5-7c38fc710e76)
![image](https://github.com/user-attachments/assets/aff6f80c-37cf-4261-aa17-b293c123cd53)
![image](https://github.com/user-attachments/assets/c220b083-f529-49a8-bf9e-cf500d5801b5)


# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
