### PR TITLE
[IGNORE] `dac build`: remove useless check for output flag

### DIFF
--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -51,17 +51,9 @@ func (o *option) Complete(args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("no args are supported by the command 'build'")
 	}
-
-	// Complete the output only if it has been set by the user
-	if len(o.Output) > 0 {
-		if outputErr := o.OutputOption.Complete(); outputErr != nil {
-			return outputErr
-		}
-	} else {
-		// Put explicitely a value when not provided, as we use it for file generation in Execute()
-		o.Output = output.YAMLOutput
+	if outputErr := o.OutputOption.Complete(); outputErr != nil {
+		return outputErr
 	}
-
 	return nil
 }
 

--- a/internal/cli/cmd/describe/describe.go
+++ b/internal/cli/cmd/describe/describe.go
@@ -57,10 +57,10 @@ func (o *option) Complete(args []string) error {
 	}
 	o.name = args[1]
 
-	// Complete the output
 	if outputErr := o.OutputOption.Complete(); outputErr != nil {
 		return outputErr
 	}
+
 	if !modelV1.IsGlobal(o.kind) {
 		// Complete the project only if the user want to get project resources
 		if projectErr := o.ProjectOption.Complete(); projectErr != nil {

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -58,6 +58,8 @@ func (o *option) Complete(args []string) error {
 	}
 
 	// Complete the output only if it has been set by the user
+	// NB: In the case of the `get` command, the default output format is/should be a table, not json
+	// or yaml, hence why we need to skip OutputOption.Complete() if the output flag is not set.
 	if len(o.Output) > 0 {
 		if outputErr := o.OutputOption.Complete(); outputErr != nil {
 			return outputErr

--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -47,7 +47,6 @@ type option struct {
 }
 
 func (o *option) Complete(_ []string) error {
-	// Complete the output
 	if outputErr := o.OutputOption.Complete(); outputErr != nil {
 		return outputErr
 	}

--- a/internal/cli/opt/opt.go
+++ b/internal/cli/opt/opt.go
@@ -84,7 +84,7 @@ func (o *OutputOption) Complete() error {
 }
 
 func AddOutputFlags(cmd *cobra.Command, o *OutputOption) {
-	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "Kind of display: json or yaml. Default is yaml")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "Format of the output: json or yaml (default is yaml).")
 }
 
 type ProjectOption struct {


### PR DESCRIPTION
# Description

The removed check was redundant with the base validation behavior coming with that flag:
https://github.com/perses/perses/blob/1f0d7cc7b2ef419592df52d1bbbdcabc1e4461cc/internal/cli/output/output.go#L33-L43

(Some commands (e.g `describe`) were already fine)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).