### PR TITLE
[ENHANCEMENT] migration: Map durations to seconds

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -18,6 +18,8 @@ import (
         m: "minutes"
         h: "hours"
         d: "days"
+        dtdurations: "seconds"
+        dtdurationms: "milliseconds"
         // percent units
         percent: "percent"
         percentunit: "percent-decimal"


### PR DESCRIPTION

# Description

Tiny patch that maps grafana durations (in seconds and ms) to seconds and milliseconds. Useful to migrate dashboards with panels showing 'Uptime'.


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
