### PR TITLE
[ENHANCEMENT] Change timeseries panel's legend migration

### DIFF
--- a/cue/schemas/panels/time-series/migrate.cue
+++ b/cue/schemas/panels/time-series/migrate.cue
@@ -3,12 +3,13 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 	spec: {
 		// legend
 		 // NB: no support of former "show" attribute from Grafana, people should migrate to latest Grafana datamodel before migrating to Perses
-		if #panel.options.legend.showLegend != _|_ if #panel.options.legend.showLegend {
+		#showLegend: *#panel.options.legend.showLegend | true
+		if #panel.options.legend != _|_ if #showLegend {
 			legend: {
 				if #panel.type == "timeseries" {
 					position: [
-						if #panel.options.legend.placement == "bottom" { "bottom" },
-						if #panel.options.legend.placement == "right" { "right" },
+						if #panel.options.legend.placement != _|_ if #panel.options.legend.placement == "right" {"right"},
+						{"bottom"}
 					][0]
 					mode: [
 						if #panel.options.legend.displayMode == "list" { "list" },


### PR DESCRIPTION
# Description
Some of the fields are actually optional in grafana such as panel.options.legend.showLegend and panel.options.legend.placement for time series panels.

Using mixins for dashboard creation, we can get such block legend:
```
"legend": {
     "calcs": [ ],
     "displayMode": "list"
 },
```
And it'll be valid for grafana.

These changes allow to avoid errors when we have jsons with such format.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
