### PR TITLE
Downgrade TypeScript version to v5.3 + enforce return typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 /bin
 /built
 /dist
+tsconfig.build.tsbuildinfo
 
 coverage.txt
 

--- a/ui/.eslintrc.base.js
+++ b/ui/.eslintrc.base.js
@@ -52,6 +52,9 @@ module.exports = {
   },
 
   rules: {
+    '@typescript-eslint/explicit-function-return-type': 'error',
+    '@typescript-eslint/explicit-module-boundary-types': 'error',
+
     'prettier/prettier': 'error',
     '@typescript-eslint/array-type': [
       'error',

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -58,7 +58,7 @@
         "ts-node": "^10.9.2",
         "turbo": "^2.0.12",
         "typedoc": "^0.25.8",
-        "typescript": "^5.4.5",
+        "typescript": "5.3.3",
         "wait-on": "^7.0.1"
       }
     },
@@ -30161,9 +30161,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/ui/package.json
+++ b/ui/package.json
@@ -75,7 +75,7 @@
     "ts-node": "^10.9.2",
     "turbo": "^2.0.12",
     "typedoc": "^0.25.8",
-    "typescript": "^5.4.5",
+    "typescript": "5.3.3",
     "wait-on": "^7.0.1"
   },
   "packageManager": "npm@10.8.2"


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Linter is only supporting Typescript < 5.4, when updating linter I have other error, quick fix for current issue. When your are using unsupported TS version, linter do not raise error during npm run lint 😅 
And enforce return typing, because it's not the default behaviour, weird...
