### PR TITLE
[BUGFIX] `dac diff`: fix output folder not found

### DIFF
--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -144,7 +144,8 @@ func (o *option) processFile(file string, extension string) error {
 	if o.Mode == modeStdout {
 		return output.HandleString(o.writer, string(cmdOutput))
 	}
-	// Otherwise, create an output file under the "built" directory:
+
+	// Otherwise, create an output file under the output directory:
 
 	// Create the folder (+ any parent folder if applicable) where to store the output
 	err = os.MkdirAll(filepath.Join(config.Global.Dac.OutputFolder, filepath.Dir(file)), os.ModePerm)

--- a/internal/cli/cmd/dac/diff/diff.go
+++ b/internal/cli/cmd/dac/diff/diff.go
@@ -88,14 +88,23 @@ func (o *option) Execute() error {
 		if err != nil {
 			return err
 		}
+
 		d, err := dashboardDiff(dashboard, preview)
 		if err != nil {
 			return err
 		}
+
+		// Create the folder (+ any parent folder if applicable) where to store the output
+		err = os.MkdirAll(config.Global.Dac.OutputFolder, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("error creating the output folder: %v", err)
+		}
+
 		filePath := path.Join(config.Global.Dac.OutputFolder, fmt.Sprintf("%s-%s.diff", project, dashboard.Metadata.Name))
 		if writeErr := os.WriteFile(filePath, []byte(d), 0644); writeErr != nil { // nolint: gosec
 			return fmt.Errorf("unable to write the diff file: %w", writeErr)
 		}
+
 		if outputErr := output.HandleString(o.writer, fmt.Sprintf("%s successfully created", filePath)); outputErr != nil {
 			return outputErr
 		}


### PR DESCRIPTION
# Description

Fixes this issue encountered when the output folder of dac-related commands doesn't already exists:
```
$ percli dac diff -f dashboard.json
Error: unable to write the diff file: open built/perses-dashboard.diff: The system cannot find the path specified.
```

The command now tries to create the output folder as part of its logic (just like for `build` command)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
