### PR TITLE
[ENHANCEMENT] migrate current.value to defaultValue

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -165,7 +165,9 @@ spec: {
                 if grafanaVar.sort != _|_ if #mapping.sort[grafanaVar.sort] != _|_ {
                     sort: #mapping.sort[grafanaVar.sort]
                 }
-                // defaultValue: nothing to map to this field
+                if (*(grafanaVar.current.value) | _|_ ) != _|_ {
+                    defaultValue: grafanaVar.current.value
+                }
                 #var: grafanaVar
                 plugin: [ // switch
                     %(conditional_variables)

--- a/internal/api/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -19,6 +19,7 @@
             "name": "PaaS",
             "hidden": true
           },
+          "defaultValue": "argos-world",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {

--- a/internal/api/migrate/testdata/old_grafana_query_perses_dashboard.json
+++ b/internal/api/migrate/testdata/old_grafana_query_perses_dashboard.json
@@ -15,6 +15,7 @@
       {
         "kind": "ListVariable",
         "spec": {
+          "defaultValue": "argos-world",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
@@ -38,6 +39,7 @@
             "name": "Paas",
             "hidden": false
           },
+          "defaultValue": "prd1",
           "allowAllValue": false,
           "allowMultiple": true,
           "sort": "alphabetical-asc",

--- a/internal/api/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/migrate/testdata/simple_perses_dashboard.json
@@ -20,6 +20,7 @@
             "description": "This Custom variable should be translated into a ListVariable > StaticListVariable in Perses",
             "hidden": false
           },
+          "defaultValue": "one",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
@@ -149,6 +150,7 @@
             "description": "ad hoc filter",
             "hidden": false
           },
+          "defaultValue": "1m",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {


### PR DESCRIPTION
# Description
Migrates current value to defaultValue in dashboard variables. This specifically useful for special values like `$__all` which can be set by default in Grafana.

NOTE: this is a copy of automatically closed https://github.com/perses/perses/pull/2383, but I removed the part that sets `defaultValue` to $__all if default value was missing in Grafana at all.


# Checklist
- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
