### PR TITLE
[ENHANCEMENT] Add cell focus on hover

### DIFF
--- a/ui/components/src/Table/TableCell.tsx
+++ b/ui/components/src/Table/TableCell.tsx
@@ -125,11 +125,16 @@ export function TableCell({
       onFocus={handleFocus}
       onClick={handleInteractionFocusTrigger}
       onKeyUp={handleInteractionFocusTrigger}
-      style={{ width: width }}
+      style={{
+        width: width,
+      }}
       sx={{
         borderBottom: isHeader
           ? (theme) => `solid 1px ${theme.palette.grey[100]}`
           : `solid 1px ${theme.palette.grey[50]}`,
+        '&:hover': {
+          width: 'auto !important',
+        },
       }}
       ref={elRef}
     >

--- a/ui/components/src/Table/TableCell.tsx
+++ b/ui/components/src/Table/TableCell.tsx
@@ -129,11 +129,13 @@ export function TableCell({
         width: width,
       }}
       sx={{
-        borderBottom: isHeader
-          ? (theme) => `solid 1px ${theme.palette.grey[100]}`
-          : `solid 1px ${theme.palette.grey[50]}`,
-        '&:hover': {
-          width: 'auto !important',
+        position: 'relative',
+        borderBottom: isHeader ? `solid 1px ${theme.palette.grey[100]}` : `solid 1px ${theme.palette.grey[50]}`,
+        '& #hovered-cell': {
+          display: 'none',
+        },
+        '&:hover #hovered-cell': {
+          display: 'block',
         },
       }}
       ref={elRef}
@@ -153,12 +155,40 @@ export function TableCell({
           // that the `TableSortLabel` uses to determine the location of the icon
           // in headers.
           flexDirection: 'inherit',
+          margin: '1px',
         }}
         style={{
           backgroundColor: backgroundColor ?? 'inherit',
           color: color ?? 'inherit',
         }}
-        title={description}
+        aria-label={description}
+        textAlign={align}
+      >
+        {children}
+      </Box>
+      <Box
+        id="hovered-cell"
+        sx={{
+          ...getTableCellLayout(theme, density, { isLastColumn, isFirstColumn }),
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          zIndex: 10,
+          width: 'fit-content',
+          whiteSpace: 'nowrap',
+          overflow: 'visible',
+
+          // Need to inherit from the MUI cell because this manages some ordering
+          // that the `TableSortLabel` uses to determine the location of the icon
+          // in headers.
+          flexDirection: 'inherit',
+          border: `solid 1px ${theme.palette.info.main}`,
+        }}
+        style={{
+          minWidth: '-webkit-fill-available',
+          backgroundColor: backgroundColor ?? theme.palette.background.default,
+          color: color ?? 'inherit',
+        }}
         aria-label={description}
         textAlign={align}
       >


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Allow user to see full cell value on hover

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
