### PR TITLE
[ENHANCEMENT] Add Kubernetes-compatible annotations for model.Duration fields

### DIFF
--- a/go-sdk/prometheus/datasource/datasource.go
+++ b/go-sdk/prometheus/datasource/datasource.go
@@ -27,8 +27,10 @@ const (
 )
 
 type PluginSpec struct {
-	DirectURL      string         `json:"directUrl,omitempty" yaml:"directUrl,omitempty"`
-	Proxy          *http.Proxy    `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	DirectURL string      `json:"directUrl,omitempty" yaml:"directUrl,omitempty"`
+	Proxy     *http.Proxy `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	ScrapeInterval model.Duration `json:"scrapeInterval,omitempty" yaml:"scrapeInterval,omitempty"`
 }
 

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -30,6 +30,8 @@ type EphemeralDashboard struct {
 	// When true user will be able to use the ephemeral dashboard at project level.
 	Enable bool `json:"enable" yaml:"enable"`
 	// The interval at which to trigger the cleanup of ephemeral dashboards, based on their TTLs.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	CleanupInterval model.Duration `json:"cleanup_interval" yaml:"cleanup_interval"`
 }
 
@@ -64,6 +66,8 @@ type Config struct {
 	// EphemeralDashboardsCleanupInterval is the interval at which the ephemeral dashboards are cleaned up
 	// DEPRECATED.
 	// Please use the config EphemeralDashboard instead.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	EphemeralDashboardsCleanupInterval model.Duration `json:"ephemeral_dashboards_cleanup_interval,omitempty" yaml:"ephemeral_dashboards_cleanup_interval,omitempty"`
 	// EphemeralDashboard contains the config about the ephemeral dashboard feature
 	EphemeralDashboard EphemeralDashboard `json:"ephemeral_dashboard,omitempty" yaml:"ephemeral_dashboard,omitempty"`

--- a/pkg/model/api/config/datasourcediscovery.go
+++ b/pkg/model/api/config/datasourcediscovery.go
@@ -80,6 +80,8 @@ type GlobalDatasourceDiscovery struct {
 	// The name of the discovery config. It is used for logging purposes only
 	DiscoveryName string `json:"discovery_name" yaml:"discovery_name"`
 	// Refresh interval to re-query the endpoint.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	RefreshInterval model.Duration `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty"`
 	// HTTP-based service discovery provides a more generic way to generate a set of global datasource and serves as an interface to plug in custom service discovery mechanisms.
 	// It fetches an HTTP endpoint containing a list of zero or more global datasources.

--- a/pkg/model/api/config/frontend.go
+++ b/pkg/model/api/config/frontend.go
@@ -36,8 +36,11 @@ type Explorer struct {
 }
 
 type TimeRange struct {
-	DisableCustomTimeRange bool             `json:"disable_custom" yaml:"disable_custom"`
-	Options                []model.Duration `json:"options,omitempty" yaml:"options,omitempty"`
+	DisableCustomTimeRange bool `json:"disable_custom" yaml:"disable_custom"`
+	// +kubebuilder:validation:Type=array
+	// +kubebuilder:validation:Items.Type=string
+	// +kubebuilder:validation:Items.Format=duration
+	Options []model.Duration `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 func (t *TimeRange) Verify() error {

--- a/pkg/model/api/config/provisioning.go
+++ b/pkg/model/api/config/provisioning.go
@@ -20,6 +20,8 @@ import (
 type ProvisioningConfig struct {
 	Folders []string `json:"folders,omitempty" yaml:"folders,omitempty"`
 	// Interval is the refresh frequency
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	Interval model.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
 }
 

--- a/pkg/model/api/config/schemas.go
+++ b/pkg/model/api/config/schemas.go
@@ -28,11 +28,13 @@ const (
 )
 
 type Schemas struct {
-	PanelsPath      string         `json:"panels_path,omitempty" yaml:"panels_path,omitempty"`
-	QueriesPath     string         `json:"queries_path,omitempty" yaml:"queries_path,omitempty"`
-	DatasourcesPath string         `json:"datasources_path,omitempty" yaml:"datasources_path,omitempty"`
-	VariablesPath   string         `json:"variables_path,omitempty" yaml:"variables_path,omitempty"`
-	Interval        model.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
+	PanelsPath      string `json:"panels_path,omitempty" yaml:"panels_path,omitempty"`
+	QueriesPath     string `json:"queries_path,omitempty" yaml:"queries_path,omitempty"`
+	DatasourcesPath string `json:"datasources_path,omitempty" yaml:"datasources_path,omitempty"`
+	VariablesPath   string `json:"variables_path,omitempty" yaml:"variables_path,omitempty"`
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
+	Interval model.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
 }
 
 func (s *Schemas) Verify() error {

--- a/pkg/model/api/v1/datasource/datasource.go
+++ b/pkg/model/api/v1/datasource/datasource.go
@@ -24,7 +24,9 @@ import (
 // Prometheus is only used for testing purpose.
 // It doesn't reflect the nature of the actual prometheus datasource
 type Prometheus struct {
-	DirectURL      *url.URL        `json:"directUrl,omitempty" yaml:"directUrl,omitempty"`
-	Proxy          *http.Proxy     `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	DirectURL *url.URL    `json:"directUrl,omitempty" yaml:"directUrl,omitempty"`
+	Proxy     *http.Proxy `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	ScrapeInterval *model.Duration `json:"scrapeInterval,omitempty" yaml:"scrapeInterval,omitempty"`
 }

--- a/pkg/model/api/v1/ephemeraldashboard.go
+++ b/pkg/model/api/v1/ephemeraldashboard.go
@@ -23,6 +23,8 @@ import (
 )
 
 type EphemeralDashboardSpecBase struct {
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	TTL model.Duration `json:"ttl" yaml:"ttl"`
 }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This PR adds Kubernetes-compatible annotations to fields of type model.Duration in the imported library for Kubernetes spec fields. The following annotations are added to relevant fields:
```yaml
// +kubebuilder:validation:Type=string
// +kubebuilder:validation:Format=duration
```
These annotations ensure that `model.Duration` fields are treated as strings with a duration format, resolving conflicts between the custom JSON serialization in prometheus/common and Kubernetes API expectations. This fix addresses validation errors in the Perses controller when updating Perses resources. 

This change ensures compatibility between the Perses and Perses Operator. 

- [ ] fixes https://github.com/perses/perses-operator/issues/20

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).