### PR TITLE
[BUGFIX] Table: mapping with min range 0 not working

### DIFF
--- a/ui/panels-plugin/src/plugins/table/TablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/table/TablePanel.tsx
@@ -57,19 +57,19 @@ function generateCellConfig(value: unknown, settings: CellSettings[]): TableCell
     if (setting.condition.kind === 'Range' && !Number.isNaN(Number(value))) {
       const numericValue = Number(value);
       if (
-        setting.condition.spec?.min &&
-        setting.condition.spec?.max &&
+        setting.condition.spec?.min !== undefined &&
+        setting.condition.spec?.max !== undefined &&
         numericValue >= +setting.condition.spec?.min &&
         numericValue <= +setting.condition.spec?.max
       ) {
         return { text: setting.text, textColor: setting.textColor, backgroundColor: setting.backgroundColor };
       }
 
-      if (setting.condition.spec?.min && numericValue >= +setting.condition.spec?.min) {
+      if (setting.condition.spec?.min !== undefined && numericValue >= +setting.condition.spec?.min) {
         return { text: setting.text, textColor: setting.textColor, backgroundColor: setting.backgroundColor };
       }
 
-      if (setting.condition.spec?.max && numericValue <= +setting.condition.spec?.max) {
+      if (setting.condition.spec?.max !== undefined && numericValue <= +setting.condition.spec?.max) {
         return { text: setting.text, textColor: setting.textColor, backgroundColor: setting.backgroundColor };
       }
     }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
When using a cell mapping with range starting from 0, it was ignored because of the if check global

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/user-attachments/assets/5e47cc05-f65f-400e-a968-e734fdd69672)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
