### PR TITLE
[BREAKINGCHANGE] Refactor the way to manage authentication in the perses http client

### DIFF
--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -522,9 +522,8 @@ discovery_name: <string>
 ```yaml
 # URL of the HTTP server exposing the global datasource list to retrieve.
 url: <url>
-
-[ auth: <Auth specification> ]
-
+[ basic_auth: <Basic Auth specification> ]
+[ oauth: <Oauth specification> ]
 # The HTTP authorization credentials for the targets.
 # Basic Auth and authorization are mutually exclusive. Use one or the other not both at the same time.
 [ authorization: <Authorization specification> ]
@@ -534,14 +533,6 @@ url: <url>
 
 headers:
   [<string>:<string>]
-```
-
-##### Auth
-
-```yaml
-[ basic_auth: <Basic Auth specification> ]
-
-[ oauth: <Oauth specification> ]
 ```
 
 ##### Oauth specification

--- a/docs/user-guides/configuration.md
+++ b/docs/user-guides/configuration.md
@@ -522,10 +522,10 @@ discovery_name: <string>
 ```yaml
 # URL of the HTTP server exposing the global datasource list to retrieve.
 url: <url>
+# The HTTP authorization credentials for the targets.
+# Basic Auth, authorization and oauth are mutually exclusive. Use one of them.
 [ basic_auth: <Basic Auth specification> ]
 [ oauth: <Oauth specification> ]
-# The HTTP authorization credentials for the targets.
-# Basic Auth and authorization are mutually exclusive. Use one or the other not both at the same time.
 [ authorization: <Authorization specification> ]
 
 # Config used to connect to the targets.

--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -375,7 +375,7 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
-			Oauth: &config.Oauth{
+			OAuth: &config.OAuth{
 				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
 				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
 				TokenURL:     persesTokenURL.String(),
@@ -402,7 +402,7 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
-			Oauth: &config.Oauth{
+			OAuth: &config.OAuth{
 				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
 				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
 				TokenURL:     persesTokenURL.String(),
@@ -445,7 +445,7 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOIDC, providerConfig.SlugID, utils.PathToken)
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
-			Oauth: &config.Oauth{
+			OAuth: &config.OAuth{
 				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
 				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
 				TokenURL:     persesTokenURL.String(),
@@ -471,7 +471,7 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 		persesTokenURL := common.MustParseURL(server.URL)
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
-			Oauth: &config.Oauth{
+			OAuth: &config.OAuth{
 				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
 				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
 				TokenURL:     persesTokenURL.String(),

--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -375,13 +375,11 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
-			Auth: &config.Auth{
-				Oauth: &config.Oauth{
-					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-					TokenURL:     persesTokenURL.String(),
-					AuthStyle:    oauth2.AuthStyleInHeader,
-				},
+			Oauth: &config.Oauth{
+				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+				TokenURL:     persesTokenURL.String(),
+				AuthStyle:    oauth2.AuthStyleInHeader,
 			},
 		})
 		assert.NoError(t, err)
@@ -404,13 +402,11 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
-			Auth: &config.Auth{
-				Oauth: &config.Oauth{
-					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-					TokenURL:     persesTokenURL.String(),
-					AuthStyle:    oauth2.AuthStyleInHeader,
-				},
+			Oauth: &config.Oauth{
+				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+				TokenURL:     persesTokenURL.String(),
+				AuthStyle:    oauth2.AuthStyleInHeader,
 			},
 		})
 		assert.NoError(t, err)
@@ -449,13 +445,11 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOIDC, providerConfig.SlugID, utils.PathToken)
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
 			URL: persesBaseURL,
-			Auth: &config.Auth{
-				Oauth: &config.Oauth{
-					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-					TokenURL:     persesTokenURL.String(),
-					AuthStyle:    oauth2.AuthStyleInHeader,
-				},
+			Oauth: &config.Oauth{
+				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+				TokenURL:     persesTokenURL.String(),
+				AuthStyle:    oauth2.AuthStyleInHeader,
 			},
 		})
 		assert.NoError(t, err)
@@ -477,13 +471,11 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 		persesTokenURL := common.MustParseURL(server.URL)
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthKindOAuth, providerConfig.SlugID, utils.PathToken)
 		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
-			Auth: &config.Auth{
-				Oauth: &config.Oauth{
-					ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
-					ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
-					TokenURL:     persesTokenURL.String(),
-					AuthStyle:    oauth2.AuthStyleInHeader,
-				},
+			Oauth: &config.Oauth{
+				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+				TokenURL:     persesTokenURL.String(),
+				AuthStyle:    oauth2.AuthStyleInHeader,
 			},
 			URL: persesBaseURL,
 		})

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -188,8 +188,8 @@ func Write(cfg *Config) error {
 				if restConfig.Authorization != nil {
 					previousConf.RestClientConfig.Authorization = restConfig.Authorization
 				}
-				if restConfig.Oauth != nil {
-					previousConf.RestClientConfig.Oauth = restConfig.Oauth
+				if restConfig.OAuth != nil {
+					previousConf.RestClientConfig.OAuth = restConfig.OAuth
 				}
 				if restConfig.BasicAuth != nil {
 					previousConf.RestClientConfig.BasicAuth = restConfig.BasicAuth

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -188,11 +188,17 @@ func Write(cfg *Config) error {
 				if restConfig.Authorization != nil {
 					previousConf.RestClientConfig.Authorization = restConfig.Authorization
 				}
+				if restConfig.Oauth != nil {
+					previousConf.RestClientConfig.Oauth = restConfig.Oauth
+				}
+				if restConfig.BasicAuth != nil {
+					previousConf.RestClientConfig.BasicAuth = restConfig.BasicAuth
+				}
+				if restConfig.NativeAuth != nil {
+					previousConf.RestClientConfig.NativeAuth = restConfig.NativeAuth
+				}
 				if len(restConfig.Headers) > 0 {
 					previousConf.RestClientConfig.Headers = restConfig.Headers
-				}
-				if restConfig.Auth != nil {
-					previousConf.RestClientConfig.Auth = restConfig.Auth
 				}
 			}
 			if len(cfg.Project) > 0 {

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/http"
@@ -55,27 +56,12 @@ func newPublicOauth(oauthConfig *Oauth) *PublicOauth {
 	}
 }
 
-type PublicAuth struct {
+// PublicRestConfigClient is the struct that should be used when printing the config
+type PublicRestConfigClient struct {
+	URL        *common.URL             `json:"url" yaml:"url"`
 	NativeAuth *api.PublicAuth         `json:"native_auth,omitempty" yaml:"native_auth,omitempty"`
 	Oauth      *PublicOauth            `json:"oauth_config,omitempty" yaml:"oauth_config,omitempty"`
 	BasicAuth  *secret.PublicBasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`
