### PR TITLE
[ENHANCEMENT] Table: add default column sorting

### DIFF
--- a/cue/schemas/panels/table/table.cue
+++ b/cue/schemas/panels/table/table.cue
@@ -34,7 +34,7 @@ spec: close({
 	cellDescription?:   string
 	align?:             "left" | "center" | "right"
 	enableSorting?:     bool
-	sort?:							"asc" | "desc"
+	sort?:              "asc" | "desc"
 	width?:             number | "auto"
 	hide?:              bool
 }

--- a/cue/schemas/panels/table/table.cue
+++ b/cue/schemas/panels/table/table.cue
@@ -34,6 +34,7 @@ spec: close({
 	cellDescription?:   string
 	align?:             "left" | "center" | "right"
 	enableSorting?:     bool
+	sort?:							"asc" | "desc"
 	width?:             number | "auto"
 	hide?:              bool
 }

--- a/ui/components/src/AlignSelector/AlignSelector.tsx
+++ b/ui/components/src/AlignSelector/AlignSelector.tsx
@@ -26,7 +26,7 @@ export function AlignSelector({ onChange, value = 'left', ...props }: AlignSelec
   };
 
   return (
-    <ButtonGroup aria-label="Alignement" sx={{ margin: 1 }} {...props}>
+    <ButtonGroup aria-label="Alignement" {...props}>
       <Button key="left" onClick={() => handleSortChange('left')} variant={value === 'left' ? 'contained' : 'outlined'}>
         Left
       </Button>

--- a/ui/components/src/SortSelector/SortSelectorButtons.tsx
+++ b/ui/components/src/SortSelector/SortSelectorButtons.tsx
@@ -25,15 +25,15 @@ export function SortSelectorButtons({ onChange, value, ...props }: SortSelectorB
   };
 
   return (
-    <ButtonGroup aria-label="Sort" sx={{ margin: 1 }} {...props}>
+    <ButtonGroup aria-label="Sort" {...props}>
       <Button onClick={() => handleSortChange(undefined)} variant={value === undefined ? 'contained' : 'outlined'}>
         None
       </Button>
       <Button onClick={() => handleSortChange('asc')} variant={value === 'asc' ? 'contained' : 'outlined'}>
-        Ascending
+        Asc
       </Button>
       <Button onClick={() => handleSortChange('desc')} variant={value === 'desc' ? 'contained' : 'outlined'}>
-        Descending
+        Desc
       </Button>
     </ButtonGroup>
   );

--- a/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
+++ b/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
@@ -13,7 +13,7 @@
 
 import { Divider, FormControlLabel, Stack, StackProps, Switch, TextField } from '@mui/material';
 import { useState } from 'react';
-import { AlignSelector } from '@perses-dev/components';
+import { AlignSelector, SortSelectorButtons } from '@perses-dev/components';
 import { ColumnSettings } from '../table-model';
 
 type OmittedMuiProps = 'children' | 'value' | 'onChange';
@@ -63,23 +63,10 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
       <Divider orientation="vertical" flexItem />
 
       <Stack gap={2} justifyContent="space-between" alignItems="start">
-        <FormControlLabel
-          label="Alignment"
-          sx={{ width: '100%', alignItems: 'start' }}
-          labelPlacement="top"
-          control={
-            <AlignSelector
-              size="medium"
-              value={column.align ?? 'left'}
-              onChange={(align) => onChange({ ...column, align: align })}
-            />
-          }
-        />
-
-        <Stack direction="row" alignItems="center" sx={{ width: '100%' }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ width: '100%' }} gap={1}>
           <FormControlLabel
             label="Hide column"
-            sx={{ width: '100%', alignItems: 'start' }}
+            sx={{ width: '100%', alignItems: 'start', textWrap: 'nowrap' }}
             labelPlacement="top"
             control={
               <Switch
@@ -89,10 +76,25 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
               />
             }
           />
+          <FormControlLabel
+            label="Alignment"
+            sx={{ width: '100%', alignItems: 'start', margin: 0 }}
+            labelPlacement="top"
+            control={
+              <AlignSelector
+                size="medium"
+                value={column.align ?? 'left'}
+                sx={{ margin: 0.5 }}
+                onChange={(align) => onChange({ ...column, align: align })}
+              />
+            }
+          />
+        </Stack>
 
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ width: '100%' }} gap={1}>
           <FormControlLabel
             label="Enable sorting"
