### PR TITLE
[ENHANCEMENT] Table panel: editor text fields are debounced 

### DIFF
--- a/ui/components/src/TransformsEditor/TransformEditor.tsx
+++ b/ui/components/src/TransformsEditor/TransformEditor.tsx
@@ -18,8 +18,8 @@ import {
   Stack,
   StackProps,
   Switch,
-  TextField,
   Typography,
+  TextField as MuiTextField,
 } from '@mui/material';
 import {
   JoinByColumnValueTransform,
@@ -29,6 +29,7 @@ import {
   Transform,
 } from '@perses-dev/core';
 import { ReactElement } from 'react';
+import { TextField } from '../controls';
 
 interface TransformSpecEditorProps<Spec> {
   value: Spec;
@@ -46,9 +47,9 @@ function JoinByColumnValueTransformEditor({
         multiple
         id="join-columns"
         sx={{ width: '100%' }}
-        options={[]}
+        options={[]} // TODO: autofill columns name when query results is available to panel editors
         value={value.spec.columns ?? []}
-        renderInput={(params) => <TextField {...params} variant="outlined" label="Columns" required />}
+        renderInput={(params) => <MuiTextField {...params} variant="outlined" label="Columns" required />}
         onChange={(_, columns) => {
           onChange({
             ...value,
@@ -92,7 +93,7 @@ function MergeColumnsTransformEditor({
         sx={{ width: '100%' }}
         options={[]}
         value={value.spec.columns ?? []}
-        renderInput={(params) => <TextField {...params} variant="outlined" label="Columns" required />}
+        renderInput={(params) => <MuiTextField {...params} variant="outlined" label="Columns" required />}
         onChange={(_, columns) => {
           onChange({
             ...value,
@@ -110,12 +111,12 @@ function MergeColumnsTransformEditor({
         label="Output Name"
         value={value.spec.name ?? ''}
         sx={{ width: '100%' }}
-        onChange={(e) => {
+        onChange={(name) => {
           onChange({
             ...value,
             spec: {
               ...value.spec,
-              name: e.target.value,
+              name: name,
             },
           });
         }}
@@ -154,10 +155,10 @@ function MergeIndexedColumnsTransformEditor({
         placeholder="Example: 'value' for merging 'value #1', 'value #2' and 'value #...'"
         value={value.spec.column ?? ''}
         sx={{ width: '100%' }}
-        onChange={(e) => {
+        onChange={(column) => {
           onChange({
             ...value,
-            spec: { ...value.spec, column: e.target.value },
+            spec: { ...value.spec, column: column },
           });
         }}
         required
@@ -217,7 +218,7 @@ export function TransformEditor({ value, onChange, ...props }: TransformEditorPr
         select
         label="Kind"
         value={value.kind}
-        onChange={(e) => onChange({ ...value, kind: e.target.value as unknown as Transform['kind'] } as Transform)}
+        onChange={(kind) => onChange({ ...value, kind: kind as unknown as Transform['kind'] } as Transform)}
       >
         <MenuItem value="JoinByColumnValue">
           <Stack>

--- a/ui/components/src/TransformsEditor/TransformsEditor.test.tsx
+++ b/ui/components/src/TransformsEditor/TransformsEditor.test.tsx
@@ -20,6 +20,13 @@ describe('TransformsEditor', () => {
     render(<TransformsEditor value={value} onChange={onChange} />);
   }
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('can add a new transformation', () => {
     const onChange = jest.fn();
     renderTableColumnsEditor([], onChange);
@@ -38,6 +45,7 @@ describe('TransformsEditor', () => {
 
     const columnInput = screen.getByRole('textbox', { name: /Column/i });
     fireEvent.change(columnInput, { target: { value: 'MySuperName' } });
+    jest.advanceTimersByTime(500);
     expect(onChange).toHaveBeenCalledWith([{ kind: 'MergeIndexedColumns', spec: { column: 'MySuperName' } }]);
   });
 });

--- a/ui/components/src/controls/TextField.tsx
+++ b/ui/components/src/controls/TextField.tsx
@@ -12,12 +12,15 @@
 // limitations under the License.
 
 import { TextFieldProps as MuiTextFieldProps, TextField as MuiTextField } from '@mui/material';
-import { ChangeEvent, forwardRef, useCallback, useMemo, useState } from 'react';
+import { ChangeEvent, ForwardedRef, forwardRef, useCallback, useMemo, useState } from 'react';
 import debounce from 'lodash/debounce';
 
 type TextFieldProps = Omit<MuiTextFieldProps, 'onChange'> & { debounceMs?: number; onChange?: (value: string) => void };
 
-export const TextField = forwardRef(function ({ debounceMs = 250, value, onChange, ...props }: TextFieldProps) {
+export const TextField = forwardRef(function (
+  { debounceMs = 250, value, onChange, ...props }: TextFieldProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   const [currentValue, setCurrentValue] = useState(value);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
@@ -34,6 +37,6 @@ export const TextField = forwardRef(function ({ debounceMs = 250, value, onChang
 
   const debounceFn = useMemo(() => debounce(handleDebounceFn, debounceMs), [debounceMs, handleDebounceFn]);
 
-  return <MuiTextField value={currentValue} onChange={handleChange} {...props} />;
+  return <MuiTextField ref={ref} value={currentValue} onChange={handleChange} {...props} />;
 });
 TextField.displayName = 'TextField';

--- a/ui/components/src/controls/TextField.tsx
+++ b/ui/components/src/controls/TextField.tsx
@@ -1,0 +1,25 @@
+import { TextFieldProps as MuiTextFieldProps, TextField as MuiTextField } from '@mui/material';
+import { ChangeEvent, useCallback, useMemo, useState } from 'react';
+import debounce from 'lodash/debounce';
+
+type TextFieldProps = Omit<MuiTextFieldProps, 'onChange'> & { debounceMs?: number; onChange?: (value: string) => void };
+
+export function TextField({ debounceMs = 250, value, onChange, ...props }: TextFieldProps) {
+  const [currentValue, setCurrentValue] = useState(value);
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    setCurrentValue(event.target.value);
+    debounceFn(event.target.value);
+  }
+
+  const handleDebounceFn = useCallback(
+    (inputValue: string) => {
+      onChange?.(inputValue);
+    },
+    [onChange]
+  );
+
+  const debounceFn = useMemo(() => debounce(handleDebounceFn, debounceMs), [debounceMs, handleDebounceFn]);
+
+  return <MuiTextField value={currentValue} onChange={handleChange} {...props} />;
+}

--- a/ui/components/src/controls/TextField.tsx
+++ b/ui/components/src/controls/TextField.tsx
@@ -23,7 +23,7 @@ export const TextField = forwardRef(function (
 ) {
   const [currentValue, setCurrentValue] = useState(value);
 
-  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>): void {
     setCurrentValue(event.target.value);
     debounceFn(event.target.value);
   }

--- a/ui/components/src/controls/TextField.tsx
+++ b/ui/components/src/controls/TextField.tsx
@@ -1,10 +1,23 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { TextFieldProps as MuiTextFieldProps, TextField as MuiTextField } from '@mui/material';
-import { ChangeEvent, useCallback, useMemo, useState } from 'react';
+import { ChangeEvent, forwardRef, useCallback, useMemo, useState } from 'react';
 import debounce from 'lodash/debounce';
 
 type TextFieldProps = Omit<MuiTextFieldProps, 'onChange'> & { debounceMs?: number; onChange?: (value: string) => void };
 
-export function TextField({ debounceMs = 250, value, onChange, ...props }: TextFieldProps) {
+export const TextField = forwardRef(function ({ debounceMs = 250, value, onChange, ...props }: TextFieldProps) {
   const [currentValue, setCurrentValue] = useState(value);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
@@ -22,4 +35,5 @@ export function TextField({ debounceMs = 250, value, onChange, ...props }: TextF
   const debounceFn = useMemo(() => debounce(handleDebounceFn, debounceMs), [debounceMs, handleDebounceFn]);
 
   return <MuiTextField value={currentValue} onChange={handleChange} {...props} />;
-}
+});
+TextField.displayName = 'TextField';

--- a/ui/components/src/controls/index.ts
+++ b/ui/components/src/controls/index.ts
@@ -1,0 +1,1 @@
+export * from './TextField';

--- a/ui/components/src/controls/index.ts
+++ b/ui/components/src/controls/index.ts
@@ -1,1 +1,14 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from './TextField';

--- a/ui/components/src/index.ts
+++ b/ui/components/src/index.ts
@@ -15,6 +15,7 @@ export * from './AlignSelector';
 export * from './BarChart';
 export * from './ColorPicker';
 export * from './ContentWithLegend';
+export * from './controls';
 export * from './Dialog';
 export * from './DensitySelector';
 export * from './DragAndDrop';

--- a/ui/panels-plugin/src/plugins/table/CellsEditor/CellEditor.tsx
+++ b/ui/panels-plugin/src/plugins/table/CellsEditor/CellEditor.tsx
@@ -17,13 +17,12 @@ import {
   MenuItem,
   Stack,
   StackProps,
-  TextField,
   Tooltip,
   Typography,
   Grid2 as Grid,
 } from '@mui/material';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
-import { OptionsColorPicker } from '@perses-dev/components';
+import { OptionsColorPicker, TextField } from '@perses-dev/components';
 import PlusIcon from 'mdi-material-ui/Plus';
 import { ReactElement } from 'react';
 import { CellSettings, Condition } from '../table-model';
@@ -41,7 +40,7 @@ function ConditionEditor({ condition, onChange, ...props }: ConditionEditorProps
           label="Value"
           placeholder="Exact value"
           value={condition.spec?.value ?? ''}
-          onChange={(e) => onChange({ ...condition, spec: { value: e.target.value } } as Condition)}
+          onChange={(value) => onChange({ ...condition, spec: { value: value } } as Condition)}
           fullWidth
         />
       </Stack>
@@ -53,14 +52,14 @@ function ConditionEditor({ condition, onChange, ...props }: ConditionEditorProps
           label="From"
           placeholder="Start of range"
           value={condition.spec?.min ?? ''}
-          onChange={(e) => onChange({ ...condition, spec: { ...condition.spec, min: +e.target.value } } as Condition)}
+          onChange={(value) => onChange({ ...condition, spec: { ...condition.spec, min: +value } } as Condition)}
           fullWidth
         />
         <TextField
           label="To"
           placeholder="End of range (inclusive)"
           value={condition.spec?.max ?? ''}
-          onChange={(e) => onChange({ ...condition, spec: { ...condition.spec, max: +e.target.value } } as Condition)}
+          onChange={(value) => onChange({ ...condition, spec: { ...condition.spec, max: +value } } as Condition)}
           fullWidth
         />
       </Stack>
@@ -72,7 +71,7 @@ function ConditionEditor({ condition, onChange, ...props }: ConditionEditorProps
           label="Regular Expression"
           placeholder="JavaScript regular expression"
           value={condition.spec?.expr ?? ''}
-          onChange={(e) => onChange({ ...condition, spec: { expr: e.target.value } } as Condition)}
+          onChange={(value) => onChange({ ...condition, spec: { expr: value } } as Condition)}
           fullWidth
         />
       </Stack>
@@ -84,7 +83,7 @@ function ConditionEditor({ condition, onChange, ...props }: ConditionEditorProps
           select
           label="Value"
           value={condition.spec?.value ?? ''}
-          onChange={(e) => onChange({ ...condition, spec: { value: e.target.value } } as Condition)}
+          onChange={(value) => onChange({ ...condition, spec: { value: value } } as Condition)}
           fullWidth
         >
           <MenuItem value="empty">
@@ -139,7 +138,7 @@ export function CellEditor({ cell, onChange, onDelete, ...props }: CellEditorPro
             select
             label="Type"
             value={cell.condition.kind}
-            onChange={(e) => onChange({ ...cell, condition: { kind: e.target.value } } as CellSettings)}
+            onChange={(value) => onChange({ ...cell, condition: { kind: value } } as CellSettings)}
             required
             sx={{ width: '120px' }}
           >
@@ -187,7 +186,7 @@ export function CellEditor({ cell, onChange, onDelete, ...props }: CellEditorPro
         <TextField
           label="Display text"
           value={cell.text}
-          onChange={(e) => onChange({ ...cell, text: e.target.value })}
+          onChange={(value) => onChange({ ...cell, text: value })}
           fullWidth
         />
       </Grid>

--- a/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
+++ b/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
@@ -144,9 +144,9 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
             type="number"
             value={width}
             fullWidth
-            // set visibility instead of wrapping in a if condition, in order to keep same layout
+            // set visibility instead of wrapping in an if condition, in order to keep same layout
             sx={{ visibility: column.width === 'auto' || column.width === undefined ? 'hidden' : 'visible', flex: 2 }}
-            InputProps={{ inputProps: { min: 1 } }}
+            slotProps={{ htmlInput: { min: 1 } }}
             onChange={(value) => {
               setWidth(+value);
               onChange({ ...column, width: +value });

--- a/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
+++ b/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Divider, FormControlLabel, Stack, StackProps, Switch, TextField } from '@mui/material';
+import { Divider, FormControlLabel, Stack, StackProps, Switch } from '@mui/material';
 import { ReactElement, useState } from 'react';
-import { AlignSelector, SortSelectorButtons } from '@perses-dev/components';
+import { AlignSelector, SortSelectorButtons, TextField } from '@perses-dev/components';
 import { ColumnSettings } from '../table-model';
 
 type OmittedMuiProps = 'children' | 'value' | 'onChange';
@@ -34,7 +34,7 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
         <TextField
           label="Name"
           value={column.name}
-          onChange={(e) => onChange({ ...column, name: e.target.value })}
+          onChange={(value) => onChange({ ...column, name: value })}
           required
         />
 
@@ -44,19 +44,19 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
           label="Header"
           value={column.header ?? ''}
           fullWidth
-          onChange={(e) => onChange({ ...column, header: e.target.value ? e.target.value : undefined })}
+          onChange={(value) => onChange({ ...column, header: value ? value : undefined })}
         />
         <TextField
           label="Header Description"
           value={column.headerDescription ?? ''}
           fullWidth
-          onChange={(e) => onChange({ ...column, headerDescription: e.target.value ? e.target.value : undefined })}
+          onChange={(value) => onChange({ ...column, headerDescription: value ? value : undefined })}
         />
         <TextField
           label="Cell Description"
           value={column.cellDescription ?? ''}
           fullWidth
-          onChange={(e) => onChange({ ...column, cellDescription: e.target.value ? e.target.value : undefined })}
+          onChange={(value) => onChange({ ...column, cellDescription: value ? value : undefined })}
         />
       </Stack>
 
@@ -147,9 +147,9 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
             // set visibility instead of wrapping in a if condition, in order to keep same layout
             sx={{ visibility: column.width === 'auto' || column.width === undefined ? 'hidden' : 'visible', flex: 2 }}
             InputProps={{ inputProps: { min: 1 } }}
-            onChange={(e) => {
-              setWidth(+e.target.value);
-              onChange({ ...column, width: +e.target.value });
+            onChange={(value) => {
+              setWidth(+value);
+              onChange({ ...column, width: +value });
             }}
           />
         </Stack>

--- a/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditorContainer.tsx
+++ b/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditorContainer.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Divider, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import { Box, Divider, IconButton, Stack, Tooltip, Typography } from '@mui/material';
 import ChevronRight from 'mdi-material-ui/ChevronRight';
 import ChevronDown from 'mdi-material-ui/ChevronDown';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
@@ -89,13 +89,16 @@ export function ColumnEditorContainer({
             </IconButton>
           </Tooltip>
           <Tooltip title="Reorder column settings" placement="top">
-            <DragButton
-              onMoveUp={onMoveUp}
-              onMoveDown={onMoveDown}
-              menuSx={{
-                '.MuiPaper-root': { backgroundColor: (theme) => theme.palette.background.lighter },
-              }}
-            />
+            {/* Drag button do not forward ref and it's needed for tooltip. Using dummy box wrapper as fix */}
+            <Box>
+              <DragButton
+                onMoveUp={onMoveUp}
+                onMoveDown={onMoveDown}
+                menuSx={{
+                  '.MuiPaper-root': { backgroundColor: (theme) => theme.palette.background.lighter },
+                }}
+              />
+            </Box>
           </Tooltip>
         </Stack>
       </Stack>

--- a/ui/panels-plugin/src/plugins/table/TableColumnsEditor.test.tsx
+++ b/ui/panels-plugin/src/plugins/table/TableColumnsEditor.test.tsx
@@ -15,10 +15,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { TableOptions } from '@perses-dev/panels-plugin';
 import { TableColumnsEditor } from './TableColumnsEditor';
 
+function renderTableColumnsEditor(value: TableOptions, onChange = jest.fn()): void {
+  render(<TableColumnsEditor value={value} onChange={onChange} />);
+}
+
 describe('TableColumnsEditor', () => {
-  function renderTableColumnsEditor(value: TableOptions, onChange = jest.fn()): void {
-    render(<TableColumnsEditor value={value} onChange={onChange} />);
-  }
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
   it('can add a new column settings', () => {
     const onChange = jest.fn();
@@ -50,6 +57,7 @@ describe('TableColumnsEditor', () => {
 
     const nameInput = screen.getByRole('textbox', { name: /Name/i });
     fireEvent.change(nameInput, { target: { value: 'MySuperName' } });
+    jest.advanceTimersByTime(500);
     expect(onChange).toHaveBeenCalledWith({ columnSettings: [{ name: 'MySuperName' }] });
   });
 });

--- a/ui/panels-plugin/src/plugins/table/TableSettingsEditor.tsx
+++ b/ui/panels-plugin/src/plugins/table/TableSettingsEditor.tsx
@@ -19,9 +19,10 @@ import {
   OptionsEditorGroup,
   TableDensity,
   DEFAULT_COLUMN_WIDTH,
+  TextField,
 } from '@perses-dev/components';
 import { OptionsEditorProps } from '@perses-dev/plugin-system';
-import { Switch, TextField } from '@mui/material';
+import { Switch } from '@mui/material';
 import { ChangeEvent, ReactElement } from 'react';
 import { TableOptions } from './table-model';
 
@@ -52,8 +53,8 @@ function DefaultColumnsWidthControl({
             <TextField
               type="number"
               value={value ?? DEFAULT_COLUMN_WIDTH}
-              InputProps={{ inputProps: { min: 1, step: 1 } }}
-              onChange={(e) => onChange(parseInt(e.target.value))}
+              slotProps={{ htmlInput: { min: 1, step: 1 } }}
+              onChange={(value) => onChange(parseInt(value))}
             />
           }
         />


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
TextField can trigger a lot of useless re-renders until the right value is typed. Debounce should reduce a little bit this issue.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
