### PR TITLE
[ENHANCEMENT] `percli dac diff`: add output + avoid early return when processing a directory

### DIFF
--- a/internal/cli/cmd/dac/diff/diff.go
+++ b/internal/cli/cmd/dac/diff/diff.go
@@ -15,11 +15,12 @@ package diff
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/kylelemons/godebug/diff"
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
@@ -29,9 +30,22 @@ import (
 	"github.com/perses/perses/internal/cli/output"
 	"github.com/perses/perses/internal/cli/resource"
 	"github.com/perses/perses/pkg/client/api"
+	"github.com/perses/perses/pkg/client/perseshttp"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+const statusNew = "NEW"
+const statusUpdated = "UPDATED"
+const statusError = "ERROR"
+
+type diffResult struct {
+	Project   string `json:"project" yaml:"project"`
+	Dashboard string `json:"dashboard" yaml:"dashboard"`
+	Status    string `json:"status" yaml:"status"`
+	Diff      string `json:"diff,omitempty" yaml:"diff,omitempty"`
+}
 
 func marshalIndent(dashboard *modelV1.Dashboard) ([]byte, error) {
 	return json.MarshalIndent(dashboard.Spec, "", "  ")
@@ -54,6 +68,7 @@ type option struct {
 	opt.ProjectOption
 	opt.FileOption
 	opt.DirectoryOption
+	opt.OutputOption
 	writer     io.Writer
 	errWriter  io.Writer
 	apiClient  api.ClientInterface
@@ -89,30 +104,55 @@ func (o *option) Execute() error {
 		return fmt.Errorf("error creating the output folder: %v", err)
 	}
 
-	var execResult strings.Builder
-	for _, preview := range o.dashboards {
-		project := resource.GetProject(preview.GetMetadata(), o.Project)
-		dashboard, err := o.apiClient.V1().Dashboard(project).Get(preview.Metadata.Name)
-		if err != nil {
-			execResult.WriteString(fmt.Sprintf("No dashboard %s found in project %s, skipping diff generation: %v\n", preview.Metadata.Name, project, err))
-			continue
-		}
+	var result []diffResult
+	for _, updatedDashboard := range o.dashboards {
+		project := resource.GetProject(updatedDashboard.GetMetadata(), o.Project)
+		status, filePath := o.processDashboardDiff(updatedDashboard, project)
 
-		d, err := dashboardDiff(dashboard, preview)
-		if err != nil {
-			execResult.WriteString(fmt.Sprintf("Diff generation failed for dashboard %s in project %s: %v", preview.Metadata.Name, project, err))
-			continue
-		}
+		result = append(result, diffResult{
+			Dashboard: updatedDashboard.Metadata.Name,
+			Project:   project,
+			Status:    status,
+			Diff:      filePath,
+		})
 
-		filePath := path.Join(config.Global.Dac.OutputFolder, fmt.Sprintf("%s-%s.diff", project, dashboard.Metadata.Name))
-		if writeErr := os.WriteFile(filePath, []byte(d), 0644); writeErr != nil { // nolint: gosec
-			execResult.WriteString(fmt.Sprintf("Unable to write the diff file for dashboard %s in project %s: %v", preview.Metadata.Name, project, writeErr))
-			continue
+		if filePath != "" {
+			logrus.Infof("%s successfully generated", filePath)
 		}
-
-		execResult.WriteString(fmt.Sprintf("%s successfully generated\n", filePath))
 	}
-	return output.HandleString(o.writer, execResult.String())
+
+	return output.Handle(o.writer, o.Output, result)
+}
+
+func (o *option) processDashboardDiff(updatedDashboard *modelV1.Dashboard, project string) (string, string) {
+	currentDashboard, err := o.apiClient.V1().Dashboard(project).Get(updatedDashboard.Metadata.Name)
+	if err != nil {
+		var reqErr *perseshttp.RequestError
+		if errors.As(err, &reqErr) {
+			if reqErr.StatusCode == http.StatusNotFound {
+				logrus.Infof("No dashboard %s found in project %s, skipping diff generation", updatedDashboard.Metadata.Name, project)
+				return statusNew, ""
+			}
+			logrus.WithError(err).Errorf("Unexpected error while fetching dashboard %s in project %s", updatedDashboard.Metadata.Name, project)
+		} else {
+			logrus.WithError(err).Errorf("Unknown error while fetching dashboard %s in project %s", updatedDashboard.Metadata.Name, project)
+		}
+		return statusError, ""
+	}
+
+	diff, err := dashboardDiff(currentDashboard, updatedDashboard)
+	if err != nil {
+		logrus.WithError(err).Warningf("Diff generation failed for dashboard %s in project %s", updatedDashboard.Metadata.Name, project)
+		return statusError, ""
+	}
+
+	filePath := path.Join(config.Global.Dac.OutputFolder, fmt.Sprintf("%s-%s.diff", project, currentDashboard.Metadata.Name))
+	if err := os.WriteFile(filePath, []byte(diff), 0644); err != nil { // nolint: gosec
+		logrus.WithError(err).Warningf("Unable to write the diff file for dashboard %s in project %s", updatedDashboard.Metadata.Name, project)
+		return statusError, ""
+	}
+
+	return statusUpdated, filePath
 }
 
 func (o *option) setDashboards() error {


### PR DESCRIPTION
# Description

- **add output**: `diff` now produces an output similar to what `preview` is doing, with project + dashboard name + status (NEW/UPDATED/ERROR) + Diff file path if applicable:
  ```bash
  $ percli dac diff -d testdata/
  time="2024-12-13T22:23:11+01:00" level=info msg="No dashboard brand-new found in project perses-github-actions, skipping diff generation"
  time="2024-12-13T22:23:11+01:00" level=info msg="built/perses-github-actions-empty_dashboard.diff successfully generated"
  - project: perses-github-actions
    dashboard: brand-new
    status: NEW
  - project: perses-github-actions
    dashboard: empty_dashboard
    status: UPDATED
    diff: built/perses-github-actions-empty_dashboard.diff
  ```
- **avoid early return when processing a directory**: This change is needed to correctly handle the common case where a user of DaC adds a new dashboard: in that case today the diff command fails, thus any further dashboard to process is ignored. This PR fixes that by not stopping the directory processing on individual file error.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).