### PR TITLE
[ENHANCEMENT] Migration: Don't fail on `fieldConfig.defaults.thresholds.steps` absence

### DIFF
--- a/cue/schemas/panels/gauge/migrate.cue
+++ b/cue/schemas/panels/gauge/migrate.cue
@@ -1,10 +1,7 @@
 if #panel.type != _|_ if #panel.type == "gauge" {
 	kind: "GaugeChart"
 	spec: {
-		#calcName: [if #panel.options.reduceOptions != _|_ if #panel.options.reduceOptions.calcs != _|_ 
-			{*"\(#panel.options.reduceOptions.calcs[0])" | null}, // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
-			{"lastNotNull"}]
-		[0]
+		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
 		calculation: [ // switch
 			if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
 			{ #defaultCalc }

--- a/cue/schemas/panels/gauge/migrate.cue
+++ b/cue/schemas/panels/gauge/migrate.cue
@@ -1,7 +1,10 @@
 if #panel.type != _|_ if #panel.type == "gauge" {
 	kind: "GaugeChart"
 	spec: {
-		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
+		#calcName: [if #panel.options.reduceOptions != _|_ if #panel.options.reduceOptions.calcs != _|_ 
+			{*"\(#panel.options.reduceOptions.calcs[0])" | null}, // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
+			{"lastNotNull"}]
+		[0]
 		calculation: [ // switch
 			if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
 			{ #defaultCalc }
@@ -14,7 +17,7 @@ if #panel.type != _|_ if #panel.type == "gauge" {
 			}
 		}
 
-		if #panel.fieldConfig.defaults.thresholds != _|_ {
+		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.thresholds.steps != _|_ {
 			thresholds: {
 				// defaultColor: TODO how to fill this one?
 				steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part? 

--- a/cue/schemas/panels/stat/migrate.cue
+++ b/cue/schemas/panels/stat/migrate.cue
@@ -1,10 +1,7 @@
 if #panel.type != _|_ if #panel.type == "stat" {
 	kind: "StatChart"
 	spec: {
-		#calcName: [if #panel.options.reduceOptions != _|_ if #panel.options.reduceOptions.calcs != _|_
-			{*"\(#panel.options.reduceOptions.calcs[0])" | null},
-			{"lastNotNull"}
-		][0] // only consider [0] here as Perses's StatChart doesn't support individual calcs
+		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
 		calculation: [ // switch
 			if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
 			{ #defaultCalc }

--- a/cue/schemas/panels/stat/migrate.cue
+++ b/cue/schemas/panels/stat/migrate.cue
@@ -1,7 +1,7 @@
 if #panel.type != _|_ if #panel.type == "stat" {
 	kind: "StatChart"
 	spec: {
-		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
+		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's StatChart doesn't support individual calcs
 		calculation: [ // switch
 			if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
 			{ #defaultCalc }

--- a/cue/schemas/panels/stat/migrate.cue
+++ b/cue/schemas/panels/stat/migrate.cue
@@ -1,7 +1,10 @@
 if #panel.type != _|_ if #panel.type == "stat" {
 	kind: "StatChart"
 	spec: {
-		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's StatChart doesn't support individual calcs
+		#calcName: [if #panel.options.reduceOptions != _|_ if #panel.options.reduceOptions.calcs != _|_
+			{*"\(#panel.options.reduceOptions.calcs[0])" | null},
+			{"lastNotNull"}
+		][0] // only consider [0] here as Perses's StatChart doesn't support individual calcs
 		calculation: [ // switch
 			if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
 			{ #defaultCalc }
@@ -14,7 +17,7 @@ if #panel.type != _|_ if #panel.type == "stat" {
 			}
 		}
 
-		if #panel.fieldConfig.defaults.thresholds != _|_ {
+		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.thresholds.steps != _|_ {
 			thresholds: {
 				// defaultColor: TODO how to fill this one?
 				steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part? 

--- a/cue/schemas/panels/time-series/migrate.cue
+++ b/cue/schemas/panels/time-series/migrate.cue
@@ -58,7 +58,7 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 		}
 		// thresholds
 		// -> migrate thresholds only if they are visible
-		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle.mode != "off" {
+		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.thresholds.steps != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle.mode != "off" {
 			thresholds: {
 				// defaultColor: TODO how to fill this one?
 				steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part?


### PR DESCRIPTION

# Description
Some of the fields are actually optional in grafana such as `fieldConfig.defaults.thresholds.steps` for stat and gauge panels.

For example,  [grafonnet](https://grafana.github.io/grafonnet/API/index.html) and [foundation-sdk](https://github.com/grafana/grafana-foundation-sdk) can generate perfectly fine grafana dashboards without those attributes. Dashboards then can be loaded to grafana and those attributes would be filled with defaults, but would fail to migrate to Perses due to migration will try to acces attributes that are missing.

This adds checks that those attributes exist before accessing them.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