-}
-
-func newPublicAuth(auth *Auth) *PublicAuth {
-	if auth == nil {
-		return nil
-	}
-	return &PublicAuth{
-		Oauth:      newPublicOauth(auth.Oauth),
-		BasicAuth:  secret.NewPublicBasicAuth(auth.BasicAuth),
-		NativeAuth: api.NewPublicAuth(auth.NativeAuth),
-	}
-}
-
-// PublicRestConfigClient is the struct that should be used when printing the config
-type PublicRestConfigClient struct {
-	URL  *common.URL `json:"url" yaml:"url"`
-	Auth *PublicAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
 	// The HTTP authorization credentials for the targets.
 	Authorization *secret.PublicAuthorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
 	// TLSConfig to use to connect to the targets.
@@ -89,7 +75,9 @@ func NewPublicRestConfigClient(config *RestConfigClient) *PublicRestConfigClient
 	}
 	return &PublicRestConfigClient{
 		URL:           config.URL,
-		Auth:          newPublicAuth(config.Auth),
+		NativeAuth:    api.NewPublicAuth(config.NativeAuth),
+		BasicAuth:     secret.NewPublicBasicAuth(config.BasicAuth),
+		Oauth:         newPublicOauth(config.Oauth),
 		Authorization: secret.NewPublicAuthorization(config.Authorization),
 		TLSConfig:     secret.NewPublicTLSConfig(config.TLSConfig),
 		Headers:       config.Headers,
@@ -114,42 +102,40 @@ type Oauth struct {
 	AuthStyle oauth2.AuthStyle `json:"auth_style" yaml:"auth_style"`
 }
 
-type Auth struct {
+// RestConfigClient defines all parameters that can be set to customize the RESTClient
+type RestConfigClient struct {
+	URL        *common.URL       `json:"url" yaml:"url"`
 	NativeAuth *api.Auth         `json:"native_auth,omitempty" yaml:"native_auth,omitempty"`
 	Oauth      *Oauth            `json:"oauth,omitempty" yaml:"oauth,omitempty"`
 	BasicAuth  *secret.BasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`
-}
-
-func (a *Auth) Validate() error {
-	if a == nil {
-		return nil
-	}
-	nbAuthConfigured := 0
-	if a.NativeAuth != nil {
-		nbAuthConfigured++
-	}
-	if a.Oauth != nil {
-		nbAuthConfigured++
-	}
-	if a.BasicAuth != nil {
-		nbAuthConfigured++
-	}
-
-	if nbAuthConfigured > 1 {
-		return fmt.Errorf("only one type of authentication should be configured")
-	}
-	return nil
-}
-
-// RestConfigClient defines all parameters that can be set to customize the RESTClient
-type RestConfigClient struct {
-	URL  *common.URL `json:"url" yaml:"url"`
-	Auth *Auth       `json:"auth,omitempty" yaml:"auth,omitempty"`
 	// The HTTP authorization credentials for the targets.
 	Authorization *secret.Authorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig *secret.TLSConfig `json:"tls_config,omitempty" yaml:"tls_config,omitempty"`
 	Headers   map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+func (c *RestConfigClient) Validate() error {
+	if c == nil {
+		return nil
+	}
+	nbAuthConfigured := 0
+	if c.NativeAuth != nil {
+		nbAuthConfigured++
+	}
+	if c.Oauth != nil {
+		nbAuthConfigured++
+	}
+	if c.BasicAuth != nil {
+		nbAuthConfigured++
+	}
+	if c.Authorization != nil {
+		nbAuthConfigured++
+	}
+	if nbAuthConfigured > 1 {
+		return fmt.Errorf("only one type of authentication should be configured")
+	}
+	return nil
 }
 
 func NewRoundTripper(timeout time.Duration, tlsConfig *secret.TLSConfig) (http.RoundTripper, error) {
@@ -174,29 +160,47 @@ func NewRESTClient(config RestConfigClient) (*perseshttp.RESTClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	var basicAuth *secret.BasicAuth
 	var httpClient *http.Client
-	if config.Auth != nil {
-		if config.Auth.BasicAuth != nil {
-			basicAuth = config.Auth.BasicAuth
+
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: roundTripper,
+		Timeout:   connectionTimeout,
+	})
+	if config.BasicAuth != nil {
+		c := oauth2.Config{}
+		password, getPasswordErr := config.BasicAuth.GetPassword()
+		if getPasswordErr != nil {
+			return nil, getPasswordErr
 		}
-		if config.Auth.NativeAuth != nil {
-			roundTripper = transport.New(config.URL.URL, roundTripper, *config.Auth.NativeAuth)
+		httpClient = c.Client(ctx, &oauth2.Token{
+			AccessToken: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", config.BasicAuth.Username, password))),
+			TokenType:   "basic",
+		})
+	}
+	if config.Authorization != nil {
+		c := oauth2.Config{}
+		credential, getCredentialErr := config.Authorization.GetCredentials()
+		if getCredentialErr != nil {
+			return nil, getCredentialErr
 		}
-		if config.Auth.Oauth != nil {
-			oauthConfig := &clientcredentials.Config{
-				ClientID:     config.Auth.Oauth.ClientID,
-				ClientSecret: config.Auth.Oauth.ClientSecret,
-				TokenURL:     config.Auth.Oauth.TokenURL,
-				Scopes:       config.Auth.Oauth.Scopes,
-				AuthStyle:    config.Auth.Oauth.AuthStyle,
-			}
-			ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
-				Transport: roundTripper,
-				Timeout:   connectionTimeout,
-			})
-			httpClient = oauthConfig.Client(ctx)
+		httpClient = c.Client(ctx, &oauth2.Token{
+			AccessToken: credential,
+			TokenType:   config.Authorization.Type,
+		})
+	}
+	if config.NativeAuth != nil {
+		roundTripper = transport.New(config.URL.URL, roundTripper, *config.NativeAuth)
+	}
+	if config.Oauth != nil {
+		oauthConfig := &clientcredentials.Config{
+			ClientID:     config.Oauth.ClientID,
+			ClientSecret: config.Oauth.ClientSecret,
+			TokenURL:     config.Oauth.TokenURL,
+			Scopes:       config.Oauth.Scopes,
+			AuthStyle:    config.Oauth.AuthStyle,
 		}
+
+		httpClient = oauthConfig.Client(ctx)
 	}
 
 	if httpClient == nil {
@@ -207,10 +211,8 @@ func NewRESTClient(config RestConfigClient) (*perseshttp.RESTClient, error) {
 	}
 
 	return &perseshttp.RESTClient{
-		BaseURL:       config.URL.URL,
-		Authorization: config.Authorization,
-		BasicAuth:     basicAuth,
-		Client:        httpClient,
-		Headers:       config.Headers,
+		BaseURL: config.URL.URL,
+		Client:  httpClient,
+		Headers: config.Headers,
 	}, nil
 }

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -33,7 +33,7 @@ import (
 
 const connectionTimeout = 30 * time.Second
 
-type PublicOauth struct {
+type PublicOAuth struct {
 	ClientID       secret.Hidden    `json:"client_id" yaml:"client_id"`
 	ClientSecret   secret.Hidden    `json:"client_secret" yaml:"client_secret"`
 	TokenURL       string           `json:"token_url" yaml:"token_url"`
@@ -42,11 +42,11 @@ type PublicOauth struct {
 	AuthStyle      oauth2.AuthStyle `json:"auth_style" yaml:"auth_style"`
 }
 
-func newPublicOauth(oauthConfig *Oauth) *PublicOauth {
+func newPublicOauth(oauthConfig *OAuth) *PublicOAuth {
 	if oauthConfig == nil {
 		return nil
 	}
-	return &PublicOauth{
+	return &PublicOAuth{
 		ClientID:       secret.Hidden(oauthConfig.ClientID),
 		ClientSecret:   secret.Hidden(oauthConfig.ClientSecret),
 		TokenURL:       oauthConfig.TokenURL,
@@ -60,7 +60,7 @@ func newPublicOauth(oauthConfig *Oauth) *PublicOauth {
 type PublicRestConfigClient struct {
 	URL        *common.URL             `json:"url" yaml:"url"`
 	NativeAuth *api.PublicAuth         `json:"native_auth,omitempty" yaml:"native_auth,omitempty"`
-	Oauth      *PublicOauth            `json:"oauth_config,omitempty" yaml:"oauth_config,omitempty"`
+	Oauth      *PublicOAuth            `json:"oauth_config,omitempty" yaml:"oauth_config,omitempty"`
 	BasicAuth  *secret.PublicBasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`
 	// The HTTP authorization credentials for the targets.
 	Authorization *secret.PublicAuthorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
@@ -77,14 +77,14 @@ func NewPublicRestConfigClient(config *RestConfigClient) *PublicRestConfigClient
 		URL:           config.URL,
 		NativeAuth:    api.NewPublicAuth(config.NativeAuth),
 		BasicAuth:     secret.NewPublicBasicAuth(config.BasicAuth),
-		Oauth:         newPublicOauth(config.Oauth),
+		Oauth:         newPublicOauth(config.OAuth),
 		Authorization: secret.NewPublicAuthorization(config.Authorization),
 		TLSConfig:     secret.NewPublicTLSConfig(config.TLSConfig),
 		Headers:       config.Headers,
 	}
 }
 
-type Oauth struct {
+type OAuth struct {
 	// ClientID is the application's ID.
 	ClientID string `json:"client_id" yaml:"client_id"`
 	// ClientSecret is the application's secret.
@@ -106,7 +106,7 @@ type Oauth struct {
 type RestConfigClient struct {
 	URL        *common.URL       `json:"url" yaml:"url"`
 	NativeAuth *api.Auth         `json:"native_auth,omitempty" yaml:"native_auth,omitempty"`
-	Oauth      *Oauth            `json:"oauth,omitempty" yaml:"oauth,omitempty"`
+	OAuth      *OAuth            `json:"oauth,omitempty" yaml:"oauth,omitempty"`
 	BasicAuth  *secret.BasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`
 	// The HTTP authorization credentials for the targets.
 	Authorization *secret.Authorization `json:"authorization,omitempty" yaml:"authorization,omitempty"`
@@ -123,7 +123,7 @@ func (c *RestConfigClient) Validate() error {
 	if c.NativeAuth != nil {
 		nbAuthConfigured++
 	}
-	if c.Oauth != nil {
+	if c.OAuth != nil {
 		nbAuthConfigured++
 	}
 	if c.BasicAuth != nil {
@@ -191,13 +191,13 @@ func NewRESTClient(config RestConfigClient) (*perseshttp.RESTClient, error) {
 	if config.NativeAuth != nil {
 		roundTripper = transport.New(config.URL.URL, roundTripper, *config.NativeAuth)
 	}
-	if config.Oauth != nil {
+	if config.OAuth != nil {
 		oauthConfig := &clientcredentials.Config{
-			ClientID:     config.Oauth.ClientID,
-			ClientSecret: config.Oauth.ClientSecret,
-			TokenURL:     config.Oauth.TokenURL,
-			Scopes:       config.Oauth.Scopes,
-			AuthStyle:    config.Oauth.AuthStyle,
+			ClientID:     config.OAuth.ClientID,
+			ClientSecret: config.OAuth.ClientSecret,
+			TokenURL:     config.OAuth.TokenURL,
+			Scopes:       config.OAuth.Scopes,
+			AuthStyle:    config.OAuth.AuthStyle,
 		}
 
 		httpClient = oauthConfig.Client(ctx)

--- a/pkg/client/perseshttp/client.go
+++ b/pkg/client/perseshttp/client.go
@@ -16,17 +16,10 @@ package perseshttp
 import (
 	"net/http"
 	"net/url"
-
-	"github.com/perses/perses/pkg/model/api/v1/secret"
 )
 
 // RESTClient defines an HTTP client designed for the HTTP request to a REST API.
 type RESTClient struct {
-	// Usually it contains the bearer token required to contact the remote API.
-	Authorization *secret.Authorization
-	// basicAuth to be used for each request (not editable)
-	// Using a basicAuth has the priority other the token
-	BasicAuth *secret.BasicAuth
 	// Default headers for all client requests (not editable)
 	Headers map[string]string
 	// base is the root URL for all invocations of the client
@@ -61,5 +54,5 @@ func (c *RESTClient) Delete() *Request {
 }
 
 func (c *RESTClient) newRequest(method string) *Request {
-	return NewRequest(c.Client, method, c.BaseURL, c.Authorization, c.BasicAuth, c.Headers)
+	return NewRequest(c.Client, method, c.BaseURL, c.Headers)
 }


### PR DESCRIPTION
I am breaking (again) the RestConfig for the perses http client regarding the way the authentication is managed.

I believe it will simplify a bit the config. It also simplify the way we are managing the auth in the client. Now everything is handled inside the `http.Client` and not anymore partially in the object `Request`