### PR TITLE
[BUGFIX] Fix migration of decimal units

### DIFF
--- a/cue/schemas/common/migrate/mapping.cue
+++ b/cue/schemas/common/migrate/mapping.cue
@@ -28,6 +28,8 @@ package migrate
 		percent:     "percent"
 		percentunit: "percent-decimal"
 		// decimal units
+        none: "decimal"
+        short: "decimal"
 		// TODO
 		// bytes units
 		bytes:    "bytes"

--- a/cue/schemas/common/migrate/mapping.cue
+++ b/cue/schemas/common/migrate/mapping.cue
@@ -28,8 +28,8 @@ package migrate
 		percent:     "percent"
 		percentunit: "percent-decimal"
 		// decimal units
-        none: "decimal"
-        short: "decimal"
+		none:	"decimal"
+		short:	"decimal"
 		// TODO
 		// bytes units
 		bytes:    "bytes"

--- a/cue/schemas/panels/bar/migrate/migrate.cue
+++ b/cue/schemas/panels/bar/migrate/migrate.cue
@@ -29,7 +29,7 @@ spec: {
 		format: unit: #unit
 	}
 
-	#decimal: *#panel.fieldConfig.defaults.decimal | null
+	#decimal: *#panel.fieldConfig.defaults.decimals | null
 	if #decimal != null {
 		format: decimalPlaces: #decimal
 	}

--- a/cue/schemas/panels/gauge/migrate/migrate.cue
+++ b/cue/schemas/panels/gauge/migrate/migrate.cue
@@ -29,7 +29,7 @@ spec: {
 		format: unit: #unit
 	}
 
-	#decimal: *#panel.fieldConfig.defaults.decimal | null
+	#decimal: *#panel.fieldConfig.defaults.decimals | null
 	if #decimal != null {
 		format: decimalPlaces: #decimal
 	}

--- a/cue/schemas/panels/pie/migrate/migrate.cue
+++ b/cue/schemas/panels/pie/migrate/migrate.cue
@@ -30,7 +30,7 @@ spec: {
 		format: unit: #unit
 	}
 
-	#decimal: *#panel.fieldConfig.defaults.decimal | null
+	#decimal: *#panel.fieldConfig.defaults.decimals | null
 	if #decimal != null {
 		format: decimalPlaces: #decimal
 	}

--- a/cue/schemas/panels/stat/migrate/migrate.cue
+++ b/cue/schemas/panels/stat/migrate/migrate.cue
@@ -29,7 +29,7 @@ spec: {
 		format: unit: #unit
 	}
 
-	#decimal: *#panel.fieldConfig.defaults.decimal | null
+	#decimal: *#panel.fieldConfig.defaults.decimals | null
 	if #decimal != null {
 		format: decimalPlaces: #decimal
 	}

--- a/cue/schemas/panels/time-series/migrate/migrate.cue
+++ b/cue/schemas/panels/time-series/migrate/migrate.cue
@@ -61,7 +61,7 @@ spec: {
 		yAxis: format: unit: #unit
 	}
 
-	#decimal: *#panel.fieldConfig.defaults.decimal | null
+	#decimal: *#panel.fieldConfig.defaults.decimals | null
 	if #decimal != null {
 		yAxis: format: decimalPlaces: #decimal
 	}

--- a/internal/api/migrate/testdata/barchart_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/barchart_grafana_dashboard.json
@@ -28,7 +28,7 @@
                   "max": 100,
                   "min": 0,
                   "unit": "percent",
-                  "decimal": 2
+                  "decimals": 2
               },
               "overrides": []
           },

--- a/internal/api/migrate/testdata/simple_grafana_dashboard.json
+++ b/internal/api/migrate/testdata/simple_grafana_dashboard.json
@@ -123,7 +123,7 @@
             ]
           },
           "unit": "Bps",
-          "decimal": 2
+          "decimals": 2
         },
         "overrides": []
       },
@@ -191,7 +191,7 @@
             ]
           },
           "unit": "h",
-          "decimal": 1
+          "decimals": 1
         },
         "overrides": []
       },
@@ -287,7 +287,7 @@
               }
             ]
           },
-          "decimal": 3
+          "decimals": 3
         },
         "overrides": []
       },


### PR DESCRIPTION
# Description
Fix for migration of decimal units. 
Name of **Decimals** field in json was fixed in migration scripts. (Was **panel.fieldConfig.defaults.decimal**, changed to **panel.fieldConfig.defaults.decimals**)
Example from Grafana dashboard:
```
  "fieldConfig": {
    "defaults": {
      "mappings": [
        {
          "options": {
            "match": "null",
            "result": {
              "text": "N/A"
            }
          },
          "type": "special"
        }
      ],
      "thresholds": {
        "mode": "absolute",
        "steps": [
          {
            "color": "green",
            "value": null
          }
        ]
      },
      "color": {
        "fixedColor": "rgb(31, 120, 193)",
        "mode": "fixed"
      },
      "decimals": 0,
      "unit": "short"
    },
    "overrides": []
  },
```

+ Add unit mapping for "none" to"decimal" and "short" to "decimal".

# Screenshots
![image](https://github.com/user-attachments/assets/a19de10b-dcd6-4b9d-974f-3847fdc3a1ae)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
