### PR TITLE
[BUGFIX] Fix tree view broken when using prometheus built-in vars

### DIFF
--- a/ui/prometheus-plugin/src/components/PromQLEditor.tsx
+++ b/ui/prometheus-plugin/src/components/PromQLEditor.tsx
@@ -21,7 +21,7 @@ import { ErrorAlert } from '@perses-dev/components';
 import CloseIcon from 'mdi-material-ui/Close';
 import { useReplaceVariablesInString } from '@perses-dev/plugin-system';
 import { PrometheusDatasourceSelector } from '../model';
-import { replacePromBuiltinVariables } from '../utils';
+import { replacePromBuiltinVariables } from '../plugins/prometheus-time-series-query/replace-prom-builtin-variables';
 import { useParseQuery } from './parse';
 import TreeNode from './TreeNode';
 

--- a/ui/prometheus-plugin/src/components/PromQLEditor.tsx
+++ b/ui/prometheus-plugin/src/components/PromQLEditor.tsx
@@ -21,6 +21,7 @@ import { ErrorAlert } from '@perses-dev/components';
 import CloseIcon from 'mdi-material-ui/Close';
 import { useReplaceVariablesInString } from '@perses-dev/plugin-system';
 import { PrometheusDatasourceSelector } from '../model';
+import { replacePromBuiltinVariables } from '../utils';
 import { useParseQuery } from './parse';
 import TreeNode from './TreeNode';
 
@@ -50,7 +51,10 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
     return new PromQLExtension().activateLinter(false).setComplete(completeConfig).asExtension();
   }, [completeConfig]);
 
-  const queryExpr = useReplaceVariablesInString(rest.value);
+  let queryExpr = useReplaceVariablesInString(rest.value);
+  if (queryExpr) {
+    queryExpr = replacePromBuiltinVariables(queryExpr, 12345, 12345); // TODO placeholder values to replace
+  }
 
   const { data: parseQueryResponse, isLoading, error } = useParseQuery(queryExpr ?? '', datasource, isTreeViewVisible);
   const errorMessage = useMemo(() => getErrMessage(error), [error]);

--- a/ui/prometheus-plugin/src/components/PromQLEditor.tsx
+++ b/ui/prometheus-plugin/src/components/PromQLEditor.tsx
@@ -53,7 +53,11 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
 
   let queryExpr = useReplaceVariablesInString(rest.value);
   if (queryExpr) {
-    queryExpr = replacePromBuiltinVariables(queryExpr, 12345, 12345); // TODO placeholder values to replace
+    // TODO placeholder values for steps to be replaced with actual values
+    // Looks like providing proper values involves some refactoring: currently we'd need to rely on the timeseries query context,
+    // but these step values are actually computed independently / before the queries are getting fired, so it's useless to fire
+    // queries here, so maybe we should extract this part to independant hook(s), to be reused here?
+    queryExpr = replacePromBuiltinVariables(queryExpr, 12345, 12345);
   }
 
   const { data: parseQueryResponse, isLoading, error } = useParseQuery(queryExpr ?? '', datasource, isTreeViewVisible);

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -32,9 +32,10 @@ import {
   VectorData,
   ScalarData,
 } from '../../model';
-import { getFormattedPrometheusSeriesName, replacePromBuiltinVariables } from '../../utils';
+import { getFormattedPrometheusSeriesName } from '../../utils';
 import { DEFAULT_SCRAPE_INTERVAL, PrometheusDatasourceSpec } from '../types';
 import { PrometheusTimeSeriesQuerySpec } from './time-series-query-model';
