### PR TITLE
[ENHANCEMENT] More user-friendly helpers for prometheus built-in variables

### DIFF
--- a/ui/dashboards/src/components/Variables/BuiltinVariableAccordions.tsx
+++ b/ui/dashboards/src/components/Variables/BuiltinVariableAccordions.tsx
@@ -73,10 +73,10 @@ export function BuiltinVariableAccordions({ builtinVariableDefinitions }: Builti
           <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="builtin" id="builtin">
             <Typography variant="h2">
               <InfoTooltip
-                title={`${source} Builtin Variables`}
+                title={`${source} Built-in Variables`}
                 description="Variables computed during dashboard rendering."
               >
-                <span>{source} Builtin Variables</span>
+                <span>{source} Built-in Variables</span>
               </InfoTooltip>
             </Typography>
           </AccordionSummary>

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
@@ -69,7 +69,7 @@ const getBuiltinVariableDefinitions: () => BuiltinVariableDefinition[] = () => {
         display: {
           name: '__interval',
           description:
-            'Interval that can be used to group by time in queries. When there are more data points than can be shown on a graph then queries can be made more efficient by grouping by a larger interval.',
+            'For dynamic queries that adapt across different time ranges, use $__interval instead of hardcoded intervals. It represents the actual spacing between data points: it’s calculated based on the current time range and the pixel width - plus taking the "Min step" as a lower bound.',
           hidden: true,
         },
       },
@@ -82,8 +82,7 @@ const getBuiltinVariableDefinitions: () => BuiltinVariableDefinition[] = () => {
         source: 'Prometheus',
         display: {
           name: '__interval_ms',
-          description:
-            'Interval in millisecond that can be used to group by time in queries. When there are more data points than can be shown on a graph then queries can be made more efficient by grouping by a larger interval.',
+          description: 'Same as $__interval but in milliseconds.',
           hidden: true,
         },
       },
@@ -97,7 +96,7 @@ const getBuiltinVariableDefinitions: () => BuiltinVariableDefinition[] = () => {
         display: {
           name: '__rate_interval',
           description:
-            "Interval at least four times the value of the scrape interval. It avoids problems specific to Prometheus when using 'rate' and 'increase' functions.",
+            'Use this one rather than $__interval as the range parameter of functions like rate, increase, etc. With such function it is advised to choose a range that is at least 4x the scrape interval (this is to allow for various races, and to be resilient to a failed scrape). $__rate_interval provides that, as it is defined as `max($__interval + Min Step, 4 * Min Step)`, where Min Step value should represent the scrape interval of the metrics.',
           hidden: true,
         },
       },

--- a/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-datasource.tsx
@@ -69,7 +69,7 @@ const getBuiltinVariableDefinitions: () => BuiltinVariableDefinition[] = () => {
         display: {
           name: '__interval',
           description:
-            'For dynamic queries that adapt across different time ranges, use $__interval instead of hardcoded intervals. It represents the actual spacing between data points: it’s calculated based on the current time range and the pixel width - plus taking the "Min step" as a lower bound.',
+            'For dynamic queries that adapt across different time ranges, use $__interval instead of hardcoded intervals. It represents the actual spacing between data points: it’s calculated based on the current time range and the panel pixel width (taking the "Min step" as a lower bound).',
           hidden: true,
         },
       },

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -99,7 +99,7 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
         <TextField
           label="Min Step"
           placeholder={minStepPlaceholder}
-          helperText="Step parameter of the query. Used by $__interval and $__rate_interval too."
+          helperText="Lower bound for the step. If not provided, the scrape interval of the datasource is used."
           value={minStep}
           onChange={(e) => handleMinStepChange(e.target.value as DurationString)}
           onBlur={handleMinStepBlur}


### PR DESCRIPTION
# Description

Rework the description of prom built-in vars & min step parameters: start first by explaining what's their interest for the user, then provide more details about what they represent concretely.

# Screenshots

![2024-11-08_12h20_02](https://github.com/user-attachments/assets/ac691dbc-a5b7-492d-97d7-eecd9a13cb64)

![image](https://github.com/user-attachments/assets/ef3bf5bc-d91b-49f7-8558-8dfcdb78ee01)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
