### PR TITLE
[ENHANCEMENT] Add yellow mapping from grafana

### DIFF
--- a/internal/api/migrate/mapping.cuepart
+++ b/internal/api/migrate/mapping.cuepart
@@ -94,6 +94,12 @@ import (
         "purple": "#b877d9"
         "light-purple": "#b877d9"
         "super-light-purple": "#deb6f2"
+
+        "dark-yellow": "#e0b400"
+        "semi-dark-yellow": "#f2cc0c"
+        "yellow": "#fade2a"
+        "light-yellow": "#ffee52"
+        "super-light-yellow": "#fff899"
     }
 }
 #defaultCalc: "last"


### PR DESCRIPTION
Migratoin: Add missing color aliases from grafana pallete (yellow).
<img width="247" alt="image" src="https://github.com/user-attachments/assets/d16ebffe-0723-4860-b946-6cc497737c77">
