### PR TITLE
[ENHANCEMENT] add kubebuilder annotations to all duration types

### DIFF
--- a/go-sdk/prometheus/datasource/datasource.go
+++ b/go-sdk/prometheus/datasource/datasource.go
@@ -29,6 +29,7 @@ const (
 type PluginSpec struct {
 	DirectURL string      `json:"directUrl,omitempty" yaml:"directUrl,omitempty"`
 	Proxy     *http.Proxy `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	ScrapeInterval model.Duration `json:"scrapeInterval,omitempty" yaml:"scrapeInterval,omitempty"`

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -47,6 +47,9 @@ func appendIfMissing[T comparable](slice []T, value T) ([]T, bool) {
 }
 
 type HTTP struct {
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	Timeout   model.Duration    `json:"timeout" yaml:"timeout"`
 	TLSConfig *secret.TLSConfig `json:"tls_config" yaml:"tls_config"`
 }
@@ -148,10 +151,16 @@ func (p *AuthProviders) Verify() error {
 
 type AuthenticationConfig struct {
 	// AccessTokenTTL is the time to live of the access token. By default, it is 15 minutes.
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	AccessTokenTTL model.Duration `json:"access_token_ttl,omitempty" yaml:"access_token_ttl,omitempty"`
 	// RefreshTokenTTL is the time to live of the refresh token.
 	// The refresh token is used to get a new access token when it is expired.
 	// By default, it is 24 hours.
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	RefreshTokenTTL model.Duration `json:"refresh_token_ttl,omitempty" yaml:"refresh_token_ttl,omitempty"`
 	// DisableSignUp deactivates the Sign-up page in the UI.
 	// It also disables the endpoint that gives the possibility to create a user.

--- a/pkg/model/api/config/authorization.go
+++ b/pkg/model/api/config/authorization.go
@@ -26,6 +26,9 @@ var (
 
 type AuthorizationConfig struct {
 	// CheckLatestUpdateInterval that checks if the RBAC cache needs to be refreshed with db content. Only for SQL database setup.
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	CheckLatestUpdateInterval model.Duration `json:"check_latest_update_interval,omitempty" yaml:"check_latest_update_interval,omitempty"`
 	// Default permissions for guest users (logged-in users)
 	GuestPermissions []*role.Permission `json:"guest_permissions,omitempty" yaml:"guest_permissions,omitempty"`

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -30,6 +30,7 @@ type EphemeralDashboard struct {
 	// When true user will be able to use the ephemeral dashboard at project level.
 	Enable bool `json:"enable" yaml:"enable"`
 	// The interval at which to trigger the cleanup of ephemeral dashboards, based on their TTLs.
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	CleanupInterval model.Duration `json:"cleanup_interval" yaml:"cleanup_interval"`
@@ -66,6 +67,7 @@ type Config struct {
 	// EphemeralDashboardsCleanupInterval is the interval at which the ephemeral dashboards are cleaned up
 	// DEPRECATED.
 	// Please use the config EphemeralDashboard instead.
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	EphemeralDashboardsCleanupInterval model.Duration `json:"ephemeral_dashboards_cleanup_interval,omitempty" yaml:"ephemeral_dashboards_cleanup_interval,omitempty"`

--- a/pkg/model/api/config/database.go
+++ b/pkg/model/api/config/database.go
@@ -75,10 +75,19 @@ type SQL struct {
 	// Server public key name
 	ServerPubKey string `json:"server_pub_key" yaml:"server_pub_key"`
 	// Dial timeout
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	Timeout model.Duration `json:"timeout" yaml:"timeout"`
 	// I/O read timeout
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	ReadTimeout model.Duration `json:"read_timeout" yaml:"read_timeout"`
 	// I/O write timeout
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	WriteTimeout model.Duration `json:"write_timeout" yaml:"write_timeout"`
 	// Allow all files to be used with LOAD DATA LOCAL INFILE
 	AllowAllFiles bool `json:"allow_all_files" yaml:"allow_all_files"`

--- a/pkg/model/api/config/datasourcediscovery.go
+++ b/pkg/model/api/config/datasourcediscovery.go
@@ -80,6 +80,7 @@ type GlobalDatasourceDiscovery struct {
 	// The name of the discovery config. It is used for logging purposes only
 	DiscoveryName string `json:"discovery_name" yaml:"discovery_name"`
 	// Refresh interval to re-query the endpoint.
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	RefreshInterval model.Duration `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty"`

--- a/pkg/model/api/config/frontend.go
+++ b/pkg/model/api/config/frontend.go
@@ -37,6 +37,7 @@ type Explorer struct {
 
 type TimeRange struct {
 	DisableCustomTimeRange bool `json:"disable_custom" yaml:"disable_custom"`
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=array
 	// +kubebuilder:validation:Items.Type=string
 	// +kubebuilder:validation:Items.Format=duration
@@ -61,5 +62,8 @@ type Frontend struct {
 	// ImportantDashboards contains important dashboard selectors
 	ImportantDashboards []dashboardSelector `json:"important_dashboards,omitempty" yaml:"important_dashboards,omitempty"`
 	// TimeRange contains the time range configuration for the dropdown
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	TimeRange TimeRange `json:"time_range,omitempty" yaml:"time_range,omitempty"`
 }

--- a/pkg/model/api/config/provisioning.go
+++ b/pkg/model/api/config/provisioning.go
@@ -20,6 +20,7 @@ import (
 type ProvisioningConfig struct {
 	Folders []string `json:"folders,omitempty" yaml:"folders,omitempty"`
 	// Interval is the refresh frequency
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	Interval model.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`

--- a/pkg/model/api/config/schemas.go
+++ b/pkg/model/api/config/schemas.go
@@ -32,6 +32,7 @@ type Schemas struct {
 	QueriesPath     string `json:"queries_path,omitempty" yaml:"queries_path,omitempty"`
 	DatasourcesPath string `json:"datasources_path,omitempty" yaml:"datasources_path,omitempty"`
 	VariablesPath   string `json:"variables_path,omitempty" yaml:"variables_path,omitempty"`
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	Interval model.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`

--- a/pkg/model/api/v1/datasource/datasource.go
+++ b/pkg/model/api/v1/datasource/datasource.go
@@ -26,6 +26,7 @@ import (
 type Prometheus struct {
 	DirectURL *url.URL    `json:"directUrl,omitempty" yaml:"directUrl,omitempty"`
 	Proxy     *http.Proxy `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	ScrapeInterval *model.Duration `json:"scrapeInterval,omitempty" yaml:"scrapeInterval,omitempty"`

--- a/pkg/model/api/v1/ephemeraldashboard.go
+++ b/pkg/model/api/v1/ephemeraldashboard.go
@@ -23,6 +23,7 @@ import (
 )
 
 type EphemeralDashboardSpecBase struct {
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	TTL model.Duration `json:"ttl" yaml:"ttl"`


### PR DESCRIPTION
# Description

Add kubebuilder custom validations for duration all types

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).


# Fixes

https://github.com/perses/perses-operator/pull/21