### PR TITLE
[ENHANCEMENT] TraceTable: show scrollbar only if content overflows

### DIFF
--- a/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.tsx
@@ -62,7 +62,7 @@ export function TraceTablePanel(props: TraceTablePanelProps) {
   }
 
   return (
-    <Box sx={{ height: '100%', padding: `${contentPadding}px`, overflowY: 'scroll' }}>
+    <Box sx={{ height: '100%', padding: `${contentPadding}px`, overflowY: 'auto' }}>
       <DataTable
         options={spec}
         result={queryResults}


### PR DESCRIPTION
# Description

TraceTable: show scrollbar only if content overflows

# Screenshots

Before (scrollbar is always shown):
![image](https://github.com/user-attachments/assets/fd75755b-355f-4075-87f0-15603c2101b8)

After (scrollbar is not shown because the content does not overflow):
![image](https://github.com/user-attachments/assets/f2d185e7-9a1c-4689-be72-516519622876)

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