-            sx={{ width: '100%', alignItems: 'start' }}
+            sx={{ width: '100%', alignItems: 'start', textWrap: 'nowrap' }}
             labelPlacement="top"
             control={
               <Switch
@@ -102,12 +104,26 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
               />
             }
           />
+
+          <FormControlLabel
+            label="Default Sort"
+            sx={{ width: '100%', alignItems: 'start', margin: 0 }}
+            labelPlacement="top"
+            control={
+              <SortSelectorButtons
+                size="medium"
+                value={column.sort}
+                sx={{ margin: 0.5 }}
+                onChange={(sort) => onChange({ ...column, sort: sort })}
+              />
+            }
+          />
         </Stack>
 
-        <Stack direction="row" alignItems="center" sx={{ width: '100%' }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ width: '100%' }} gap={1}>
           <FormControlLabel
             label="Custom width"
-            sx={{ width: '100%', alignItems: 'start' }}
+            sx={{ width: '100%', alignItems: 'start', textWrap: 'nowrap', flex: 1 }}
             labelPlacement="top"
             control={
               <Switch
@@ -122,7 +138,7 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
             value={width}
             fullWidth
             // set visibility instead of wrapping in a if condition, in order to keep same layout
-            sx={{ visibility: column.width === 'auto' || column.width === undefined ? 'hidden' : 'visible' }}
+            sx={{ visibility: column.width === 'auto' || column.width === undefined ? 'hidden' : 'visible', flex: 2 }}
             InputProps={{ inputProps: { min: 1 } }}
             onChange={(e) => {
               setWidth(+e.target.value);

--- a/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
+++ b/ui/panels-plugin/src/plugins/table/ColumnsEditor/ColumnEditor.tsx
@@ -107,13 +107,20 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
 
           <FormControlLabel
             label="Default Sort"
-            sx={{ width: '100%', alignItems: 'start', margin: 0 }}
+            sx={{
+              width: '100%',
+              alignItems: 'start',
+              margin: 0,
+              visibility: column.enableSorting ? 'visible' : 'hidden',
+            }}
             labelPlacement="top"
             control={
               <SortSelectorButtons
                 size="medium"
                 value={column.sort}
-                sx={{ margin: 0.5 }}
+                sx={{
+                  margin: 0.5,
+                }}
                 onChange={(sort) => onChange({ ...column, sort: sort })}
               />
             }

--- a/ui/panels-plugin/src/plugins/table/TablePanel.tsx
+++ b/ui/panels-plugin/src/plugins/table/TablePanel.tsx
@@ -213,7 +213,20 @@ export function TablePanel({ contentDimensions, spec }: TableProps) {
     return result;
   }, [data, keys, spec.cellSettings]);
 
-  const [sorting, setSorting] = useState<SortingState>([]);
+  function generateDefaultSortingState(): SortingState {
+    return (
+      spec.columnSettings
+        ?.filter((column) => column.sort !== undefined)
+        .map((column) => {
+          return {
+            id: column.name,
+            desc: column.sort === 'desc',
+          };
+        }) ?? []
+    );
+  }
+
+  const [sorting, setSorting] = useState<SortingState>(generateDefaultSortingState());
 
   if (isLoading || isFetching) {
     return <LoadingOverlay />;

--- a/ui/panels-plugin/src/plugins/table/table-model.ts
+++ b/ui/panels-plugin/src/plugins/table/table-model.ts
@@ -37,7 +37,8 @@ export interface ColumnSettings {
   // When `true`, the column will be sortable.
   enableSorting?: boolean;
 
-  // TODO: Allow user to set default sort => sort?: 'asc' | 'desc';
+  // Default sort order for the column.
+  sort?: 'asc' | 'desc';
 
   /**
    * Width of the column when rendered in a table. It should be a number in pixels


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Allow user to predefine column sorting in column settings

# Screenshots

<!-- If there are UI changes -->
![image](https://github.com/user-attachments/assets/e4764d01-bb0f-4aa4-8acd-9e8bb8de4751)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
