### PR TITLE
[FEATURE] Value mapping settings for Status History and Stat Chart

### DIFF
--- a/cue/schemas/common/mappings.cue
+++ b/cue/schemas/common/mappings.cue
@@ -28,8 +28,8 @@ import (
 #rangeCondition: {
 	kind: "Range"
 	spec: {
-		from?: number
-		to?: number
+		from?:  number
+		to?:    number
 		result: #mappingResult
 	}
 }
@@ -38,21 +38,21 @@ import (
 	kind: "Regex"
 	spec: {
 		pattern: strings.MinRunes(1)
-		result: #mappingResult
+		result:  #mappingResult
 	}
 }
 
 #miscCondition: {
 	kind: "Misc"
 	spec: {
-		value: "empty" | "null" | "NaN" | "true" | "false"
+		value:  "empty" | "null" | "NaN" | "true" | "false"
 		result: #mappingResult
 	}
 }
 
 #mappingResult: {
-	value:            string
-  	color?:           =~"^#(?:[0-9a-fA-F]{3}){1,2}$"
+	value:  string
+	color?: =~"^#(?:[0-9a-fA-F]{3}){1,2}$"
 }
 
 #mappings: #valueCondition | #rangeCondition | #regexCondition | #miscCondition

--- a/cue/schemas/common/mappings.cue
+++ b/cue/schemas/common/mappings.cue
@@ -1,0 +1,58 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"strings"
+)
+
+#valueCondition: {
+	kind: "Value"
+	spec: {
+		value:  strings.MinRunes(1)
+		result: #mappingResult
+	}
+}
+
+#rangeCondition: {
+	kind: "Range"
+	spec: {
+		from?: number
+		to?: number
+		result: #mappingResult
+	}
+}
+
+#regexCondition: {
+	kind: "Regex"
+	spec: {
+		pattern: strings.MinRunes(1)
+		result: #mappingResult
+	}
+}
+
+#miscCondition: {
+	kind: "Misc"
+	spec: {
+		value: "empty" | "null" | "NaN" | "true" | "false"
+		result: #mappingResult
+	}
+}
+
+#mappingResult: {
+	value:            string
+  	color?:           =~"^#(?:[0-9a-fA-F]{3}){1,2}$"
+}
+
+#mappings: #valueCondition | #rangeCondition | #regexCondition | #miscCondition

--- a/cue/schemas/panels/stat/migrate/migrate.cue
+++ b/cue/schemas/panels/stat/migrate/migrate.cue
@@ -16,9 +16,20 @@ package migrate
 import (
 	commonMigrate "github.com/perses/perses/cue/schemas/common/migrate"
 )
+import "list"
 
 #grafanaType: "stat"
 #panel:       _
+
+#mapping: {
+    type: string
+    options: [...{
+        key: string
+        value: string
+        text: string
+        color: string
+    }]
+}
 
 kind: "StatChart"
 spec: {
@@ -48,7 +59,7 @@ spec: {
 					if step.value == null {0},
 					{step.value},
 				][0]
-				color: step.color // TODO how to manage the overrides part? 
+				color: step.color // TODO how to manage the overrides part?
 			}]
 		}
 	}
@@ -56,5 +67,76 @@ spec: {
 	#sparkline: *#panel.options.graphMode | "none"
 	if #sparkline == "area" {
 		sparkline: {}
+	}
+
+	// Using flatten to avoid having an array of arrays with "value" mappings
+	// (https://cuelang.org/docs/howto/use-list-flattenn-to-flatten-lists/)
+	let x = list.FlattenN([
+		if (*#panel.fieldConfig.defaults.mappings | null) != null for mapping in #panel.fieldConfig.defaults.mappings {
+			if mapping.type == "value" {
+				[for key, option in mapping.options {
+					{
+						kind: "Value"
+						spec: {
+							value: key
+							result: {
+								if option.text != _|_ {
+									value: option.text
+								}
+								if option.color != _|_ {
+									color: *commonMigrate.#mapping.color[option.color] | option.color
+								}
+							}
+						}
+					}
+
+				}]
+			}
+
+			if mapping.type == "range" || mapping.type == "regex" || mapping.type == "special" {
+				#result: {
+					value: *mapping.options.result.text | ""
+					if mapping.options.result.color != _|_ {
+						color: *commonMigrate.#mapping.color[mapping.options.result.color] | mapping.options.result.color
+					}
+				}
+				[//switch
+					if mapping.type == "range" {
+						kind: "Range"
+						spec: {
+							if mapping.options.from != _|_ {
+								from: mapping.options.from
+							}
+							if mapping.options.to != _|_ {
+								to: mapping.options.to
+							}
+							result: #result
+						}
+					},
+					if mapping.type == "regex" {
+						kind: "Regex"
+						spec: {
+							pattern: mapping.options.pattern
+							result:  #result
+						}
+					},
+					if mapping.type == "special" {
+						kind: "Misc"
+						spec: {
+							value: [//switch
+								if mapping.options.match == "nan" {"NaN"},
+								if mapping.options.match == "null+nan" {"null"},
+								mapping.options.match,
+							][0]
+							result: #result
+						}
+					},
+				][0]
+			}
+		},
+	], 1)
+
+	if len(x) > 0 {
+		mappings: x
 	}
 }

--- a/cue/schemas/panels/stat/stat.cue
+++ b/cue/schemas/panels/stat/stat.cue
@@ -24,7 +24,7 @@ spec: close({
 	thresholds?:    common.#thresholds
 	sparkline?:     #sparkline
 	valueFontSize?: number
-	mappings?:      [...common.#mappings]
+	mappings?: [...common.#mappings]
 
 	#sparkline: {
 		color?: string

--- a/cue/schemas/panels/status-history/migrate/migrate.cue
+++ b/cue/schemas/panels/status-history/migrate/migrate.cue
@@ -12,9 +12,23 @@
 // limitations under the License.
 
 package migrate
+import (
+	commonMigrate "github.com/perses/perses/cue/schemas/common/migrate"
+)
+import "list"
 
 #grafanaType: "status-history"
 #panel:       _
+
+#mapping: {
+    type: string
+    options: [...{
+        key: string
+        value: string
+        text: string
+        color: string
+    }]
+}
 
 kind: "StatusHistoryChart"
 spec: {
@@ -41,7 +55,7 @@ spec: {
 										value: option.text
 									}
 									if option.color != _|_ {
-										color: *#mapping.color[option.color] | option.color
+										color: *commonMigrate.#mapping.color[option.color] | option.color
 									}
 								}
 							}
@@ -54,7 +68,7 @@ spec: {
 					#result: {
 						value: *mapping.options.result.text | ""
 						if mapping.options.result.color != _|_ {
-							color: *#mapping.color[mapping.options.result.color] | mapping.options.result.color
+							color: *commonMigrate.#mapping.color[mapping.options.result.color] | mapping.options.result.color
 						}
 					}
 					[//switch

--- a/cue/schemas/panels/status-history/migrate/migrate.cue
+++ b/cue/schemas/panels/status-history/migrate/migrate.cue
@@ -33,4 +33,66 @@ spec: {
 			}
 		}
 	}
+	// Add migration logic for Value mapping
+	if #panel.options.mappings != _|_ {
+		mappings: [ for mapping in #panel.options.mappings {
+			if mapping.type == "value" {
+				{
+					kind: "Value"
+					spec: {
+						value: mapping.value
+						result: {
+							value: mapping.text
+							if mapping.color != _|_ {
+								color: mapping.color
+							}
+						}
+					}
+				}
+				}
+			if mapping.type == "range" {
+				{
+					kind: "Range"
+					spec: {
+						from: mapping.from
+						to: mapping.to
+						result: {
+							value: mapping.text
+							if mapping.color != _|_ {
+								color: mapping.color
+							}
+						}
+					}
+				}
+			}
+			if mapping.type == "regex" {
+				{
+					kind: "Regex"
+					spec: {
+						pattern: mapping.pattern
+						result: {
+							value: mapping.text
+							if mapping.color != _|_ {
+								color: mapping.color
+							}
+						}
+					}
+				}
+			}
+			if mapping.type == "misc" {
+				{
+					kind: "Misc"
+					spec: {
+						value: mapping.value
+						result: {
+							value: mapping.text
+							if mapping.color != _|_ {
+								color: mapping.color
+							}
+						}
+					}
+				}
+			}
+		}]
+	}
 }

--- a/cue/schemas/panels/status-history/migrate/migrate.cue
+++ b/cue/schemas/panels/status-history/migrate/migrate.cue
@@ -18,81 +18,82 @@ package migrate
 
 kind: "StatusHistoryChart"
 spec: {
-	#showLegend: *#panel.options.legend.showLegend | true
-	if #panel.options.legend != _|_ if #showLegend {
-		legend: {
-			if #panel.type == "status-history" {
-				position: [
-					if #panel.options.legend.placement != _|_ if #panel.options.legend.placement == "right" {"right"},
-					{"bottom"},
-				][0]
-				mode: [
-					if #panel.options.legend.displayMode == "list" {"list"},
-					if #panel.options.legend.displayMode == "table" {"table"},
-				][0]
+		#showLegend: *#panel.options.legend.showLegend | true
+		if #showLegend {
+			legend: {
+				position: *(#panel.options.legend.placement & "right") | "bottom"
+				mode:     *(#panel.options.legend.displayMode & "table") | "list"
 			}
 		}
+
+		// Using flatten to avoid having an array of arrays with "value" mappings
+		// (https://cuelang.org/docs/howto/use-list-flattenn-to-flatten-lists/)
+		let x = list.FlattenN([
+			if (*#panel.fieldConfig.defaults.mappings | null) != null for mapping in #panel.fieldConfig.defaults.mappings {
+				if mapping.type == "value" {
+					[for key, option in mapping.options {
+						{
+							kind: "Value"
+							spec: {
+								value: key
+								result: {
+									if option.text != _|_ {
+										value: option.text
+									}
+									if option.color != _|_ {
+										color: *#mapping.color[option.color] | option.color
+									}
+								}
+							}
+						}
+
+					}]
+				}
+
+				if mapping.type == "range" || mapping.type == "regex" || mapping.type == "special" {
+					#result: {
+						value: *mapping.options.result.text | ""
+						if mapping.options.result.color != _|_ {
+							color: *#mapping.color[mapping.options.result.color] | mapping.options.result.color
+						}
+					}
+					[//switch
+						if mapping.type == "range" {
+							kind: "Range"
+							spec: {
+								if mapping.options.from != _|_ {
+									from: mapping.options.from
+								}
+								if mapping.options.to != _|_ {
+									to: mapping.options.to
+								}
+								result: #result
+							}
+						},
+						if mapping.type == "regex" {
+							kind: "Regex"
+							spec: {
+								pattern: mapping.options.pattern
+								result:  #result
+							}
+						},
+						if mapping.type == "special" {
+							kind: "Misc"
+							spec: {
+								value: [//switch
+									if mapping.options.match == "nan" {"NaN"},
+									if mapping.options.match == "null+nan" {"null"},
+									mapping.options.match,
+								][0]
+								result: #result
+							}
+						},
+					][0]
+				}
+			},
+		], 1)
+
+		if len(x) > 0 {
+			mappings: x
+		}
 	}
-	// Add migration logic for Value mapping
-	if #panel.options.mappings != _|_ {
-		mappings: [ for mapping in #panel.options.mappings {
-			if mapping.type == "value" {
-				{
-					kind: "Value"
-					spec: {
-						value: mapping.value
-						result: {
-							value: mapping.text
-							if mapping.color != _|_ {
-								color: mapping.color
-							}
-						}
-					}
-				}
-				}
-			if mapping.type == "range" {
-				{
-					kind: "Range"
-					spec: {
-						from: mapping.from
-						to: mapping.to
-						result: {
-							value: mapping.text
-							if mapping.color != _|_ {
-								color: mapping.color
-							}
-						}
-					}
-				}
-			}
-			if mapping.type == "regex" {
-				{
-					kind: "Regex"
-					spec: {
-						pattern: mapping.pattern
-						result: {
-							value: mapping.text
-							if mapping.color != _|_ {
-								color: mapping.color
-							}
-						}
-					}
-				}
-			}
-			if mapping.type == "misc" {
-				{
-					kind: "Misc"
-					spec: {
-						value: mapping.value
-						result: {
-							value: mapping.text
-							if mapping.color != _|_ {
-								color: mapping.color
-							}
-						}
-					}
-				}
-			}
-		}]
-	}
-}

