### PR TITLE
[BUGFIX] Migration: Fix table migration fail when excludeByName is not present in transformation="organize"

### DIFF
--- a/cue/schemas/panels/table/migrate.cue
+++ b/cue/schemas/panels/table/migrate.cue
@@ -25,16 +25,19 @@ if #panel.type != _|_ if #panel.type == "table" {
 		// 		#var
 		// 	][0]
 		// }
-		// if #panel.transformations != _|_ for transformation in #panel.transformations if transformation.id == "organize" {
-		// 	for excludedColumn, value in transformation.options.excludeByName if value {
-		// 		let name = {_nameBuilder & {#var: excludedColumn}}.output
-		// 		_settingsGatherer: "\(name)": hide: true
-		// 	}
-		// 	for technicalName, displayName in transformation.options.renameByName {
-		// 		let name = {_nameBuilder & {#var: technicalName}}.output
-		// 		_settingsGatherer: "\(name)": headers: "\(displayName)": true
-		// 	}
-		// }
+		//if #panel.transformations != _|_ for transformation in #panel.transformations if transformation.id == "organize" {
+		//	if transformation.options.excludeByName != _|_ {
+		//		for excludedColumn, value in transformation.options.excludeByName if value {
+		//			let name = {_nameBuilder & {#var: excludedColumn}}.output
+		//			_settingsGatherer: "\(name)": hide: true
+		//		}}
+		//	if transformation.options.renameByName != _|_ {
+		//		for technicalName, displayName in transformation.options.renameByName {
+		//			let name = {_nameBuilder & {#var: technicalName}}.output
+		//			_settingsGatherer: "\(name)": headers: "\(displayName)": true
+		//		}
+		//	}
+		//}
 		// if #panel.fieldConfig.overrides != _|_ {
 		// 	for override in #panel.fieldConfig.overrides if override.matcher.id == "byName" && override.matcher.options != _|_ {
 		// 		for property in override.properties {


### PR DESCRIPTION
# Description
Fix table migration fail when excludeByName is not present in transformation="organize".
Note: Logic is currently disable altogther.
# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
