### PR TITLE
[BUGFIX] Edit mode not working after clicking on the resource row

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,13 @@ checkunused:
 
 .PHONY: checkstyle
 checkstyle:
-	@echo ">> checking code style"
+	@echo ">> checking Go code style"
 	$(GOCI) run --timeout 5m
+
+.PHONY: checklint
+checklint:
+	@echo ">> checking TS code style"
+	cd ui && npm run lint
 
 .PHONY: checklicense
 checklicense:

--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -16,15 +16,23 @@ import { useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DatasourceEditorForm, PluginRegistry, ValidationProvider } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
-import { DrawerProps } from '../drawer';
+import { DrawerProps } from '../form-drawers';
 import { DeleteResourceDialog } from '../dialogs';
 
 interface DatasourceDrawerProps<T extends Datasource> extends DrawerProps<T> {
   datasource: T;
 }
 
-export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerProps<T>) {
-  const { datasource, isOpen, action, isReadonly, onSave, onClose, onDelete } = props;
+export function DatasourceDrawer<T extends Datasource>({
+  datasource,
+  action,
+  isOpen,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: DatasourceDrawerProps<T>) {
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
@@ -49,9 +57,10 @@ export function DatasourceDrawer<T extends Datasource>(props: DatasourceDrawerPr
             {isOpen && (
               <DatasourceEditorForm
                 initialDatasourceDefinition={{ name: datasource.metadata.name, spec: datasource.spec }}
-                initialAction={action}
+                action={action}
                 isDraft={false}
                 isReadonly={isReadonly}
+                onActionChange={onActionChange}
                 onSave={handleSave}
                 onClose={onClose}
                 onDelete={onDelete ? () => setDeleteDatasourceDialogStateOpened(true) : undefined}

--- a/ui/app/src/components/datasource/DatasourceList.tsx
+++ b/ui/app/src/components/datasource/DatasourceList.tsx
@@ -204,9 +204,10 @@ export function DatasourceList<T extends Datasource>(props: ListPropertiesWithCa
         <>
           <DatasourceDrawer
             datasource={targetedDatasource}
-            isOpen={isDatasourceDrawerOpened}
             action={action}
+            isOpen={isDatasourceDrawerOpened}
             isReadonly={isReadonly}
+            onActionChange={setAction}
             onSave={handleDatasourceSave}
             onDelete={(v) => onDelete(v).then(() => setDeleteDatasourceDialogOpened(false))}
             onClose={() => setDatasourceDrawerOpened(false)}

--- a/ui/app/src/components/form-drawers.tsx
+++ b/ui/app/src/components/form-drawers.tsx
@@ -15,10 +15,22 @@ import { Action, DispatchWithPromise } from '@perses-dev/core';
 import { Dispatch, DispatchWithoutAction } from 'react';
 
 export interface DrawerProps<T> {
-  isOpen: boolean;
   action: Action;
+  isOpen: boolean;
   isReadonly?: boolean;
+  onActionChange?: Dispatch<Action>;
   onSave: Dispatch<T>;
   onDelete?: DispatchWithPromise<T>;
+  onClose: DispatchWithoutAction;
+}
+
+export interface FormEditorProps<T> {
+  initialValue: T;
+  action: Action;
+  isDraft: boolean;
+  isReadonly?: boolean;
+  onActionChange?: Dispatch<Action>;
+  onSave: Dispatch<T>;
+  onDelete?: DispatchWithoutAction;
   onClose: DispatchWithoutAction;
 }

--- a/ui/app/src/components/rolebindings/RoleBindingDrawer.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingDrawer.tsx
@@ -14,7 +14,7 @@
 import { RoleBinding } from '@perses-dev/core';
 import { Dispatch, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { DrawerProps } from '../drawer';
+import { DrawerProps } from '../form-drawers';
 import { DeleteResourceDialog } from '../dialogs';
 import { RoleBindingEditorForm } from './RoleBindingEditorForm';
 
@@ -23,8 +23,17 @@ interface RoleBindingDrawerProps<T extends RoleBinding> extends DrawerProps<T> {
   roleSuggestions?: string[];
 }
 
-export function RoleBindingDrawer<T extends RoleBinding>(props: RoleBindingDrawerProps<T>) {
-  const { roleBinding, roleSuggestions, isOpen, action, isReadonly, onSave, onClose, onDelete } = props;
+export function RoleBindingDrawer<T extends RoleBinding>({
+  roleBinding,
+  roleSuggestions,
+  action,
+  isOpen,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: RoleBindingDrawerProps<T>) {
   const [isDeleteRoleBindingDialogStateOpened, setDeleteRoleBindingDialogStateOpened] = useState<boolean>(false);
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
@@ -38,11 +47,12 @@ export function RoleBindingDrawer<T extends RoleBinding>(props: RoleBindingDrawe
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         {isOpen && (
           <RoleBindingEditorForm
-            initialRoleBinding={roleBinding}
-            initialAction={action}
+            initialValue={roleBinding}
+            action={action}
             roleSuggestions={roleSuggestions ?? []}
             isDraft={false}
             isReadonly={isReadonly}
+            onActionChange={onActionChange}
             onSave={onSave as Dispatch<RoleBinding>}
             onClose={onClose}
             onDelete={onDelete ? () => setDeleteRoleBindingDialogStateOpened(true) : undefined}

--- a/ui/app/src/components/rolebindings/RoleBindingEditorForm.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingEditorForm.tsx
@@ -50,7 +50,6 @@ export function RoleBindingEditorForm({
   });
 
   const processForm: SubmitHandler<RoleBinding> = (data: RoleBinding) => {
-    console.log('RoleBindingEditorForm.tsx', data);
     onSave(data);
   };
 

--- a/ui/app/src/components/rolebindings/RoleBindingEditorForm.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingEditorForm.tsx
@@ -15,8 +15,8 @@ import { RoleBinding, roleBindingsEditorSchema } from '@perses-dev/core';
 import { getSubmitText, getTitleAction } from '@perses-dev/plugin-system';
 import React, { useMemo, useState } from 'react';
 import { Controller, FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
-import { Autocomplete, Box, Button, Divider, IconButton, Stack, TextField, Typography } from '@mui/material';
-import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
+import { Autocomplete, Box, Divider, IconButton, Stack, TextField, Typography } from '@mui/material';
+import { DiscardChangesConfirmationDialog, FormActions } from '@perses-dev/components';
 import { zodResolver } from '@hookform/resolvers/zod';
 import PlusIcon from 'mdi-material-ui/Plus';
 import MinusIcon from 'mdi-material-ui/Minus';
@@ -87,49 +87,16 @@ export function RoleBindingEditorForm({
         }}
       >
         <Typography variant="h2">{titleAction} Role Binding</Typography>
-        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          {action === 'read' ? (
-            <>
-              {/* TODO: refactor to generic */}
-              {onActionChange && (
-                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
-                  Edit
-                </Button>
-              )}
-              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
-                Delete
-              </Button>
-              <Divider
-                orientation="vertical"
-                flexItem
-                sx={(theme) => ({
-                  borderColor: theme.palette.grey['500'],
-                  '&.MuiDivider-root': {
-                    marginLeft: 2,
-                    marginRight: 1,
-                  },
-                })}
-              />
-              <Button color="secondary" variant="outlined" onClick={onClose}>
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                type="submit"
-                variant="contained"
-                disabled={!form.formState.isValid}
-                onClick={form.handleSubmit(processForm)}
-              >
-                {submitText}
-              </Button>
-              <Button color="secondary" variant="outlined" onClick={handleCancel}>
-                Cancel
-              </Button>
-            </>
-          )}
-        </Stack>
+        <FormActions
+          action={action}
+          submitText={submitText}
+          isReadonly={isReadonly}
+          isValid={form.formState.isValid}
+          onActionChange={onActionChange}
+          onSubmit={form.handleSubmit(processForm)}
+          onDelete={onDelete}
+          onCancel={handleCancel}
+        />
       </Box>
       <Stack padding={2} gap={2} sx={{ overflowY: 'scroll' }}>
         <Stack gap={2} direction="row">

--- a/ui/app/src/components/rolebindings/RoleBindingList.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingList.tsx
@@ -77,7 +77,6 @@ export function RoleBindingList<T extends RoleBinding>(props: ListPropertiesWith
 
   const handleRoleBindingSave = useCallback(
     async (roleBinding: T) => {
-      console.log('RoleBindingList.tsx', roleBinding);
       if (action === 'create') {
         await onCreate(roleBinding);
       } else if (action === 'update') {

--- a/ui/app/src/components/rolebindings/RoleBindingList.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingList.tsx
@@ -77,6 +77,7 @@ export function RoleBindingList<T extends RoleBinding>(props: ListPropertiesWith
 
   const handleRoleBindingSave = useCallback(
     async (roleBinding: T) => {
+      console.log('RoleBindingList.tsx', roleBinding);
       if (action === 'create') {
         await onCreate(roleBinding);
       } else if (action === 'update') {
@@ -186,9 +187,10 @@ export function RoleBindingList<T extends RoleBinding>(props: ListPropertiesWith
         <>
           <RoleBindingDrawer
             roleBinding={targetedRoleBinding}
-            isOpen={isRoleBindingDrawerOpened}
             action={action}
+            isOpen={isRoleBindingDrawerOpened}
             isReadonly={isReadonly}
+            onActionChange={setAction}
             onSave={handleRoleBindingSave}
             onDelete={(v) => onDelete(v).then(() => setDeleteRoleBindingDialogOpened(false))}
             onClose={() => setRoleBindingDrawerOpened(false)}

--- a/ui/app/src/components/roles/RoleDrawer.tsx
+++ b/ui/app/src/components/roles/RoleDrawer.tsx
@@ -14,7 +14,7 @@
 import { Role } from '@perses-dev/core';
 import { Dispatch, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { DrawerProps } from '../drawer';
+import { DrawerProps } from '../form-drawers';
 import { DeleteResourceDialog } from '../dialogs';
 import { RoleEditorForm } from './RoleEditorForm';
 
@@ -22,8 +22,16 @@ interface RoleDrawerProps<T extends Role> extends DrawerProps<T> {
   role: T;
 }
 
-export function RoleDrawer<T extends Role>(props: RoleDrawerProps<T>) {
-  const { role, isOpen, action, isReadonly, onSave, onClose, onDelete } = props;
+export function RoleDrawer<T extends Role>({
+  role,
+  action,
+  isOpen,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: RoleDrawerProps<T>) {
   const [isDeleteRoleDialogStateOpened, setDeleteRoleDialogStateOpened] = useState<boolean>(false);
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
@@ -37,10 +45,11 @@ export function RoleDrawer<T extends Role>(props: RoleDrawerProps<T>) {
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         {isOpen && (
           <RoleEditorForm
-            initialRole={role}
-            initialAction={action}
+            initialValue={role}
+            action={action}
             isDraft={false}
             isReadonly={isReadonly}
+            onActionChange={onActionChange}
             onSave={onSave as Dispatch<Role>}
             onClose={onClose}
             onDelete={onDelete ? () => setDeleteRoleDialogStateOpened(true) : undefined}

--- a/ui/app/src/components/roles/RoleEditorForm.tsx
+++ b/ui/app/src/components/roles/RoleEditorForm.tsx
@@ -20,22 +20,21 @@ import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import { zodResolver } from '@hookform/resolvers/zod';
 import PlusIcon from 'mdi-material-ui/Plus';
 import MinusIcon from 'mdi-material-ui/Minus';
+import { FormEditorProps } from '../form-drawers';
 
-interface RoleEditorFormProps {
-  initialRole: Role;
-  initialAction: Action;
-  isDraft: boolean;
-  isReadonly?: boolean;
-  onSave: (def: Role) => void;
-  onClose: () => void;
-  onDelete?: DispatchWithoutAction;
-}
+type RoleEditorFormProps = FormEditorProps<Role>;
 
-export function RoleEditorForm(props: RoleEditorFormProps) {
-  const { initialRole, initialAction, isDraft, isReadonly, onSave, onClose, onDelete } = props;
-
+export function RoleEditorForm({
+  initialValue,
+  action,
+  isDraft,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: RoleEditorFormProps) {
   const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
-  const [action, setAction] = useState(initialAction);
 
   const titleAction = getTitleAction(action, isDraft);
   const submitText = getSubmitText(action, isDraft);
@@ -43,7 +42,7 @@ export function RoleEditorForm(props: RoleEditorFormProps) {
   const form = useForm<Role>({
     resolver: zodResolver(rolesEditorSchema),
     mode: 'onBlur',
-    defaultValues: initialRole,
+    defaultValues: initialValue,
   });
 
   const processForm: SubmitHandler<Role> = (data: Role) => {
@@ -60,7 +59,7 @@ export function RoleEditorForm(props: RoleEditorFormProps) {
   // - update action: ask for discard approval if changed
   // - read action: don´t ask for discard approval
   function handleCancel() {
-    if (JSON.stringify(initialRole) !== JSON.stringify(form.getValues())) {
+    if (JSON.stringify(initialValue) !== JSON.stringify(form.getValues())) {
       setDiscardDialogOpened(true);
     } else {
       onClose();
@@ -81,9 +80,11 @@ export function RoleEditorForm(props: RoleEditorFormProps) {
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
           {action === 'read' ? (
             <>
-              <Button disabled={isReadonly} variant="contained" onClick={() => setAction('update')}>
-                Edit
-              </Button>
+              {onActionChange && (
+                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
+                  Edit
+                </Button>
+              )}
               <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
                 Delete
               </Button>

--- a/ui/app/src/components/roles/RoleEditorForm.tsx
+++ b/ui/app/src/components/roles/RoleEditorForm.tsx
@@ -13,10 +13,10 @@
 
 import { Action, ACTIONS, GLOBAL_SCOPES, PROJECT_SCOPES, Role, rolesEditorSchema } from '@perses-dev/core';
 import { getSubmitText, getTitleAction } from '@perses-dev/plugin-system';
-import React, { DispatchWithoutAction, Fragment, useMemo, useState } from 'react';
+import React, { Fragment, useMemo, useState } from 'react';
 import { Control, Controller, FormProvider, SubmitHandler, useFieldArray, useForm, useWatch } from 'react-hook-form';
-import { Box, Button, Divider, IconButton, MenuItem, Stack, TextField, Typography } from '@mui/material';
-import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
+import { Box, Divider, IconButton, MenuItem, Stack, TextField, Typography } from '@mui/material';
+import { DiscardChangesConfirmationDialog, FormActions } from '@perses-dev/components';
 import { zodResolver } from '@hookform/resolvers/zod';
 import PlusIcon from 'mdi-material-ui/Plus';
 import MinusIcon from 'mdi-material-ui/Minus';
@@ -77,48 +77,16 @@ export function RoleEditorForm({
         }}
       >
         <Typography variant="h2">{titleAction} Role</Typography>
-        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          {action === 'read' ? (
-            <>
-              {onActionChange && (
-                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
-                  Edit
-                </Button>
-              )}
-              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
-                Delete
-              </Button>
-              <Divider
-                orientation="vertical"
-                flexItem
-                sx={(theme) => ({
-                  borderColor: theme.palette.grey['500'],
-                  '&.MuiDivider-root': {
-                    marginLeft: 2,
-                    marginRight: 1,
-                  },
-                })}
-              />
-              <Button color="secondary" variant="outlined" onClick={onClose}>
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                type="submit"
-                variant="contained"
-                disabled={!form.formState.isValid}
-                onClick={form.handleSubmit(processForm)}
-              >
-                {submitText}
-              </Button>
-              <Button color="secondary" variant="outlined" onClick={handleCancel}>
-                Cancel
-              </Button>
-            </>
-          )}
-        </Stack>
+        <FormActions
+          action={action}
+          submitText={submitText}
+          isReadonly={isReadonly}
+          isValid={form.formState.isValid}
+          onActionChange={onActionChange}
+          onSubmit={form.handleSubmit(processForm)}
+          onDelete={onDelete}
+          onCancel={handleCancel}
+        />
       </Box>
       <Stack padding={2} gap={2} sx={{ overflowY: 'scroll' }}>
         <Stack gap={2} direction="row">

--- a/ui/app/src/components/roles/RoleList.tsx
+++ b/ui/app/src/components/roles/RoleList.tsx
@@ -181,9 +181,10 @@ export function RoleList<T extends Role>(props: ListPropertiesWithCallbacks<T>) 
         <>
           <RoleDrawer
             role={targetedRole}
-            isOpen={isRoleDrawerOpened}
             action={action}
+            isOpen={isRoleDrawerOpened}
             isReadonly={isReadonly}
+            onActionChange={setAction}
             onSave={handleRoleSave}
             onDelete={(v) => onDelete(v).then(() => setRoleDrawerOpened(false))}
             onClose={() => setRoleDrawerOpened(false)}

--- a/ui/app/src/components/secrets/SecretDrawer.tsx
+++ b/ui/app/src/components/secrets/SecretDrawer.tsx
@@ -14,7 +14,7 @@
 import { Secret } from '@perses-dev/core';
 import { Dispatch, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { DrawerProps } from '../drawer';
+import { DrawerProps } from '../form-drawers';
 import { DeleteResourceDialog } from '../dialogs';
 import { SecretEditorForm } from './SecretEditorForm';
 
@@ -22,8 +22,16 @@ interface SecretDrawerProps<T extends Secret> extends DrawerProps<T> {
   secret: T;
 }
 
-export function SecretDrawer<T extends Secret>(props: SecretDrawerProps<T>) {
-  const { secret, isOpen, action, isReadonly, onSave, onClose, onDelete } = props;
+export function SecretDrawer<T extends Secret>({
+  secret,
+  action,
+  isOpen,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: SecretDrawerProps<T>) {
   const [isDeleteSecretDialogStateOpened, setDeleteSecretDialogStateOpened] = useState<boolean>(false);
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
@@ -37,10 +45,11 @@ export function SecretDrawer<T extends Secret>(props: SecretDrawerProps<T>) {
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         {isOpen && (
           <SecretEditorForm
-            initialSecret={secret}
-            initialAction={action}
+            initialValue={secret}
+            action={action}
             isDraft={false}
             isReadonly={isReadonly}
+            onActionChange={onActionChange}
             onSave={onSave as Dispatch<Secret>}
             onClose={onClose}
             onDelete={onDelete ? () => setDeleteSecretDialogStateOpened(true) : undefined}

--- a/ui/app/src/components/secrets/SecretEditorForm.tsx
+++ b/ui/app/src/components/secrets/SecretEditorForm.tsx
@@ -11,15 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Action, Secret, secretsEditorSchema, SecretsEditorSchemaType } from '@perses-dev/core';
-import React, { DispatchWithoutAction, SyntheticEvent, useEffect, useMemo, useState } from 'react';
+import { Secret, secretsEditorSchema, SecretsEditorSchemaType } from '@perses-dev/core';
+import React, { SyntheticEvent, useEffect, useMemo, useState } from 'react';
 import { getSubmitText, getTitleAction } from '@perses-dev/plugin-system';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Box,
   BoxProps,
-  Button,
   Divider,
   FormControl,
   FormControlLabel,
@@ -31,7 +30,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
+import { DiscardChangesConfirmationDialog, FormActions } from '@perses-dev/components';
 import TrashIcon from 'mdi-material-ui/TrashCan';
 import PlusIcon from 'mdi-material-ui/Plus';
 import { FormEditorProps } from '../form-drawers';
@@ -131,48 +130,16 @@ export function SecretEditorForm({
         }}
       >
         <Typography variant="h2">{titleAction} Secret</Typography>
-        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          {action === 'read' ? (
-            <>
-              {onActionChange && (
-                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
-                  Edit
-                </Button>
-              )}
-              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
-                Delete
-              </Button>
-              <Divider
-                orientation="vertical"
-                flexItem
-                sx={(theme) => ({
-                  borderColor: theme.palette.grey['500'],
-                  '&.MuiDivider-root': {
-                    marginLeft: 2,
-                    marginRight: 1,
-                  },
-                })}
-              />
-              <Button color="secondary" variant="outlined" onClick={onClose}>
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                type="submit"
-                variant="contained"
-                disabled={!form.formState.isValid}
-                onClick={form.handleSubmit(processForm)}
-              >
-                {submitText}
-              </Button>
-              <Button color="secondary" variant="outlined" onClick={handleCancel}>
-                Cancel
-              </Button>
-            </>
-          )}
-        </Stack>
+        <FormActions
+          action={action}
+          submitText={submitText}
+          isReadonly={isReadonly}
+          isValid={form.formState.isValid}
+          onActionChange={onActionChange}
+          onSubmit={form.handleSubmit(processForm)}
+          onDelete={onDelete}
+          onCancel={handleCancel}
+        />
       </Box>
       <Stack padding={2} gap={2} sx={{ overflowY: 'scroll' }}>
         <Stack gap={2} direction="row">

--- a/ui/app/src/components/secrets/SecretEditorForm.tsx
+++ b/ui/app/src/components/secrets/SecretEditorForm.tsx
@@ -34,36 +34,35 @@ import {
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import TrashIcon from 'mdi-material-ui/TrashCan';
 import PlusIcon from 'mdi-material-ui/Plus';
+import { FormEditorProps } from '../form-drawers';
 
 const basicAuthIndex = 'basicAuth';
 const authorizationIndex = 'authorization';
 
-interface SecretEditorFormProps {
-  initialSecret: Secret;
-  initialAction: Action;
-  isDraft: boolean;
-  isReadonly?: boolean;
-  onSave: (def: Secret) => void;
-  onClose: () => void;
-  onDelete?: DispatchWithoutAction;
-}
+type SecretEditorFormProps = FormEditorProps<Secret>;
 
-export function SecretEditorForm(props: SecretEditorFormProps) {
-  const { initialSecret, initialAction, isDraft, isReadonly, onSave, onClose, onDelete } = props;
-
+export function SecretEditorForm({
+  initialValue,
+  action,
+  isDraft,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: SecretEditorFormProps) {
   // Reset all attributes that are "hidden" by the API and are returning <secret> as value
   const initialSecretClean: Secret = useMemo(() => {
-    const result = { ...initialSecret };
+    const result = { ...initialValue };
     if (result.spec.basicAuth?.password) result.spec.basicAuth.password = '';
     if (result.spec.authorization?.credentials) result.spec.authorization.credentials = '';
     if (result.spec.tlsConfig?.ca) result.spec.tlsConfig.ca = '';
     if (result.spec.tlsConfig?.cert) result.spec.tlsConfig.cert = '';
     if (result.spec.tlsConfig?.key) result.spec.tlsConfig.key = '';
     return result;
-  }, [initialSecret]);
+  }, [initialValue]);
 
   const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
-  const [action, setAction] = useState(initialAction);
 
   const titleAction = getTitleAction(action, isDraft);
   const submitText = getSubmitText(action, isDraft);
@@ -135,9 +134,11 @@ export function SecretEditorForm(props: SecretEditorFormProps) {
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
           {action === 'read' ? (
             <>
-              <Button disabled={isReadonly} variant="contained" onClick={() => setAction('update')}>
-                Edit
-              </Button>
+              {onActionChange && (
+                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
+                  Edit
+                </Button>
+              )}
               <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
                 Delete
               </Button>

--- a/ui/app/src/components/secrets/SecretList.tsx
+++ b/ui/app/src/components/secrets/SecretList.tsx
@@ -240,6 +240,7 @@ export function SecretList<T extends Secret>({
             isOpen={isSecretDrawerOpened}
             action={action}
             isReadonly={isReadonly}
+            onActionChange={setAction}
             onSave={handleSecretSave}
             onDelete={(v) => onDelete(v).then(() => setDeleteSecretDialogOpened(false))}
             onClose={() => setSecretDrawerOpened(false)}

--- a/ui/app/src/components/users/UserDrawer.tsx
+++ b/ui/app/src/components/users/UserDrawer.tsx
@@ -15,15 +15,23 @@ import { Dispatch, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { UserResource } from '@perses-dev/core';
 import { DeleteResourceDialog } from '../dialogs';
-import { DrawerProps } from '../drawer';
+import { DrawerProps } from '../form-drawers';
 import { UserEditorForm } from './UserEditorForm';
 
 interface UserDrawerProps extends DrawerProps<UserResource> {
   user: UserResource;
 }
 
-export function UserDrawer(props: UserDrawerProps) {
-  const { user, isOpen, action, isReadonly, onSave, onClose, onDelete } = props;
+export function UserDrawer({
+  user,
+  action,
+  isOpen,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: UserDrawerProps) {
   const [isDeleteUserDialogStateOpened, setDeleteUserDialogStateOpened] = useState<boolean>(false);
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
@@ -37,10 +45,11 @@ export function UserDrawer(props: UserDrawerProps) {
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         {isOpen && (
           <UserEditorForm
-            initialUser={user}
-            initialAction={action}
+            initialValue={user}
+            action={action}
             isDraft={false}
             isReadonly={isReadonly}
+            onActionChange={onActionChange}
             onSave={onSave as Dispatch<UserResource>}
             onClose={onClose}
             onDelete={onDelete ? () => setDeleteUserDialogStateOpened(true) : undefined}

--- a/ui/app/src/components/users/UserEditorForm.tsx
+++ b/ui/app/src/components/users/UserEditorForm.tsx
@@ -15,8 +15,8 @@ import { Action, UserEditorSchemaType, UserResource, userSchema } from '@perses-
 import { getSubmitText, getTitleAction } from '@perses-dev/plugin-system';
 import React, { Fragment, useMemo, useState } from 'react';
 import { Control, Controller, FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
-import { Alert, Box, Button, Divider, FormControl, IconButton, Stack, TextField, Typography } from '@mui/material';
-import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
+import { Alert, Box, Divider, FormControl, IconButton, Stack, TextField, Typography } from '@mui/material';
+import { DiscardChangesConfirmationDialog, FormActions } from '@perses-dev/components';
 import { zodResolver } from '@hookform/resolvers/zod';
 import MinusIcon from 'mdi-material-ui/Minus';
 import PlusIcon from 'mdi-material-ui/Plus';
@@ -92,48 +92,16 @@ export function UserEditorForm({
         }}
       >
         <Typography variant="h2">{titleAction} User</Typography>
-        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          {action === 'read' ? (
-            <>
-              {onActionChange && (
-                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
-                  Edit
-                </Button>
-              )}
-              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
-                Delete
-              </Button>
-              <Divider
-                orientation="vertical"
-                flexItem
-                sx={(theme) => ({
-                  borderColor: theme.palette.grey['500'],
-                  '&.MuiDivider-root': {
-                    marginLeft: 2,
-                    marginRight: 1,
-                  },
-                })}
-              />
-              <Button color="secondary" variant="outlined" onClick={onClose}>
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                type="submit"
-                variant="contained"
-                disabled={!form.formState.isValid}
-                onClick={form.handleSubmit(processForm)}
-              >
-                {submitText}
-              </Button>
-              <Button color="secondary" variant="outlined" onClick={handleCancel}>
-                Cancel
-              </Button>
-            </>
-          )}
-        </Stack>
+        <FormActions
+          action={action}
+          submitText={submitText}
+          isReadonly={isReadonly}
+          isValid={form.formState.isValid}
+          onActionChange={onActionChange}
+          onSubmit={form.handleSubmit(processForm)}
+          onDelete={onDelete}
+          onCancel={handleCancel}
+        />
       </Box>
       <Stack padding={2} gap={2} sx={{ overflowY: 'scroll' }}>
         <Stack gap={2} direction="row">

--- a/ui/app/src/components/users/UserEditorForm.tsx
+++ b/ui/app/src/components/users/UserEditorForm.tsx
@@ -13,7 +13,7 @@
 
 import { Action, UserEditorSchemaType, UserResource, userSchema } from '@perses-dev/core';
 import { getSubmitText, getTitleAction } from '@perses-dev/plugin-system';
-import React, { DispatchWithoutAction, Fragment, useMemo, useState } from 'react';
+import React, { Fragment, useMemo, useState } from 'react';
 import { Control, Controller, FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { Alert, Box, Button, Divider, FormControl, IconButton, Stack, TextField, Typography } from '@mui/material';
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
@@ -22,33 +22,32 @@ import MinusIcon from 'mdi-material-ui/Minus';
 import PlusIcon from 'mdi-material-ui/Plus';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import { useIsExternalProviderEnabled, useIsNativeProviderEnabled } from '../../context/Config';
+import { FormEditorProps } from '../form-drawers';
 
-interface UserEditorFormProps {
-  initialUser: UserResource;
-  initialAction: Action;
-  isDraft: boolean;
-  isReadonly?: boolean;
-  onSave: (def: UserResource) => void;
-  onClose: () => void;
-  onDelete?: DispatchWithoutAction;
-}
+type UserEditorFormProps = FormEditorProps<UserResource>;
 
-export function UserEditorForm(props: UserEditorFormProps) {
-  const { initialUser, initialAction, isDraft, isReadonly, onSave, onClose, onDelete } = props;
-
+export function UserEditorForm({
+  initialValue,
+  action,
+  isDraft,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: UserEditorFormProps) {
   const externalProvidersEnabled = useIsExternalProviderEnabled();
   const nativeProviderEnabled = useIsNativeProviderEnabled();
 
   // Reset all attributes that are "hidden" by the API and are returning <secret> as value
   const initialUserClean: UserResource = useMemo(() => {
-    const result = { ...initialUser };
+    const result = { ...initialValue };
     if (result.spec.nativeProvider?.password) result.spec.nativeProvider.password = '';
     if (result.spec.oauthProviders === undefined) result.spec.oauthProviders = [];
     return result;
-  }, [initialUser]);
+  }, [initialValue]);
 
   const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
-  const [action, setAction] = useState(initialAction);
 
   const titleAction = getTitleAction(action, isDraft);
   const submitText = getSubmitText(action, isDraft);
@@ -96,9 +95,11 @@ export function UserEditorForm(props: UserEditorFormProps) {
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
           {action === 'read' ? (
             <>
-              <Button disabled={isReadonly} variant="contained" onClick={() => setAction('update')}>
-                Edit
-              </Button>
+              {onActionChange && (
+                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
+                  Edit
+                </Button>
+              )}
               <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
                 Delete
               </Button>

--- a/ui/app/src/components/users/UserList.tsx
+++ b/ui/app/src/components/users/UserList.tsx
@@ -194,9 +194,10 @@ export function UserList(props: ListPropertiesWithCallbacks<UserResource>) {
         <>
           <UserDrawer
             user={targetedUser}
-            isOpen={isUserDrawerOpened}
             action={action}
+            isOpen={isUserDrawerOpened}
             isReadonly={isReadonly}
+            onActionChange={setAction}
             onSave={handleUserSave}
             onDelete={(v) => onDelete(v).then(() => setUserDrawerOpened(false))}
             onClose={() => setUserDrawerOpened(false)}

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -24,15 +24,23 @@ import {
 } from '@perses-dev/plugin-system';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../model/datasource-api';
-import { DrawerProps } from '../drawer';
+import { DrawerProps } from '../form-drawers';
 import { DeleteResourceDialog } from '../dialogs';
 
 interface VariableDrawerProps<T extends Variable> extends DrawerProps<T> {
   variable: T;
 }
 
-export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>) {
-  const { variable, isOpen, action, isReadonly, onSave, onDelete, onClose } = props;
+export function VariableDrawer<T extends Variable>({
+  variable,
+  action,
+  isOpen,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onDelete,
+  onClose,
+}: VariableDrawerProps<T>) {
   const projectName = getVariableProject(variable);
   const [isDeleteVariableDialogStateOpened, setDeleteVariableDialogStateOpened] = useState<boolean>(false);
 
@@ -75,9 +83,10 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
                 <VariableProviderWithQueryParams initialVariableDefinitions={[]}>
                   <VariableEditorForm
                     initialVariableDefinition={variableDef}
-                    initialAction={action}
+                    action={action}
                     isDraft={false}
                     isReadonly={isReadonly}
+                    onActionChange={onActionChange}
                     onSave={handleSave}
                     onClose={onClose}
                     onDelete={onDelete ? () => setDeleteVariableDialogStateOpened(true) : undefined}

--- a/ui/app/src/components/variable/VariableList.tsx
+++ b/ui/app/src/components/variable/VariableList.tsx
@@ -226,9 +226,10 @@ export function VariableList<T extends Variable>(props: ListPropertiesWithCallba
         <>
           <VariableDrawer
             variable={targetedVariable}
-            isOpen={isVariableDrawerOpened}
             action={action}
+            isOpen={isVariableDrawerOpened}
             isReadonly={isReadonly}
+            onActionChange={setAction}
             onSave={handleVariableSave}
             onDelete={(v) => onDelete(v).then(() => setDeleteVariableDialogOpened(false))}
             onClose={() => setVariableDrawerOpened(false)}

--- a/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
@@ -58,6 +58,8 @@ export function GlobalRoleBindings(props: GlobalRoleBindingsProps) {
   const handleGlobalRoleBindingUpdate = useCallback(
     (roleBinding: GlobalRoleBindingResource): Promise<void> =>
       new Promise((resolve, reject) => {
+        console.log('GlobalRoleBindings', roleBinding);
+
         updateRoleBindingMutation.mutate(roleBinding, {
           onSuccess: (updatedRoleBinding: RoleBinding) => {
             successSnackbar(`GlobalRoleBinding ${updatedRoleBinding.metadata.name} has been successfully updated`);

--- a/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
+++ b/ui/app/src/views/admin/tabs/GlobalRoleBindings.tsx
@@ -58,8 +58,6 @@ export function GlobalRoleBindings(props: GlobalRoleBindingsProps) {
   const handleGlobalRoleBindingUpdate = useCallback(
     (roleBinding: GlobalRoleBindingResource): Promise<void> =>
       new Promise((resolve, reject) => {
-        console.log('GlobalRoleBindings', roleBinding);
-
         updateRoleBindingMutation.mutate(roleBinding, {
           onSuccess: (updatedRoleBinding: RoleBinding) => {
             successSnackbar(`GlobalRoleBinding ${updatedRoleBinding.metadata.name} has been successfully updated`);

--- a/ui/components/src/FormEditor/FormActions.tsx
+++ b/ui/components/src/FormEditor/FormActions.tsx
@@ -1,0 +1,78 @@
+import { Button, Divider, Stack, StackProps } from '@mui/material';
+import React from 'react';
+import { Action } from '@perses-dev/core';
+
+export interface FormActionsProps extends StackProps {
+  action: Action;
+  submitText?: string;
+  cancelText?: string;
+  isReadonly?: boolean;
+  isValid?: boolean;
+  onActionChange?: (action: Action) => void;
+  onSubmit?: () => void;
+  onDelete?: () => void;
+  onCancel?: () => void;
+}
+
+export function FormActions({
+  action,
+  submitText = 'Save',
+  cancelText = 'Cancel',
+  isReadonly,
+  isValid,
+  onActionChange,
+  onSubmit,
+  onDelete,
+  onCancel,
+  ...props
+}: FormActionsProps) {
+  return (
+    <Stack direction="row" gap={1} sx={{ marginLeft: 'auto' }} {...props}>
+      {action === 'read' ? (
+        <>
+          {onActionChange && (
+            <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
+              Edit
+            </Button>
+          )}
+          {onDelete && (
+            <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
+              Delete
+            </Button>
+          )}
+          {onCancel && (onSubmit || onDelete) && (
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{
+                borderColor: (theme) => theme.palette.grey['500'],
+                '&.MuiDivider-root': {
+                  marginLeft: 2,
+                  marginRight: 1,
+                },
+              }}
+            />
+          )}
+          {onCancel && (
+            <Button color="secondary" variant="outlined" onClick={onCancel}>
+              {cancelText}
+            </Button>
+          )}
+        </>
+      ) : (
+        <>
+          {onSubmit && (
+            <Button variant="contained" disabled={!isValid} onClick={onSubmit}>
+              {submitText}
+            </Button>
+          )}
+          {onCancel && (
+            <Button color="secondary" variant="outlined" onClick={onCancel}>
+              {cancelText}
+            </Button>
+          )}
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/ui/components/src/FormEditor/FormActions.tsx
+++ b/ui/components/src/FormEditor/FormActions.tsx
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Button, Divider, Stack, StackProps } from '@mui/material';
 import React from 'react';
 import { Action } from '@perses-dev/core';

--- a/ui/components/src/FormEditor/index.ts
+++ b/ui/components/src/FormEditor/index.ts
@@ -1,1 +1,14 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from './FormActions';

--- a/ui/components/src/FormEditor/index.ts
+++ b/ui/components/src/FormEditor/index.ts
@@ -1,0 +1,1 @@
+export * from './FormActions';

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -22,6 +22,7 @@ export * from './EChart';
 export * from './ErrorAlert';
 export * from './ErrorBoundary';
 export * from './FontSizeSelector';
+export * from './FormEditor';
 export * from './GaugeChart';
 export * from './InfoTooltip';
 export * from './JSONEditor';

--- a/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
+++ b/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
@@ -99,8 +99,9 @@ export function DatasourceEditor(props: {
         <ValidationProvider>
           <DatasourceEditorForm
             initialDatasourceDefinition={datasourceEdit}
-            initialAction={datasourceFormAction}
+            action={datasourceFormAction}
             isDraft={true}
+            onActionChange={setDatasourceFormAction}
             onSave={(def: DatasourceDefinition) => {
               setDatasources((draft) => {
                 delete draft[datasourceEdit.name]; // to tackle the case where datasource name has been changed

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -183,8 +183,9 @@ export function VariableEditor(props: {
         <ValidationProvider>
           <VariableEditorForm
             initialVariableDefinition={currentEditingVariableDefinition}
-            initialAction={variableFormAction}
+            action={variableFormAction}
             isDraft={true}
+            onActionChange={setVariableFormAction}
             onSave={(definition: VariableDefinition) => {
               setVariableDefinitions((draft) => {
                 draft[variableEditIdx] = definition;

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 import { Action, DatasourceDefinition } from '@perses-dev/core';
-import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
+import { Box, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
 import React, { DispatchWithoutAction, useState } from 'react';
-import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
+import { DiscardChangesConfirmationDialog, FormActions } from '@perses-dev/components';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { PluginEditor } from '../PluginEditor';
@@ -84,45 +84,16 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
         }}
       >
         <Typography variant="h2">{titleAction} Datasource</Typography>
-        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          {action === 'read' ? (
-            <>
-              {onActionChange && (
-                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
-                  Edit
-                </Button>
-              )}
-              {onDelete && (
-                <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
-                  Delete
-                </Button>
-              )}
-              <Divider
-                orientation="vertical"
-                flexItem
-                sx={(theme) => ({
-                  borderColor: theme.palette.grey['500'],
-                  '&.MuiDivider-root': {
-                    marginLeft: 2,
-                    marginRight: 1,
-                  },
-                })}
-              />
-              <Button color="secondary" variant="outlined" onClick={onClose}>
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button variant="contained" disabled={!form.formState.isValid} onClick={form.handleSubmit(processForm)}>
-                {submitText}
-              </Button>
-              <Button color="secondary" variant="outlined" onClick={handleCancel}>
-                Cancel
-              </Button>
-            </>
-          )}
-        </Stack>
+        <FormActions
+          action={action}
+          submitText={submitText}
+          isReadonly={isReadonly}
+          isValid={form.formState.isValid}
+          onActionChange={onActionChange}
+          onSubmit={form.handleSubmit(processForm)}
+          onDelete={onDelete}
+          onCancel={handleCancel}
+        />
       </Box>
       <Box padding={2} sx={{ overflowY: 'scroll' }}>
         <Grid container spacing={2} mb={2}>

--- a/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
+++ b/ui/plugin-system/src/components/DatasourceEditorForm/DatasourceEditorForm.tsx
@@ -13,7 +13,7 @@
 
 import { Action, DatasourceDefinition } from '@perses-dev/core';
 import { Box, Button, Divider, FormControlLabel, Grid, Stack, Switch, TextField, Typography } from '@mui/material';
-import { DispatchWithoutAction, useState } from 'react';
+import React, { DispatchWithoutAction, useState } from 'react';
 import { DiscardChangesConfirmationDialog } from '@perses-dev/components';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -23,19 +23,19 @@ import { useValidationSchemas } from '../../context';
 
 interface DatasourceEditorFormProps {
   initialDatasourceDefinition: DatasourceDefinition;
-  initialAction: Action;
+  action: Action;
   isDraft: boolean;
   isReadonly?: boolean;
+  onActionChange?: (action: Action) => void;
   onSave: (def: DatasourceDefinition) => void;
   onClose: DispatchWithoutAction;
   onDelete?: DispatchWithoutAction;
 }
 
 export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
-  const { initialDatasourceDefinition, initialAction, isDraft, isReadonly, onSave, onClose, onDelete } = props;
+  const { initialDatasourceDefinition, action, isDraft, isReadonly, onActionChange, onSave, onClose, onDelete } = props;
 
   const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
-  const [action, setAction] = useState(initialAction);
   const titleAction = getTitleAction(action, isDraft);
   const submitText = getSubmitText(action, isDraft);
 
@@ -87,12 +87,16 @@ export function DatasourceEditorForm(props: DatasourceEditorFormProps) {
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
           {action === 'read' ? (
             <>
-              <Button disabled={isReadonly} variant="contained" onClick={() => setAction('update')}>
-                Edit
-              </Button>
-              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
-                Delete
-              </Button>
+              {onActionChange && (
+                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
+                  Edit
+                </Button>
+              )}
+              {onDelete && (
+                <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
+                  Delete
+                </Button>
+              )}
               <Divider
                 orientation="vertical"
                 flexItem

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -20,13 +20,12 @@ import {
   Grid,
   FormControlLabel,
   MenuItem,
-  Button,
   Stack,
   ClickAwayListener,
   Divider,
 } from '@mui/material';
 import { VariableDefinition, ListVariableDefinition, Action } from '@perses-dev/core';
-import { DiscardChangesConfirmationDialog, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { DiscardChangesConfirmationDialog, ErrorAlert, ErrorBoundary, FormActions } from '@perses-dev/components';
 import { Control, Controller, FormProvider, SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { getSubmitText, getTitleAction } from '../../../utils';
@@ -409,48 +408,16 @@ export function VariableEditorForm({
         }}
       >
         <Typography variant="h2">{titleAction} Variable</Typography>
-        <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
-          {action === 'read' ? (
-            <>
-              {onActionChange && (
-                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
-                  Edit
-                </Button>
-              )}
-              <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
-                Delete
-              </Button>
-              <Divider
-                orientation="vertical"
-                flexItem
-                sx={(theme) => ({
-                  borderColor: theme.palette.grey['500'],
-                  '&.MuiDivider-root': {
-                    marginLeft: 2,
-                    marginRight: 1,
-                  },
-                })}
-              />
-              <Button color="secondary" variant="outlined" onClick={onClose}>
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                type="submit"
-                variant="contained"
-                disabled={!form.formState.isValid}
-                onClick={form.handleSubmit(processForm)}
-              >
-                {submitText}
-              </Button>
-              <Button color="secondary" variant="outlined" onClick={handleCancel}>
-                Cancel
-              </Button>
-            </>
-          )}
-        </Stack>
+        <FormActions
+          action={action}
+          submitText={submitText}
+          isReadonly={isReadonly}
+          isValid={form.formState.isValid}
+          onActionChange={onActionChange}
+          onSubmit={form.handleSubmit(processForm)}
+          onDelete={onDelete}
+          onCancel={handleCancel}
+        />
       </Box>
       <Box padding={2} sx={{ overflowY: 'scroll' }}>
         <Grid container spacing={2} mb={2}>

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -337,19 +337,26 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
 
 interface VariableEditorFormProps {
   initialVariableDefinition: VariableDefinition;
-  initialAction: Action;
+  action: Action;
   isDraft: boolean;
   isReadonly?: boolean;
+  onActionChange?: (action: Action) => void;
   onSave: (def: VariableDefinition) => void;
   onClose: () => void;
   onDelete?: DispatchWithoutAction;
 }
 
-export function VariableEditorForm(props: VariableEditorFormProps) {
-  const { initialVariableDefinition, initialAction, isDraft, isReadonly, onSave, onClose, onDelete } = props;
-
+export function VariableEditorForm({
+  initialVariableDefinition,
+  action,
+  isDraft,
+  isReadonly,
+  onActionChange,
+  onSave,
+  onClose,
+  onDelete,
+}: VariableEditorFormProps) {
   const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
-  const [action, setAction] = useState(initialAction);
   const titleAction = getTitleAction(action, isDraft);
   const submitText = getSubmitText(action, isDraft);
 
@@ -405,9 +412,11 @@ export function VariableEditorForm(props: VariableEditorFormProps) {
         <Stack direction="row" spacing={1} sx={{ marginLeft: 'auto' }}>
           {action === 'read' ? (
             <>
-              <Button disabled={isReadonly} variant="contained" onClick={() => setAction('update')}>
-                Edit
-              </Button>
+              {onActionChange && (
+                <Button disabled={isReadonly} variant="contained" onClick={() => onActionChange('update')}>
+                  Edit
+                </Button>
+              )}
               <Button color="error" disabled={isReadonly} variant="outlined" onClick={onDelete}>
                 Delete
               </Button>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
When clicking on a resource row, in order to see resource detail, when you click on the edit button, made some change and saved: the drawer is closed and nothing happened. It's now fixed.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