--- a/cue/schemas/panels/status-history/status-history.cue
+++ b/cue/schemas/panels/status-history/status-history.cue
@@ -17,8 +17,6 @@ import (
 	"github.com/perses/perses/cue/schemas/common"
 )
 
-#legendValue: common.#calculation
-
 #legend: {
 	position: "bottom" | "right"
 	mode?:    "list" | "table"
@@ -26,6 +24,8 @@ import (
 }
 
 kind: "StatusHistoryChart"
+
 spec: close({
 	legend?: #legend
+	mappings?: [...common.#mappings]
 })

--- a/internal/api/migrate/migrate_test.go
+++ b/internal/api/migrate/migrate_test.go
@@ -97,7 +97,7 @@ func TestMig_Migrate(t *testing.T) {
 			inputGrafanaDashboardFile:   "statushistory_grafana_dashboard.json",
 			expectedPersesDashboardFile: "statushistory_perses_dashboard.json",
 			expectedErrorStr:            "",
-		}
+		},
 	}
 	projectPath := testUtils.GetRepositoryPath()
 

--- a/internal/api/migrate/migrate_test.go
+++ b/internal/api/migrate/migrate_test.go
@@ -92,6 +92,12 @@ func TestMig_Migrate(t *testing.T) {
 			expectedPersesDashboardFile: "grafana_user_perses_dashboard.json",
 			expectedErrorStr:            "",
 		},
+		{
+			title:                       "dashboard with a statushistory",
+			inputGrafanaDashboardFile:   "statushistory_grafana_dashboard.json",
+			expectedPersesDashboardFile: "statushistory_perses_dashboard.json",
+			expectedErrorStr:            "",
+		}
 	}
 	projectPath := testUtils.GetRepositoryPath()
 

