### PR TITLE
[BUGFIX] Redirect to the desired page after login success

### DIFF
--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -36,6 +36,14 @@ import (
 const (
 	xForwardedProto = "X-Forwarded-Proto"
 	xForwardedHost  = "X-Forwarded-Host"
+	// redirectQueryParam is a query param key used to retrieve the original path that
+	// a user desired before being redirected to the login page.
+	// It is used in native and external authentication flows.
+	redirectQueryParam = "rd"
+	// redirectURLQueryParam is a query param key used to send to external provider the
+	// callback URL that will serve to retrieve the token.
+	// It is used only in external authentication flows.
+	redirectURIQueryParam = "redirect_uri"
 )
 
 func getRedirectURI(r *http.Request, authKind string, slugID string) string {

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -153,13 +153,17 @@ function Router(): ReactElement {
  * @constructor
  */
 function RequireAuth({ children }: { children: ReactElement }): ReactElement | null {
-  const isAuthenticated = useIsAccessTokenExist();
-  const path = useLocation().pathname;
-  let to = SignInRoute;
-  if (path !== '' && path !== '/') {
-    to += `?${buildRedirectQueryString(path)}`;
+  const isAuthEnabled = useIsAuthEnabled();
+  const isAuthenticated = useIsAccessTokenExist(isAuthEnabled);
+  const location = useLocation();
+  if (!isAuthEnabled || isAuthenticated) {
+    return children;
   }
-  return isAuthenticated ? children : <Navigate to={to} />;
+  let to = SignInRoute;
+  if (location.pathname !== '' && location.pathname !== '/') {
+    to += `?${buildRedirectQueryString(location.pathname + location.search)}`;
+  }
+  return <Navigate to={to} />;
 }
 
 export default Router;

--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -30,13 +30,14 @@ export interface NativeAuthBody {
   password: string;
 }
 
-export function useIsAccessTokenExist(): boolean {
+export function useIsAccessTokenExist(isAuthEnabled: boolean): boolean {
   const [cookies] = useCookies();
+
   // Warm the access token request cache back
   // If the refresh token is not expired, the debounce mechanism will get the refreshed accedd token.
   // Otherwise, debounce will let pass the empty access token and auth guard will redirect to sign in.
-  if (cookies[jwtPayload] === undefined) {
-    refreshToken().then();
+  if (isAuthEnabled && cookies[jwtPayload] === undefined) {
+    refreshToken();
   }
 
   // Don't directly say "false" when cookie disappear as it's removed/recreated directly by refresh mechanism.

--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -32,6 +32,12 @@ export interface NativeAuthBody {
 
 export function useIsAccessTokenExist(): boolean {
   const [cookies] = useCookies();
+  // Warm the access token request cache back
+  // If the refresh token is not expired, the debounce mechanism will get the refreshed accedd token.
+  // Otherwise, debounce will let pass the empty access token and auth guard will redirect to sign in.
+  if (cookies[jwtPayload] === undefined) {
+    refreshToken().then();
+  }
 
   // Don't directly say "false" when cookie disappear as it's removed/recreated directly by refresh mechanism.
   const [debouncedValue, setDebouncedValue] = useState(cookies);
@@ -40,7 +46,7 @@ export function useIsAccessTokenExist(): boolean {
       setDebouncedValue(cookies);
     }, cookieRefreshTime);
 
-    return () => clearTimeout(timer);
+    return (): void => clearTimeout(timer);
   }, [cookies]);
 
   return debouncedValue[jwtPayload] !== undefined;
@@ -50,7 +56,7 @@ export function useIsAccessTokenExist(): boolean {
  * Get the redirect path from URL's query params.
  * This is used to retrieve the original path that a user desired before being redirected to the login page.
  */
-export function useRedirectQueryParam() {
+export function useRedirectQueryParam(): string {
   const [path] = useQueryParam<string>(redirectQueryParam);
   return path ?? '/';
 }
@@ -59,7 +65,7 @@ export function useRedirectQueryParam() {
  * Build a query string with the redirect path. Related with {@link useRedirectQueryParam}
  * @param path original path desired by the user before being redirected to the login page.
  */
-export function buildRedirectQueryString(path: string) {
+export function buildRedirectQueryString(path: string): string {
   return `${redirectQueryParam}=${encodeURIComponent(path)}`;
 }
 

--- a/ui/app/src/model/fetch.ts
+++ b/ui/app/src/model/fetch.ts
@@ -13,7 +13,6 @@
 
 import { fetch as initialFetch, StatusError } from '@perses-dev/core';
 import { refreshToken } from './auth-client';
-import { SignInRoute } from './route';
 
 export async function fetch(...args: Parameters<typeof global.fetch>): Promise<Response> {
   return initialFetch(...args).catch((error: StatusError) => {
@@ -21,10 +20,7 @@ export async function fetch(...args: Parameters<typeof global.fetch>): Promise<R
       throw error;
     }
     return refreshToken()
-      .catch((refreshTokenError: StatusError) => {
-        if (refreshTokenError.status === 400) {
-          window.location.href = SignInRoute;
-        }
+      .catch((_: StatusError) => {
         throw error;
       })
       .then(() => {

--- a/ui/app/src/views/auth/SignInView.tsx
+++ b/ui/app/src/views/auth/SignInView.tsx
@@ -12,22 +12,22 @@
 // limitations under the License.
 
 import { Button, LinearProgress, Link, TextField, Typography } from '@mui/material';
-import { ReactElement, useEffect, useState } from 'react';
+import { ReactElement, useState } from 'react';
 import { useSnackbar } from '@perses-dev/components';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
-import { useNativeAuthMutation, useIsAccessTokenExist } from '../../model/auth-client';
+import { useNativeAuthMutation, useRedirectQueryParam } from '../../model/auth-client';
 import { SignUpRoute } from '../../model/route';
 import { useIsSignUpDisable } from '../../context/Config';
 import { SignWrapper } from './SignWrapper';
 
 function SignInView(): ReactElement {
   const isSignUpDisable = useIsSignUpDisable();
-  const isAccessTokenExist = useIsAccessTokenExist();
   const authMutation = useNativeAuthMutation();
   const navigate = useNavigate();
   const { successSnackbar, exceptionSnackbar } = useSnackbar();
   const [login, setLogin] = useState<string>('');
   const [password, setPassword] = useState<string>('');
+  const redirectPath = useRedirectQueryParam();
 
   const handleLogin = (): void => {
     authMutation.mutate(
@@ -35,7 +35,7 @@ function SignInView(): ReactElement {
       {
         onSuccess: () => {
           successSnackbar(`Successfully login`);
-          navigate('/');
+          navigate(redirectPath);
         },
         onError: (err) => {
           exceptionSnackbar(err);
@@ -58,12 +58,6 @@ function SignInView(): ReactElement {
       handleLogin();
     }
   };
-
-  useEffect(() => {
-    if (isAccessTokenExist) {
-      navigate('/');
-    }
-  });
 
   return (
     <SignWrapper>

--- a/ui/app/src/views/auth/SignWrapper.tsx
+++ b/ui/app/src/views/auth/SignWrapper.tsx
@@ -48,6 +48,7 @@ import DarkThemePersesLogo from '../../components/logo/DarkThemePersesLogo';
 import LightThemePersesLogo from '../../components/logo/LightThemePersesLogo';
 import { useIsLaptopSize } from '../../utils/browser-size';
 import { useConfigContext } from '../../context/Config';
+import { buildRedirectQueryString, useRedirectQueryParam } from '../../model/auth-client';
 
 // A simple map to know which button to use, according to the configuration.
 // If the issuer/auth url contains the given key, this will use the corresponding button.
@@ -136,6 +137,7 @@ export function SignWrapper(props: { children: ReactNode }): ReactElement {
   }));
   const socialProviders = [...oidcProviders, ...oauthProviders];
   const nativeProviderIsEnabled = config.config?.security?.authentication?.providers?.enable_native;
+  const path = useRedirectQueryParam();
 
   return (
     <Stack
@@ -169,7 +171,7 @@ export function SignWrapper(props: { children: ReactNode }): ReactElement {
               fullWidth={true}
               style={{ fontSize: '1em' }}
               onClick={() => {
-                window.location.href = `/api/auth/providers/${provider.path}/login`;
+                window.location.href = `/api/auth/providers/${provider.path}/login?${buildRedirectQueryString(path)}`;
               }}
             >
               Sign in with {provider.name}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR aims to fix #2284

This is two main changes:

## Redirection query params (UI + API change)
Make sure that the original route is never lost, passing it everywhere. To the Perses backend and to the OIDC/Oauth providers.

## Refactor how the UI refresh the access token presence (UI only change)
The main idea is to simplify relying on cookie presence only to know if we need to redirect or not. 
=> All routes/redirections are in the Router 💪 
From what I understood, the standard way appears to be creating a guard component in the Router which will react on the cookie presence/absence. And to place all the routes component under that guard.

### Problem 1
The main tricky point resided then in the fact that **when we refresh the access token with the refresh token, it was removing the cookie and recreated it**. The guard was then too reactive and redirected directly to signin page. 😢 
=> Solution to that is to use a debounce mechanism that you will see in the ``useIsAccessTokenExist`` function, completely copy pasted from there https://dev.to/vikas2426/debouncing-in-react-a-custom-hook-example-3i4n
Thanks to this debounce mechanism, the user is not redirected to sign in page when the refresh mechanism happens, because the guard will wait for 500ms before react on a cookie removal.

### Problem 2
Second tricky point: when a query get a 401 and try refresh a token, it's very likely that a lot of other queries are also doing the same. They can then enter in conflicts with each other. We need a solution to prevent this from happening.
=> It seems that it's sufficient to additionally refresh the token at the time it disappear, in the auth guard (debounce will make sure it's waiting the token update)

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
