### PR TITLE
[FEATURE] Status History panel

### DIFF
--- a/cue/schemas/panels/status-history/migrate.cue
+++ b/cue/schemas/panels/status-history/migrate.cue
@@ -1,0 +1,10 @@
+ if #panel.type != _|_ if #panel.type == "status-history" {
+	kind: "StatusHistoryChart"
+	spec: {
+		// simple legend
+		#showLegend: *#panel.options.legend | true
+		if #panel.options.legend != _|_ if #showLegend {
+			legend: {}
+		}
+	}
+}

--- a/cue/schemas/panels/status-history/migrate.cue
+++ b/cue/schemas/panels/status-history/migrate.cue
@@ -1,10 +1,21 @@
  if #panel.type != _|_ if #panel.type == "status-history" {
 	kind: "StatusHistoryChart"
 	spec: {
-		// simple legend
-		#showLegend: *#panel.options.legend | true
+		#showLegend: *#panel.options.legend.showLegend | true
 		if #panel.options.legend != _|_ if #showLegend {
-			legend: {}
+			legend: {
+				if #panel.type == "status-history" {
+					position: [
+						if #panel.options.legend.placement != _|_ if #panel.options.legend.placement == "right" {"right"},
+						{"bottom"}
+					][0]
+					mode: [
+						if #panel.options.legend.displayMode == "list" { "list" },
+						if #panel.options.legend.displayMode == "table" { "table" },
+					][0]
+				}
+			}
 		}
+
 	}
 }

--- a/cue/schemas/panels/status-history/status-history.cue
+++ b/cue/schemas/panels/status-history/status-history.cue
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,15 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './plugins/bar-chart';
-export * from './plugins/gauge-chart';
-export * from './plugins/markdown';
-export * from './plugins/scatterplot';
-export * from './plugins/stat-chart';
-export * from './plugins/table';
-export * from './plugins/time-series-chart';
-export * from './plugins/time-series-table';
-export * from './plugins/trace-table';
-export * from './plugins/tracing-gantt-chart';
-export * from './plugins/pie-chart';
-export * from './plugins/status-history-chart';
+package model
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#legendValue: common.#calculation
+
+#legend: {
+	position: "bottom" | "right"
+	mode?:    "list" | "table"
+	size?:    "small" | "medium"
+}
+
+kind: "StatusHistoryChart"
+spec: close({
+	legend?:    #legend
+})

--- a/cue/schemas/panels/status-history/status-history.cue
+++ b/cue/schemas/panels/status-history/status-history.cue
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 package model
+
 import (
 	"github.com/perses/perses/cue/schemas/common"
 )