--- a/internal/api/migrate/testdata/stat_calc_undefined_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/stat_calc_undefined_grafana_dashboard.json
@@ -10,10 +10,50 @@
         "defaults": {
           "mappings": [
             {
-              "id": 1,
-              "text": "unset",
-              "type": 1,
-              "value": 0
+              "type": "value",
+              "options": {
+                "0": {
+                  "color": "light-red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "light-green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              }
+            },
+            {
+              "type": "range",
+              "options": {
+                "from": 10,
+                "to": 100,
+                "result": {
+                  "text": "xxx",
+                  "index": 2
+                }
+              }
+            },
+            {
+              "type": "special",
+              "options": {
+                "match": "nan",
+                "result": {
+                  "text": "bac",
+                  "index": 3
+                }
+              }
+            },
+            {
+              "type": "regex",
+              "options": {
+                "pattern": "asdf;sndf",
+                "result": {
+                  "text": "xxx",
+                  "index": 4
+                }
+              }
             }
           ],
           "thresholds": {

--- a/internal/api/migrate/testdata/stat_calc_undefined_perses_dashboard.json
+++ b/internal/api/migrate/testdata/stat_calc_undefined_perses_dashboard.json
@@ -23,6 +23,56 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#ff7383",
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#96d98d",
+                      "value": "Up"
+                    },
+                    "value": "1"
+                  }
+                },
+                {
+                  "kind": "Range",
+                  "spec": {
+                    "from": 10,
+                    "result": {
+                      "value": "xxx"
+                    },
+                    "to": 100
+                  }
+                },
+                {
+                  "kind": "Misc",
+                  "spec": {
+                    "result": {
+                      "value": "bac"
+                    },
+                    "value": "NaN"
+                  }
+                },
+                {
+                  "kind": "Regex",
+                  "spec": {
+                    "pattern": "asdf;sndf",
+                    "result": {
+                      "value": "xxx"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/internal/api/migrate/testdata/statushistory_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/statushistory_grafana_dashboard.json
@@ -1,0 +1,142 @@
+{
+    "annotations": {
+        "list": []
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 927,
+    "links": [],
+    "panels": [
+        {
+            "description": "Network interfaces carrier status",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "fixed"
+                    },
+                    "custom": {
+                        "fillOpacity": 70,
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineWidth": 1
+                    },
+                    "mappings": [
+                        {
+                            "type": "value",
+                            "options": {
+                                "0": {
+                                    "color": "light-red",
+                                    "index": 0,
+                                    "text": "Down"
+                                },
+                                "1": {
+                                    "color": "light-green",
+                                    "index": 1,
+                                    "text": "Up"
+                                }
+                            }
+                        },
+                        {
+                            "type": "range",
+                            "options": {
+                                "from": 10,
+                                "to": 100,
+                                "result": {
+                                    "text": "xxx",
+                                    "index": 2
+                                }
+                            }
+                        },
+                        {
+                            "type": "special",
+                            "options": {
+                                "match": "nan",
+                                "result": {
+                                    "text": "bac",
+                                    "index": 3
+                                }
+                            }
+                        },
+                        {
+                            "type": "regex",
+                            "options": {
+                                "pattern": "asdf;sndf",
+                                "result": {
+                                    "text": "xxx",
+                                    "index": 4
+                                }
+                            }
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 9
+            },
+            "id": 1,
+            "maxDataPoints": 50,
+            "options": {
+                "colWidth": 0.9,
+                "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "rowHeight": 0.9,
+                "showValue": "never",
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0-pre",
+            "targets": [
+                {
+                    "expr": "node_network_carrier{}",
+                    "legendFormat": "{{device}}",
+                    "refId": "A"
+                }
+            ],
+            "title": "Network interfaces status",
+            "type": "status-history"
+        }
+    ],
+    "preload": false,
+    "refresh": "30s",
+    "schemaVersion": 40,
+    "tags": [],
+    "templating": {
+        "list": []
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "status history",
+    "uid": "sh",
+    "version": 1,
+    "weekStart": ""
+}

--- a/internal/api/migrate/testdata/statushistory_perses_dashboard.json
+++ b/internal/api/migrate/testdata/statushistory_perses_dashboard.json
@@ -1,0 +1,118 @@
+{
+    "kind": "Dashboard",
+    "metadata": {
+        "name": "sh",
+        "createdAt": "0001-01-01T00:00:00Z",
+        "updatedAt": "0001-01-01T00:00:00Z",
+        "version": 0,
+        "project": ""
+    },
+    "spec": {
+        "display": {
+            "name": "status history"
+        },
+        "panels": {
+            "0": {
+                "kind": "Panel",
+                "spec": {
+                    "display": {
+                        "name": "Network interfaces status",
+                        "description": "Network interfaces carrier status"
+                    },
+                    "plugin": {
+                        "kind": "StatusHistoryChart",
+                        "spec": {
+                            "legend": {
+                                "mode": "list",
+                                "position": "bottom"
+                            },
+                            "mappings": [
+                                {
+                                    "kind": "Value",
+                                    "spec": {
+                                        "result": {
+                                            "color": "#ff7383",
+                                            "value": "Down"
+                                        },
+                                        "value": "0"
+                                    }
+                                },
+                                {
+                                    "kind": "Value",
+                                    "spec": {
+                                        "result": {
+                                            "color": "#96d98d",
+                                            "value": "Up"
+                                        },
+                                        "value": "1"
+                                    }
+                                },
+                                {
+                                    "kind": "Range",
+                                    "spec": {
+                                        "from": 10,
+                                        "result": {
+                                            "value": "xxx"
+                                        },
+                                        "to": 100
+                                    }
+                                },
+                                {
+                                    "kind": "Misc",
+                                    "spec": {
+                                        "result": {
+                                            "value": "bac"
+                                        },
+                                        "value": "NaN"
+                                    }
+                                },
+                                {
+                                    "kind": "Regex",
+                                    "spec": {
+                                        "pattern": "asdf;sndf",
+                                        "result": {
+                                            "value": "xxx"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "queries": [
+                        {
+                            "kind": "TimeSeriesQuery",
+                            "spec": {
+                                "plugin": {
+                                    "kind": "PrometheusTimeSeriesQuery",
+                                    "spec": {
+                                        "query": "node_network_carrier{}",
+                                        "seriesNameFormat": "{{device}}"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "layouts": [
+            {
+                "kind": "Grid",
+                "spec": {
+                    "items": [
+                        {
+                            "x": 12,
+                            "y": 9,
+                            "width": 12,
+                            "height": 8,
+                            "content": {
+                                "$ref": "#/spec/panels/0"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "duration": "1h"
+    }
+}

--- a/ui/components/src/StatChart/StatChart.stories.tsx
+++ b/ui/components/src/StatChart/StatChart.stories.tsx
@@ -17,6 +17,7 @@ import { ReactElement } from 'react';
 
 const DEFAULT_DATA: StatChartData = {
   calculatedValue: 7.57037037037037,
+  color: '#1976d2',
   seriesData: {
     name: 'prometheus_http_requests_total{code="302",handler="/",instance="demo.do.prometheus.io:9090",job="prometheus"}',
     values: [

--- a/ui/components/src/StatChart/StatChart.test.tsx
+++ b/ui/components/src/StatChart/StatChart.test.tsx
@@ -41,6 +41,7 @@ describe('StatChart', () => {
 
   const mockStatData: StatChartData = {
     calculatedValue: 7.72931659687181,
+    color: '#1976d2',
     seriesData: {
       name: '(((count(count(node_cpu_seconds_total{job="example"}) by (cpu))',
       values: [

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ReactElement, useMemo } from 'react';
-import { formatValue, FormatOptions } from '@perses-dev/core';
+import { useMemo } from 'react';
+import { FormatOptions } from '@perses-dev/core';
 import { Box, Typography, styled } from '@mui/material';
 import merge from 'lodash/merge';
 import { use, EChartsCoreOption } from 'echarts/core';
@@ -24,6 +24,7 @@ import { EChart } from '../EChart';
 import { GraphSeries } from '../model';
 import { FontSizeOption } from '../FontSizeSelector';
 import { useOptimalFontSize } from './calculateFontSize';
+import { formatStatChartValue } from './utils/formatStatChartValue';
 
 use([EChartsLineChart, GridComponent, DatasetComponent, TitleComponent, TooltipComponent, CanvasRenderer]);
 
@@ -33,6 +34,7 @@ const SERIES_NAME_FONT_WEIGHT = 400;
 const VALUE_FONT_WEIGHT = 700;
 
 export interface StatChartData {
+  color: string;
   calculatedValue?: string | number | null | undefined;
   seriesData?: GraphSeries;
 }
@@ -42,26 +44,17 @@ export interface StatChartProps {
   height: number;
   data: StatChartData;
   format?: FormatOptions;
-  color?: string;
   sparkline?: LineSeriesOption;
   showSeriesName?: boolean;
   valueFontSize?: FontSizeOption;
 }
 
 export function StatChart(props: StatChartProps) {
-  const { width, height, data, color, sparkline, showSeriesName, format, valueFontSize } = props;
+  const { width, height, data, sparkline, showSeriesName, format, valueFontSize } = props;
   const chartsTheme = useChartsTheme();
+  const color = data.color;
 
-  let formattedValue = '';
-  if (data.calculatedValue === null) {
-    formattedValue = 'null';
-  } else if (typeof data.calculatedValue === 'number') {
-    formattedValue = formatValue(data.calculatedValue, format);
-  } else if (data.calculatedValue === undefined) {
-    formattedValue = '';
-  } else {
-    formattedValue = data.calculatedValue;
-  }
+  const formattedValue = formatStatChartValue(data.calculatedValue, format);
 
   const containerPadding = chartsTheme.container.padding.default;
 
@@ -74,6 +67,7 @@ export function StatChart(props: StatChartProps) {
     lineHeight: LINE_HEIGHT,
     maxSize: SERIES_NAME_MAX_FONT_SIZE,
   });
+
   const seriesNameHeight = showSeriesName ? seriesNameFontSize * LINE_HEIGHT + containerPadding : 0;
 
   // calculate value font size and height
@@ -112,19 +106,7 @@ export function StatChart(props: StatChartProps) {
         animation: false,
         silent: true,
       };
-
-      const sparklineConfig = {
-        lineStyle: {
-          width: sparkline.width ?? chartsTheme.sparkline.width,
-          color,
-          opacity: 1,
-        },
-        areaStyle: {
-          color,
-          opacity: 0.4,
-        },
-      };
-      const mergedSeries = merge(lineSeries, sparklineConfig);
+      const mergedSeries = merge(lineSeries, sparkline);
       statSeries.push(mergedSeries);
     }
 

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -33,7 +33,7 @@ const SERIES_NAME_FONT_WEIGHT = 400;
 const VALUE_FONT_WEIGHT = 700;
 
 export interface StatChartData {
-  calculatedValue?: number | null;
+  calculatedValue?: string | number | null | undefined;
   seriesData?: GraphSeries;
 }
 
@@ -48,8 +48,8 @@ export interface StatChartProps {
   valueFontSize?: FontSizeOption;
 }
 
-export function StatChart(props: StatChartProps): ReactElement {
-  const { width, height, data, format, color, sparkline, showSeriesName, valueFontSize } = props;
+export function StatChart(props: StatChartProps) {
+  const { width, height, data, color, sparkline, showSeriesName, format, valueFontSize } = props;
   const chartsTheme = useChartsTheme();
 
   let formattedValue = '';
@@ -57,6 +57,10 @@ export function StatChart(props: StatChartProps): ReactElement {
     formattedValue = 'null';
   } else if (typeof data.calculatedValue === 'number') {
     formattedValue = formatValue(data.calculatedValue, format);
+  } else if (data.calculatedValue === undefined) {
+    formattedValue = '';
+  } else {
+    formattedValue = data.calculatedValue;
   }
 
   const containerPadding = chartsTheme.container.padding.default;
@@ -108,7 +112,19 @@ export function StatChart(props: StatChartProps): ReactElement {
         animation: false,
         silent: true,
       };
-      const mergedSeries = merge(lineSeries, sparkline);
+
+      const sparklineConfig = {
+        lineStyle: {
+          width: sparkline.width ?? chartsTheme.sparkline.width,
+          color,
+          opacity: 1,
+        },
+        areaStyle: {
+          color,
+          opacity: 0.4,
+        },
+      };
+      const mergedSeries = merge(lineSeries, sparklineConfig);
       statSeries.push(mergedSeries);
     }
 

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useMemo } from 'react';
+import { FC, useMemo } from 'react';
 import { FormatOptions } from '@perses-dev/core';
 import { Box, Typography, styled } from '@mui/material';
 import merge from 'lodash/merge';
@@ -49,7 +49,7 @@ export interface StatChartProps {
   valueFontSize?: FontSizeOption;
 }
 
-export function StatChart(props: StatChartProps) {
+export const StatChart: FC<StatChartProps> = (props) => {
   const { width, height, data, sparkline, showSeriesName, format, valueFontSize } = props;
   const chartsTheme = useChartsTheme();
   const color = data.color;
@@ -178,7 +178,7 @@ export function StatChart(props: StatChartProps) {
       )}
     </Box>
   );
-}
+};
 
 const SeriesName = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'padding' && prop !== 'fontSize',

--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -35,7 +35,7 @@ const VALUE_FONT_WEIGHT = 700;
 
 export interface StatChartData {
   color: string;
-  calculatedValue?: string | number | null | undefined;
+  calculatedValue?: string | number | null;
   seriesData?: GraphSeries;
 }
 

--- a/ui/components/src/StatChart/utils/formatStatChartValue.ts
+++ b/ui/components/src/StatChart/utils/formatStatChartValue.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,23 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package model
+import { FormatOptions, formatValue } from '@perses-dev/core';
 
-import (
-	"github.com/perses/perses/cue/schemas/common"
-)
-
-kind: "StatChart"
-spec: close({
-	calculation:    common.#calculation
-	format?:        common.#format
-	thresholds?:    common.#thresholds
-	sparkline?:     #sparkline
-	valueFontSize?: number
-	mappings?:      [...common.#mappings]
-
-	#sparkline: {
-		color?: string
-		width?: number
-	}
-})
+export const formatStatChartValue = (value?: string | number | null, format?: FormatOptions) => {
+  if (value === null) {
+    return 'null';
+  } else if (typeof value === 'number') {
+    return formatValue(value, format);
+  } else if (value === undefined) {
+    return '';
+  } else {
+    return value;
+  }
+};

--- a/ui/components/src/StatChart/utils/formatStatChartValue.ts
+++ b/ui/components/src/StatChart/utils/formatStatChartValue.ts
@@ -13,7 +13,7 @@
 
 import { FormatOptions, formatValue } from '@perses-dev/core';
 
-export const formatStatChartValue = (value?: string | number | null, format?: FormatOptions) => {
+export const formatStatChartValue = (value?: string | number | null, format?: FormatOptions): string => {
   if (value === null) {
     return 'null';
   } else if (typeof value === 'number') {

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import type { Meta, StoryObj } from '@storybook/react';
+import { ReactElement } from 'react';
 import { StatusHistoryChart, StatusHistoryChartProps, StatusHistoryDataItem } from './StatusHistoryChart';
 
 const DEFAULT_DATA: StatusHistoryDataItem[] = [

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.stories.tsx
@@ -12,16 +12,33 @@
 // limitations under the License.
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { ReactElement } from 'react';
-import { StatusHistoryChart, StatusHistoryChartProps, StatusHistoryData } from './StatusHistoryChart';
+import { StatusHistoryChart, StatusHistoryChartProps, StatusHistoryDataItem } from './StatusHistoryChart';
 
-const DEFAULT_DATA: StatusHistoryData[] = [
-  [0, 0, 1],
-  [1, 0, 2],
-  [2, 0, 3],
-  [0, 1, 2],
-  [1, 1, 3],
-  [2, 1, 1],
+const DEFAULT_DATA: StatusHistoryDataItem[] = [
+  {
+    value: [0, 0, 1],
+    label: '1',
+  },
+  {
+    value: [1, 0, 2],
+    label: '2',
+  },
+  {
+    value: [2, 0, 3],
+    label: '3',
+  },
+  {
+    value: [0, 1, 2],
+    label: '2',
+  },
+  {
+    value: [1, 1, 3],
+    label: '3',
+  },
+  {
+    value: [2, 1, 1],
+    label: '1',
+  },
 ];
 
 const meta: Meta<typeof StatusHistoryChart> = {

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
@@ -21,13 +21,13 @@ import {
   VisualMapComponent,
   LegendComponentOption,
 } from 'echarts/components';
-import { EChartsCoreOption, use } from 'echarts/core';
+import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { TimeScale } from '@perses-dev/core';
-import { ReactElement, useMemo } from 'react';
-import { useChartsTheme, useTimeZone } from '../context';
+import { EChartsCoreOption } from 'echarts';
+import { useChartsTheme } from '../context/ChartsProvider';
+import { useTimeZone } from '../context/TimeZoneProvider';
 import { EChart } from '../EChart';
-import { getColorsForValues } from './utils/get-color';
 import { getFormattedStatusHistoryAxisLabel } from './get-formatted-axis-label';
 import { generateTooltipHTML } from './StatusHistoryTooltip';
 
@@ -43,44 +43,39 @@ use([
 
 export type StatusHistoryData = [number, number, number | undefined];
 
+export interface StatusHistoryDataItem {
+  value: StatusHistoryData;
+  label?: string;
+  itemStyle?: {
+    color?: string;
+    borderColor?: string;
+    borderWidth?: number;
+  };
+}
+
 export interface StatusHistoryChartProps {
   height: number;
-  data: StatusHistoryData[];
+  data: StatusHistoryDataItem[];
   xAxisCategories: number[];
   yAxisCategories: string[];
   legend?: LegendComponentOption;
   timeScale?: TimeScale;
+  colors?: Array<{ value: number | string; color: string }>;
 }
 
-export function StatusHistoryChart(props: StatusHistoryChartProps): ReactElement {
-  const { height, data, xAxisCategories, yAxisCategories, timeScale } = props;
+export function StatusHistoryChart(props: StatusHistoryChartProps) {
+  const { height, data, xAxisCategories, yAxisCategories, timeScale, colors } = props;
   const { timeZone } = useTimeZone();
   const chartsTheme = useChartsTheme();
   const theme = useTheme();
 
-  const uniqueValues = useMemo(
-    () => [...new Set(data.map((item) => item[2]))].filter((value): value is number => value !== undefined),
-    [data]
-  );
-
-  // get colors from theme and generate colors if not provided
-  const pieces = useMemo(() => {
-    const themeColors = Array.isArray(chartsTheme.echartsTheme.color)
-      ? chartsTheme.echartsTheme.color.filter((color): color is string => typeof color === 'string')
-      : [];
-
-    return uniqueValues.map((value, index) => ({
-      value,
-      color: getColorsForValues(uniqueValues, themeColors)[index],
-    }));
-  }, [uniqueValues, chartsTheme.echartsTheme.color]);
-
   const option: EChartsCoreOption = {
     tooltip: {
       appendToBody: true,
-      formatter: (params: { data: StatusHistoryData; marker: string }) => {
+      formatter: (params: { data: StatusHistoryDataItem; marker: string }) => {
         return generateTooltipHTML({
-          data: params.data,
+          data: params.data.value,
+          label: params.data.label,
           marker: params.marker,
           xAxisCategories,
           yAxisCategories,
@@ -126,7 +121,7 @@ export function StatusHistoryChart(props: StatusHistoryChartProps): ReactElement
     visualMap: {
       show: false,
       type: 'piecewise',
-      pieces,
+      pieces: colors,
     },
     series: [
       {
@@ -152,7 +147,7 @@ export function StatusHistoryChart(props: StatusHistoryChartProps): ReactElement
   };
 
   return (
-    <Box style={{ height: height }} sx={{ overflow: 'auto' }}>
+    <Box sx={{ height: height, overflow: 'auto' }}>
       <EChart
         sx={{
           width: '100%',

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
@@ -147,7 +147,7 @@ export function StatusHistoryChart(props: StatusHistoryChartProps) {
   };
 
   return (
-    <Box sx={{ height: height, overflow: 'auto' }}>
+    <Box style={{ height: height }} sx={{ overflow: 'auto' }}>
       <EChart
         sx={{
           width: '100%',

--- a/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryChart.tsx
@@ -25,6 +25,7 @@ import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { TimeScale } from '@perses-dev/core';
 import { EChartsCoreOption } from 'echarts';
+import { FC } from 'react';
 import { useChartsTheme } from '../context/ChartsProvider';
 import { useTimeZone } from '../context/TimeZoneProvider';
 import { EChart } from '../EChart';
@@ -63,7 +64,7 @@ export interface StatusHistoryChartProps {
   colors?: Array<{ value: number | string; color: string }>;
 }
 
-export function StatusHistoryChart(props: StatusHistoryChartProps) {
+export const StatusHistoryChart: FC<StatusHistoryChartProps> = (props) => {
   const { height, data, xAxisCategories, yAxisCategories, timeScale, colors } = props;
   const { timeZone } = useTimeZone();
   const chartsTheme = useChartsTheme();
@@ -158,4 +159,4 @@ export function StatusHistoryChart(props: StatusHistoryChartProps) {
       />
     </Box>
   );
-}
+};

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -17,7 +17,7 @@ import { StatusHistoryData } from './StatusHistoryChart';
 
 interface CustomTooltipProps {
   data: StatusHistoryData;
-  label: string;
+  label: string | undefined;
   marker: string;
   xAxisCategories: number[];
   yAxisCategories: string[];

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -17,6 +17,7 @@ import { StatusHistoryData } from './StatusHistoryChart';
 
 interface CustomTooltipProps {
   data: StatusHistoryData;
+  label: string;
   marker: string;
   xAxisCategories: number[];
   yAxisCategories: string[];
@@ -25,12 +26,13 @@ interface CustomTooltipProps {
 
 export function generateTooltipHTML({
   data,
+  label,
   marker,
   xAxisCategories,
   yAxisCategories,
   theme,
 }: CustomTooltipProps): string {
-  const [x, y, value] = data;
+  const [x, y] = data;
   const xAxisLabel = xAxisCategories[x];
 
   const { formattedDate, formattedTime } = getDateAndTime(xAxisLabel);
@@ -59,7 +61,7 @@ export function generateTooltipHTML({
           <strong>${yAxisCategories[y]}</strong>
         </div>
         <div>
-          ${value}
+          ${label}
         </div>
       </div>
     </div>

--- a/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
+++ b/ui/components/src/StatusHistoryChart/StatusHistoryTooltip.ts
@@ -17,7 +17,7 @@ import { StatusHistoryData } from './StatusHistoryChart';
 
 interface CustomTooltipProps {
   data: StatusHistoryData;
-  label: string | undefined;
+  label?: string;
   marker: string;
   xAxisCategories: number[];
   yAxisCategories: string[];

--- a/ui/components/src/StatusHistoryChart/utils/get-color.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.ts
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const fallbackColor = '#1f77b4';
+export const FALLBACK_COLOR = '#1f77b4';
 
 export function getColorForValue(value: number | string, baseColor: string): string {
   // Validate base color
   if (!baseColor.match(/^#[0-9A-Fa-f]{6}$/)) {
-    baseColor = fallbackColor;
+    baseColor = FALLBACK_COLOR;
   }
 
   try {
@@ -53,8 +53,8 @@ export function getColorForValue(value: number | string, baseColor: string): str
     }
 
     return color;
-  } catch (_) {
-    return fallbackColor;
+  } catch (error) {
+    return FALLBACK_COLOR;
   }
 }
 
@@ -67,9 +67,9 @@ export function getColorsForValues(uniqueValues: Array<number | string>, themeCo
   // Use theme colors first, then generate additional ones
   return uniqueValues.map((value, index) => {
     if (index < themeColors.length) {
-      return themeColors[index] || fallbackColor;
+      return themeColors[index] || FALLBACK_COLOR;
     }
-    return getColorForValue(value, themeColors[0] || fallbackColor);
+    return getColorForValue(value, themeColors[0] || FALLBACK_COLOR);
   });
 }
 

--- a/ui/components/src/StatusHistoryChart/utils/get-color.ts
+++ b/ui/components/src/StatusHistoryChart/utils/get-color.ts
@@ -53,7 +53,7 @@ export function getColorForValue(value: number | string, baseColor: string): str
     }
 
     return color;
-  } catch (error) {
+  } catch (_) {
     return FALLBACK_COLOR;
   }
 }

--- a/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
@@ -25,6 +25,7 @@ import {
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import PlusIcon from 'mdi-material-ui/Plus';
 import { ValueMapping } from '@perses-dev/core';
+import { FC } from 'react';
 import { OptionsColorPicker } from '../ColorPicker/OptionsColorPicker';
 
 interface ValueMappingConditionEditorProps extends Omit<StackProps, 'onChange'> {
@@ -32,7 +33,7 @@ interface ValueMappingConditionEditorProps extends Omit<StackProps, 'onChange'> 
   onChange: (condition: ValueMapping) => void;
 }
 
-function ConditionEditor({ mapping, onChange, ...props }: ValueMappingConditionEditorProps) {
+const ConditionEditor: FC<ValueMappingConditionEditorProps> = ({ mapping, onChange, ...props }) => {
   switch (mapping.kind) {
     case 'Value':
       return (
@@ -146,15 +147,15 @@ function ConditionEditor({ mapping, onChange, ...props }: ValueMappingConditionE
     default:
       return null;
   }
-}
+};
 export interface ValueMappingEditorProps extends Omit<GridProps, 'onChange'> {
   mapping: ValueMapping;
   onChange: (mapping: ValueMapping) => void;
   onDelete: () => void;
 }
 
-export function ValueMappingEditor({ mapping, onChange, onDelete, ...props }: ValueMappingEditorProps) {
-  const handleColorChange = (color?: string) => {
+export const ValueMappingEditor: FC<ValueMappingEditorProps> = ({ mapping, onChange, onDelete, ...props }) => {
+  const handleColorChange = (color?: string): void => {
     onChange({
       ...mapping,
       spec: {
@@ -260,4 +261,4 @@ export function ValueMappingEditor({ mapping, onChange, onDelete, ...props }: Va
       </Grid>
     </Grid>
   );
-}
+};

--- a/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
@@ -11,8 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GridProps, IconButton, MenuItem, Stack, StackProps, TextField, Tooltip, Typography } from '@mui/material';
-import Grid from '@mui/material/Unstable_Grid2';
+import {
+  Grid2Props as GridProps,
+  IconButton,
+  MenuItem,
+  Stack,
+  StackProps,
+  TextField,
+  Tooltip,
+  Typography,
+  Grid2 as Grid,
+} from '@mui/material';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import PlusIcon from 'mdi-material-ui/Plus';
 import { ValueMapping } from '@perses-dev/core';
@@ -159,7 +168,7 @@ export function ValueMappingEditor({ mapping, onChange, onDelete, ...props }: Va
   };
   return (
     <Grid container spacing={2} {...props}>
-      <Grid xs={5}>
+      <Grid size={{ xs: 5 }}>
         <Stack direction="row" gap={1} width="100%">
           <TextField
             select
@@ -207,7 +216,7 @@ export function ValueMappingEditor({ mapping, onChange, onDelete, ...props }: Va
           />
         </Stack>
       </Grid>
-      <Grid xs={4}>
+      <Grid size={{ xs: 4 }}>
         <TextField
           label="Display text"
           value={mapping.spec?.result?.value ?? ''}
@@ -226,7 +235,7 @@ export function ValueMappingEditor({ mapping, onChange, onDelete, ...props }: Va
           fullWidth
         />
       </Grid>
-      <Grid xs={1}>
+      <Grid size={{ xs: 1 }}>
         <Stack direction="row" justifyContent="center" gap={1}>
           {mapping.spec?.result?.color ? (
             <OptionsColorPicker
@@ -242,7 +251,7 @@ export function ValueMappingEditor({ mapping, onChange, onDelete, ...props }: Va
           )}
         </Stack>
       </Grid>
-      <Grid xs={1} textAlign="end">
+      <Grid size={{ xs: 1 }} textAlign="end">
         <Tooltip title="Remove mapping settings" placement="top">
           <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={onDelete}>
             <DeleteIcon />

--- a/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
@@ -59,14 +59,24 @@ const ConditionEditor: FC<ValueMappingConditionEditorProps> = ({ mapping, onChan
             label="From"
             placeholder="Start of range"
             value={mapping.spec?.from ?? ''}
-            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, from: e.target.value === '' ? undefined : +e.target.value } })}
+            onChange={(e) =>
+              onChange({
+                ...mapping,
+                spec: { ...mapping.spec, from: e.target.value === '' ? undefined : +e.target.value },
+              })
+            }
             fullWidth
           />
           <TextField
             label="To"
             placeholder="End of range (inclusive)"
             value={mapping.spec?.to ?? ''}
-            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, to: e.target.value === '' ? undefined : +e.target.value } })}
+            onChange={(e) =>
+              onChange({
+                ...mapping,
+                spec: { ...mapping.spec, to: e.target.value === '' ? undefined : +e.target.value },
+              })
+            }
             fullWidth
           />
         </Stack>

--- a/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
@@ -59,14 +59,14 @@ const ConditionEditor: FC<ValueMappingConditionEditorProps> = ({ mapping, onChan
             label="From"
             placeholder="Start of range"
             value={mapping.spec?.from ?? ''}
-            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, from: +e.target.value } })}
+            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, from: e.target.value === '' ? undefined : +e.target.value } })}
             fullWidth
           />
           <TextField
             label="To"
             placeholder="End of range (inclusive)"
             value={mapping.spec?.to ?? ''}
-            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, to: +e.target.value } })}
+            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, to: e.target.value === '' ? undefined : +e.target.value } })}
             fullWidth
           />
         </Stack>

--- a/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingEditor.tsx
@@ -1,0 +1,254 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { GridProps, IconButton, MenuItem, Stack, StackProps, TextField, Tooltip, Typography } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
+import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import PlusIcon from 'mdi-material-ui/Plus';
+import { ValueMapping } from '@perses-dev/core';
+import { OptionsColorPicker } from '../ColorPicker/OptionsColorPicker';
+
+interface ValueMappingConditionEditorProps extends Omit<StackProps, 'onChange'> {
+  mapping: ValueMapping;
+  onChange: (condition: ValueMapping) => void;
+}
+
+function ConditionEditor({ mapping, onChange, ...props }: ValueMappingConditionEditorProps) {
+  switch (mapping.kind) {
+    case 'Value':
+      return (
+        <Stack gap={1} direction="row" {...props}>
+          <TextField
+            label="Value"
+            placeholder="Exact value"
+            value={mapping.spec?.value ?? ''}
+            onChange={(e) =>
+              onChange({
+                ...mapping,
+                spec: { ...mapping.spec, value: e.target.value },
+              })
+            }
+            fullWidth
+          />
+        </Stack>
+      );
+    case 'Range':
+      return (
+        <Stack gap={1} direction="row" {...props}>
+          <TextField
+            label="From"
+            placeholder="Start of range"
+            value={mapping.spec?.from ?? ''}
+            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, from: +e.target.value } })}
+            fullWidth
+          />
+          <TextField
+            label="To"
+            placeholder="End of range (inclusive)"
+            value={mapping.spec?.to ?? ''}
+            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, to: +e.target.value } })}
+            fullWidth
+          />
+        </Stack>
+      );
+    case 'Regex':
+      return (
+        <Stack gap={1} direction="row" {...props}>
+          <TextField
+            label="Regular Expression"
+            placeholder="JavaScript regular expression"
+            value={mapping.spec?.pattern ?? ''}
+            onChange={(e) => onChange({ ...mapping, spec: { ...mapping.spec, pattern: e.target.value } })}
+            fullWidth
+          />
+        </Stack>
+      );
+    case 'Misc':
+      return (
+        <Stack gap={1} direction="row" {...props}>
+          <TextField
+            select
+            label="Value"
+            value={mapping.spec?.value ?? ''}
+            onChange={(e) => onChange({ ...mapping, spec: { value: e.target.value } } as ValueMapping)}
+            SelectProps={{
+              renderValue: (selected) => {
+                switch (selected) {
+                  case 'empty':
+                    return 'Empty';
+                  case 'null':
+                    return 'Null';
+                  case 'NaN':
+                    return 'NaN';
+                  case 'true':
+                    return 'True';
+                  case 'false':
+                    return 'False';
+                  default:
+                    return String(selected);
+                }
+              },
+            }}
+            fullWidth
+          >
+            <MenuItem value="empty">
+              <Stack>
+                <Typography>Empty</Typography>
+                <Typography variant="caption">Matches empty string</Typography>
+              </Stack>
+            </MenuItem>
+            <MenuItem value="null">
+              <Stack>
+                <Typography>Null</Typography>
+                <Typography variant="caption">Matches null or undefined</Typography>
+              </Stack>
+            </MenuItem>
+            <MenuItem value="NaN">
+              <Stack>
+                <Typography>NaN</Typography>
+                <Typography variant="caption">Matches Not a Number value</Typography>
+              </Stack>
+            </MenuItem>
+            <MenuItem value="true">
+              <Stack>
+                <Typography>True</Typography>
+                <Typography variant="caption">Matches true boolean</Typography>
+              </Stack>
+            </MenuItem>
+            <MenuItem value="false">
+              <Stack>
+                <Typography>False</Typography>
+                <Typography variant="caption">Matches false boolean</Typography>
+              </Stack>
+            </MenuItem>
+          </TextField>
+        </Stack>
+      );
+    default:
+      return null;
+  }
+}
+export interface ValueMappingEditorProps extends Omit<GridProps, 'onChange'> {
+  mapping: ValueMapping;
+  onChange: (mapping: ValueMapping) => void;
+  onDelete: () => void;
+}
+
+export function ValueMappingEditor({ mapping, onChange, onDelete, ...props }: ValueMappingEditorProps) {
+  const handleColorChange = (color?: string) => {
+    onChange({
+      ...mapping,
+      spec: {
+        ...mapping.spec,
+        result: {
+          ...mapping.spec.result,
+          color,
+        },
+      },
+    } as ValueMapping);
+  };
+  return (
+    <Grid container spacing={2} {...props}>
+      <Grid xs={5}>
+        <Stack direction="row" gap={1} width="100%">
+          <TextField
+            select
+            label="Type"
+            value={mapping.kind}
+            onChange={(e) => onChange({ ...mapping, kind: e.target.value } as ValueMapping)}
+            required
+            sx={{ width: '120px' }}
+          >
+            <MenuItem value="Value">
+              <Stack>
+                <Typography>Value</Typography>
+                {mapping.kind !== 'Value' && <Typography variant="caption">Matches an exact text value</Typography>}
+              </Stack>
+            </MenuItem>
+            <MenuItem value="Range">
+              <Stack>
+                <Typography>Range</Typography>
+                {mapping.kind !== 'Range' && (
+                  <Typography variant="caption">Matches against a numerical range</Typography>
+                )}
+              </Stack>
+            </MenuItem>
+            <MenuItem value="Regex">
+              <Stack>
+                <Typography>Regex</Typography>
+                {mapping.kind !== 'Regex' && (
+                  <Typography variant="caption">Matches against a regular expression</Typography>
+                )}
+              </Stack>
+            </MenuItem>
+            <MenuItem value="Misc">
+              <Stack>
+                <Typography>Misc</Typography>
+                {mapping.kind !== 'Misc' && (
+                  <Typography variant="caption">Matches against empty, null and NaN values</Typography>
+                )}
+              </Stack>
+            </MenuItem>
+          </TextField>
+          <ConditionEditor
+            width="100%"
+            mapping={mapping}
+            onChange={(updatedMapping) => onChange({ ...mapping, ...updatedMapping })}
+          />
+        </Stack>
+      </Grid>
+      <Grid xs={4}>
+        <TextField
+          label="Display text"
+          value={mapping.spec?.result?.value ?? ''}
+          onChange={(e) =>
+            onChange({
+              ...mapping,
+              spec: {
+                ...mapping.spec,
+                result: {
+                  ...mapping.spec?.result,
+                  value: e.target.value,
+                },
+              },
+            } as ValueMapping)
+          }
+          fullWidth
+        />
+      </Grid>
+      <Grid xs={1}>
+        <Stack direction="row" justifyContent="center" gap={1}>
+          {mapping.spec?.result?.color ? (
+            <OptionsColorPicker
+              label="Color"
+              color={mapping.spec.result.color ?? '#000'}
+              onColorChange={handleColorChange}
+              onClear={() => handleColorChange(undefined)}
+            />
+          ) : (
+            <IconButton onClick={() => handleColorChange('#000')}>
+              <PlusIcon />
+            </IconButton>
+          )}
+        </Stack>
+      </Grid>
+      <Grid xs={1} textAlign="end">
+        <Tooltip title="Remove mapping settings" placement="top">
+          <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={onDelete}>
+            <DeleteIcon />
+          </IconButton>
+        </Tooltip>
+      </Grid>
+    </Grid>
+  );
+}

--- a/ui/components/src/ValueMappingEditor/ValueMappingsEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingsEditor.tsx
@@ -1,0 +1,81 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Button, Divider, Stack, Typography } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
+
+import { useState } from 'react';
+import AddIcon from 'mdi-material-ui/Plus';
+import { ValueMapping } from '@perses-dev/core';
+import { ValueMappingEditor } from './ValueMappingEditor';
+
+export interface ValueMappingsEditorProps {
+  mappings: ValueMapping[];
+  onChange: (valueMappings: ValueMapping[]) => void;
+}
+
+export function ValueMappingsEditor({ mappings, onChange }: ValueMappingsEditorProps) {
+  const [valueMappings, setValueMappings] = useState<ValueMapping[]>(mappings);
+
+  function handleValueMappingChange(index: number, mapping: ValueMapping): void {
+    const updatedValueMapings = [...valueMappings];
+    updatedValueMapings[index] = mapping;
+    setValueMappings(updatedValueMapings);
+    onChange(updatedValueMapings);
+  }
+
+  function handleAddValueMappingEditor(): void {
+    const updatedValueMapings = [...valueMappings];
+    updatedValueMapings.push({ kind: 'Value', spec: { result: { value: '' } } } as ValueMapping);
+    setValueMappings(updatedValueMapings);
+    onChange(updatedValueMapings);
+  }
+
+  function handleValueMappingDelete(index: number): void {
+    const updatedValueMapings = [...valueMappings];
+    updatedValueMapings.splice(index, 1);
+    setValueMappings(updatedValueMapings);
+    onChange(updatedValueMapings);
+  }
+
+  return (
+    <Stack spacing={1}>
+      <Grid container spacing={2}>
+        <Grid xs={5}>
+          <Typography variant="subtitle1">Condition</Typography>
+        </Grid>
+        <Grid xs={4}>
+          <Typography variant="subtitle1">Display Text</Typography>
+        </Grid>
+        <Grid xs={1} textAlign="center">
+          <Typography variant="subtitle1">Color</Typography>
+        </Grid>
+        <Grid xs={1}></Grid>
+      </Grid>
+      <Stack gap={1.5} divider={<Divider flexItem orientation="horizontal" />}>
+        {valueMappings.map((mapping, i) => (
+          <ValueMappingEditor
+            key={i}
+            mapping={mapping}
+            onChange={(updatedMapping: ValueMapping) => handleValueMappingChange(i, updatedMapping)}
+            onDelete={() => handleValueMappingDelete(i)}
+          />
+        ))}
+      </Stack>
+
+      <Button variant="contained" startIcon={<AddIcon />} sx={{ marginTop: 1 }} onClick={handleAddValueMappingEditor}>
+        Add value mappings
+      </Button>
+    </Stack>
+  );
+}

--- a/ui/components/src/ValueMappingEditor/ValueMappingsEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingsEditor.tsx
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Button, Divider, Stack, Typography } from '@mui/material';
-import Grid from '@mui/material/Unstable_Grid2';
+import { Button, Divider, Stack, Typography, Grid2 as Grid } from '@mui/material';
 
 import { useState } from 'react';
 import AddIcon from 'mdi-material-ui/Plus';
@@ -51,16 +50,16 @@ export function ValueMappingsEditor({ mappings, onChange }: ValueMappingsEditorP
   return (
     <Stack spacing={1}>
       <Grid container spacing={2}>
-        <Grid xs={5}>
+        <Grid size={{ xs: 5 }}>
           <Typography variant="subtitle1">Condition</Typography>
         </Grid>
-        <Grid xs={4}>
+        <Grid size={{ xs: 4 }}>
           <Typography variant="subtitle1">Display Text</Typography>
         </Grid>
-        <Grid xs={1} textAlign="center">
+        <Grid size={{ xs: 1 }} textAlign="center">
           <Typography variant="subtitle1">Color</Typography>
         </Grid>
-        <Grid xs={1}></Grid>
+        <Grid size={{ xs: 1 }}></Grid>
       </Grid>
       <Stack gap={1.5} divider={<Divider flexItem orientation="horizontal" />}>
         {valueMappings.map((mapping, i) => (

--- a/ui/components/src/ValueMappingEditor/ValueMappingsEditor.tsx
+++ b/ui/components/src/ValueMappingEditor/ValueMappingsEditor.tsx
@@ -13,7 +13,7 @@
 
 import { Button, Divider, Stack, Typography, Grid2 as Grid } from '@mui/material';
 
-import { useState } from 'react';
+import { FC, useState } from 'react';
 import AddIcon from 'mdi-material-ui/Plus';
 import { ValueMapping } from '@perses-dev/core';
 import { ValueMappingEditor } from './ValueMappingEditor';
@@ -23,7 +23,7 @@ export interface ValueMappingsEditorProps {
   onChange: (valueMappings: ValueMapping[]) => void;
 }
 
-export function ValueMappingsEditor({ mappings, onChange }: ValueMappingsEditorProps) {
+export const ValueMappingsEditor: FC<ValueMappingsEditorProps> = ({ mappings, onChange }) => {
   const [valueMappings, setValueMappings] = useState<ValueMapping[]>(mappings);
 
   function handleValueMappingChange(index: number, mapping: ValueMapping): void {
@@ -77,4 +77,4 @@ export function ValueMappingsEditor({ mappings, onChange }: ValueMappingsEditorP
       </Button>
     </Stack>
   );
-}
+};

--- a/ui/components/src/ValueMappingEditor/index.ts
+++ b/ui/components/src/ValueMappingEditor/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,13 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './event';
-export * from './fetch';
-export * from './is-empty-object';
-export * from './memo';
-export * from './panel-refs';
-export * from './text';
-export * from './time-series-data';
-export * from './transform-data';
-export * from './value-mapping';
-export * from './types';
+export * from './ValueMappingsEditor';

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -53,3 +53,4 @@ export * from './TransformsEditor';
 export * from './RefreshIntervalPicker';
 export * from './PieChart';
 export * from './StatusHistoryChart';
+export * from './ValueMappingEditor';

--- a/ui/core/src/model/index.ts
+++ b/ui/core/src/model/index.ts
@@ -39,3 +39,4 @@ export * from './transforms';
 export * from './units';
 export * from './user';
 export * from './variables';
+export * from './value-mapping';

--- a/ui/core/src/model/value-mapping.ts
+++ b/ui/core/src/model/value-mapping.ts
@@ -1,0 +1,56 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export type ValueMapping =
+  | ValueMappingOptions
+  | ValueMappingOptionsRange
+  | ValueMappingOptionsRegex
+  | ValueMappingOptionsMisc;
+
+export interface ValueMappingOptions {
+  kind: 'Value';
+  spec: {
+    value: string | number;
+    result: MappedValue;
+  };
+}
+
+export interface ValueMappingOptionsRange {
+  kind: 'Range';
+  spec: {
+    from: number;
+    to: number;
+    result: MappedValue;
+  };
+}
+
+export interface ValueMappingOptionsRegex {
+  kind: 'Regex';
+  spec: {
+    pattern: string;
+    result: MappedValue;
+  };
+}
+
+export interface ValueMappingOptionsMisc {
+  kind: 'Misc';
+  spec: {
+    value: 'empty' | 'null' | 'NaN' | 'true' | 'false';
+    result: MappedValue;
+  };
+}
+
+export interface MappedValue {
+  value: number | string;
+  color?: string;
+}

--- a/ui/core/src/model/value-mapping.ts
+++ b/ui/core/src/model/value-mapping.ts
@@ -28,8 +28,8 @@ export interface ValueMappingOptions {
 export interface ValueMappingOptionsRange {
   kind: 'Range';
   spec: {
-    from: number;
-    to: number;
+    from?: number;
+    to?: number;
     result: MappedValue;
   };
 }

--- a/ui/core/src/utils/regexp.ts
+++ b/ui/core/src/utils/regexp.ts
@@ -1,0 +1,49 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Checks if a string is a regex pattern.
+ */
+export function isRegexPattern(input: string | null | undefined): boolean {
+  return Boolean(input?.startsWith('/'));
+}
+
+/**
+ * Converts a string to RegExp. Handles both regular strings and regex patterns.
+ * For regular strings, creates exact match regex.
+ * For patterns like "/pattern/flags", creates corresponding RegExp.
+ */
+export function createRegexFromString(input: string): RegExp {
+  if (!input) {
+    throw new Error('Input string cannot be empty');
+  }
+
+  if (!isRegexPattern(input)) {
+    return new RegExp(`^${input}$`);
+  }
+
+  const regexPattern = /^\/(.+)\/([gimy]*)$/;
+  const matches = input.match(regexPattern);
+
+  if (!matches) {
+    throw new Error(`Invalid regular expression format: ${input}`);
+  }
+
+  const [, pattern = '', flags = ''] = matches;
+
+  try {
+    return new RegExp(pattern, flags);
+  } catch (error) {
+    throw new Error(`Failed to create RegExp ${error}`);
+  }
+}

--- a/ui/core/src/utils/value-mapping.test.ts
+++ b/ui/core/src/utils/value-mapping.test.ts
@@ -49,7 +49,7 @@ describe('applyValueMapping', () => {
     expect(result).toEqual({ value: 'in range', color: 'blue' });
   });
 
-  it('should map value based on Regex mapping', () => {
+  it('should map value based on Regex exact match mapping', () => {
     const mappings: ValueMapping[] = [
       {
         kind: 'Regex',
@@ -61,6 +61,20 @@ describe('applyValueMapping', () => {
     ];
     const result = applyValueMapping('test123', mappings);
     expect(result).toEqual({ value: 'regex match', color: 'green' });
+  });
+
+  it('should map value based on Regex with groups mapping', () => {
+    const mappings: ValueMapping[] = [
+      {
+        kind: 'Regex',
+        spec: {
+          pattern: '(.+)0+(.+)0+(.+)',
+          result: { value: '$1.$2.$3', color: 'green' },
+        },
+      },
+    ];
+    const result = applyValueMapping('30300', mappings);
+    expect(result).toEqual({ value: '3.3.0', color: 'green' });
   });
 
   it('should map value based on Misc mapping', () => {

--- a/ui/core/src/utils/value-mapping.test.ts
+++ b/ui/core/src/utils/value-mapping.test.ts
@@ -1,0 +1,93 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ValueMapping } from '../model';
+import { applyValueMapping } from './value-mapping';
+
+describe('applyValueMapping', () => {
+  it('should return the original value if no mappings are provided', () => {
+    const result = applyValueMapping('test');
+    expect(result).toEqual({ value: 'test' });
+  });
+
+  it('should map value based on Value mapping', () => {
+    const mappings: ValueMapping[] = [
+      {
+        kind: 'Value',
+        spec: {
+          value: 'test',
+          result: { value: 'mapped', color: 'red' },
+        },
+      },
+    ];
+    const result = applyValueMapping('test', mappings);
+    expect(result).toEqual({ value: 'mapped', color: 'red' });
+  });
+
+  it('should map value based on Range mapping', () => {
+    const mappings: ValueMapping[] = [
+      {
+        kind: 'Range',
+        spec: {
+          from: 1,
+          to: 10,
+          result: { value: 'in range', color: 'blue' },
+        },
+      },
+    ];
+    const result = applyValueMapping(5, mappings);
+    expect(result).toEqual({ value: 'in range', color: 'blue' });
+  });
+
+  it('should map value based on Regex mapping', () => {
+    const mappings: ValueMapping[] = [
+      {
+        kind: 'Regex',
+        spec: {
+          pattern: '^test.*',
+          result: { value: 'regex match', color: 'green' },
+        },
+      },
+    ];
+    const result = applyValueMapping('test123', mappings);
+    expect(result).toEqual({ value: 'regex match', color: 'green' });
+  });
+
+  it('should map value based on Misc mapping', () => {
+    const mappings: ValueMapping[] = [
+      {
+        kind: 'Misc',
+        spec: {
+          value: 'empty',
+          result: { value: 'is empty', color: 'yellow' },
+        },
+      },
+    ];
+    const result = applyValueMapping('', mappings);
+    expect(result).toEqual({ value: 'is empty', color: 'yellow' });
+  });
+
+  it('should return the original value if no mapping matches', () => {
+    const mappings: ValueMapping[] = [
+      {
+        kind: 'Value',
+        spec: {
+          value: 'no match',
+          result: { value: 'mapped', color: 'red' },
+        },
+      },
+    ];
+    const result = applyValueMapping('test', mappings);
+    expect(result).toEqual({ value: 'test' });
+  });
+});

--- a/ui/core/src/utils/value-mapping.ts
+++ b/ui/core/src/utils/value-mapping.ts
@@ -1,0 +1,69 @@
+import { MappedValue, ValueMapping } from '../model';
+
+export function applyValueMapping(value: number | string, mappings: ValueMapping[] = []): MappedValue {
+  if (!mappings.length) {
+    return { value };
+  }
+
+  const mappedItem: MappedValue = { value };
+
+  mappings.forEach((mapping) => {
+    switch (mapping.kind) {
+      case 'Value': {
+        const valueOptions = mapping.spec;
+
+        if (String(valueOptions.value) === String(value)) {
+          mappedItem.value = valueOptions.result.value;
+          mappedItem.color = valueOptions.result.color;
+        }
+        break;
+      }
+      case 'Range': {
+        const rangeOptions = mapping.spec;
+        const newValue = value as number;
+        if (newValue >= rangeOptions.from && newValue <= rangeOptions.to) {
+          mappedItem.value = rangeOptions.result.value;
+          mappedItem.color = rangeOptions.result.color;
+        }
+        break;
+      }
+      case 'Regex': {
+        const regexOptions = mapping.spec;
+        const regex = new RegExp(regexOptions.pattern);
+        if (regex.test(value.toString())) {
+          mappedItem.value = regexOptions.result.value;
+          mappedItem.color = regexOptions.result.color;
+        }
+        break;
+      }
+      case 'Misc': {
+        const miscOptions = mapping.spec;
+        if (isMiscValueMatch(miscOptions.value, value)) {
+          mappedItem.value = miscOptions.result.value;
+          mappedItem.color = miscOptions.result.color;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  });
+  return mappedItem;
+}
+
+function isMiscValueMatch(miscValue: string, value: number | string | boolean): boolean {
+  switch (miscValue) {
+    case 'empty':
+      return value === '';
+    case 'null':
+      return value === null || value === undefined;
+    case 'NaN':
+      return Number.isNaN(value);
+    case 'true':
+      return value === true;
+    case 'false':
+      return value === false;
+    default:
+      return false;
+  }
+}

--- a/ui/core/src/utils/value-mapping.ts
+++ b/ui/core/src/utils/value-mapping.ts
@@ -27,7 +27,7 @@ export function applyValueMapping(value: number | string, mappings: ValueMapping
         const valueOptions = mapping.spec;
 
         if (String(valueOptions.value) === String(value)) {
-          mappedItem.value = valueOptions.result.value;
+          mappedItem.value = valueOptions.result.value || mappedItem.value;
           mappedItem.color = valueOptions.result.color;
         }
         break;
@@ -35,8 +35,15 @@ export function applyValueMapping(value: number | string, mappings: ValueMapping
       case 'Range': {
         const rangeOptions = mapping.spec;
         const newValue = value as number;
-        if (newValue >= rangeOptions.from && newValue <= rangeOptions.to) {
-          mappedItem.value = rangeOptions.result.value;
+
+        if (rangeOptions.from === undefined && rangeOptions.to === undefined) {
+          break;
+        }
+
+        const from = rangeOptions.from !== undefined ? rangeOptions.from : -Infinity;
+        const to = rangeOptions.to !== undefined ? rangeOptions.to : Infinity;
+        if (newValue >= from && newValue <= to) {
+          mappedItem.value = rangeOptions.result.value || mappedItem.value;
           mappedItem.color = rangeOptions.result.color;
         }
         break;
@@ -53,7 +60,8 @@ export function applyValueMapping(value: number | string, mappings: ValueMapping
 
         if (stringValue.match(regex)) {
           if (regexOptions.result.value !== null) {
-            mappedItem.value = stringValue.replace(regex, regexOptions.result.value.toString() || '');
+            mappedItem.value =
+              stringValue.replace(regex, regexOptions.result.value.toString() || '') || mappedItem.value;
             mappedItem.color = regexOptions.result.color;
           }
         }
@@ -62,7 +70,7 @@ export function applyValueMapping(value: number | string, mappings: ValueMapping
       case 'Misc': {
         const miscOptions = mapping.spec;
         if (isMiscValueMatch(miscOptions.value, value)) {
-          mappedItem.value = miscOptions.result.value;
+          mappedItem.value = miscOptions.result.value || mappedItem.value;
           mappedItem.color = miscOptions.result.color;
         }
         break;

--- a/ui/core/src/utils/value-mapping.ts
+++ b/ui/core/src/utils/value-mapping.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { MappedValue, ValueMapping } from '../model';
+import { createRegexFromString } from './regexp';
 
 export function applyValueMapping(value: number | string, mappings: ValueMapping[] = []): MappedValue {
   if (!mappings.length) {
@@ -42,10 +43,19 @@ export function applyValueMapping(value: number | string, mappings: ValueMapping
       }
       case 'Regex': {
         const regexOptions = mapping.spec;
-        const regex = new RegExp(regexOptions.pattern);
-        if (regex.test(value.toString())) {
-          mappedItem.value = regexOptions.result.value;
-          mappedItem.color = regexOptions.result.color;
+        const stringValue = value.toString();
+
+        if (!regexOptions.pattern) {
+          break;
+        }
+
+        const regex = createRegexFromString(regexOptions.pattern);
+
+        if (stringValue.match(regex)) {
+          if (regexOptions.result.value !== null) {
+            mappedItem.value = stringValue.replace(regex, regexOptions.result.value.toString() || '');
+            mappedItem.color = regexOptions.result.color;
+          }
         }
         break;
       }

--- a/ui/core/src/utils/value-mapping.ts
+++ b/ui/core/src/utils/value-mapping.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { MappedValue, ValueMapping } from '../model';
 
 export function applyValueMapping(value: number | string, mappings: ValueMapping[] = []): MappedValue {

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChart.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChart.ts
@@ -13,6 +13,7 @@
 
 import { PanelPlugin } from '@perses-dev/plugin-system';
 import { createInitialStatChartOptions, StatChartOptions } from './stat-chart-model';
+import { StatChartValueMappingEditor } from './StatChartValueMappingEditor';
 import { StatChartOptionsEditorSettings } from './StatChartOptionsEditorSettings';
 import { StatChartPanel } from './StatChartPanel';
 
@@ -27,6 +28,7 @@ export const StatChart: PanelPlugin<StatChartOptions> = {
       label: 'Settings',
       content: StatChartOptionsEditorSettings,
     },
+    { label: 'Value mapping', content: StatChartValueMappingEditor },
   ],
   createInitialOptions: createInitialStatChartOptions,
 };

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -128,8 +128,15 @@ const useStatChartData = (
   }, [queryResults, spec, chartsTheme]);
 };
 
-const getValueOrLabel = (value?: number | null, mappings?: ValueMapping[]): string | number | undefined | null => {
-  if (mappings?.length && value) {
+const getValueOrLabel = (
+  value?: number | null,
+  mappings?: ValueMapping[],
+  label?: string
+): string | number | undefined | null => {
+  if (label) {
+    return label;
+  }
+  if (mappings?.length && value !== undefined && value !== null) {
     return applyValueMapping(value, mappings).value;
   } else {
     return value;

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -25,8 +25,9 @@ import { useMemo } from 'react';
 import { applyValueMapping, TimeSeriesData, ValueMapping } from '@perses-dev/core';
 import { useDataQueries, UseDataQueryResults, PanelProps } from '@perses-dev/plugin-system';
 import { StatChartOptions } from './stat-chart-model';
-import { convertSparkline, getStatChartColor } from './utils/data-transform';
+import { convertSparkline } from './utils/data-transform';
 import { calculateValue } from './utils/calculate-value';
+import { getStatChartColor } from './utils/get-color';
 
 const MIN_WIDTH = 100;
 const SPACING = 2;

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartPanel.tsx
@@ -21,7 +21,7 @@ import {
   PersesChartsTheme,
 } from '@perses-dev/components';
 import { Stack, Typography, SxProps } from '@mui/material';
-import { useMemo } from 'react';
+import { FC, useMemo } from 'react';
 import { applyValueMapping, TimeSeriesData, ValueMapping } from '@perses-dev/core';
 import { useDataQueries, UseDataQueryResults, PanelProps } from '@perses-dev/plugin-system';
 import { StatChartOptions } from './stat-chart-model';
@@ -34,7 +34,7 @@ const SPACING = 2;
 
 export type StatChartPanelProps = PanelProps<StatChartOptions>;
 
-export function StatChartPanel(props: StatChartPanelProps) {
+export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   const { spec, contentDimensions } = props;
 
   const { format, sparkline, valueFontSize: valueFontSize } = spec;
@@ -95,7 +95,7 @@ export function StatChartPanel(props: StatChartPanelProps) {
       )}
     </Stack>
   );
-}
+};
 
 const useStatChartData = (
   queryResults: UseDataQueryResults<TimeSeriesData>['queryResults'],

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartValueMappingEditor.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartValueMappingEditor.tsx
@@ -15,13 +15,14 @@ import { OptionsEditorProps } from '@perses-dev/plugin-system';
 import { ValueMapping } from '@perses-dev/core';
 import { ValueMappingsEditor } from '@perses-dev/components';
 import { StatChartOptions } from '@perses-dev/panels-plugin';
+import { FC } from 'react';
 
 export type StatChartValueMappingEditorProps = OptionsEditorProps<StatChartOptions>;
 
-export function StatChartValueMappingEditor({ onChange, value }: StatChartValueMappingEditorProps) {
+export const StatChartValueMappingEditor: FC<StatChartValueMappingEditorProps> = ({ onChange, value }) => {
   function handleValueMappingChange(mappings: ValueMapping[]): void {
     onChange({ ...value, mappings });
   }
 
   return <ValueMappingsEditor mappings={value.mappings ?? []} onChange={handleValueMappingChange} />;
-}
+};

--- a/ui/panels-plugin/src/plugins/stat-chart/StatChartValueMappingEditor.tsx
+++ b/ui/panels-plugin/src/plugins/stat-chart/StatChartValueMappingEditor.tsx
@@ -11,16 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
 import { ValueMapping } from '@perses-dev/core';
-import { LegendSpecOptions, OptionsEditorProps } from '@perses-dev/plugin-system';
+import { ValueMappingsEditor } from '@perses-dev/components';
+import { StatChartOptions } from '@perses-dev/panels-plugin';
 
-export function createInitialStatusHistoryChartOptions(): Record<string, unknown> {
-  return {};
+export type StatChartValueMappingEditorProps = OptionsEditorProps<StatChartOptions>;
+
+export function StatChartValueMappingEditor({ onChange, value }: StatChartValueMappingEditorProps) {
+  function handleValueMappingChange(mappings: ValueMapping[]): void {
+    onChange({ ...value, mappings });
+  }
+
+  return <ValueMappingsEditor mappings={value.mappings ?? []} onChange={handleValueMappingChange} />;
 }
-
-export interface StatusHistoryChartOptions {
-  legend?: LegendSpecOptions;
-  mappings?: ValueMapping[];
-}
-
-export type StatusHistroyChartEditorProps = OptionsEditorProps<StatusHistoryChartOptions>;

--- a/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/stat-chart-model.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CalculationType, Definition, ThresholdOptions, FormatOptions } from '@perses-dev/core';
+import { CalculationType, Definition, ThresholdOptions, FormatOptions, ValueMapping } from '@perses-dev/core';
 import { FontSizeOption } from '@perses-dev/components';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 
@@ -28,6 +28,7 @@ export interface StatChartOptions {
   thresholds?: ThresholdOptions;
   sparkline?: StatChartSparklineOptions;
   valueFontSize?: FontSizeOption;
+  mappings?: ValueMapping[];
 }
 
 export interface StatChartSparklineOptions {

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/calculate-value.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/calculate-value.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,23 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package model
+import { CalculationsMap, CalculationType, DEFAULT_CALCULATION, TimeSeries } from '@perses-dev/core';
 
-import (
-	"github.com/perses/perses/cue/schemas/common"
-)
-
-kind: "StatChart"
-spec: close({
-	calculation:    common.#calculation
-	format?:        common.#format
-	thresholds?:    common.#thresholds
-	sparkline?:     #sparkline
-	valueFontSize?: number
-	mappings?:      [...common.#mappings]
-
-	#sparkline: {
-		color?: string
-		width?: number
-	}
-})
+export const calculateValue = (calculation: CalculationType, seriesData: TimeSeries) => {
+  if (CalculationsMap[calculation] === undefined) {
+    console.warn(`Invalid StatChart panel calculation ${calculation}, fallback to ${DEFAULT_CALCULATION}`);
+  }
+  const calculate = CalculationsMap[calculation] ?? CalculationsMap[DEFAULT_CALCULATION];
+  return calculate(seriesData.values);
+};

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/calculate-value.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/calculate-value.ts
@@ -13,7 +13,10 @@
 
 import { CalculationsMap, CalculationType, DEFAULT_CALCULATION, TimeSeries } from '@perses-dev/core';
 
-export const calculateValue = (calculation: CalculationType, seriesData: TimeSeries) => {
+export const calculateValue = (
+  calculation: CalculationType,
+  seriesData: TimeSeries
+): ReturnType<(typeof CalculationsMap)[CalculationType]> => {
   if (CalculationsMap[calculation] === undefined) {
     console.warn(`Invalid StatChart panel calculation ${calculation}, fallback to ${DEFAULT_CALCULATION}`);
   }

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
@@ -15,7 +15,8 @@ import { testChartsTheme } from '@perses-dev/components';
 import { ThresholdOptions } from '@perses-dev/core';
 import { LineSeriesOption } from 'echarts';
 import { StatChartOptions, StatChartSparklineOptions } from '../stat-chart-model';
-import { convertSparkline, getStatChartColor } from './data-transform';
+import { convertSparkline } from './data-transform';
+import { getStatChartColor } from './get-color';
 
 const thresholds: ThresholdOptions = {
   steps: [

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.test.ts
@@ -14,8 +14,8 @@
 import { testChartsTheme } from '@perses-dev/components';
 import { ThresholdOptions } from '@perses-dev/core';
 import { LineSeriesOption } from 'echarts';
-import { StatChartSparklineOptions } from '../stat-chart-model';
-import { convertSparkline, getColorFromThresholds } from './data-transform';
+import { StatChartOptions, StatChartSparklineOptions } from '../stat-chart-model';
+import { convertSparkline, getStatChartColor } from './data-transform';
 
 const thresholds: ThresholdOptions = {
   steps: [
@@ -34,22 +34,31 @@ const thresholds: ThresholdOptions = {
   ],
 };
 
-describe('getColorFromThresholds', () => {
+describe('getStatChartColor', () => {
   describe('if threshold is not met', () => {
     it('should return thresholds.defaultColor if defined', () => {
       const defaultColor = 'purple';
-      const value = getColorFromThresholds(testChartsTheme, { ...thresholds, defaultColor }, 5);
+      const testSpec = {
+        thresholds: { ...thresholds, defaultColor },
+      } as StatChartOptions;
+      const value = getStatChartColor(testChartsTheme, testSpec, 5);
       expect(value).toEqual(defaultColor);
     });
 
     it('should return charts theme default threshold color if thresholds.defaultColor is undefined', () => {
-      const value = getColorFromThresholds(testChartsTheme, thresholds, 5);
+      const testSpec = {
+        thresholds,
+      } as StatChartOptions;
+      const value = getStatChartColor(testChartsTheme, testSpec, 5);
       expect(value).toEqual(testChartsTheme.thresholds.defaultColor);
     });
   });
 
   it('should return orange if value meets the threshold', () => {
-    const value = getColorFromThresholds(testChartsTheme, thresholds, 25);
+    const testSpec = {
+      thresholds,
+    } as StatChartOptions;
+    const value = getStatChartColor(testChartsTheme, testSpec, 25);
     expect(value).toEqual('orange');
   });
 });
@@ -61,26 +70,22 @@ describe('convertSparkline', () => {
 
   it('should render charts theme default threshold color', () => {
     testChartsTheme.thresholds.defaultColor = 'green';
-    const options = convertSparkline(testChartsTheme, {}, thresholds, 5) as LineSeriesOption;
+    const options = convertSparkline(testChartsTheme, 'green', sparkline) as LineSeriesOption;
     expect(options.lineStyle?.color).toEqual('green');
     expect(options.areaStyle?.color).toEqual('green');
   });
 
   it('should render threshold default color if threshold is not met ', () => {
     const defaultColor = 'purple';
-    const options = convertSparkline(
-      testChartsTheme,
-      sparkline,
-      { ...thresholds, defaultColor },
-      5
-    ) as LineSeriesOption;
+    const options = convertSparkline(testChartsTheme, defaultColor, sparkline) as LineSeriesOption;
     expect(options.lineStyle?.color).toEqual(defaultColor);
     expect(options.areaStyle?.color).toEqual(defaultColor);
   });
 
   it('should render orange if value meets the threshold', () => {
-    const options = convertSparkline(testChartsTheme, sparkline, thresholds, 25) as LineSeriesOption;
-    expect(options.lineStyle?.color).toEqual('orange');
-    expect(options.areaStyle?.color).toEqual('orange');
+    const defaultColor = 'orange';
+    const options = convertSparkline(testChartsTheme, defaultColor, sparkline) as LineSeriesOption;
+    expect(options.lineStyle?.color).toEqual(defaultColor);
+    expect(options.areaStyle?.color).toEqual(defaultColor);
   });
 });

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
@@ -13,45 +13,7 @@
 
 import { PersesChartsTheme } from '@perses-dev/components';
 import { LineSeriesOption } from 'echarts/charts';
-import { applyValueMapping } from '@perses-dev/core';
-import { StatChartOptions, StatChartSparklineOptions } from '../stat-chart-model';
-
-export function getStatChartColor(
-  chartsTheme: PersesChartsTheme,
-  spec?: StatChartOptions,
-  value?: number | string | null
-) {
-  const { mappings, thresholds } = spec ?? {};
-
-  // thresholds color takes priority over other colors
-  const defaultColor = thresholds?.defaultColor ?? chartsTheme.thresholds.defaultColor;
-
-  if (!value || (!thresholds?.steps && !mappings)) {
-    return defaultColor;
-  }
-
-  // Check thresholds first (they take priority)
-  if (thresholds?.steps && typeof value === 'number') {
-    const matchingColors = thresholds.steps
-      .map((step, index) => {
-        if (value > step.value) {
-          return step.color ?? chartsTheme.thresholds.palette[index] ?? defaultColor;
-        }
-        return null;
-      })
-      .filter((color): color is string => color !== null);
-
-    // Return last matching color or default
-    return matchingColors[matchingColors.length - 1] ?? defaultColor;
-  }
-
-  if (mappings?.length) {
-    const { color } = applyValueMapping(value, mappings);
-    return color || defaultColor;
-  }
-
-  return defaultColor;
-}
+import { StatChartSparklineOptions } from '../stat-chart-model';
 
 export function convertSparkline(
   chartsTheme: PersesChartsTheme,

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/data-transform.ts
@@ -19,8 +19,8 @@ import { StatChartSparklineOptions } from '../stat-chart-model';
 export function getColorFromThresholds(
   chartsTheme: PersesChartsTheme,
   thresholds?: ThresholdOptions,
-  value?: number | null
-): string {
+  value?: number | string | null
+) {
   // thresholds color takes priority over other colors
   const defaultColor = thresholds?.defaultColor ?? chartsTheme.thresholds.defaultColor;
 
@@ -46,7 +46,7 @@ export function convertSparkline(
   chartsTheme: PersesChartsTheme,
   sparkline?: StatChartSparklineOptions,
   thresholds?: ThresholdOptions,
-  value?: number | null
+  value?: number | string | null
 ): LineSeriesOption | undefined {
   if (sparkline === undefined) return;
 

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/get-color.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/get-color.ts
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { PersesChartsTheme } from '@perses-dev/components';
 import { applyValueMapping, ThresholdOptions, ValueMapping } from '@perses-dev/core';
 import { StatChartOptions } from '../stat-chart-model';

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/get-color.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/get-color.ts
@@ -55,7 +55,7 @@ function getColorFromThresholds(
   if (thresholds?.steps && typeof value === 'number') {
     const matchingColors = thresholds.steps
       .map((step, index) => {
-        if (value > step.value) {
+        if (value >= step.value) {
           return step.color ?? chartsTheme.thresholds.palette[index] ?? defaultColor;
         }
         return null;

--- a/ui/panels-plugin/src/plugins/stat-chart/utils/get-color.ts
+++ b/ui/panels-plugin/src/plugins/stat-chart/utils/get-color.ts
@@ -1,0 +1,68 @@
+import { PersesChartsTheme } from '@perses-dev/components';
+import { applyValueMapping, ThresholdOptions, ValueMapping } from '@perses-dev/core';
+import { StatChartOptions } from '../stat-chart-model';
+
+type StatChartValue = number | string | null;
+
+export function getStatChartColor(
+  chartsTheme: PersesChartsTheme,
+  spec?: StatChartOptions,
+  value?: StatChartValue
+): string {
+  const { mappings, thresholds } = spec ?? {};
+
+  // Determine the default color from thresholds or theme
+  const defaultColor = thresholds?.defaultColor ?? chartsTheme.thresholds.defaultColor;
+
+  if (!value || (!thresholds?.steps && !mappings)) {
+    return defaultColor;
+  }
+
+  // Check mappings first
+  if (mappings?.length) {
+    const colorFromMappings = getColorFromMappings(value, mappings);
+    if (colorFromMappings) {
+      return colorFromMappings;
+    }
+  }
+
+  // Check thresholds next
+  if (thresholds) {
+    const colorFromThresholds = getColorFromThresholds(value, thresholds, chartsTheme, defaultColor);
+    if (colorFromThresholds) {
+      return colorFromThresholds;
+    }
+  }
+
+  // Fallback to default color
+  return defaultColor;
+}
+
+function getColorFromMappings(value: StatChartValue, mappings: ValueMapping[]): string | null {
+  if (mappings?.length && value) {
+    const { color } = applyValueMapping(value, mappings);
+    return color || null;
+  }
+  return null;
+}
+
+function getColorFromThresholds(
+  value: StatChartValue,
+  thresholds: ThresholdOptions,
+  chartsTheme: PersesChartsTheme,
+  defaultColor: string
+): string | null {
+  if (thresholds?.steps && typeof value === 'number') {
+    const matchingColors = thresholds.steps
+      .map((step, index) => {
+        if (value > step.value) {
+          return step.color ?? chartsTheme.thresholds.palette[index] ?? defaultColor;
+        }
+        return null;
+      })
+      .filter((color): color is string => color !== null);
+
+    return matchingColors[matchingColors.length - 1] ?? null;
+  }
+  return null;
+}

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChart.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryChart.ts
@@ -16,10 +16,14 @@ import { PanelPlugin } from '@perses-dev/plugin-system';
 import { createInitialStatusHistoryChartOptions, StatusHistoryChartOptions } from './status-history-model';
 import { StatusHistoryChartOptionsEditorSettings } from './StatusHistoryChartOptionsEditorSettings';
 import { StatusHistoryPanel } from './StatusHistoryPanel';
+import { StatusHistoryValueMappingEditor } from './StatusHistoryValueMappingEditor';
 
 export const StatusHistoryChart: PanelPlugin<StatusHistoryChartOptions> = {
   PanelComponent: StatusHistoryPanel,
   supportedQueryTypes: ['TimeSeriesQuery'],
-  panelOptionsEditorComponents: [{ label: 'Settings', content: StatusHistoryChartOptionsEditorSettings }],
+  panelOptionsEditorComponents: [
+    { label: 'Settings', content: StatusHistoryChartOptionsEditorSettings },
+    { label: 'Value mapping', content: StatusHistoryValueMappingEditor },
+  ],
   createInitialOptions: createInitialStatusHistoryChartOptions,
 };

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryPanel.tsx
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryPanel.tsx
@@ -32,10 +32,8 @@ export function StatusHistoryPanel(props: StatusHistoryChartPanelProps): ReactEl
   const PADDING = chartsTheme.container.padding.default;
   const { queryResults, isLoading, isFetching } = useDataQueries('TimeSeriesQuery');
 
-  const { statusHistoryData, yAxisCategories, xAxisCategories, legendItems, timeScale } = useStatusHistoryDataModel(
-    queryResults,
-    chartsTheme.echartsTheme.color as string[]
-  );
+  const { statusHistoryData, yAxisCategories, xAxisCategories, legendItems, timeScale, colors } =
+    useStatusHistoryDataModel(queryResults, chartsTheme.echartsTheme.color as string[], spec);
 
   const adjustedContentDimensions: typeof contentDimensions = contentDimensions
     ? {
@@ -75,6 +73,7 @@ export function StatusHistoryPanel(props: StatusHistoryChartPanelProps): ReactEl
                 data={statusHistoryData}
                 timeScale={timeScale}
                 height={height}
+                colors={colors}
               />
             </Box>
           );

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryValueMappingEditor.tsx
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryValueMappingEditor.tsx
@@ -14,14 +14,15 @@
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
 import { ValueMapping } from '@perses-dev/core';
 import { ValueMappingsEditor } from '@perses-dev/components';
+import { FC } from 'react';
 import { StatusHistoryChartOptions } from './status-history-model';
 
 export type StatusHistoryValueMappingEditorProps = OptionsEditorProps<StatusHistoryChartOptions>;
 
-export function StatusHistoryValueMappingEditor({ onChange, value }: StatusHistoryValueMappingEditorProps) {
+export const StatusHistoryValueMappingEditor: FC<StatusHistoryValueMappingEditorProps> = ({ onChange, value }) => {
   function handleValueMappingChange(mappings: ValueMapping[]): void {
     onChange({ ...value, mappings });
   }
 
   return <ValueMappingsEditor mappings={value.mappings ?? []} onChange={handleValueMappingChange} />;
-}
+};

--- a/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryValueMappingEditor.tsx
+++ b/ui/panels-plugin/src/plugins/status-history-chart/StatusHistoryValueMappingEditor.tsx
@@ -11,16 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
 import { ValueMapping } from '@perses-dev/core';
-import { LegendSpecOptions, OptionsEditorProps } from '@perses-dev/plugin-system';
+import { ValueMappingsEditor } from '@perses-dev/components';
+import { StatusHistoryChartOptions } from './status-history-model';
 
-export function createInitialStatusHistoryChartOptions(): Record<string, unknown> {
-  return {};
+export type StatusHistoryValueMappingEditorProps = OptionsEditorProps<StatusHistoryChartOptions>;
+
+export function StatusHistoryValueMappingEditor({ onChange, value }: StatusHistoryValueMappingEditorProps) {
+  function handleValueMappingChange(mappings: ValueMapping[]): void {
+    onChange({ ...value, mappings });
+  }
+
+  return <ValueMappingsEditor mappings={value.mappings ?? []} onChange={handleValueMappingChange} />;
 }
-
-export interface StatusHistoryChartOptions {
-  legend?: LegendSpecOptions;
-  mappings?: ValueMapping[];
-}
-
-export type StatusHistroyChartEditorProps = OptionsEditorProps<StatusHistoryChartOptions>;

--- a/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
+++ b/ui/panels-plugin/src/plugins/status-history-chart/utils/data-transform.test.ts
@@ -18,12 +18,13 @@ import { useStatusHistoryDataModel } from './data-transform';
 
 describe('useStatusHistoryDataModel', () => {
   it('should return empty model for empty query results', () => {
-    const { result } = renderHook(() => useStatusHistoryDataModel([], []));
+    const { result } = renderHook(() => useStatusHistoryDataModel([], [], {}));
     expect(result.current).toEqual({
       legendItems: [],
       statusHistoryData: [],
       xAxisCategories: [],
       yAxisCategories: [],
+      colors: [],
     });
   });
 
@@ -57,15 +58,16 @@ describe('useStatusHistoryDataModel', () => {
       },
     ];
     const colors = ['#ff0000', '#00ff00'];
-    const { result } = renderHook(() => useStatusHistoryDataModel(queryResults, colors));
+    const { result } = renderHook(() => useStatusHistoryDataModel(queryResults, colors, {}));
 
     expect(result.current.legendItems).toEqual([
       { id: '0-1', label: '1', color: '#ff0000' },
       { id: '1-2', label: '2', color: '#00ff00' },
     ]);
+
     expect(result.current.statusHistoryData).toEqual([
-      [0, 0, 1],
-      [1, 0, 2],
+      { value: [0, 0, 1], label: '1' },
+      { value: [1, 0, 2], label: '2' },
     ]);
     expect(result.current.xAxisCategories).toEqual([1609459200000, 1609459260000]);
     expect(result.current.yAxisCategories).toEqual(['instance1']);


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This PR adds a new value mapping feature, letting users define custom mappings for specific values. This makes data visualization more flexible and customizable by transforming raw values into more meaningful representations.

This functionality is designed to be reusable by any panel and is currently implemented for status history and stat chart components.

Resolves #2337

# Screenshots

![Screenshot 2024-12-04 at 22 34 04](https://github.com/user-attachments/assets/6d3ad008-9571-4ed4-81f6-e9956e87a500)
![image](https://github.com/user-attachments/assets/422a0294-ff9c-4fcd-947a-5e0075bc15e0)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
