### PR TITLE
[BUGFIX] PromQL Tree view: stop firing the parse query before the show button gets clicked

### DIFF
--- a/ui/e2e/src/fixtures/dashboardTest.ts
+++ b/ui/e2e/src/fixtures/dashboardTest.ts
@@ -92,9 +92,6 @@ const IGNORE_CONSOLE_ERRORS = [
   // care about at this time. We track those here, so they can be ignored.
   // See https://github.com/emotion-js/emotion/issues/1105
   'potentially unsafe when doing server-side rendering',
-  // Ignore 404 not found errors that are likely raised by the tree view feature, that depends on a new endpoint potentially not available.
-  // TODO: Remove this once Prometheus 3.0 & compatible backends are widely available.
-  '404 (Not Found)',
 ];
 function shouldIgnoreConsoleError(message: ConsoleMessage) {
   const msgText = message.text();

--- a/ui/prometheus-plugin/src/components/parse.ts
+++ b/ui/prometheus-plugin/src/components/parse.ts
@@ -16,11 +16,11 @@ import { DatasourceSelector } from '@perses-dev/core';
 import { useQuery } from '@tanstack/react-query';
 import { ParseQueryRequestParameters, ParseQueryResponse, PrometheusClient } from '../model';
 
-export function useParseQuery(content: string, datasource: DatasourceSelector) {
+export function useParseQuery(content: string, datasource: DatasourceSelector, enabled?: boolean) {
   const { data: client } = useDatasourceClient<PrometheusClient>(datasource);
 
   return useQuery<ParseQueryResponse>({
-    enabled: !!client,
+    enabled: !!client && enabled,
     queryKey: ['parseQuery', content, 'datasource', datasource],
     queryFn: async () => {
       const params: ParseQueryRequestParameters = { query: content };


### PR DESCRIPTION
# Description

Change the PromQL tree view behavior to only fire the request to the parse_query endpoint if the user decided to show the Tree view.
Previous design was to prevent relevant syntax errors to be hidden by default to the user, but in the end it causes other issues / unwanted console errors so in the end 'getting rid of that.
This should also fix the issue we have with e2e tests currently.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