+import { replacePromBuiltinVariables } from './replace-prom-builtin-variables';
 
 export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
   spec,

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/replace-prom-builtin-variables.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/replace-prom-builtin-variables.ts
@@ -1,0 +1,40 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { replaceVariable } from '@perses-dev/plugin-system';
+import { formatDuration, msToPrometheusDuration } from '@perses-dev/core';
+
+/*
+ * Replace variable placeholders in a PromQL query
+
+ * @param query The base promQL expression that contains variable placeholders
+ * @param minStepMs the lower bound of the interval between data points, in milliseconds
+ * @param intervalMs the actual interval between data points, in milliseconds
+ * 
+ * @returns a PromQL expression with variable placeholders replaced by their values
+ */
+export function replacePromBuiltinVariables(query: string, minStepMs: number, intervalMs: number): string {
+  let updatedQuery = replaceVariable(query, '__interval_ms', intervalMs.toString());
+  updatedQuery = replaceVariable(updatedQuery, '__interval', formatDuration(msToPrometheusDuration(intervalMs)));
+
+  // The $__rate_interval variable is meant to be used with the rate() promQL function.
+  // It is defined as max($__interval + Min step, 4 * Min step)
+  const rateIntervalMs = Math.max(intervalMs + minStepMs, 4 * minStepMs);
+  updatedQuery = replaceVariable(
+    updatedQuery,
+    '__rate_interval',
+    formatDuration(msToPrometheusDuration(rateIntervalMs))
+  );
+
+  return updatedQuery;
+}

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { replaceVariable } from '@perses-dev/plugin-system';
-import { formatDuration, msToPrometheusDuration } from '@perses-dev/core';
 import { Metric } from '../model/api-types';
 
 /**
@@ -91,29 +89,4 @@ export function getFormattedPrometheusSeriesName(query: string, metric: Metric, 
   // This controls the regex used to customize legend and tooltip display.
   const formattedName = formatter ? formatSeriesName(formatter, metric) : name;
   return { name, formattedName };
-}
-
-/*
- * Replace variable placeholders in a PromQL query
-
- * @param query The base promQL expression that contains variable placeholders
- * @param minStepMs the lower bound of the interval between data points, in milliseconds
- * @param intervalMs the actual interval between data points, in milliseconds
- * 
- * @returns a PromQL expression with variable placeholders replaced by their values
- */
-export function replacePromBuiltinVariables(query: string, minStepMs: number, intervalMs: number): string {
-  let updatedQuery = replaceVariable(query, '__interval_ms', intervalMs.toString());
-  updatedQuery = replaceVariable(updatedQuery, '__interval', formatDuration(msToPrometheusDuration(intervalMs)));
-
-  // The $__rate_interval variable is meant to be used with the rate() promQL function.
-  // It is defined as max($__interval + Min step, 4 * Min step)
-  const rateIntervalMs = Math.max(intervalMs + minStepMs, 4 * minStepMs);
-  updatedQuery = replaceVariable(
-    updatedQuery,
-    '__rate_interval',
-    formatDuration(msToPrometheusDuration(rateIntervalMs))
-  );
-
-  return updatedQuery;
 }

--- a/ui/prometheus-plugin/src/utils/utils.ts
+++ b/ui/prometheus-plugin/src/utils/utils.ts
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { replaceVariable } from '@perses-dev/plugin-system';
+import { formatDuration, msToPrometheusDuration } from '@perses-dev/core';
 import { Metric } from '../model/api-types';
 
 /**
@@ -89,4 +91,29 @@ export function getFormattedPrometheusSeriesName(query: string, metric: Metric, 
   // This controls the regex used to customize legend and tooltip display.
   const formattedName = formatter ? formatSeriesName(formatter, metric) : name;
   return { name, formattedName };
+}
+
+/*
+ * Replace variable placeholders in a PromQL query
+
+ * @param query The base promQL expression that contains variable placeholders
+ * @param minStepMs the lower bound of the interval between data points, in milliseconds
+ * @param intervalMs the actual interval between data points, in milliseconds
+ * 
+ * @returns a PromQL expression with variable placeholders replaced by their values
+ */
+export function replacePromBuiltinVariables(query: string, minStepMs: number, intervalMs: number): string {
+  let updatedQuery = replaceVariable(query, '__interval_ms', intervalMs.toString());
+  updatedQuery = replaceVariable(updatedQuery, '__interval', formatDuration(msToPrometheusDuration(intervalMs)));
+
+  // The $__rate_interval variable is meant to be used with the rate() promQL function.
+  // It is defined as max($__interval + Min step, 4 * Min step)
+  const rateIntervalMs = Math.max(intervalMs + minStepMs, 4 * minStepMs);
+  updatedQuery = replaceVariable(
+    updatedQuery,
+    '__rate_interval',
+    formatDuration(msToPrometheusDuration(rateIntervalMs))
+  );
+
+  return updatedQuery;
 }

--- a/ui/tempo-plugin/package.json
+++ b/ui/tempo-plugin/package.json
@@ -23,8 +23,8 @@
         "build:types": "tsc --project tsconfig.build.json",
         "type-check": "tsc --noEmit",
         "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",
-        "test": "TZ=UTC jest",
-        "test:watch": "TZ=UTC jest --watch",
+        "test": "cross-env TZ=UTC jest",
+        "test:watch": "cross-env TZ=UTC jest --watch",
         "lint": "eslint src --ext .ts,.tsx",
         "lint:fix": "eslint --fix src --ext .ts,.tsx"
     },


### PR DESCRIPTION
# Description

With https://github.com/perses/perses/pull/2344 I missed the fact that prometheus-specific builtin variables (`$__interval`, `$__rate_interval`..) aren't getting replaced by proper values with the current logic.. Thus any query containing such variable is producing an error (prometheus cannot parse this perses-specific syntax). This PR aims to fix that.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
