### PR TITLE
[BUGFIX] Remove some SX props leaking

### DIFF
--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -114,7 +114,13 @@ export function BarChart(props: BarChartProps) {
   }, [data, chartsTheme, width, mode, format]);
 
   return (
-    <Box sx={{ width: width, height: height, overflow: 'auto' }}>
+    <Box
+      style={{
+        width: width,
+        height: height,
+      }}
+      sx={{ overflow: 'auto' }}
+    >
       <EChart
         sx={{
           minHeight: height,

--- a/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
+++ b/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
@@ -48,17 +48,21 @@ export function ContentWithLegend({
 
   return (
     <Box
-      sx={{
+      style={{
         width,
         height,
+      }}
+      sx={{
         position: 'relative',
         overflow: 'hidden',
       }}
     >
       <Box
-        sx={{
+        style={{
           width: content.width,
           height: content.height,
+        }}
+        sx={{
           marginRight: `${margin.right}px`,
           marginBottom: `${margin.bottom}px`,
           overflow: 'hidden',

--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -141,9 +141,11 @@ export function Legend({
   if (options.position === 'right') {
     return (
       <Box
-        sx={{
+        style={{
           width: width,
           height: height,
+        }}
+        sx={{
           position: 'absolute',
           top: 0,
           right: 0,
@@ -157,9 +159,11 @@ export function Legend({
   // Position bottom
   return (
     <Box
-      sx={{
+      style={{
         width: width,
         height: height,
+      }}
+      sx={{
         position: 'absolute',
         bottom: 0,
       }}

--- a/ui/components/src/PieChart/PieChart.tsx
+++ b/ui/components/src/PieChart/PieChart.tsx
@@ -83,7 +83,13 @@ export function PieChart(props: PieChartProps) {
   };
 
   return (
-    <Box sx={{ width: width, height: height, overflow: 'auto' }}>
+    <Box
+      style={{
+        width: width,
+        height: height,
+      }}
+      sx={{ overflow: 'auto' }}
+    >
       <EChart
         sx={{
           minHeight: height,

--- a/ui/components/src/Table/TableCell.tsx
+++ b/ui/components/src/Table/TableCell.tsx
@@ -125,8 +125,8 @@ export function TableCell({
       onFocus={handleFocus}
       onClick={handleInteractionFocusTrigger}
       onKeyUp={handleInteractionFocusTrigger}
+      style={{ width: width }}
       sx={{
-        width: width,
         borderBottom: isHeader
           ? (theme) => `solid 1px ${theme.palette.grey[100]}`
           : `solid 1px ${theme.palette.grey[50]}`,

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -287,7 +287,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
 
   return (
     <Box
-      sx={{ height }}
+      style={{ height }}
       // onContextMenu={(e) => {
       //   // TODO: confirm tooltip pinning works correctly on Windows, should e.preventDefault() be added here
       //   e.preventDefault(); // Prevent the default behaviour when right clicked

--- a/ui/components/src/YAxisLabel.tsx
+++ b/ui/components/src/YAxisLabel.tsx
@@ -21,11 +21,13 @@ interface YAxisLabelProps {
 export function YAxisLabel({ name, height }: YAxisLabelProps) {
   return (
     <Box
+      style={{
+        maxWidth: height, // allows rotated text to truncate instead of causing overlap
+        top: `calc(${height}px / 2)`,
+      }}
       sx={{
         display: 'inline-block',
-        maxWidth: height, // allows rotated text to truncate instead of causing overlap
         position: 'absolute',
-        top: `calc(${height}px / 2)`,
         transform: 'translateX(-50%) rotate(-90deg)',
         transformOrigin: 'top',
         textAlign: 'center',

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.tsx
@@ -421,7 +421,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps) {
       >
         {({ height, width }) => {
           return (
-            <Box sx={{ height, width }}>
+            <Box style={{ height, width }}>
               {yAxis && yAxis.show && yAxis.label && <YAxisLabel name={yAxis.label} height={height} />}
               <TimeChart
                 ref={chartRef}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Thanks to @andreasgerstmayr comment on one of his PR, I discovered dynamic values in SX is bad: [https://mui.com/system/getting-started/the-sx-prop/#dynamic-values](https://mui.com/system/getting-started/the-sx-prop/#dynamic-values) and should move to inline style.

It's a first pass on height / width props, but there are probably still some left. The biggest one is still on the [EChart component](https://github.com/perses/perses/blob/5a36eded73cf73b13781e40db35b829b2442d484/ui/components/src/EChart/EChart.tsx#L207) but look like it's used as a trick to re-render the component 🤔 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
