### PR TITLE
[IGNORE] CUE: bump to latest alpha

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.10.0"
+          cue_version: "v0.11.0-alpha.4"
       - name: check format
         run: make checkformat
       - name: check go.mod
@@ -64,7 +64,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
-          cue_version: "v0.10.0"
+          cue_version: "v0.11.0-alpha.4"
       - name: test
         run: make integration-test
   test-mysql:
@@ -88,7 +88,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
-          cue_version: "v0.10.0"
+          cue_version: "v0.11.0-alpha.4"
       - name: test
         run: make mysql-integration-test
   golangci:
@@ -122,7 +122,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.10.0"
+          cue_version: "v0.11.0-alpha.4"
       - name: eval cue schema
         run: make cue-eval
       - name: test cue schema
@@ -138,7 +138,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.10.0"
+          cue_version: "v0.11.0-alpha.4"
       - name: generate cue files
         run: make cue-gen
       - name: check for changes

--- a/cue/dac-utils/prometheus/filter/filter.cue
+++ b/cue/dac-utils/prometheus/filter/filter.cue
@@ -23,7 +23,7 @@ import (
 
 // Have to use an intermediary variable here to handle the fact that labelNames variable should be excluded from the filter
 // This is again a case where proper support of short-circuit on CUE side would help simplify the code (see https://github.com/cue-lang/cue/issues/2232)
-_filterArr: [for var in #input {
+_matchers: [for var in #input {
 	[// switch
 		if var.#kind == "TextVariable" {"\(var.#name)=~\"$\(var.#name)\""},
 		if var.#kind == "ListVariable" if var.#pluginKind != labelNamesVar.kind {"\(var.#name)=~\"$\(var.#name)\""},
@@ -31,4 +31,4 @@ _filterArr: [for var in #input {
 	][0]
 }]
 
-filter: strings.Join([for matcher in _filterArr if matcher != null {matcher}], ",")
+filter: strings.Join([for matcher in _matchers if matcher != null {matcher}], ",")

--- a/cue/dac-utils/prometheus/variable/labelnames/labelnames.cue
+++ b/cue/dac-utils/prometheus/variable/labelnames/labelnames.cue
@@ -32,7 +32,7 @@ filter: {filterBuilder & {#input: #dependencies}}.filter
 
 queryExpr: [// switch
 	if #query != _|_ {#query},
-	{#metric + "{" + filter + "}"},
+	#metric + "{" + filter + "}",
 ][0]
 
 variable: promVarBuilder.variable & {

--- a/cue/dac-utils/prometheus/variable/labelvalues/labelvalues.cue
+++ b/cue/dac-utils/prometheus/variable/labelvalues/labelvalues.cue
@@ -35,7 +35,7 @@ filter: {filterBuilder & {#input: #dependencies}}.filter
 
 queryExpr: [// switch
 	if #query != _|_ {#query},
-	{#metric + "{" + filter + "}"},
+	#metric + "{" + filter + "}",
 ][0]
 
 variable: promVarBuilder.variable & {

--- a/cue/dac-utils/prometheus/variable/promql/promql.cue
+++ b/cue/dac-utils/prometheus/variable/promql/promql.cue
@@ -35,7 +35,7 @@ filter: {filterBuilder & {#input: #dependencies}}.filter
 
 queryExpr: [// switch
 	if #query != _|_ {#query},
-	{"group by (\(#label)) (\(#metric){\(filter)})"},
+	"group by (\(#label)) (\(#metric){\(filter)})",
 ][0]
 
 variable: promVarBuilder.variable & {

--- a/cue/schemas/panels/gauge/migrate.cue
+++ b/cue/schemas/panels/gauge/migrate.cue
@@ -4,7 +4,7 @@ if #panel.type != _|_ if #panel.type == "gauge" {
 		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
 		calculation: [ // switch
 			if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
-			{ #defaultCalc }
+			#defaultCalc
 		][0]
 
 		#unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
@@ -20,7 +20,7 @@ if #panel.type != _|_ if #panel.type == "gauge" {
 				steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part? 
 					value: [ // switch
 						if step.value == null { 0 },
-						{ step.value }
+						step.value
 					][0]
 					color: step.color
 				}]

--- a/cue/schemas/panels/stat/migrate.cue
+++ b/cue/schemas/panels/stat/migrate.cue
@@ -4,7 +4,7 @@ if #panel.type != _|_ if #panel.type == "stat" {
 		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's StatChart doesn't support individual calcs
 		calculation: [ // switch
 			if #mapping.calc[#calcName] != _|_ { #mapping.calc[#calcName] },
-			{ #defaultCalc }
+			#defaultCalc
 		][0]
 
 		#unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null

--- a/cue/schemas/panels/table/migrate.cue
+++ b/cue/schemas/panels/table/migrate.cue
@@ -4,8 +4,8 @@ if #panel.type != _|_ if #panel.type == "table" {
 		if #panel.options != _|_ if #panel.options.cellHeight != _|_ {
 			density: [
 				if #panel.options.cellHeight == "sm" { "compact" },
-				if #panel.options.cellHeight == "md" { "standard" },
 				if #panel.options.cellHeight == "lg" { "comfortable" }
+				"standard"
 			][0]
 		}
 
@@ -130,7 +130,7 @@ if #panel.type != _|_ if #panel.type == "table" {
 						if option.text != _|_ { text: option.text }
 						if option.color != _|_ { backgroundColor: [ // switch
 							if #mapping.color[option.color] != _|_ { #mapping.color[option.color] },
-							{ option.color }
+							option.color
 						][0]}
 					}]
 				}
@@ -152,7 +152,7 @@ if #panel.type != _|_ if #panel.type == "table" {
 					if mapping.options.result.text != _|_ { text: mapping.options.result.text }
 					if mapping.options.result.color != _|_ { backgroundColor: [ // switch
 						if #mapping.color[mapping.options.result.color] != _|_ { #mapping.color[mapping.options.result.color] },
-						{ mapping.options.result.color }
+						mapping.options.result.color
 					][0]}
 				}
 			}

--- a/cue/schemas/panels/time-series/migrate.cue
+++ b/cue/schemas/panels/time-series/migrate.cue
@@ -9,11 +9,11 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 				if #panel.type == "timeseries" {
 					position: [
 						if #panel.options.legend.placement != _|_ if #panel.options.legend.placement == "right" {"right"},
-						{"bottom"}
+						"bottom"
 					][0]
 					mode: [
-						if #panel.options.legend.displayMode == "list" { "list" },
 						if #panel.options.legend.displayMode == "table" { "table" },
+						"list"
 					][0]
 					values: [ for calc in #panel.options.legend.calcs 
 						if (#mapping.calc[calc] != _|_) { #mapping.calc[calc] }
@@ -22,11 +22,11 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 				if #panel.type == "graph" {
 					position: [ // switch
 						if #panel.legend.rightSide != _|_ if #panel.legend.rightSide { "right" },
-						{ "bottom" }
+						"bottom"
 					][0]
 					mode: [
 						if #panel.legend.alignAsTable != _|_ if #panel.legend.alignAsTable { "table" },
-						{ "list" }
+						"list"
 					][0]
 					values: [ for oldCalc, newCalc in #mapping.calc  
 						// Check if the mapping field is set on the legend and 
@@ -65,7 +65,7 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 				steps: [ for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ { // TODO how to manage the overrides part?
 					value: [ // switch
 						if step.value == null { 0 },
-						{ step.value }
+						step.value
 					][0]
 					color: step.color
 				}]
@@ -77,7 +77,7 @@ if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
 				lineWidth: [ // switch
 					if #panel.fieldConfig.defaults.custom.lineWidth > 3 { 3 }, // line width can't go beyond 3 in Perses
 					if #panel.fieldConfig.defaults.custom.lineWidth < 0.25 { 0.25 }, // line width can't go below 0.25 in Perses
-					{ #panel.fieldConfig.defaults.custom.lineWidth }
+					#panel.fieldConfig.defaults.custom.lineWidth
 				][0]
 			}
 			if #panel.fieldConfig.defaults.custom.fillOpacity != _|_ {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/perses/perses
 go 1.22.5
 
 require (
-	cuelang.org/go v0.11.0-alpha.3
+	cuelang.org/go v0.11.0-alpha.4
 	github.com/brunoga/deep v1.2.4
 	github.com/charmbracelet/huh v0.6.0
 	github.com/efficientgo/core v1.0.0-rc.3
@@ -141,7 +141,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf // indirect
+	github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cuelabs.dev/go/oci/ociregistry v0.0.0-20240906074133-82eb438dd565 h1:R5wwEcbEZSBmeyg91MJZTxfd7WpBo2jPof3AYjRbxwY=
 cuelabs.dev/go/oci/ociregistry v0.0.0-20240906074133-82eb438dd565/go.mod h1:5A4xfTzHTXfeVJBU6RAUf+QrlfTCW+017q/QiW+sMLg=
-cuelang.org/go v0.11.0-alpha.3 h1:KipbP157eNB59we+6p6VvR2VgskMR/x3UhflJZF++y0=
-cuelang.org/go v0.11.0-alpha.3/go.mod h1:v4uj1INFL5yGorRYlr5W2oMjRjKi/ClHU8AeipYie/8=
+cuelang.org/go v0.11.0-alpha.4 h1:+OzuIIrCcXl8+lOBdxVFjb+D9xcj+ZTlnSG+1lf0V5w=
+cuelang.org/go v0.11.0-alpha.4/go.mod h1:3OQOwNq6qr1BJy1AVShmUZJceKMVYSnBto2txFc0BWE=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
@@ -351,8 +351,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/prometheus/promu v0.17.0 h1:lrYuxTON9hImNM3lS0CgjJKqsV3WereHQoqrMMuyFmI=
 github.com/prometheus/promu v0.17.0/go.mod h1:H4qXHbrvfowu3bY33DuI9fkO69nBbEF8tWu6arhhPoA=
-github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf h1:014O62zIzQwvoD7Ekj3ePDF5bv9Xxy0w6AZk0qYbjUk=
-github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef h1:ej+64jiny5VETZTqcc1GFVAPEtaSk6U1D0kKC2MS5Yc=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/api/discovery/cuetils/cuetils.go
+++ b/internal/api/discovery/cuetils/cuetils.go
@@ -41,7 +41,7 @@ func NewFromSchema(v cue.Value) ([]*Node, error) {
 	}
 	for it.Next() {
 		queue = append(queue, iteratorQueue{
-			fieldName: it.Label(),
+			fieldName: it.Selector().String(),
 			value:     it.Value(),
 			parent:    root,
 		})

--- a/internal/api/discovery/cuetils/node.go
+++ b/internal/api/discovery/cuetils/node.go
@@ -182,7 +182,7 @@ func buildTree(queue []iteratorQueue) error {
 			for it.Next() {
 				node.Type = StructNodeType
 				queue = append(queue, iteratorQueue{
-					fieldName: it.Label(),
+					fieldName: it.Selector().String(),
 					value:     it.Value(),
 					parent:    node,
 				})
@@ -259,7 +259,7 @@ func buildMapFromStructValue(v cue.Value) map[string]cue.Value {
 	result := make(map[string]cue.Value)
 	it, _ := v.Fields()
 	for it.Next() {
-		result[it.Label()] = it.Value()
+		result[it.Selector().String()] = it.Value()
 	}
 	return result
 }


### PR DESCRIPTION
# Description

This bump to [v0.11.0-alpha.4](https://github.com/cue-lang/cue/releases/tag/v0.11.0-alpha.4) enforced to:
- fix some deprecated lib usage
- stop cheating with the switch-like statements (it can no longer deal with the 0 index when the array is empty)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).