### PR TITLE
[ENHANCEMENT] Table: add default column width setting

### DIFF
--- a/cue/schemas/panels/table/table.cue
+++ b/cue/schemas/panels/table/table.cue
@@ -21,6 +21,7 @@ import (
 kind: "Table"
 spec: close({
 	density?: "compact" | "standard" | "comfortable"
+	defaultColumnWidth?: "auto" | number
 	columnSettings?: [...#columnSettings]
 	cellSettings?: [...#cellSettings]
 	transforms?: [...common.#transform]

--- a/cue/schemas/panels/table/table.cue
+++ b/cue/schemas/panels/table/table.cue
@@ -20,7 +20,7 @@ import (
 
 kind: "Table"
 spec: close({
-	density?: "compact" | "standard" | "comfortable"
+	density?:            "compact" | "standard" | "comfortable"
 	defaultColumnWidth?: "auto" | number
 	columnSettings?: [...#columnSettings]
 	cellSettings?: [...#cellSettings]

--- a/ui/components/src/Legend/TableLegend.tsx
+++ b/ui/components/src/Legend/TableLegend.tsx
@@ -91,6 +91,7 @@ export function TableLegend({
       data={items}
       columns={columns}
       density="compact"
+      defaultColumnWidth="auto"
       getRowId={getRowId}
       getCheckboxColor={getCheckboxColor}
       checkboxSelection

--- a/ui/components/src/Table/Table.tsx
+++ b/ui/components/src/Table/Table.tsx
@@ -26,7 +26,7 @@ import { useTheme } from '@mui/material';
 import { useCallback, useMemo } from 'react';
 import { VirtualizedTable } from './VirtualizedTable';
 import { TableCheckbox } from './TableCheckbox';
-import { TableProps, persesColumnsToTanstackColumns } from './model/table-model';
+import { TableProps, persesColumnsToTanstackColumns, DEFAULT_COLUMN_WIDTH } from './model/table-model';
 
 const DEFAULT_GET_ROW_ID = (data: unknown, index: number) => {
   return `${index}`;
@@ -49,6 +49,7 @@ export function Table<TableData>({
   columns,
   cellConfigs,
   density = 'standard',
+  defaultColumnWidth = DEFAULT_COLUMN_WIDTH,
   checkboxSelection,
   onRowSelectionChange,
   onSortingChange,
@@ -179,6 +180,7 @@ export function Table<TableData>({
     <VirtualizedTable
       {...otherProps}
       density={density}
+      defaultColumnWidth={defaultColumnWidth}
       onRowClick={handleRowClick}
       rows={table.getRowModel().rows}
       columns={table.getAllFlatColumns()}

--- a/ui/components/src/Table/VirtualizedTable.tsx
+++ b/ui/components/src/Table/VirtualizedTable.tsx
@@ -30,7 +30,9 @@ type TableCellPosition = {
   column: number;
 };
 
-export type VirtualizedTableProps<TableData> = Required<Pick<TableProps<TableData>, 'height' | 'width' | 'density'>> &
+export type VirtualizedTableProps<TableData> = Required<
+  Pick<TableProps<TableData>, 'height' | 'width' | 'density' | 'defaultColumnWidth'>
+> &
   Pick<TableProps<TableData>, 'onRowMouseOver' | 'onRowMouseOut'> & {
     onRowClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>, id: string) => void;
     rows: Array<Row<TableData>>;
@@ -46,6 +48,7 @@ export function VirtualizedTable<TableData>({
   width,
   height,
   density,
+  defaultColumnWidth,
   onRowClick,
   onRowMouseOver,
   onRowMouseOut,
@@ -151,7 +154,7 @@ export function VirtualizedTable<TableData>({
                           onSort={column.getCanSort() ? column.getToggleSortingHandler() : undefined}
                           sortDirection={typeof isSorted === 'string' ? isSorted : undefined}
                           nextSortDirection={typeof nextSorting === 'string' ? nextSorting : undefined}
-                          width={column.getSize() || 'auto'}
+                          width={column.getSize() || defaultColumnWidth}
                           align={column.columnDef.meta?.align}
                           variant="head"
                           density={density}
@@ -210,7 +213,7 @@ export function VirtualizedTable<TableData>({
                     key={cell.id}
                     data-testid={cell.id}
                     title={description || cellConfig?.text || cellContent}
-                    width={cell.column.getSize() || 'auto'}
+                    width={cell.column.getSize() || defaultColumnWidth}
                     align={cell.column.columnDef.meta?.align}
                     density={density}
                     focusState={getFocusState(position)}

--- a/ui/components/src/Table/model/table-model.ts
+++ b/ui/components/src/Table/model/table-model.ts
@@ -23,6 +23,8 @@ import {
 } from '@tanstack/react-table';
 import { CSSProperties } from 'react';
 
+export const DEFAULT_COLUMN_WIDTH = 150;
+
 export type TableDensity = 'compact' | 'standard' | 'comfortable';
 export type SortDirection = 'asc' | 'desc' | undefined;
 
@@ -74,6 +76,12 @@ export interface TableProps<TableData> {
    * by content in the table (e.g. font size, padding).
    */
   density?: TableDensity;
+
+  /**
+   *  When using "auto", the table will try to automatically adjust the width of columns to fit without overflowing.
+   *  If there is not enough width for each column, the display can unreadable.
+   */
+  defaultColumnWidth?: 'auto' | number;
 
   /**
    * When `true`, the first column of the table will include checkboxes.

--- a/ui/panels-plugin/src/plugins/table/TablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/table/TablePanel.tsx
@@ -231,6 +231,7 @@ export function TablePanel({ contentDimensions, spec }: TableProps) {
       height={contentDimensions.height}
       width={contentDimensions.width}
       density={spec.density}
+      defaultColumnWidth={spec.defaultColumnWidth}
       sorting={sorting}
       onSortingChange={setSorting}
     />

--- a/ui/panels-plugin/src/plugins/table/TableSettingsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/table/TableSettingsEditor.tsx
@@ -14,12 +14,53 @@
 import {
   DensitySelector,
   OptionsEditorColumn,
+  OptionsEditorControl,
   OptionsEditorGrid,
   OptionsEditorGroup,
   TableDensity,
+  DEFAULT_COLUMN_WIDTH,
 } from '@perses-dev/components';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { Switch, TextField } from '@mui/material';
+import { ChangeEvent } from 'react';
 import { TableOptions } from './table-model';
+
+function DefaultColumnsWidthControl({
+  value,
+  onChange,
+}: {
+  value?: 'auto' | number;
+  onChange: (defaultWidth: 'auto' | number) => void;
+}) {
+  function handleAutoWidthChange(_: ChangeEvent, checked: boolean): void {
+    if (checked) {
+      return onChange('auto');
+    }
+    onChange(DEFAULT_COLUMN_WIDTH);
+  }
+
+  return (
+    <>
+      <OptionsEditorControl
+        label="Auto Columns Width"
+        control={<Switch checked={value === 'auto'} onChange={handleAutoWidthChange} />}
+      />
+      {value !== 'auto' && (
+        <OptionsEditorControl
+          label="Default Columns Width"
+          control={
+            <TextField
+              type="number"
+              value={value ?? DEFAULT_COLUMN_WIDTH}
+              InputProps={{ inputProps: { min: 1, step: 1 } }}
+              onChange={(e) => onChange(parseInt(e.target.value))}
+            />
+          }
+        />
+      )}
+    </>
+  );
+}
 
 export type TableSettingsEditorProps = OptionsEditorProps<TableOptions>;
 
@@ -28,11 +69,16 @@ export function TableSettingsEditor({ onChange, value }: TableSettingsEditorProp
     onChange({ ...value, density: density });
   }
 
+  function handleAutoWidthChange(newValue: 'auto' | number): void {
+    onChange({ ...value, defaultColumnWidth: newValue });
+  }
+
   return (
     <OptionsEditorGrid>
       <OptionsEditorColumn>
         <OptionsEditorGroup title="Display">
           <DensitySelector value={value.density} onChange={handleDensityChange} />
+          <DefaultColumnsWidthControl value={value.defaultColumnWidth} onChange={handleAutoWidthChange} />
         </OptionsEditorGroup>
       </OptionsEditorColumn>
     </OptionsEditorGrid>

--- a/ui/panels-plugin/src/plugins/table/table-model.ts
+++ b/ui/panels-plugin/src/plugins/table/table-model.ts
@@ -98,9 +98,16 @@ export interface TableDefinition extends Definition<TableOptions> {
  * The Options object type supported by the Table panel plugin.
  */
 export interface TableOptions {
+  // Change row height.
   density?: TableDensity;
+  // When true, the table will try to automatically adjust the width of columns to fit without overflowing.
+  // Only for column without custom width specified in columnSettings.
+  defaultColumnWidth?: 'auto' | number;
+  // Customize column display and order them by their index in the array.
   columnSettings?: ColumnSettings[];
+  // Customize cell display based on their value.
   cellSettings?: CellSettings[];
+  // Apply transforms to the data before rendering the table.
   transforms?: Transform[];
 }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
On the Table panel, allow users to set a custom default width to all columns. Column associated to a column setting can override this default value.

Auto column width will try to automatically adjust the width of columns to fit without overflowing. When there is a lot of columns, the table can be unreadable.


# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/user-attachments/assets/62e3fb0c-38df-4ea9-90fe-eca1b8f35c07)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
