### PR TITLE
[BUGFIX] TraceTable: expand the span count bubble in the service name chips

### DIFF
--- a/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
@@ -220,7 +220,7 @@ function ServiceChip({ serviceName, stats, serviceColor }: ServiceChipProps) {
       avatar={
         <Avatar
           sx={{
-            width: 'auto !important', // by default width is fixed to 18px, which is not enough for multi-digit span counts
+            minWidth: 'fit-content', // by default width is fixed to 18px, which is not enough for multi-digit span counts
             padding: '6px',
             backgroundColor: 'var(--service-color)',
             fontSize: '0.65rem',

--- a/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/DataTable.tsx
@@ -220,6 +220,8 @@ function ServiceChip({ serviceName, stats, serviceColor }: ServiceChipProps) {
       avatar={
         <Avatar
           sx={{
+            width: 'auto !important', // by default width is fixed to 18px, which is not enough for multi-digit span counts
+            padding: '6px',
             backgroundColor: 'var(--service-color)',
             fontSize: '0.65rem',
             fontWeight: 'bold',


### PR DESCRIPTION
# Description

TraceTable: expand the span count bubble in the service name chips

# Screenshots

Before:
![image](https://github.com/user-attachments/assets/83fe2e97-953f-46db-913e-2ccaddecd5d9)

After:
![image](https://github.com/user-attachments/assets/d957906b-798c-45da-99e9-7f71a2258269)


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
