### PR TITLE
[ENHANCEMENT] migration: Handle collapsed/panels missing in row definition

### DIFF
--- a/internal/api/migrate/migrate.go
+++ b/internal/api/migrate/migrate.go
@@ -247,8 +247,8 @@ func rearrangeGrafanaPanelsWithinExpandedRows(grafanaDashboardRaw json.RawMessag
 
 		if panel["type"] == "row" {
 			if _, found := panel["collapsed"]; !found {
-				logrus.Error(errors.New("expected attribute `collapsed` not found in row"))
-				return grafanaDashboardRaw
+				// add collaped=false in row if missing
+				panel["collapsed"] = false
 			}
 			collapsed, ok := panel["collapsed"].(bool)
 			if !ok {
@@ -288,9 +288,9 @@ func rearrangeGrafanaPanelsWithinExpandedRows(grafanaDashboardRaw json.RawMessag
 				// panelB, <- current iterated panel
 				// ...
 				// -> in this case we have to move this non-row panel inside the saved parentRow
+				// add empty panels array to row if missing
 				if _, found := parentRow["panels"]; !found {
-					logrus.Error(errors.New("expected attribute `panels` not found in row"))
-					return grafanaDashboardRaw
+					parentRow["panels"] = []any{}
 				}
 				subPanelsList, ok := parentRow["panels"].([]any)
 				if !ok {

--- a/internal/api/migrate/testdata/expanded_rows_before.json
+++ b/internal/api/migrate/testdata/expanded_rows_before.json
@@ -66,9 +66,7 @@
     },
     {
       "title": "My 14th panel is an expanded row",
-      "type": "row",
-      "collapsed": false,
-      "panels": []
+      "type": "row"
     },
     {
       "title": "My 15th panel has a parent",


### PR DESCRIPTION
# Description
Similar to #2325 , panels and collapsed attributes may be missing in rows definitions, for example, when generated. Handling such situation in migrations.



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
