### PR TITLE
[ENHANCEMENT] TracingGanttChart: align span duration label location based on available space

### DIFF
--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.test.tsx
@@ -36,7 +36,21 @@ describe('SpanDuration', () => {
       viewport: { startTimeUnixMs: trace1_root.startTimeUnixMs, endTimeUnixMs: trace1_root.endTimeUnixMs },
     });
     expect(screen.getByText('150ms')).toBeInTheDocument();
+    expect(parseInt(screen.getByText('150ms').style.left)).toEqual(44); // 44%, on the right side of the span bar
     expect(screen.getByTestId('span-duration-bar').style.backgroundColor).toEqual('rgba(83, 83, 83, 0.9)');
+  });
+
+  it('render span bar duration on left side', () => {
+    renderComponent({
+      options: {},
+      span: trace1_root_child1_child1,
+      viewport: {
+        startTimeUnixMs: trace1_root.startTimeUnixMs + 290,
+        endTimeUnixMs: trace1_root.startTimeUnixMs + 400,
+      },
+    });
+    expect(screen.getByText('150ms')).toBeInTheDocument();
+    expect(parseInt(screen.getByText('150ms').style.left)).toEqual(9); // 9%, on the left side of the span bar
   });
 
   it('render span bar with colors from eCharts theme', () => {

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.tsx
@@ -47,6 +47,7 @@ export function SpanDuration(props: SpanDurationProps) {
           top: 0,
           bottom: 0,
           margin: 'auto',
+          minWidth: '2px',
           height: '8px',
           borderRadius: muiTheme.shape.borderRadius,
         }}
@@ -61,13 +62,21 @@ export function SpanDuration(props: SpanDurationProps) {
           position: 'absolute',
           top: '50%',
           transform: 'translateY(-50%)',
-          marginLeft: '8px',
+          padding: '0 8px',
           color: muiTheme.palette.grey[700],
           fontSize: '.7rem',
         }}
-        style={{
-          left: `${(relativeStart + relativeDuration) * 100}%`,
-        }}
+        style={
+          /* print span duration on right side of the span bar, if there is space */
+          relativeStart + relativeDuration < 0.95
+            ? {
+                left: `${(relativeStart + relativeDuration) * 100}%`,
+              }
+            : {
+                left: `${relativeStart * 100}%`,
+                transform: 'translateY(-50%) translateX(-100%)',
+              }
+        }
       >
         {formatDuration(spanDuration)}
       </Box>


### PR DESCRIPTION
# Description

TracingGanttChart: align span duration label location based on available space. Show the label on the left side if there is no space on the right side.

Additionally, set a `min-width` of `2px` for the span bar, otherwise span bars with very small durations would be invisible.

# Screenshots
The span duration label of the pink bar is shown on the left side, because there is no space on the right side:
![image](https://github.com/user-attachments/assets/4e252db3-5cf9-478b-852c-67080a38937e)

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
