### PR TITLE
[BUGFIX] TracingGanttChart: calculate start and end time from all spans

### DIFF
--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/DetailPane/DetailPane.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/DetailPane/DetailPane.tsx
@@ -15,12 +15,13 @@ import { Box, Divider, IconButton, Tab, Tabs, Typography } from '@mui/material';
 import { Span } from '@perses-dev/core';
 import { useState } from 'react';
 import CloseIcon from 'mdi-material-ui/Close';
+import { GanttTrace } from '../trace';
 import { AttributeLinks, AttributeList } from './Attributes';
 import { SpanEventList } from './SpanEvents';
 
 export interface DetailPaneProps {
   attributeLinks?: AttributeLinks;
-  rootSpan: Span;
+  trace: GanttTrace;
   span: Span;
   onCloseBtnClick: () => void;
 }
@@ -29,7 +30,7 @@ export interface DetailPaneProps {
  * DetailPane renders a sidebar showing the span attributes etc.
  */
 export function DetailPane(props: DetailPaneProps) {
-  const { attributeLinks, rootSpan, span, onCloseBtnClick } = props;
+  const { attributeLinks, trace, span, onCloseBtnClick } = props;
   const [tab, setTab] = useState<'attributes' | 'events'>('attributes');
 
   // if the events tab is selected, and then a span without events is clicked,
@@ -60,7 +61,7 @@ export function DetailPane(props: DetailPaneProps) {
           <AttributeList attributeLinks={attributeLinks} attributes={span.resource.attributes} />
         </>
       )}
-      {tab === 'events' && <SpanEventList rootSpan={rootSpan} span={span} />}
+      {tab === 'events' && <SpanEventList trace={trace} span={span} />}
     </Box>
   );
 }

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/DetailPane/SpanEvents.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/DetailPane/SpanEvents.test.tsx
@@ -13,7 +13,7 @@
 
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import { MOCK_TRACE } from '../../../../test';
+import { MOCK_GANTT_TRACE } from '../../../../test';
 import { SpanEventList, SpanEventListProps } from './SpanEvents';
 
 describe('SpanEvents', () => {
@@ -22,7 +22,7 @@ describe('SpanEvents', () => {
   };
 
   it('render', () => {
-    renderComponent({ rootSpan: MOCK_TRACE.rootSpan, span: MOCK_TRACE.rootSpan.childSpans[0]! });
+    renderComponent({ trace: MOCK_GANTT_TRACE, span: MOCK_GANTT_TRACE.rootSpan.childSpans[0]! });
 
     expect(screen.getByText('150ms')).toBeInTheDocument();
     expect(screen.getByText('event1_name')).toBeInTheDocument();

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/DetailPane/SpanEvents.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/DetailPane/SpanEvents.tsx
@@ -15,35 +15,36 @@ import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/
 import { Span, SpanEvent } from '@perses-dev/core';
 import ExpandMoreIcon from 'mdi-material-ui/ChevronDown';
 import { formatDuration } from '../utils';
+import { GanttTrace } from '../trace';
 import { AttributeList } from './Attributes';
 
 export interface SpanEventListProps {
-  rootSpan: Span;
+  trace: GanttTrace;
   span: Span;
 }
 
 export function SpanEventList(props: SpanEventListProps) {
-  const { rootSpan, span } = props;
+  const { trace, span } = props;
 
   return (
     <>
       {span.events
         .sort((a, b) => a.timeUnixMs - b.timeUnixMs)
         .map((event, i) => (
-          <SpanEventItem key={i} rootSpan={rootSpan} event={event} />
+          <SpanEventItem key={i} trace={trace} event={event} />
         ))}
     </>
   );
 }
 
 interface SpanEventItemProps {
-  rootSpan: Span;
+  trace: GanttTrace;
   event: SpanEvent;
 }
 
 function SpanEventItem(props: SpanEventItemProps) {
-  const { rootSpan, event } = props;
-  const relativeTime = event.timeUnixMs - rootSpan.startTimeUnixMs;
+  const { trace, event } = props;
+  const relativeTime = event.timeUnixMs - trace.startTimeUnixMs;
 
   return (
     <Accordion disableGutters>

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.test.tsx
@@ -15,7 +15,7 @@ import { render } from '@testing-library/react';
 import { fireEvent, screen } from '@testing-library/dom';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import { ChartsProvider, testChartsTheme } from '@perses-dev/components';
-import { MOCK_TRACE } from '../../../../test';
+import { MOCK_GANTT_TRACE } from '../../../../test';
 import { GanttTableProvider } from './GanttTableProvider';
 import { GanttTable, GanttTableProps } from './GanttTable';
 
@@ -36,10 +36,10 @@ describe('GanttTable', () => {
   it('render table', () => {
     renderComponent({
       options: {},
-      rootSpan: MOCK_TRACE.rootSpan,
+      trace: MOCK_GANTT_TRACE,
       viewport: {
-        startTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs,
-        endTimeUnixMs: MOCK_TRACE.rootSpan.endTimeUnixMs,
+        startTimeUnixMs: MOCK_GANTT_TRACE.startTimeUnixMs,
+        endTimeUnixMs: MOCK_GANTT_TRACE.endTimeUnixMs,
       },
     });
     expect(screen.getByText('testRootSpan')).toBeInTheDocument();
@@ -50,10 +50,10 @@ describe('GanttTable', () => {
   it('collapses a span on click', () => {
     renderComponent({
       options: {},
-      rootSpan: MOCK_TRACE.rootSpan,
+      trace: MOCK_GANTT_TRACE,
       viewport: {
-        startTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs,
-        endTimeUnixMs: MOCK_TRACE.rootSpan.endTimeUnixMs,
+        startTimeUnixMs: MOCK_GANTT_TRACE.startTimeUnixMs,
+        endTimeUnixMs: MOCK_GANTT_TRACE.endTimeUnixMs,
       },
     });
     fireEvent.click(screen.getAllByTitle('collapse')[1]!);

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTable.tsx
@@ -17,6 +17,7 @@ import { useMemo, useRef, useState } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { Viewport } from '../utils';
 import { TracingGanttChartOptions } from '../../gantt-chart-model';
+import { GanttTrace } from '../trace';
 import { useGanttTableContext } from './GanttTableProvider';
 import { GanttTableRow } from './GanttTableRow';
 import { GanttTableHeader } from './GanttTableHeader';
@@ -24,14 +25,14 @@ import { ResizableDivider } from './ResizableDivider';
 
 export interface GanttTableProps {
   options: TracingGanttChartOptions;
-  rootSpan: Span;
+  trace: GanttTrace;
   viewport: Viewport;
   selectedSpan?: Span;
   onSpanClick: (span: Span) => void;
 }
 
 export function GanttTable(props: GanttTableProps) {
-  const { options, rootSpan, viewport, selectedSpan, onSpanClick } = props;
+  const { options, trace, viewport, selectedSpan, onSpanClick } = props;
   const { collapsedSpans, setVisibleSpans } = useGanttTableContext();
   const [nameColumnWidth, setNameColumnWidth] = useState<number>(0.25);
   const tableRef = useRef<HTMLDivElement>(null);
@@ -39,9 +40,9 @@ export function GanttTable(props: GanttTableProps) {
 
   const rows = useMemo(() => {
     const rows: Span[] = [];
-    treeToRows(rows, rootSpan, collapsedSpans);
+    treeToRows(rows, trace.rootSpan, collapsedSpans);
     return rows;
-  }, [rootSpan, collapsedSpans]);
+  }, [trace.rootSpan, collapsedSpans]);
 
   const divider = <ResizableDivider parentRef={tableRef} onMove={setNameColumnWidth} />;
 
@@ -65,7 +66,7 @@ export function GanttTable(props: GanttTableProps) {
         borderRadius: `${theme.shape.borderRadius}px`,
       }}
     >
-      <GanttTableHeader rootSpan={rootSpan} viewport={viewport} nameColumnWidth={nameColumnWidth} divider={divider} />
+      <GanttTableHeader trace={trace} viewport={viewport} nameColumnWidth={nameColumnWidth} divider={divider} />
       <Virtuoso
         data={rows}
         itemContent={(_, span) => (

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTableHeader.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/GanttTableHeader.tsx
@@ -12,19 +12,19 @@
 // limitations under the License.
 
 import { Box, Stack, useTheme } from '@mui/material';
-import { Span } from '@perses-dev/core';
 import { Viewport, rowHeight } from '../utils';
 import { TicksHeader } from '../Ticks';
+import { GanttTrace } from '../trace';
 
 interface GanttTableHeaderProps {
-  rootSpan: Span;
+  trace: GanttTrace;
   viewport: Viewport;
   nameColumnWidth: number;
   divider: React.ReactNode;
 }
 
 export function GanttTableHeader(props: GanttTableHeaderProps) {
-  const { rootSpan, viewport, nameColumnWidth, divider } = props;
+  const { trace, viewport, nameColumnWidth, divider } = props;
   const theme = useTheme();
 
   return (
@@ -42,7 +42,7 @@ export function GanttTableHeader(props: GanttTableHeaderProps) {
       </Box>
       {divider}
       <Box sx={{ position: 'relative', height: '100%', flexGrow: 1 }}>
-        <TicksHeader rootSpan={rootSpan} viewport={viewport} />
+        <TicksHeader trace={trace} viewport={viewport} />
       </Box>
     </Stack>
   );

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.test.tsx
@@ -14,7 +14,7 @@
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
 import { ChartsProvider, testChartsTheme } from '@perses-dev/components';
-import { MOCK_TRACE } from '../../../../test';
+import { MOCK_GANTT_TRACE } from '../../../../test';
 import { GanttTableProvider } from './GanttTableProvider';
 import { SpanDuration, SpanDurationProps } from './SpanDuration';
 
@@ -32,10 +32,10 @@ describe('SpanDuration', () => {
   it('render span bar', () => {
     renderComponent({
       options: {},
-      span: MOCK_TRACE.rootSpan.childSpans[0]!.childSpans[0]!,
+      span: MOCK_GANTT_TRACE.rootSpan.childSpans[0]!.childSpans[0]!,
       viewport: {
-        startTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs,
-        endTimeUnixMs: MOCK_TRACE.rootSpan.endTimeUnixMs,
+        startTimeUnixMs: MOCK_GANTT_TRACE.startTimeUnixMs,
+        endTimeUnixMs: MOCK_GANTT_TRACE.endTimeUnixMs,
       },
     });
     expect(screen.getByText('150ms')).toBeInTheDocument();
@@ -46,10 +46,10 @@ describe('SpanDuration', () => {
   it('render span bar duration on left side', () => {
     renderComponent({
       options: {},
-      span: MOCK_TRACE.rootSpan.childSpans[0]!.childSpans[0]!,
+      span: MOCK_GANTT_TRACE.rootSpan.childSpans[0]!.childSpans[0]!,
       viewport: {
-        startTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs + 290,
-        endTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs + 400,
+        startTimeUnixMs: MOCK_GANTT_TRACE.startTimeUnixMs + 290,
+        endTimeUnixMs: MOCK_GANTT_TRACE.startTimeUnixMs + 400,
       },
     });
     expect(screen.getByText('150ms')).toBeInTheDocument();
@@ -59,10 +59,10 @@ describe('SpanDuration', () => {
   it('render span bar with colors from eCharts theme', () => {
     renderComponent({
       options: { visual: { palette: { mode: 'categorical' } } },
-      span: MOCK_TRACE.rootSpan.childSpans[0]!.childSpans[0]!,
+      span: MOCK_GANTT_TRACE.rootSpan.childSpans[0]!.childSpans[0]!,
       viewport: {
-        startTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs,
-        endTimeUnixMs: MOCK_TRACE.rootSpan.endTimeUnixMs,
+        startTimeUnixMs: MOCK_GANTT_TRACE.startTimeUnixMs,
+        endTimeUnixMs: MOCK_GANTT_TRACE.endTimeUnixMs,
       },
     });
     expect(screen.getByText('150ms')).toBeInTheDocument();

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanDuration.tsx
@@ -14,7 +14,7 @@
 import { Box, useTheme } from '@mui/material';
 import { Span } from '@perses-dev/core';
 import { useChartsTheme } from '@perses-dev/components';
-import { Viewport, formatDuration, getSpanColor } from '../utils';
+import { Viewport, formatDuration, getSpanColor, minSpanWidthPx } from '../utils';
 import { Ticks } from '../Ticks';
 import { TracingGanttChartOptions } from '../../gantt-chart-model';
 
@@ -47,7 +47,7 @@ export function SpanDuration(props: SpanDurationProps) {
           top: 0,
           bottom: 0,
           margin: 'auto',
-          minWidth: '2px',
+          minWidth: `${minSpanWidthPx}px`,
           height: '8px',
           borderRadius: muiTheme.shape.borderRadius,
         }}

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanName.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/GanttTable/SpanName.test.tsx
@@ -13,7 +13,7 @@
 
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import { MOCK_TRACE } from '../../../../test';
+import { MOCK_GANTT_TRACE } from '../../../../test';
 import { SpanName, SpanNameProps } from './SpanName';
 import { GanttTableProvider } from './GanttTableProvider';
 
@@ -27,13 +27,13 @@ describe('SpanName', () => {
   };
 
   it('render span name without error', () => {
-    renderComponent({ span: MOCK_TRACE.rootSpan.childSpans[0]!.childSpans[0]! });
+    renderComponent({ span: MOCK_GANTT_TRACE.rootSpan.childSpans[0]!.childSpans[0]! });
     expect(screen.getByText('testChildSpan3')).toBeInTheDocument();
     expect(screen.queryByText('error')).not.toBeInTheDocument();
   });
 
   it('render span name with error', () => {
-    renderComponent({ span: MOCK_TRACE.rootSpan.childSpans[0]! });
+    renderComponent({ span: MOCK_GANTT_TRACE.rootSpan.childSpans[0]! });
     expect(screen.getByText('testChildSpan2')).toBeInTheDocument();
     expect(screen.getByText('error')).toBeInTheDocument();
   });

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/MiniGanttChart.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/MiniGanttChart.tsx
@@ -12,21 +12,21 @@
 // limitations under the License.
 
 import { Box, useTheme } from '@mui/material';
-import { Span } from '@perses-dev/core';
 import { TicksHeader } from '../Ticks';
 import { Viewport, rowHeight } from '../utils';
 import { TracingGanttChartOptions } from '../../gantt-chart-model';
+import { GanttTrace } from '../trace';
 import { Canvas } from './Canvas';
 
 interface MiniGanttChartProps {
   options: TracingGanttChartOptions;
-  rootSpan: Span;
+  trace: GanttTrace;
   viewport: Viewport;
   setViewport: (v: Viewport) => void;
 }
 
 export function MiniGanttChart(props: MiniGanttChartProps) {
-  const { options, rootSpan, viewport, setViewport } = props;
+  const { options, trace, viewport, setViewport } = props;
   const theme = useTheme();
 
   return (
@@ -37,9 +37,12 @@ export function MiniGanttChart(props: MiniGanttChartProps) {
       }}
     >
       <Box sx={{ position: 'relative', height: rowHeight, borderBottom: `1px solid ${theme.palette.divider}` }}>
-        <TicksHeader rootSpan={rootSpan} viewport={rootSpan} />
+        <TicksHeader
+          trace={trace}
+          viewport={{ startTimeUnixMs: trace.startTimeUnixMs, endTimeUnixMs: trace.endTimeUnixMs }}
+        />
       </Box>
-      <Canvas options={options} rootSpan={rootSpan} viewport={viewport} setViewport={setViewport} />
+      <Canvas options={options} trace={trace} viewport={viewport} setViewport={setViewport} />
     </Box>
   );
 }

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/draw.ts
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/MiniGanttChart/draw.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 
 import { Span } from '@perses-dev/core';
+import { GanttTrace } from '../trace';
+import { minSpanWidthPx } from '../utils';
 
 const MIN_BAR_HEIGHT = 1;
 const MAX_BAR_HEIGHT = 7;
@@ -28,25 +30,30 @@ export function drawSpans(
   ctx: CanvasRenderingContext2D,
   width: number,
   height: number,
-  rootSpan: Span,
+  trace: GanttTrace,
   spanColorGenerator: (span: Span) => string
 ) {
   // calculate optimal height, enforce min and max bar height and finally round to an integer
-  const numSpans = countSpans(rootSpan);
+  const numSpans = countSpans(trace.rootSpan);
   const barHeight = Math.round(Math.min(Math.max(height / numSpans, MIN_BAR_HEIGHT), MAX_BAR_HEIGHT));
 
-  const traceDuration = rootSpan.endTimeUnixMs - rootSpan.startTimeUnixMs;
+  const traceDuration = trace.endTimeUnixMs - trace.startTimeUnixMs;
   const yChange = height / numSpans;
   let y = 0;
 
   const drawSpan = (span: Span) => {
     const spanDuration = span.endTimeUnixMs - span.startTimeUnixMs;
     const relativeDuration = spanDuration / traceDuration;
-    const relativeStart = (span.startTimeUnixMs - rootSpan.startTimeUnixMs) / traceDuration;
+    const relativeStart = (span.startTimeUnixMs - trace.startTimeUnixMs) / traceDuration;
 
     ctx.fillStyle = spanColorGenerator(span);
     ctx.beginPath();
-    ctx.rect(Math.round(relativeStart * width), Math.round(y), Math.round(relativeDuration * width), barHeight);
+    ctx.rect(
+      Math.round(relativeStart * width),
+      Math.round(y),
+      Math.max(minSpanWidthPx, Math.round(relativeDuration * width)),
+      barHeight
+    );
     ctx.fill();
     y += yChange;
 
@@ -55,5 +62,5 @@ export function drawSpans(
     }
   };
 
-  drawSpan(rootSpan);
+  drawSpan(trace.rootSpan);
 }

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/Ticks.test.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/Ticks.test.tsx
@@ -13,7 +13,7 @@
 
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import { MOCK_TRACE } from '../../../test';
+import { MOCK_GANTT_TRACE } from '../../../test';
 import { TicksHeader, TicksHeaderProps } from './Ticks';
 
 describe('Ticks', () => {
@@ -23,11 +23,8 @@ describe('Ticks', () => {
 
   it('render <TicksHeader>', () => {
     renderComponent({
-      rootSpan: MOCK_TRACE.rootSpan,
-      viewport: {
-        startTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs,
-        endTimeUnixMs: MOCK_TRACE.rootSpan.endTimeUnixMs,
-      },
+      trace: MOCK_GANTT_TRACE,
+      viewport: { startTimeUnixMs: MOCK_GANTT_TRACE.startTimeUnixMs, endTimeUnixMs: MOCK_GANTT_TRACE.endTimeUnixMs },
     });
     expect(screen.getByText('0μs')).toBeInTheDocument();
     expect(screen.getByText('250ms')).toBeInTheDocument();

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/Ticks.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/Ticks.tsx
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 import { Box, styled } from '@mui/material';
-import { Span } from '@perses-dev/core';
 import { Viewport, formatDuration } from './utils';
+import { GanttTrace } from './trace';
 
 export interface TicksHeaderProps {
-  rootSpan: Span;
+  trace: GanttTrace;
   viewport: Viewport;
 }
 
@@ -24,10 +24,10 @@ export interface TicksHeaderProps {
  * TicksHeader renders all tick labels in the header
  */
 export function TicksHeader(props: TicksHeaderProps) {
-  const { rootSpan, viewport } = props;
+  const { trace, viewport } = props;
 
   const duration = viewport.endTimeUnixMs - viewport.startTimeUnixMs;
-  const startAt = viewport.startTimeUnixMs - rootSpan.startTimeUnixMs;
+  const startAt = viewport.startTimeUnixMs - trace.startTimeUnixMs;
 
   return (
     <>

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.stories.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.stories.tsx
@@ -16,13 +16,13 @@ import { MOCK_TRACE } from '../../../test';
 import { TracingGanttChart } from './TracingGanttChart';
 
 const exampleTraces = {
-  Demo: MOCK_TRACE.rootSpan,
+  Demo: MOCK_TRACE,
 };
 
 const meta: Meta<typeof TracingGanttChart> = {
   component: TracingGanttChart,
   argTypes: {
-    rootSpan: {
+    trace: {
       options: Object.keys(exampleTraces),
       mapping: exampleTraces,
     },
@@ -42,6 +42,6 @@ export const Primary: Story = {
         },
       },
     },
-    rootSpan: MOCK_TRACE.rootSpan,
+    trace: exampleTraces.Demo,
   },
 };

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/TracingGanttChart.tsx
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Box, Stack, useTheme } from '@mui/material';
-import { Span } from '@perses-dev/core';
+import { Span, Trace } from '@perses-dev/core';
 import { TracingGanttChartOptions } from '../gantt-chart-model';
 import { MiniGanttChart } from './MiniGanttChart/MiniGanttChart';
 import { DetailPane } from './DetailPane/DetailPane';
@@ -22,11 +22,12 @@ import { GanttTable } from './GanttTable/GanttTable';
 import { GanttTableProvider } from './GanttTable/GanttTableProvider';
 import { ResizableDivider } from './GanttTable/ResizableDivider';
 import { AttributeLinks } from './DetailPane/Attributes';
+import { getTraceModel } from './trace';
 
 export interface TracingGanttChartProps {
   options: TracingGanttChartOptions;
   attributeLinks?: AttributeLinks;
-  rootSpan: Span;
+  trace: Trace;
 }
 
 /**
@@ -36,14 +37,18 @@ export interface TracingGanttChartProps {
  * https://github.com/jaegertracing/jaeger-ui
  */
 export function TracingGanttChart(props: TracingGanttChartProps) {
-  const { options, attributeLinks, rootSpan } = props;
+  const { options, attributeLinks, trace: coreTrace } = props;
 
   const theme = useTheme();
-  const [selectedSpan, setSelectedSpan] = useState<Span | undefined>(undefined);
+  const trace = useMemo(() => {
+    // calculate (and memoize) common properties, for example start and end time of the trace
+    return getTraceModel(coreTrace);
+  }, [coreTrace]);
   const [viewport, setViewport] = useState<Viewport>({
-    startTimeUnixMs: rootSpan.startTimeUnixMs,
-    endTimeUnixMs: rootSpan.endTimeUnixMs,
+    startTimeUnixMs: trace.startTimeUnixMs,
+    endTimeUnixMs: trace.endTimeUnixMs,
   });
+  const [selectedSpan, setSelectedSpan] = useState<Span | undefined>(undefined);
 
   const ganttChart = useRef<HTMLDivElement>(null);
   // tableWidth only comes to effect if the detail pane is visible.
@@ -54,11 +59,11 @@ export function TracingGanttChart(props: TracingGanttChartProps) {
   return (
     <Stack ref={ganttChart} direction="row" sx={{ height: '100%', minHeight: '240px', gap }}>
       <Stack sx={{ flexGrow: 1, gap }}>
-        <MiniGanttChart options={options} rootSpan={rootSpan} viewport={viewport} setViewport={setViewport} />
+        <MiniGanttChart options={options} trace={trace} viewport={viewport} setViewport={setViewport} />
         <GanttTableProvider>
           <GanttTable
             options={options}
-            rootSpan={rootSpan}
+            trace={trace}
             viewport={viewport}
             selectedSpan={selectedSpan}
             onSpanClick={setSelectedSpan}
@@ -71,7 +76,7 @@ export function TracingGanttChart(props: TracingGanttChartProps) {
           <Box sx={{ width: `${(1 - tableWidth) * 100}%`, overflow: 'auto' }}>
             <DetailPane
               attributeLinks={attributeLinks}
-              rootSpan={rootSpan}
+              trace={trace}
               span={selectedSpan}
               onCloseBtnClick={() => setSelectedSpan(undefined)}
             />

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/trace.test.ts
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/trace.test.ts
@@ -1,0 +1,29 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { MOCK_TRACE, MOCK_TRACE_ASYNC } from '../../../test';
+import { getTraceModel } from './trace';
+
+describe('trace', () => {
+  it('computes a GanttTrace model from a trace', () => {
+    const ganttTrace = getTraceModel(MOCK_TRACE);
+    expect(ganttTrace.startTimeUnixMs).toEqual(1000);
+    expect(ganttTrace.endTimeUnixMs).toEqual(2000);
+  });
+
+  it('computes a GanttTrace model from a trace where trace duration != root span duration', () => {
+    const ganttTrace = getTraceModel(MOCK_TRACE_ASYNC);
+    expect(ganttTrace.startTimeUnixMs).toEqual(1729001599633.602);
+    expect(ganttTrace.endTimeUnixMs).toEqual(1729001599964.748);
+  });
+});

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/trace.ts
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/trace.ts
@@ -1,0 +1,52 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Span, Trace } from '@perses-dev/core';
+
+/** holds the trace and computed properties required for the Gantt chart */
+export interface GanttTrace {
+  rootSpan: Span;
+
+  // computed properties of the rootSpan
+  startTimeUnixMs: number;
+  endTimeUnixMs: number;
+}
+
+/** this function precomputes common fields, for example the start and end time of a trace */
+export function getTraceModel(trace: Trace): GanttTrace {
+  const limits = { startTimeUnixMs: trace.rootSpan.startTimeUnixMs, endTimeUnixMs: trace.rootSpan.endTimeUnixMs };
+  getStartAndEndTime(trace.rootSpan, limits);
+
+  return {
+    rootSpan: trace.rootSpan,
+    startTimeUnixMs: limits.startTimeUnixMs,
+    endTimeUnixMs: limits.endTimeUnixMs,
+  };
+}
+
+/**
+ * Compute the start and end of a trace.
+ * In most cases (but not all) this is rootSpan.startTime / rootSpan.endTime.
+ */
+function getStartAndEndTime(span: Span, limits: { startTimeUnixMs: number; endTimeUnixMs: number }) {
+  if (span.startTimeUnixMs < limits.startTimeUnixMs) {
+    limits.startTimeUnixMs = span.startTimeUnixMs;
+  }
+  if (span.endTimeUnixMs > limits.endTimeUnixMs) {
+    limits.endTimeUnixMs = span.endTimeUnixMs;
+  }
+
+  for (const child of span.childSpans) {
+    getStartAndEndTime(child, limits);
+  }
+}

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/utils.ts
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChart/utils.ts
@@ -24,6 +24,8 @@ export interface Viewport {
   endTimeUnixMs: number;
 }
 
+/** minimum span width, i.e. increase width if the calculated width is too small to be visible */
+export const minSpanWidthPx = 2;
 export const rowHeight = '2rem';
 export const spanHasError = (span: Span) => span.status?.code === SpanStatusError;
 

--- a/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/tracing-gantt-chart/TracingGanttChartPanel.tsx
@@ -55,7 +55,7 @@ export function TracingGanttChartPanel(props: TracingGanttChartPanelProps) {
 
   return (
     <Box sx={{ height: '100%', padding: `${contentPadding}px` }}>
-      <TracingGanttChart options={spec} attributeLinks={attributeLinks} rootSpan={trace.rootSpan} />
+      <TracingGanttChart options={spec} attributeLinks={attributeLinks} trace={trace} />
     </Box>
   );
 }

--- a/ui/panels-plugin/src/test/get-trace-data-jaeger.ts
+++ b/ui/panels-plugin/src/test/get-trace-data-jaeger.ts
@@ -1,0 +1,147 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Span, Trace, TraceAttribute, TraceAttributeValue, TraceResource } from '@perses-dev/core';
+
+// the following jaeger data types and parsing function should eventually be moved to a jaeger plugin
+
+export interface JaegerTrace {
+  traceID: string;
+  spans: JaegerSpan[];
+  processes: unknown;
+  warnings: unknown;
+}
+
+export interface JaegerSpan {
+  traceID: string;
+  spanID: string;
+  hasChildren: boolean;
+  childSpanIds: string[];
+  depth: number;
+  processID: string;
+  process: JaegerProcess;
+
+  operationName: string;
+  /** start time in microseconds */
+  startTime: number;
+  relativeStartTime: number;
+  duration: number;
+  tags: JaegerTag[];
+  references: unknown;
+  logs: unknown;
+  warnings: unknown;
+}
+
+interface JaegerProcess {
+  serviceName: string;
+  tags: JaegerTag[];
+}
+
+type JaegerTag =
+  | {
+      type: 'string';
+      key: string;
+      value: string;
+    }
+  | {
+      type: 'int64';
+      key: string;
+      value: number;
+    };
+
+function parseTag(tags: JaegerTag): TraceAttribute {
+  let value: TraceAttributeValue;
+  switch (tags.type) {
+    case 'string':
+      value = { stringValue: tags.value };
+      break;
+    case 'int64':
+      value = { intValue: tags.value.toString() };
+      break;
+    default:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      throw new Error(`unknown jaeger tag type ${(tags as any).type}`);
+  }
+  return { key: tags.key, value };
+}
+
+function parseProcess(process: JaegerProcess): TraceResource {
+  return {
+    serviceName: process.serviceName,
+    attributes: process.tags.map(parseTag),
+  };
+}
+
+function parseSpan(span: JaegerSpan) {
+  return {
+    traceId: span.traceID,
+    spanId: span.spanID,
+    name: span.operationName,
+    kind: '',
+    startTimeUnixMs: span.startTime / 1000,
+    endTimeUnixMs: (span.startTime + span.duration) / 1000,
+    attributes: span.tags.map(parseTag),
+    events: [],
+    status: {},
+  };
+}
+
+export function parseJaegerTrace(jaegerTrace: JaegerTrace): Trace {
+  // first pass: build lookup table <spanId, Span>
+  const lookup = new Map<string, Span>();
+  for (const jaegerSpan of jaegerTrace.spans) {
+    const span: Span = {
+      resource: parseProcess(jaegerSpan.process),
+      scope: {
+        name: jaegerSpan.processID,
+      },
+      childSpans: [],
+      ...parseSpan(jaegerSpan),
+    };
+    lookup.set(jaegerSpan.spanID, span);
+  }
+
+  // second pass: build tree based on childSpanIds property
+  let rootSpan: Span | null = null;
+  for (const jaegerSpan of jaegerTrace.spans) {
+    const span = lookup.get(jaegerSpan.spanID);
+    if (!span) {
+      continue;
+    }
+
+    if (jaegerSpan.depth === 0) {
+      rootSpan = span;
+    }
+
+    const childSpans: Span[] = [];
+    for (const childSpanId of jaegerSpan.childSpanIds) {
+      const childSpan = lookup.get(childSpanId);
+      if (!childSpan) {
+        continue;
+      }
+
+      childSpan.parentSpan = span;
+      childSpan.parentSpanId = span.spanId;
+      childSpans.push(childSpan);
+    }
+    span.childSpans = childSpans.sort((a, b) => a.startTimeUnixMs - b.startTimeUnixMs);
+  }
+
+  if (!rootSpan) {
+    throw new Error('root span not found');
+  }
+
+  return {
+    rootSpan,
+  };
+}

--- a/ui/panels-plugin/src/test/mock-trace-data.ts
+++ b/ui/panels-plugin/src/test/mock-trace-data.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 
 import { Span, Trace, TraceData } from '@perses-dev/core';
+import { GanttTrace } from '../plugins/tracing-gantt-chart/TracingGanttChart/trace';
+import { JaegerTrace, parseJaegerTrace } from './get-trace-data-jaeger';
 
 function addParentReferences(span: Span) {
   for (const child of span.childSpans) {
@@ -188,3 +190,696 @@ export const MOCK_TRACE: Trace = {
   },
 };
 addParentReferences(MOCK_TRACE.rootSpan);
+
+export const MOCK_GANTT_TRACE: GanttTrace = {
+  rootSpan: MOCK_TRACE.rootSpan,
+  startTimeUnixMs: MOCK_TRACE.rootSpan.startTimeUnixMs,
+  endTimeUnixMs: MOCK_TRACE.rootSpan.endTimeUnixMs,
+};
+
+const MOCK_JAEGER_TRACE_ASYNC: JaegerTrace = {
+  traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+  spans: [
+    {
+      traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+      spanID: 'b93f60c81f2a4ce0',
+      operationName: 'script',
+      references: [],
+      startTime: 1729001599633602,
+      duration: 3,
+      tags: [
+        {
+          key: 'span.kind',
+          type: 'string',
+          value: 'client',
+        },
+      ],
+      logs: [],
+      processID: 'p1',
+      warnings: [],
+      process: {
+        serviceName: 'hermes',
+        tags: [
+          {
+            key: 'otel.library.name',
+            type: 'string',
+            value: 'hermes_client',
+          },
+          {
+            key: 'telemetry.sdk.language',
+            type: 'string',
+            value: 'cpp',
+          },
+          {
+            key: 'telemetry.sdk.name',
+            type: 'string',
+            value: 'opentelemetry',
+          },
+          {
+            key: 'telemetry.sdk.version',
+            type: 'string',
+            value: '1.12.0',
+          },
+        ],
+      },
+      relativeStartTime: 0,
+      depth: 0,
+      hasChildren: true,
+      childSpanIds: ['4653459b582b47cb', '8a83db29894c10c4', '0bd40fdf749d38af', '5b6c5367c8f55a07'],
+    },
+    {
+      traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+      spanID: '5b6c5367c8f55a07',
+      operationName: 'post1',
+      references: [
+        {
+          refType: 'CHILD_OF',
+          traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+          spanID: 'b93f60c81f2a4ce0',
+          span: {
+            traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+            spanID: 'b93f60c81f2a4ce0',
+            operationName: 'script',
+            references: [],
+            startTime: 1729001599633602,
+            duration: 3,
+            tags: [
+              {
+                key: 'span.kind',
+                type: 'string',
+                value: 'client',
+              },
+            ],
+            logs: [],
+            processID: 'p1',
+            warnings: [],
+            process: {
+              serviceName: 'hermes',
+              tags: [
+                {
+                  key: 'otel.library.name',
+                  type: 'string',
+                  value: 'hermes_client',
+                },
+                {
+                  key: 'telemetry.sdk.language',
+                  type: 'string',
+                  value: 'cpp',
+                },
+                {
+                  key: 'telemetry.sdk.name',
+                  type: 'string',
+                  value: 'opentelemetry',
+                },
+                {
+                  key: 'telemetry.sdk.version',
+                  type: 'string',
+                  value: '1.12.0',
+                },
+              ],
+            },
+            relativeStartTime: 0,
+            depth: 0,
+            hasChildren: true,
+            childSpanIds: ['4653459b582b47cb', '8a83db29894c10c4', '0bd40fdf749d38af', '5b6c5367c8f55a07'],
+          },
+        },
+      ],
+      startTime: 1729001599633651,
+      duration: 3081,
+      tags: [
+        {
+          key: 'http.request.method',
+          type: 'string',
+          value: 'POST',
+        },
+        {
+          key: 'http.response.status_code',
+          type: 'int64',
+          value: 200,
+        },
+        {
+          key: 'otel.status_code',
+          type: 'string',
+          value: 'OK',
+        },
+        {
+          key: 'span.kind',
+          type: 'string',
+          value: 'client',
+        },
+        {
+          key: 'url.full',
+          type: 'string',
+          value: 'http://server-mock:8080/url/example/path/id-24',
+        },
+      ],
+      logs: [
+        {
+          timestamp: 1729001599633766,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Request sent',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599636650,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Response received',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599636673,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Body received',
+            },
+          ],
+        },
+      ],
+      processID: 'p1',
+      warnings: [],
+      process: {
+        serviceName: 'hermes',
+        tags: [
+          {
+            key: 'otel.library.name',
+            type: 'string',
+            value: 'hermes_client',
+          },
+          {
+            key: 'telemetry.sdk.language',
+            type: 'string',
+            value: 'cpp',
+          },
+          {
+            key: 'telemetry.sdk.name',
+            type: 'string',
+            value: 'opentelemetry',
+          },
+          {
+            key: 'telemetry.sdk.version',
+            type: 'string',
+            value: '1.12.0',
+          },
+        ],
+      },
+      relativeStartTime: 49,
+      depth: 1,
+      hasChildren: false,
+      childSpanIds: [],
+    },
+    {
+      traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+      spanID: '0bd40fdf749d38af',
+      operationName: 'get1',
+      references: [
+        {
+          refType: 'CHILD_OF',
+          traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+          spanID: 'b93f60c81f2a4ce0',
+          span: {
+            traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+            spanID: 'b93f60c81f2a4ce0',
+            operationName: 'script',
+            references: [],
+            startTime: 1729001599633602,
+            duration: 3,
+            tags: [
+              {
+                key: 'span.kind',
+                type: 'string',
+                value: 'client',
+              },
+            ],
+            logs: [],
+            processID: 'p1',
+            warnings: [],
+            process: {
+              serviceName: 'hermes',
+              tags: [
+                {
+                  key: 'otel.library.name',
+                  type: 'string',
+                  value: 'hermes_client',
+                },
+                {
+                  key: 'telemetry.sdk.language',
+                  type: 'string',
+                  value: 'cpp',
+                },
+                {
+                  key: 'telemetry.sdk.name',
+                  type: 'string',
+                  value: 'opentelemetry',
+                },
+                {
+                  key: 'telemetry.sdk.version',
+                  type: 'string',
+                  value: '1.12.0',
+                },
+              ],
+            },
+            relativeStartTime: 0,
+            depth: 0,
+            hasChildren: true,
+            childSpanIds: ['4653459b582b47cb', '8a83db29894c10c4', '0bd40fdf749d38af', '5b6c5367c8f55a07'],
+          },
+        },
+      ],
+      startTime: 1729001599733700,
+      duration: 2719,
+      tags: [
+        {
+          key: 'http.request.method',
+          type: 'string',
+          value: 'GET',
+        },
+        {
+          key: 'http.response.status_code',
+          type: 'int64',
+          value: 200,
+        },
+        {
+          key: 'otel.status_code',
+          type: 'string',
+          value: 'OK',
+        },
+        {
+          key: 'span.kind',
+          type: 'string',
+          value: 'client',
+        },
+        {
+          key: 'url.full',
+          type: 'string',
+          value: 'http://server-mock:8080/url/example/path?id=id-24',
+        },
+      ],
+      logs: [
+        {
+          timestamp: 1729001599733877,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Request sent',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599736343,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Response received',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599736364,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Body received',
+            },
+          ],
+        },
+      ],
+      processID: 'p1',
+      warnings: [],
+      process: {
+        serviceName: 'hermes',
+        tags: [
+          {
+            key: 'otel.library.name',
+            type: 'string',
+            value: 'hermes_client',
+          },
+          {
+            key: 'telemetry.sdk.language',
+            type: 'string',
+            value: 'cpp',
+          },
+          {
+            key: 'telemetry.sdk.name',
+            type: 'string',
+            value: 'opentelemetry',
+          },
+          {
+            key: 'telemetry.sdk.version',
+            type: 'string',
+            value: '1.12.0',
+          },
+        ],
+      },
+      relativeStartTime: 100098,
+      depth: 1,
+      hasChildren: false,
+      childSpanIds: [],
+    },
+    {
+      traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+      spanID: '8a83db29894c10c4',
+      operationName: 'put1',
+      references: [
+        {
+          refType: 'CHILD_OF',
+          traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+          spanID: 'b93f60c81f2a4ce0',
+          span: {
+            traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+            spanID: 'b93f60c81f2a4ce0',
+            operationName: 'script',
+            references: [],
+            startTime: 1729001599633602,
+            duration: 3,
+            tags: [
+              {
+                key: 'span.kind',
+                type: 'string',
+                value: 'client',
+              },
+            ],
+            logs: [],
+            processID: 'p1',
+            warnings: [],
+            process: {
+              serviceName: 'hermes',
+              tags: [
+                {
+                  key: 'otel.library.name',
+                  type: 'string',
+                  value: 'hermes_client',
+                },
+                {
+                  key: 'telemetry.sdk.language',
+                  type: 'string',
+                  value: 'cpp',
+                },
+                {
+                  key: 'telemetry.sdk.name',
+                  type: 'string',
+                  value: 'opentelemetry',
+                },
+                {
+                  key: 'telemetry.sdk.version',
+                  type: 'string',
+                  value: '1.12.0',
+                },
+              ],
+            },
+            relativeStartTime: 0,
+            depth: 0,
+            hasChildren: true,
+            childSpanIds: ['4653459b582b47cb', '8a83db29894c10c4', '0bd40fdf749d38af', '5b6c5367c8f55a07'],
+          },
+        },
+      ],
+      startTime: 1729001599833654,
+      duration: 2803,
+      tags: [
+        {
+          key: 'http.request.method',
+          type: 'string',
+          value: 'PUT',
+        },
+        {
+          key: 'http.response.status_code',
+          type: 'int64',
+          value: 200,
+        },
+        {
+          key: 'otel.status_code',
+          type: 'string',
+          value: 'OK',
+        },
+        {
+          key: 'span.kind',
+          type: 'string',
+          value: 'client',
+        },
+        {
+          key: 'url.full',
+          type: 'string',
+          value: 'http://server-mock:8080/url/example/path/id-24',
+        },
+      ],
+      logs: [
+        {
+          timestamp: 1729001599833794,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Request sent',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599836396,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Response received',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599836408,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Body received',
+            },
+          ],
+        },
+      ],
+      processID: 'p1',
+      warnings: [],
+      process: {
+        serviceName: 'hermes',
+        tags: [
+          {
+            key: 'otel.library.name',
+            type: 'string',
+            value: 'hermes_client',
+          },
+          {
+            key: 'telemetry.sdk.language',
+            type: 'string',
+            value: 'cpp',
+          },
+          {
+            key: 'telemetry.sdk.name',
+            type: 'string',
+            value: 'opentelemetry',
+          },
+          {
+            key: 'telemetry.sdk.version',
+            type: 'string',
+            value: '1.12.0',
+          },
+        ],
+      },
+      relativeStartTime: 200052,
+      depth: 1,
+      hasChildren: false,
+      childSpanIds: [],
+    },
+    {
+      traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+      spanID: '4653459b582b47cb',
+      operationName: 'delete1',
+      references: [
+        {
+          refType: 'CHILD_OF',
+          traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+          spanID: 'b93f60c81f2a4ce0',
+          span: {
+            traceID: '7d73f3ae841bf59a74cf5b52a328cfca',
+            spanID: 'b93f60c81f2a4ce0',
+            operationName: 'script',
+            references: [],
+            startTime: 1729001599633602,
+            duration: 3,
+            tags: [
+              {
+                key: 'span.kind',
+                type: 'string',
+                value: 'client',
+              },
+            ],
+            logs: [],
+            processID: 'p1',
+            warnings: [],
+            process: {
+              serviceName: 'hermes',
+              tags: [
+                {
+                  key: 'otel.library.name',
+                  type: 'string',
+                  value: 'hermes_client',
+                },
+                {
+                  key: 'telemetry.sdk.language',
+                  type: 'string',
+                  value: 'cpp',
+                },
+                {
+                  key: 'telemetry.sdk.name',
+                  type: 'string',
+                  value: 'opentelemetry',
+                },
+                {
+                  key: 'telemetry.sdk.version',
+                  type: 'string',
+                  value: '1.12.0',
+                },
+              ],
+            },
+            relativeStartTime: 0,
+            depth: 0,
+            hasChildren: true,
+            childSpanIds: ['4653459b582b47cb', '8a83db29894c10c4', '0bd40fdf749d38af', '5b6c5367c8f55a07'],
+          },
+        },
+      ],
+      startTime: 1729001599944592,
+      duration: 20156,
+      tags: [
+        {
+          key: 'http.request.method',
+          type: 'string',
+          value: 'DELETE',
+        },
+        {
+          key: 'http.response.status_code',
+          type: 'int64',
+          value: 200,
+        },
+        {
+          key: 'otel.status_code',
+          type: 'string',
+          value: 'OK',
+        },
+        {
+          key: 'span.kind',
+          type: 'string',
+          value: 'client',
+        },
+        {
+          key: 'url.full',
+          type: 'string',
+          value: 'http://server-mock:8080/url/example/path/id-24',
+        },
+      ],
+      logs: [
+        {
+          timestamp: 1729001599944786,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Request sent',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599964619,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Response received',
+            },
+          ],
+        },
+        {
+          timestamp: 1729001599964650,
+          fields: [
+            {
+              key: 'event',
+              type: 'string',
+              value: 'Body received',
+            },
+          ],
+        },
+      ],
+      processID: 'p1',
+      warnings: [],
+      process: {
+        serviceName: 'hermes',
+        tags: [
+          {
+            key: 'otel.library.name',
+            type: 'string',
+            value: 'hermes_client',
+          },
+          {
+            key: 'telemetry.sdk.language',
+            type: 'string',
+            value: 'cpp',
+          },
+          {
+            key: 'telemetry.sdk.name',
+            type: 'string',
+            value: 'opentelemetry',
+          },
+          {
+            key: 'telemetry.sdk.version',
+            type: 'string',
+            value: '1.12.0',
+          },
+        ],
+      },
+      relativeStartTime: 310990,
+      depth: 1,
+      hasChildren: false,
+      childSpanIds: [],
+    },
+  ],
+  processes: {
+    p1: {
+      serviceName: 'hermes',
+      tags: [
+        {
+          key: 'otel.library.name',
+          type: 'string',
+          value: 'hermes_client',
+        },
+        {
+          key: 'telemetry.sdk.language',
+          type: 'string',
+          value: 'cpp',
+        },
+        {
+          key: 'telemetry.sdk.name',
+          type: 'string',
+          value: 'opentelemetry',
+        },
+        {
+          key: 'telemetry.sdk.version',
+          type: 'string',
+          value: '1.12.0',
+        },
+      ],
+    },
+  },
+  warnings: null,
+};
+
+export const MOCK_TRACE_ASYNC = parseJaegerTrace(MOCK_JAEGER_TRACE_ASYNC);


### PR DESCRIPTION
# Description

In some cases, the trace start and end time does not match the start and end time of the root span (in other words, some spans are in progress or started after the root span has ended).

* compute and memoize start and end time of the trace by scanning all spans of the trace
* introduce a GanttTrace data type which holds these pre-computed fields
* update all React props `rootSpan` --> `trace` and all references `rootSpan.startTimeUnixMs` --> `trace.startTimeUnixMs` (and `.endTime`)

# Screenshots

The trace contains spans starting after the root span has ended:
![image](https://github.com/user-attachments/assets/cd54a327-23e7-41b5-a42c-7bce4fbbc884)


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
