### PR TITLE
[BUGFIX] Fix login command avoiding reusing previous config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
   - type: textarea
     attributes:
       label: Perses configuration file
-      description: Insert relevant configuration here. Don't forget to remove secrets.
+      description: Insert relevant configuration here. Don't forget to remove secrets. You can use the CLI to get it (all secret will be hidden). percli config --online
       render: yaml
   - type: textarea
     attributes:

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -220,3 +220,26 @@ func Write(cfg *Config) error {
 
 	return os.WriteFile(filePath, data, 0600)
 }
+
+func WriteFromScratch(cfg *Config) error {
+	// this value has been set by the root command, and that will be the path where the config must be saved
+	filePath := Global.filePath
+	directory := filepath.Dir(filePath)
+
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		mkdirError := os.Mkdir(directory, 0700)
+		if mkdirError != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(cfg)
+
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, data, 0600)
+}


### PR DESCRIPTION
Currently if you log using the CLI in the demo and then you are waiting for the token to expire, you won't be able to log again. Instead you will the following error:

```bash
$ ./bin/percli login http://demo.perses.dev/
Error: something wrong happened with the request to the API. Error: Get “http://demo.perses.dev/api/config”: oauth2: token expired and refresh token is not set
```

Also you cannot log into a Perses instance where the auth is disabled. You will face the same issue. 

All of that is because when using the command `percli login` we are creating the Perses HTTP client based on a previous config where potentially token is expired or doesn't exist.

Creating from scratch the Perses HTTP client is fixing the issues mentioned above.