@@ -26,5 +27,5 @@ import (
 
 kind: "StatusHistoryChart"
 spec: close({
-	legend?:    #legend
+	legend?: #legend
 })

--- a/cue/schemas/panels/status-history/status-history.json
+++ b/cue/schemas/panels/status-history/status-history.json
@@ -1,0 +1,8 @@
+{
+    "kind": "StatusHistoryChart",
+    "spec": {
+        "legend": {
+            "position": "bottom"
+        }
+    }
+}

--- a/ui/components/src/StatusHistoryChart/StatusHistory.md
+++ b/ui/components/src/StatusHistoryChart/StatusHistory.md
@@ -1,0 +1,41 @@
+# Status History Chart
+It allows you to visualize the status of various metrics over time.
+
+## Usage
+
+```tsx
+<StatusHistoryChart
+    xAxisCategories={xAxisCategories}
+    yAxisCategories={yAxisCategories}
+    data={chartData}
+    timeScale={timeScale}
+    height={contentDimensions.height}
+/>
+```
+
+## Example
+
+Here is an example configuration for the custom Status History panel:
+
+```tsx
+const xAxisCategories = [1627849200000, 1627852800000, 1627856400000];
+const yAxisCategories = ['Service A', 'Service B', 'Service C'];
+const chartData = [
+  [0, 0, 1],
+  [0, 1, 2],
+  [0, 2, 0],
+];
+const timeScale = {
+  startMs: 1627849200000,
+  endMs: 1627856400000,
+  stepMs: 3600000,
+};
+
+<StatusHistoryChart
+    xAxisCategories={xAxisCategories}
+    yAxisCategories={yAxisCategories}
+    data={chartData}
+    timeScale={timeScale}
+    height={400}
+/>
+```

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatusHistoryChart, StatusHistoryChartProps, StatusHistoryData } from './StatusHistoryChart';
+
+const DEFAULT_DATA: StatusHistoryData[] = [
+  [0, 0, 1],
+  [1, 0, 2],
+  [2, 0, 3],
+  [0, 1, 2],
+  [1, 1, 3],
+  [2, 1, 1],
+];
+
+const meta: Meta<typeof StatusHistoryChart> = {
+  component: StatusHistoryChart,
+  args: {
+    height: 300,
+    data: DEFAULT_DATA,
+    xAxisCategories: [1677338340000, 1677338370000, 1677338400000],
+    yAxisCategories: ['Category 1', 'Category 2'],
+  },
+  render: (args) => <StatusHistoryChartWrapper {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatusHistoryChart>;
+
+const StatusHistoryChartWrapper = (props: StatusHistoryChartProps) => {
+  // This wrapper is needed or the status history chart does not size as expected.
+  return (
+    <div
+      style={{
+        height: props.height,
+        width: '100%',
+      }}
+    >
+      <StatusHistoryChart {...props} />
+    </div>
+  );
+};
+
+export const Primary: Story = {
+  args: {},
+};
+
+export const WithLegend: Story = {
+  args: {
+    legend: {
+      show: true,
+      data: ['Status 1', 'Status 2', 'Status 3'],
+    },
+  },
+};

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import type { Meta, StoryObj } from '@storybook/react';
 import { StatusHistoryChart, StatusHistoryChartProps, StatusHistoryData } from './StatusHistoryChart';
 

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
@@ -1,0 +1,169 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box } from '@mui/material';
+import { HeatmapChart as EChartsHeatmapChart } from 'echarts/charts';
+import {
+  GridComponent,
+  DatasetComponent,
+  TitleComponent,
+  TooltipComponent,
+  VisualMapComponent,
+  LegendComponentOption,
+} from 'echarts/components';
+import { EChartsCoreOption, use } from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { TimeScale } from '@perses-dev/core';
+import { useChartsTheme } from '../context/ChartsProvider';
+import { useTimeZone } from '../context/TimeZoneProvider';
+import { formatWithTimeZone } from '../utils';
+import { EChart } from '../EChart';
+import { getColorsForValues } from './utils/get-color';
+import { getFormattedStatusHistoryAxisLabel } from './get-formatted-axis-label';
+import { getTooltipPosition } from './utils/get-tooltip-position';
+
+use([
+  EChartsHeatmapChart,
+  VisualMapComponent,
+  GridComponent,
+  DatasetComponent,
+  TitleComponent,
+  TooltipComponent,
+  CanvasRenderer,
+]);
+
+export type StatusHistoryData = [number, number, number | undefined];
+
+export interface StatusHistoryChartProps {
+  height: number;
+  data: StatusHistoryData[];
+  xAxisCategories: number[];
+  yAxisCategories: string[];
+  legend?: LegendComponentOption;
+  timeScale?: TimeScale;
+}
+
+export function StatusHistoryChart(props: StatusHistoryChartProps) {
+  const { height, data, xAxisCategories, yAxisCategories, timeScale } = props;
+  const { timeZone } = useTimeZone();
+  const chartsTheme = useChartsTheme();
+
+  const uniqueValues = [...new Set(data.map((item) => item[2]))].filter(
+    (value): value is number => value !== undefined
+  );
+
+  // get colors from theme and generate colors if not provided
+  const colors = uniqueValues.map((value, index) => ({
+    value,
+    color: getColorsForValues(
+      uniqueValues,
+      Array.isArray(chartsTheme.echartsTheme.color)
+        ? chartsTheme.echartsTheme.color.filter((color): color is string => typeof color === 'string')
+        : []
+    )[index],
+  }));
+
+  const option: EChartsCoreOption = {
+    tooltip: {
+      position: getTooltipPosition,
+      formatter: (params: { data: StatusHistoryData }) => {
+        const { data } = params;
+        const [x, y, value] = data;
+        const xAxisLabel = xAxisCategories[x];
+        const date = xAxisLabel ? new Date(xAxisLabel) : null;
+        const time = date ? formatWithTimeZone(date, 'yyyy-MM-dd HH:mm:ss', timeZone) : '';
+        return `
+              <div style="padding: 5px;">
+                  ${time}<br/>
+                  <strong>${yAxisCategories[y]}</strong><br/>
+                  ${value}<br/>
+              </div>
+          `;
+      },
+    },
+    grid: {
+      top: '5%',
+      bottom: '5%',
+    },
+    xAxis: {
+      type: 'category',
+      data: xAxisCategories,
+      axisLine: {
+        show: false,
+      },
+      splitArea: {
+        show: false,
+      },
+      axisLabel: {
+        hideOverlap: true,
+        formatter: getFormattedStatusHistoryAxisLabel(timeScale?.rangeMs ?? 0, timeZone),
+      },
+    },
+    yAxis: {
+      type: 'category',
+      data: yAxisCategories,
+      axisLine: {
+        show: false,
+      },
+      splitArea: {
+        show: false,
+        interval: 0,
+      },
+      splitLine: {
+        show: false,
+      },
+      axisLabel: {
+        interval: 0,
+      },
+    },
+    visualMap: {
+      show: false,
+      type: 'piecewise',
+      pieces: colors,
+    },
+    series: [
+      {
+        name: 'Status history',
+        type: 'heatmap',
+        coordinateSystem: 'cartesian2d',
+        data: data,
+        label: {
+          show: false,
+        },
+        itemStyle: {
+          borderWidth: 1,
+          borderType: 'solid',
+          borderColor: '#ffffff',
+        },
+        emphasis: {
+          itemStyle: {
+            opacity: 0.5,
+          },
+        },
+      },
+    ],
+  };
+
+  return (
+    <Box sx={{ height: height, overflow: 'auto' }}>
+      <EChart
+        sx={{
+          width: '100%',
+          height: height,
+        }}
+        option={option}
+        theme={chartsTheme.echartsTheme}
+      />
+    </Box>
+  );
+}

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
@@ -153,7 +153,7 @@ export function StatusHistoryChart(props: StatusHistoryChartProps) {
   };
 
   return (
-    <Box sx={{ height: height, overflow: 'auto' }}>
+    <Box style={{ height: height }} sx={{ overflow: 'auto' }}>
       <EChart
         sx={{
           width: '100%',

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -46,11 +46,16 @@ export function generateTooltipHTML({
     padding-top: 8px;
   `;
 
+  const labelStyles = css`
+    margin-right: 16px;
+  `;
+
   return `
     <div>
-      <div style="${tooltipHeader.styles}">${formattedDate} - ${formattedTime}</div>
+      <div style="${tooltipHeader.styles}">${formattedDate} ${formattedTime}</div>
       <div style="${tooltipContentStyles.styles}">
-        <div>${marker} <strong>${yAxisCategories[y]}</strong>
+        <div style="${labelStyles.styles}">
+          ${marker} <strong>${yAxisCategories[y]}</strong>
         </div>
         <div>
           ${value}

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -1,0 +1,48 @@
+import { css, Theme } from '@mui/material';
+import { getDateAndTime } from '../utils';
+import { StatusHistoryData } from './StatusHistoryChart';
+
+interface CustomTooltipProps {
+  data: StatusHistoryData;
+  marker: string;
+  xAxisCategories: number[];
+  yAxisCategories: string[];
+  theme: Theme;
+}
+
+export function generateTooltipHTML({
+  data,
+  marker,
+  xAxisCategories,
+  yAxisCategories,
+  theme,
+}: CustomTooltipProps): string {
+  const [x, y, value] = data;
+  const xAxisLabel = xAxisCategories[x];
+
+  const { formattedDate, formattedTime } = xAxisLabel ? getDateAndTime(xAxisLabel) : {};
+
+  const tooltipHeader = css`
+    border-bottom: 1px solid ${theme.palette.grey[500]};
+    padding-bottom: 8px;
+  `;
+
+  const tooltipContentStyles = css`
+    display: flex;
+    justify-content: space-between;
+    padding-top: 8px;
+  `;
+
+  return `
+    <div>
+      <div style="${tooltipHeader.styles}">${formattedDate} ${formattedTime}</div>
+      <div style="${tooltipContentStyles.styles}">
+        <div>${marker} <strong>${yAxisCategories[y]}</strong>
+        </div>
+        <div>
+          ${value}
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -20,7 +20,7 @@ export function generateTooltipHTML({
   const [x, y, value] = data;
   const xAxisLabel = xAxisCategories[x];
 
-  const { formattedDate, formattedTime } = xAxisLabel ? getDateAndTime(xAxisLabel) : {};
+  const { formattedDate, formattedTime } = getDateAndTime(xAxisLabel);
 
   const tooltipHeader = css`
     border-bottom: 1px solid ${theme.palette.grey[500]};
@@ -35,7 +35,7 @@ export function generateTooltipHTML({
 
   return `
     <div>
-      <div style="${tooltipHeader.styles}">${formattedDate} ${formattedTime}</div>
+      <div style="${tooltipHeader.styles}">${formattedDate} - ${formattedTime}</div>
       <div style="${tooltipContentStyles.styles}">
         <div>${marker} <strong>${yAxisCategories[y]}</strong>
         </div>

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -55,7 +55,8 @@ export function generateTooltipHTML({
       <div style="${tooltipHeader.styles}">${formattedDate} ${formattedTime}</div>
       <div style="${tooltipContentStyles.styles}">
         <div style="${labelStyles.styles}">
-          ${marker} <strong>${yAxisCategories[y]}</strong>
+          ${marker}
+          <strong>${yAxisCategories[y]}</strong>
         </div>
         <div>
           ${value}

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { css, Theme } from '@mui/material';
 import { getDateAndTime } from '../utils';
 import { StatusHistoryData } from './StatusHistoryChart';

--- a/ui/components/src/StatusHistoryChart/get-formatted-axis-label.ts
+++ b/ui/components/src/StatusHistoryChart/get-formatted-axis-label.ts
@@ -1,0 +1,47 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { formatWithTimeZone } from '../utils';
+
+// https://echarts.apache.org/en/option.html#xAxis.axisLabel.formatter
+export function getFormattedStatusHistoryAxisLabel(rangeMs: number, timezone: string) {
+  return function (value: number) {
+    const dayMs = 86400000;
+    const monthMs = 2629440000;
+    const yearMs = 31536000000;
+
+    const timeStamp = new Date(Number(value));
+
+    // more than 5 years
+    if (rangeMs > yearMs * 5) {
+      return formatWithTimeZone(timeStamp, 'yyy', timezone);
+    }
+
+    // more than 2 years
+    if (rangeMs > yearMs * 2) {
+      return formatWithTimeZone(timeStamp, 'MMM yyy', timezone);
+    }
+
+    // between 5 days to 6 months
+    if (rangeMs > dayMs * 10 && rangeMs < monthMs * 6) {
+      return formatWithTimeZone(timeStamp, 'dd.MM', timezone); // 12-01
+    }
+
+    // between 2 and 10 days
+    if (rangeMs > dayMs * 2 && rangeMs <= dayMs * 10) {
+      return formatWithTimeZone(timeStamp, 'dd.MM HH:mm', timezone); // 12-01; // 12-01 12:30
+    }
+
+    return formatWithTimeZone(timeStamp, 'HH:mm', timezone);
+  };
+}

--- a/ui/components/src/StatusHistoryChart/index.ts
+++ b/ui/components/src/StatusHistoryChart/index.ts
@@ -11,15 +11,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './plugins/bar-chart';
-export * from './plugins/gauge-chart';
-export * from './plugins/markdown';
-export * from './plugins/scatterplot';
-export * from './plugins/stat-chart';
-export * from './plugins/table';
-export * from './plugins/time-series-chart';
-export * from './plugins/time-series-table';
-export * from './plugins/trace-table';
-export * from './plugins/tracing-gantt-chart';
-export * from './plugins/pie-chart';
-export * from './plugins/status-history-chart';
+export * from './StatusHistoryChart';
+export * from './utils/get-color';

--- a/ui/components/src/StatusHistoryChart/utils/get-color.test.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.test.ts
@@ -1,0 +1,56 @@
+import { getColorForValue, getColorsForValues, hexToHSL, hslToHex } from './get-color';
+
+describe('getColorForValue', () => {
+  it('should return a valid color for a given value and base color', () => {
+    const color = getColorForValue('test', '#ff0000');
+    expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+
+  it('should fall back to default color for invalid base color', () => {
+    const color = getColorForValue('test', 'invalid-color');
+    expect(color).toBe('#1f77b4');
+  });
+
+  it('should handle numeric values correctly', () => {
+    const color = getColorForValue(123, '#00ff00');
+    expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+
+  it('should return fallback color on error', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const color = getColorForValue('test', '#zzzzzz');
+    expect(color).toBe('#1f77b4');
+    jest.restoreAllMocks();
+  });
+});
+
+describe('getColorsForValues', () => {
+  it('should return theme colors if enough are provided', () => {
+    const colors = getColorsForValues(['a', 'b'], ['#ff0000', '#00ff00']);
+    expect(colors).toEqual(['#ff0000', '#00ff00']);
+  });
+
+  it('should generate additional colors if not enough theme colors are provided', () => {
+    const colors = getColorsForValues(['a', 'b', 'c'], ['#ff0000']);
+    expect(colors.length).toBe(3);
+    expect(colors[0]).toBe('#ff0000');
+    expect(colors[1]).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    expect(colors[2]).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+});
+
+describe('hexToHSL', () => {
+  it('should convert hex to HSL correctly', () => {
+    const [h, s, l] = hexToHSL('#ff0000');
+    expect(h).toBeCloseTo(0);
+    expect(s).toBeCloseTo(100);
+    expect(l).toBeCloseTo(50);
+  });
+});
+
+describe('hslToHex', () => {
+  it('should convert HSL to hex correctly', () => {
+    const hex = hslToHex(0, 100, 50);
+    expect(hex).toBe('#ff0000');
+  });
+});

--- a/ui/components/src/StatusHistoryChart/utils/get-color.test.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.test.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { getColorForValue, getColorsForValues, hexToHSL, hslToHex } from './get-color';
 
 describe('getColorForValue', () => {

--- a/ui/components/src/StatusHistoryChart/utils/get-color.test.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.test.ts
@@ -8,7 +8,7 @@ describe('getColorForValue', () => {
 
   it('should fall back to default color for invalid base color', () => {
     const color = getColorForValue('test', 'invalid-color');
-    expect(color).toBe('#1f77b4');
+    expect(color).toBe('#588a0f');
   });
 
   it('should handle numeric values correctly', () => {
@@ -16,11 +16,9 @@ describe('getColorForValue', () => {
     expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
   });
 
-  it('should return fallback color on error', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+  it('should use fallback color on error', () => {
     const color = getColorForValue('test', '#zzzzzz');
-    expect(color).toBe('#1f77b4');
-    jest.restoreAllMocks();
+    expect(color).toBe('#588a0f');
   });
 });
 

--- a/ui/components/src/StatusHistoryChart/utils/get-color.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.ts
@@ -1,0 +1,108 @@
+const fallbackColor = '#1f77b4';
+
+export function getColorForValue(value: number | string, baseColor: string): string {
+  // Validate base color
+  if (!baseColor.match(/^#[0-9A-Fa-f]{6}$/)) {
+    console.warn('Invalid base color, falling back to default');
+    baseColor = fallbackColor;
+  }
+
+  try {
+    const [baseH, baseS, baseL] = hexToHSL(baseColor);
+
+    // Ensure numeric values are valid
+    if (isNaN(baseH) || isNaN(baseS) || isNaN(baseL)) {
+      throw new Error('Invalid HSL values');
+    }
+
+    // Create deterministic hash
+    const hash = String(value)
+      .split('')
+      .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+
+    const hueStep = 60;
+    const lightnessVariation = 15;
+
+    const hueOffset = (hash % 6) * hueStep; // 6 segments of 60° each
+    const newH = (baseH + hueOffset) % 360;
+    const newL = baseL + (hash % 2 ? lightnessVariation : -lightnessVariation);
+
+    // Keep saturation high for better distinction
+    const newS = Math.min(baseS + 10, 90);
+    const color = hslToHex(
+      Math.abs(newH),
+      Math.min(Math.max(newS, 50), 90), // Keep saturation 50-90%
+      Math.min(Math.max(newL, 30), 70) // Keep lightness 30-70%
+    );
+
+    // Validate generated color
+    if (!color.match(/^#[0-9A-Fa-f]{6}$/)) {
+      throw new Error('Invalid generated color');
+    }
+
+    return color;
+  } catch (error) {
+    console.error('Color generation failed:', error);
+    return fallbackColor;
+  }
+}
+
+export function getColorsForValues(uniqueValues: Array<number | string>, themeColors: string[]): string[] {
+  // If we have enough theme colors, use them
+  if (themeColors.length >= uniqueValues.length) {
+    return themeColors.slice(0, uniqueValues.length);
+  }
+
+  // Use theme colors first, then generate additional ones
+  return uniqueValues.map((value, index) => {
+    if (index < themeColors.length) {
+      return themeColors[index] || fallbackColor;
+    }
+    return getColorForValue(value, themeColors[0] || fallbackColor);
+  });
+}
+
+export function hexToHSL(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return [h * 360, s * 100, l * 100];
+}
+
+export function hslToHex(h: number, s: number, l: number): string {
+  l /= 100;
+  const a = (s * Math.min(l, 1 - l)) / 100;
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}

--- a/ui/components/src/StatusHistoryChart/utils/get-color.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.ts
@@ -1,9 +1,8 @@
-const fallbackColor = '#1f77b4';
+export const fallbackColor = '#1f77b4';
 
 export function getColorForValue(value: number | string, baseColor: string): string {
   // Validate base color
   if (!baseColor.match(/^#[0-9A-Fa-f]{6}$/)) {
-    console.warn('Invalid base color, falling back to default');
     baseColor = fallbackColor;
   }
 
@@ -42,7 +41,6 @@ export function getColorForValue(value: number | string, baseColor: string): str
 
     return color;
   } catch (error) {
-    console.error('Color generation failed:', error);
     return fallbackColor;
   }
 }

--- a/ui/components/src/StatusHistoryChart/utils/get-color.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export const fallbackColor = '#1f77b4';
 
 export function getColorForValue(value: number | string, baseColor: string): string {

--- a/ui/components/src/StatusHistoryChart/utils/get-tooltip-position.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-tooltip-position.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getTooltipPosition = (point: [number, number], params: any, dom: any, rect: any, size: any) => {
   // calculate the position to avoid overflow

--- a/ui/components/src/StatusHistoryChart/utils/get-tooltip-position.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-tooltip-position.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getTooltipPosition = (point: [number, number], params: any, dom: any, rect: any, size: any) => {
+  // calculate the position to avoid overflow
+  const [x, y] = point;
+  const { contentSize, viewSize } = size;
+
+  const posX = x + contentSize[0] > viewSize[0] ? x - contentSize[0] : x;
+  const posY = y + contentSize[1] > viewSize[1] ? y - contentSize[1] : y;
+
+  return [posX, posY];
+};

--- a/ui/components/src/StatusHistoryChart/utils/get-tooltip-position.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-tooltip-position.ts
@@ -11,8 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const getTooltipPosition = (point: [number, number], params: any, dom: any, rect: any, size: any) => {
+import { TooltipComponentOption } from 'echarts';
+
+export const getTooltipPosition: TooltipComponentOption['position'] = (...data) => {
+  const point = data[0];
+  const size = data[4];
+
   // calculate the position to avoid overflow
   const [x, y] = point;
   const { contentSize, viewSize } = size;

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
@@ -15,7 +15,7 @@ import { Box, Divider, Typography, Stack, Switch } from '@mui/material';
 import Pin from 'mdi-material-ui/Pin';
 import PinOutline from 'mdi-material-ui/PinOutline';
 import { memo } from 'react';
-import { format } from 'date-fns';
+import { getDateAndTime } from '../utils';
 import { NearbySeriesArray } from './nearby-series';
 import {
   TOOLTIP_BG_COLOR_FALLBACK,
@@ -49,9 +49,7 @@ export const TooltipHeader = memo(function TooltipHeader({
   }
 
   const formatTimeSeriesHeader = (timeMs: number) => {
-    const date = new Date(timeMs);
-    const formattedDate = format(date, 'MMM dd, yyyy - ');
-    const formattedTime = format(date, 'HH:mm:ss');
+    const { formattedTime, formattedDate } = getDateAndTime(timeMs);
     return (
       <Box>
         <Typography

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -50,3 +50,4 @@ export * from './theme';
 export * from './TransformsEditor';
 export * from './RefreshIntervalPicker';
 export * from './PieChart';
+export * from './StatusHistoryChart';

--- a/ui/components/src/utils/format.ts
+++ b/ui/components/src/utils/format.ts
@@ -103,3 +103,13 @@ export function getFormattedAxisLabel(rangeMs: number) {
     day: '{MM}/{dd}',
   };
 }
+
+export const getDateAndTime = (timeMs: number) => {
+  const date = new Date(timeMs);
+  const formattedDate = format(date, 'MMM dd, yyyy - ');
+  const formattedTime = format(date, 'HH:mm:ss');
+  return {
+    formattedDate,
+    formattedTime,
+  };
+};

--- a/ui/components/src/utils/format.ts
+++ b/ui/components/src/utils/format.ts
@@ -104,7 +104,15 @@ export function getFormattedAxisLabel(rangeMs: number) {
   };
 }
 
-export const getDateAndTime = (timeMs: number) => {
+interface FormattedDateTime {
+  formattedDate: string;
+  formattedTime: string;
+}
+
+export const getDateAndTime = (timeMs?: number): FormattedDateTime => {
+  if (!timeMs) {
+    return { formattedDate: '', formattedTime: '' };
+  }
   const date = new Date(timeMs);
   const formattedDate = format(date, 'MMM dd, yyyy - ');
   const formattedTime = format(date, 'HH:mm:ss');

--- a/ui/panels-plugin/plugin.json
+++ b/ui/panels-plugin/plugin.json
@@ -37,7 +37,7 @@
           "description": ""
         }
       },
-         {
+      {
         "pluginType": "Panel",
         "kind": "PieChart",
         "display": {
@@ -90,6 +90,14 @@
         "kind": "TracingGanttChart",
         "display": {
           "name": "Tracing Gantt Chart",
+          "description": ""
+        }
+      },
+      {
+        "pluginType": "Panel",
+        "kind": "StatusHistoryChart",
+        "display": {
+          "name": "Status History Chart",
           "description": ""
         }
       }

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChart.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChart.ts
@@ -1,0 +1,25 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PanelPlugin } from '@perses-dev/plugin-system';
+
+import { createInitialStatusHistoryChartOptions, StatusHistoryChartOptions } from './status-history-model';
+import { StatusHistoryChartOptionsEditorSettings } from './StatusHistoryChartOptionsEditorSettings';
+import { StatusHistoryPanel } from './StatusHistoryPanel';
+
+export const StatusHistoryChart: PanelPlugin<StatusHistoryChartOptions> = {
+  PanelComponent: StatusHistoryPanel,
+  supportedQueryTypes: ['TimeSeriesQuery'],
+  panelOptionsEditorComponents: [{ label: 'Settings', content: StatusHistoryChartOptionsEditorSettings }],
+  createInitialOptions: createInitialStatusHistoryChartOptions,
+};

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChartOptionsEditorSettings.tsx
@@ -32,7 +32,7 @@ export function StatusHistoryChartOptionsEditorSettings(props: StatusHistroyChar
   return (
     <OptionsEditorGrid>
       <OptionsEditorColumn>
-        <LegendOptionsEditor includeLegendCalcs={false} value={value.legend} onChange={handleLegendChange} />
+        <LegendOptionsEditor showValuesEditor={false} value={value.legend} onChange={handleLegendChange} />
       </OptionsEditorColumn>
       <OptionsEditorColumn>
         <OptionsEditorGroup title="Reset Settings">

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChartOptionsEditorSettings.tsx
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChartOptionsEditorSettings.tsx
@@ -1,0 +1,57 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LegendOptionsEditor, LegendOptionsEditorProps } from '@perses-dev/plugin-system';
+import { produce } from 'immer';
+import { OptionsEditorGroup, OptionsEditorGrid, OptionsEditorColumn } from '@perses-dev/components';
+import { Button } from '@mui/material';
+import { StatusHistoryChartOptions, StatusHistroyChartEditorProps } from './status-history-model.js';
+
+export function StatusHistoryChartOptionsEditorSettings(props: StatusHistroyChartEditorProps) {
+  const { onChange, value } = props;
+
+  const handleLegendChange: LegendOptionsEditorProps['onChange'] = (newLegend) => {
+    // TODO (sjcobb): fix type, add position, fix glitch
+    onChange(
+      produce(value, (draft: StatusHistoryChartOptions) => {
+        draft.legend = newLegend;
+      })
+    );
+  };
+
+  return (
+    <OptionsEditorGrid>
+      <OptionsEditorColumn>
+        <LegendOptionsEditor includeLegendCalcs={false} value={value.legend} onChange={handleLegendChange} />
+      </OptionsEditorColumn>
+      <OptionsEditorColumn>
+        <OptionsEditorGroup title="Reset Settings">
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => {
+              onChange(
+                produce(value, (draft: StatusHistoryChartOptions) => {
+                  // reset button removes all optional panel options
+                  draft.legend = undefined;
+                })
+              );
+            }}
+          >
+            Reset To Defaults
+          </Button>
+        </OptionsEditorGroup>
+      </OptionsEditorColumn>
+    </OptionsEditorGrid>
+  );
+}

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryPanel.tsx
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryPanel.tsx
@@ -16,7 +16,7 @@ import { ContentWithLegend, LoadingOverlay, StatusHistoryChart, useChartsTheme }
 import { PanelProps, useDataQueries, validateLegendSpec } from '@perses-dev/plugin-system';
 import { merge } from 'lodash';
 import { useMemo } from 'react';
-import { createStatusHistoryDataModel } from './utils/data-transform';
+import { useStatusHistoryDataModel } from './utils/data-transform';
 import { StatusHistoryChartOptions } from './status-history-model.js';
 
 export type StatusHistoryChartPanelProps = PanelProps<StatusHistoryChartOptions>;
@@ -32,16 +32,15 @@ export function StatusHistoryPanel(props: StatusHistoryChartPanelProps) {
   const PADDING = chartsTheme.container.padding.default;
   const { queryResults, isLoading, isFetching } = useDataQueries('TimeSeriesQuery');
 
-  const { statusHistoryData, yAxisCategories, xAxisCategories, legendItems, timeScale } = createStatusHistoryDataModel(
+  const { statusHistoryData, yAxisCategories, xAxisCategories, legendItems, timeScale } = useStatusHistoryDataModel(
     queryResults,
     chartsTheme.echartsTheme.color as string[]
   );
 
-  const contentPadding = chartsTheme.container.padding.default;
   const adjustedContentDimensions: typeof contentDimensions = contentDimensions
     ? {
-        width: contentDimensions.width - contentPadding * 2,
-        height: contentDimensions.height - contentPadding * 2,
+        width: contentDimensions.width - PADDING * 2,
+        height: contentDimensions.height - PADDING * 2,
       }
     : undefined;
 

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryPanel.tsx
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryPanel.tsx
@@ -1,0 +1,86 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box } from '@mui/material';
+import { ContentWithLegend, LoadingOverlay, StatusHistoryChart, useChartsTheme } from '@perses-dev/components';
+import { PanelProps, useDataQueries, validateLegendSpec } from '@perses-dev/plugin-system';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
+import { createStatusHistoryDataModel } from './utils/data-transform';
+import { StatusHistoryChartOptions } from './status-history-model.js';
+
+export type StatusHistoryChartPanelProps = PanelProps<StatusHistoryChartOptions>;
+
+export function StatusHistoryPanel(props: StatusHistoryChartPanelProps) {
+  const { spec, contentDimensions } = props;
+
+  const legend = useMemo(() => {
+    return spec.legend && validateLegendSpec(spec.legend) ? merge({}, spec.legend) : undefined;
+  }, [spec.legend]);
+
+  const chartsTheme = useChartsTheme();
+  const PADDING = chartsTheme.container.padding.default;
+  const { queryResults, isLoading, isFetching } = useDataQueries('TimeSeriesQuery');
+
+  const { statusHistoryData, yAxisCategories, xAxisCategories, legendItems, timeScale } = createStatusHistoryDataModel(
+    queryResults,
+    chartsTheme.echartsTheme.color as string[]
+  );
+
+  const contentPadding = chartsTheme.container.padding.default;
+  const adjustedContentDimensions: typeof contentDimensions = contentDimensions
+    ? {
+        width: contentDimensions.width - contentPadding * 2,
+        height: contentDimensions.height - contentPadding * 2,
+      }
+    : undefined;
+
+  if (!statusHistoryData || statusHistoryData.length === 0) {
+    return null;
+  }
+
+  if (isLoading || isFetching) {
+    return <LoadingOverlay />;
+  }
+  return (
+    <Box sx={{ padding: `${PADDING}px` }}>
+      <ContentWithLegend
+        width={adjustedContentDimensions?.width ?? 400}
+        height={adjustedContentDimensions?.height ?? 1000}
+        legendSize={legend?.size}
+        legendProps={
+          legend && {
+            options: legend,
+            data: legendItems || [],
+            selectedItems: 'ALL',
+            onSelectedItemsChange: () => null,
+          }
+        }
+      >
+        {({ height, width }) => {
+          return (
+            <Box sx={{ height, width }}>
+              <StatusHistoryChart
+                xAxisCategories={xAxisCategories}
+                yAxisCategories={yAxisCategories}
+                data={statusHistoryData}
+                timeScale={timeScale}
+                height={height}
+              />
+            </Box>
+          );
+        }}
+      </ContentWithLegend>
+    </Box>
+  );
+}

--- a/ui/panels-plugin/src/plugins/status-history-chart/index.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/index.ts
@@ -11,15 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './plugins/bar-chart';
-export * from './plugins/gauge-chart';
-export * from './plugins/markdown';
-export * from './plugins/scatterplot';
-export * from './plugins/stat-chart';
-export * from './plugins/table';
-export * from './plugins/time-series-chart';
-export * from './plugins/time-series-table';
-export * from './plugins/trace-table';
-export * from './plugins/tracing-gantt-chart';
-export * from './plugins/pie-chart';
-export * from './plugins/status-history-chart';
+export * from './StatusHistoryChart';

--- a/ui/panels-plugin/src/plugins/status-history-chart/status-history-model.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/status-history-model.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,15 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './plugins/bar-chart';
-export * from './plugins/gauge-chart';
-export * from './plugins/markdown';
-export * from './plugins/scatterplot';
-export * from './plugins/stat-chart';
-export * from './plugins/table';
-export * from './plugins/time-series-chart';
-export * from './plugins/time-series-table';
-export * from './plugins/trace-table';
-export * from './plugins/tracing-gantt-chart';
-export * from './plugins/pie-chart';
-export * from './plugins/status-history-chart';
+import { LegendSpecOptions, OptionsEditorProps } from '@perses-dev/plugin-system';
+
+export function createInitialStatusHistoryChartOptions() {
+  return {};
+}
+
+export interface StatusHistoryChartOptions {
+  legend?: LegendSpecOptions;
+}
+
+export type StatusHistroyChartEditorProps = OptionsEditorProps<StatusHistoryChartOptions>;

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
@@ -13,12 +13,13 @@
 
 import { TimeSeriesData } from '@perses-dev/core';
 import { QueryData } from '@perses-dev/plugin-system';
-import { createStatusHistoryDataModel } from './data-transform';
+import { renderHook } from '@testing-library/react';
+import { useStatusHistoryDataModel } from './data-transform';
 
-describe('createStatusHistoryDataModel', () => {
+describe('useStatusHistoryDataModel', () => {
   it('should return empty model for empty query results', () => {
-    const result = createStatusHistoryDataModel([], []);
-    expect(result).toEqual({
+    const { result } = renderHook(() => useStatusHistoryDataModel([], []));
+    expect(result.current).toEqual({
       legendItems: [],
       statusHistoryData: [],
       xAxisCategories: [],
@@ -56,17 +57,17 @@ describe('createStatusHistoryDataModel', () => {
       },
     ];
     const colors = ['#ff0000', '#00ff00'];
-    const result = createStatusHistoryDataModel(queryResults, colors);
+    const { result } = renderHook(() => useStatusHistoryDataModel(queryResults, colors));
 
-    expect(result.legendItems).toEqual([
+    expect(result.current.legendItems).toEqual([
       { id: '0-1', label: '1', color: '#ff0000' },
       { id: '1-2', label: '2', color: '#00ff00' },
     ]);
-    expect(result.statusHistoryData).toEqual([
+    expect(result.current.statusHistoryData).toEqual([
       [0, 0, 1],
       [1, 0, 2],
     ]);
-    expect(result.xAxisCategories).toEqual([1609459200000, 1609459260000]);
-    expect(result.yAxisCategories).toEqual(['instance1']);
+    expect(result.current.xAxisCategories).toEqual([1609459200000, 1609459260000]);
+    expect(result.current.yAxisCategories).toEqual(['instance1']);
   });
 });

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
@@ -17,6 +17,11 @@ describe('createStatusHistoryDataModel', () => {
     const queryResults: Array<QueryData<TimeSeriesData>> = [
       {
         data: {
+          timeRange: {
+            start: new Date(1609459200000),
+            end: new Date(1609459260000),
+          },
+          stepMs: 60000,
           series: [
             {
               name: 'instance1',
@@ -25,6 +30,8 @@ describe('createStatusHistoryDataModel', () => {
                 [1609459200000, 1],
                 [1609459260000, 2],
               ],
+
+              // stepMs?: number;
             },
           ],
         },

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
@@ -1,0 +1,52 @@
+import { TimeSeriesData } from '@perses-dev/core';
+import { QueryData } from '@perses-dev/plugin-system';
+import { createStatusHistoryDataModel } from './data-transform';
+
+describe('createStatusHistoryDataModel', () => {
+  it('should return empty model for empty query results', () => {
+    const result = createStatusHistoryDataModel([], []);
+    expect(result).toEqual({
+      legendItems: [],
+      statusHistoryData: [],
+      xAxisCategories: [],
+      yAxisCategories: [],
+    });
+  });
+
+  it('should process query results correctly', () => {
+    const queryResults: Array<QueryData<TimeSeriesData>> = [
+      {
+        data: {
+          series: [
+            {
+              name: 'instance1',
+              formattedName: 'instance1',
+              values: [
+                [1609459200000, 1],
+                [1609459260000, 2],
+              ],
+            },
+          ],
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        definition: { query: 'some-query' } as any,
+        error: undefined,
+        isFetching: false,
+        isLoading: false,
+      },
+    ];
+    const colors = ['#ff0000', '#00ff00'];
+    const result = createStatusHistoryDataModel(queryResults, colors);
+
+    expect(result.legendItems).toEqual([
+      { id: '0-1', label: '1', color: '#ff0000' },
+      { id: '1-2', label: '2', color: '#00ff00' },
+    ]);
+    expect(result.statusHistoryData).toEqual([
+      [0, 0, 1],
+      [1, 0, 2],
+    ]);
+    expect(result.xAxisCategories).toEqual([1609459200000, 1609459260000]);
+    expect(result.yAxisCategories).toEqual(['instance1']);
+  });
+});

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { TimeSeriesData } from '@perses-dev/core';
 import { QueryData } from '@perses-dev/plugin-system';
 import { createStatusHistoryDataModel } from './data-transform';

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.ts
@@ -1,0 +1,98 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getColorForValue, LegendItem } from '@perses-dev/components';
+import { TimeScale, TimeSeriesData } from '@perses-dev/core';
+import { QueryData } from '@perses-dev/plugin-system';
+import { getCommonTimeScaleForQueries } from './get-timescale';
+
+interface StatusHistoryDataModel {
+  legendItems: LegendItem[];
+  statusHistoryData: Array<[number, number, number | undefined]>;
+  xAxisCategories: number[];
+  yAxisCategories: string[];
+  timeScale?: TimeScale;
+}
+
+function generateCompleteTimestamps(timescale?: TimeScale): number[] {
+  if (!timescale) {
+    return [];
+  }
+  const { startMs, endMs, stepMs } = timescale;
+  const timestamps: number[] = [];
+  for (let time = startMs; time <= endMs; time += stepMs) {
+    timestamps.push(time);
+  }
+  return timestamps;
+}
+
+export function createStatusHistoryDataModel(
+  queryResults: Array<QueryData<TimeSeriesData>>,
+  colors: string[]
+): StatusHistoryDataModel {
+  if (!queryResults || queryResults.length === 0) {
+    return {
+      legendItems: [],
+      statusHistoryData: [],
+      xAxisCategories: [],
+      yAxisCategories: [],
+    };
+  }
+
+  const timeScale = getCommonTimeScaleForQueries(queryResults);
+  const statusHistoryData: Array<[number, number, number]> = [];
+  const yAxisCategories: string[] = [];
+  const legendSet = new Set<number>();
+
+  const xAxisCategories = generateCompleteTimestamps(timeScale);
+
+  queryResults.forEach(({ data }) => {
+    if (!data) {
+      return;
+    }
+
+    data.series.forEach((item) => {
+      const instance = item.formattedName || '';
+
+      yAxisCategories.push(instance);
+
+      const yIndex = yAxisCategories.length - 1;
+
+      item.values.forEach(([time, value]) => {
+        const itemIndexOnXaxis = xAxisCategories.findIndex((v) => v === time);
+
+        if (value !== null && itemIndexOnXaxis !== -1) {
+          legendSet.add(value);
+          statusHistoryData.push([itemIndexOnXaxis, yIndex, value]);
+        }
+      });
+    });
+  });
+
+  const legendItems: LegendItem[] = Array.from(legendSet).map((value, idx) => {
+    const color = colors[idx] || getColorForValue(value, colors[0] || 'defaultColor');
+    return {
+      id: `${idx}-${value}`,
+      label: String(value),
+      color,
+    };
+  });
+
+  return {
+    xAxisCategories,
+    yAxisCategories,
+    legendItems,
+    statusHistoryData,
+    timeScale,
+  };
+}

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.ts
@@ -80,7 +80,7 @@ export function createStatusHistoryDataModel(
   });
 
   const legendItems: LegendItem[] = Array.from(legendSet).map((value, idx) => {
-    const color = colors[idx] || getColorForValue(value, colors[0] || 'defaultColor');
+    const color = colors[idx] || getColorForValue(value, colors[0] || '#1f77b4');
     return {
       id: `${idx}-${value}`,
       label: String(value),

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/get-timescale.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/get-timescale.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,15 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './plugins/bar-chart';
-export * from './plugins/gauge-chart';
-export * from './plugins/markdown';
-export * from './plugins/scatterplot';
-export * from './plugins/stat-chart';
-export * from './plugins/table';
-export * from './plugins/time-series-chart';
-export * from './plugins/time-series-table';
-export * from './plugins/trace-table';
-export * from './plugins/tracing-gantt-chart';
-export * from './plugins/pie-chart';
-export * from './plugins/status-history-chart';
+import { getCommonTimeScale, TimeScale, TimeSeriesData } from '@perses-dev/core';
+import { UseDataQueryResults } from '@perses-dev/plugin-system';
+
+export function getCommonTimeScaleForQueries(
+  queries: UseDataQueryResults<TimeSeriesData>['queryResults']
+): TimeScale | undefined {
+  const seriesData = queries.map((query) => (query.isLoading ? undefined : query.data));
+  return getCommonTimeScale(seriesData);
+}

--- a/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -63,10 +63,10 @@ const VALUE_OPTIONS: LegendValueOption[] = Object.entries(LEGEND_VALUE_CONFIG).m
 export interface LegendOptionsEditorProps {
   value?: LegendSpecOptions;
   onChange: (legend?: LegendSpecOptions) => void;
-  includeLegendCalcs?: boolean;
+  showValuesEditor?: boolean;
 }
 
-export function LegendOptionsEditor({ value, onChange, includeLegendCalcs = true }: LegendOptionsEditorProps) {
+export function LegendOptionsEditor({ value, onChange, showValuesEditor = true }: LegendOptionsEditorProps) {
   const handleLegendShowChange: SwitchProps['onChange'] = (_: unknown, checked: boolean) => {
     // legend is hidden when legend obj is undefined
     const legendValue = checked === true ? { position: DEFAULT_LEGEND.position } : undefined;
@@ -179,7 +179,7 @@ export function LegendOptionsEditor({ value, onChange, includeLegendCalcs = true
           ></SettingsAutocomplete>
         }
       />
-      {includeLegendCalcs && (
+      {showValuesEditor && (
         <OptionsEditorControl
           label="Values"
           control={

--- a/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -63,9 +63,10 @@ const VALUE_OPTIONS: LegendValueOption[] = Object.entries(LEGEND_VALUE_CONFIG).m
 export interface LegendOptionsEditorProps {
   value?: LegendSpecOptions;
   onChange: (legend?: LegendSpecOptions) => void;
+  includeLegendCalcs?: boolean;
 }
 
-export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProps) {
+export function LegendOptionsEditor({ value, onChange, includeLegendCalcs = true }: LegendOptionsEditorProps) {
   const handleLegendShowChange: SwitchProps['onChange'] = (_: unknown, checked: boolean) => {
     // legend is hidden when legend obj is undefined
     const legendValue = checked === true ? { position: DEFAULT_LEGEND.position } : undefined;
@@ -178,27 +179,29 @@ export function LegendOptionsEditor({ value, onChange }: LegendOptionsEditorProp
           ></SettingsAutocomplete>
         }
       />
-      <OptionsEditorControl
-        label="Values"
-        control={
-          // For some reason, the inferred option type doesn't always seem to work
-          // quite right when `multiple` is true. Explicitly setting the generics
-          // to work around this.
-          <SettingsAutocomplete<LegendValueOption, true, true>
-            multiple={true}
-            disableCloseOnSelect
-            disableClearable
-            value={legendValuesConfig}
-            options={VALUE_OPTIONS}
-            onChange={handleLegendValueChange}
-            disabled={value === undefined || currentMode !== 'table'}
-            limitTags={1}
-            ChipProps={{
-              size: 'small',
-            }}
-          />
-        }
-      />
+      {includeLegendCalcs && (
+        <OptionsEditorControl
+          label="Values"
+          control={
+            // For some reason, the inferred option type doesn't always seem to work
+            // quite right when `multiple` is true. Explicitly setting the generics
+            // to work around this.
+            <SettingsAutocomplete<LegendValueOption, true, true>
+              multiple={true}
+              disableCloseOnSelect
+              disableClearable
+              value={legendValuesConfig}
+              options={VALUE_OPTIONS}
+              onChange={handleLegendValueChange}
+              disabled={value === undefined || currentMode !== 'table'}
+              limitTags={1}
+              ChipProps={{
+                size: 'small',
+              }}
+            />
+          }
+        />
+      )}
     </OptionsEditorGroup>
   );
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Implements a new Status History panel for Perses that displays status changes over time, similar to Grafana's Status History panel.

Resolves #2268 

<!-- Context useful to a reviewer -->

# Screenshots
<img width="818" alt="2024-11-06_22-45" src="https://github.com/user-attachments/assets/499c214e-5f10-4b26-8acc-fb033f353e27">
<img width="812" alt="2024-11-06_22-45_1" src="https://github.com/user-attachments/assets/37a3416f-170c-488a-bd78-f46e877d880e">


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
