### PR TITLE
[ENHANCEMENT] Add counts/sec unit to mapping list for migration

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -31,6 +31,7 @@ import (
         // throughput units
         bps: "bits/sec"
         Bps: "bytes/sec"
+        cps: "counts/sec"
         // TODO add mappings for all throughput units
     }
     // mapping table for the calculation attribute (key = grafana unit, value = perses equivalent)


### PR DESCRIPTION
# Description
**cps** unit for migration mapping list was added. This unit was in code, but was skipped in mapping list (mapping.cuepart file).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
