### PR TITLE
[ENHANCEMENT] `percli dac preview`: add current dashboard URL to the output when applicable

### DIFF
--- a/internal/cli/cmd/dac/preview/preview.go
+++ b/internal/cli/cmd/dac/preview/preview.go
@@ -14,8 +14,10 @@
 package preview
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/perses/perses/internal/api/utils"
@@ -27,6 +29,7 @@ import (
 	"github.com/perses/perses/internal/cli/resource"
 	"github.com/perses/perses/internal/cli/service"
 	"github.com/perses/perses/pkg/client/api"
+	"github.com/perses/perses/pkg/client/perseshttp"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/sirupsen/logrus"
@@ -37,6 +40,7 @@ type previewResponse struct {
 	Project   string `json:"project" yaml:"project"`
 	Dashboard string `json:"dashboard" yaml:"dashboard"`
 	Preview   string `json:"preview" yaml:"preview"`
+	Current   string `json:"current,omitempty" yaml:"current,omitempty"`
 }
 
 func newEphemeralDashboard(project string, name string, ttl common.Duration, dashboard *modelV1.Dashboard) *modelV1.EphemeralDashboard {
@@ -145,11 +149,29 @@ func (o *option) computeEphemeralDashboardName(dashboardName string) string {
 }
 
 func (o *option) buildPreviewResponse(dashboard *modelV1.Dashboard, tmpDashboard *modelV1.EphemeralDashboard) previewResponse {
-	previewURL := common.NewURL(o.apiClient.RESTClient().BaseURL, utils.PathProject, tmpDashboard.Metadata.Project, utils.PathEphemeralDashboard, tmpDashboard.Metadata.Name)
+	project := tmpDashboard.Metadata.Project
+	name := dashboard.Metadata.Name
+
+	previewURL := common.NewURL(o.apiClient.RESTClient().BaseURL, utils.PathProject, project, utils.PathEphemeralDashboard, tmpDashboard.Metadata.Name)
+
+	// Check if the dashboard already exists to provide the "current" URL
+	currentURL := &common.URL{}
+	_, err := o.apiClient.V1().Dashboard(project).Get(name)
+	if err != nil {
+		var reqErr *perseshttp.RequestError
+		if errors.As(err, &reqErr) && reqErr.StatusCode == http.StatusNotFound {
+			logrus.Infof("No dashboard %s found in project %s, no current link to provide", name, project)
+		}
+	} else {
+		currentURL = common.NewURL(o.apiClient.RESTClient().BaseURL, utils.PathProject, project, utils.PathDashboard, name)
+	}
+
 	return previewResponse{
-		Dashboard: dashboard.Metadata.Name,
-		Project:   tmpDashboard.Metadata.Project,
-		Preview:   previewURL.String()}
+		Dashboard: name,
+		Project:   project,
+		Preview:   previewURL.String(),
+		Current:   currentURL.String(),
+	}
 }
 
 func (o *option) SetWriter(writer io.Writer) {

--- a/internal/cli/cmd/dac/preview/preview.go
+++ b/internal/cli/cmd/dac/preview/preview.go
@@ -156,8 +156,7 @@ func (o *option) buildPreviewResponse(dashboard *modelV1.Dashboard, tmpDashboard
 
 	// Check if the dashboard already exists to provide the "current" URL
 	currentURL := &common.URL{}
-	_, err := o.apiClient.V1().Dashboard(project).Get(name)
-	if err != nil {
+	if _, err := o.apiClient.V1().Dashboard(project).Get(name); err != nil {
 		var reqErr *perseshttp.RequestError
 		if errors.As(err, &reqErr) && reqErr.StatusCode == http.StatusNotFound {
 			logrus.Infof("No dashboard %s found in project %s, no current link to provide", name, project)

--- a/internal/cli/cmd/dac/preview/preview_test.go
+++ b/internal/cli/cmd/dac/preview/preview_test.go
@@ -46,51 +46,67 @@ func TestPreviewCMD(t *testing.T) {
 			ExpectedMessage: `- project: perses
   dashboard: Demo
   preview: http://localhost:8080/projects/perses/ephemeraldashboards/Demo
+  current: http://localhost:8080/projects/perses/dashboards/Demo
 - project: perses
   dashboard: Benchmark
   preview: http://localhost:8080/projects/perses/ephemeraldashboards/Benchmark
+  current: http://localhost:8080/projects/perses/dashboards/Benchmark
 - project: testing
   dashboard: PanelGroups
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/PanelGroups
+  current: http://localhost:8080/projects/testing/dashboards/PanelGroups
 - project: testing
   dashboard: Panels
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/Panels
+  current: http://localhost:8080/projects/testing/dashboards/Panels
 - project: testing
   dashboard: Variables
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/Variables
+  current: http://localhost:8080/projects/testing/dashboards/Variables
 - project: testing
   dashboard: MarkdownPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/MarkdownPanel
+  current: http://localhost:8080/projects/testing/dashboards/MarkdownPanel
 - project: testing
   dashboard: TimeSeriesChartPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartPanel
+  current: http://localhost:8080/projects/testing/dashboards/TimeSeriesChartPanel
 - project: testing
   dashboard: GaugeChartPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/GaugeChartPanel
+  current: http://localhost:8080/projects/testing/dashboards/GaugeChartPanel
 - project: testing
   dashboard: StatChartPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/StatChartPanel
+  current: http://localhost:8080/projects/testing/dashboards/StatChartPanel
 - project: testing
   dashboard: DuplicatePanels
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/DuplicatePanels
+  current: http://localhost:8080/projects/testing/dashboards/DuplicatePanels
 - project: testing
   dashboard: EditJson
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/EditJson
+  current: http://localhost:8080/projects/testing/dashboards/EditJson
 - project: testing
   dashboard: Defaults
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/Defaults
+  current: http://localhost:8080/projects/testing/dashboards/Defaults
 - project: testing
   dashboard: TimeSeriesChartLegends
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartLegends
+  current: http://localhost:8080/projects/testing/dashboards/TimeSeriesChartLegends
 - project: testing
   dashboard: table
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/table
+  current: http://localhost:8080/projects/testing/dashboards/table
 - project: perses
   dashboard: NodeExporter
   preview: http://localhost:8080/projects/perses/ephemeraldashboards/NodeExporter
+  current: http://localhost:8080/projects/perses/dashboards/NodeExporter
 - project: testing
   dashboard: tracing
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/tracing
+  current: http://localhost:8080/projects/testing/dashboards/tracing
 
 `,
 		},
@@ -103,51 +119,67 @@ func TestPreviewCMD(t *testing.T) {
 			ExpectedMessage: `- project: perses
   dashboard: Demo
   preview: http://localhost:8080/projects/perses/ephemeraldashboards/pr-1664-Demo
+  current: http://localhost:8080/projects/perses/dashboards/Demo
 - project: perses
   dashboard: Benchmark
   preview: http://localhost:8080/projects/perses/ephemeraldashboards/pr-1664-Benchmark
+  current: http://localhost:8080/projects/perses/dashboards/Benchmark
 - project: testing
   dashboard: PanelGroups
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-PanelGroups
+  current: http://localhost:8080/projects/testing/dashboards/PanelGroups
 - project: testing
   dashboard: Panels
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-Panels
+  current: http://localhost:8080/projects/testing/dashboards/Panels
 - project: testing
   dashboard: Variables
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-Variables
+  current: http://localhost:8080/projects/testing/dashboards/Variables
 - project: testing
   dashboard: MarkdownPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-MarkdownPanel
+  current: http://localhost:8080/projects/testing/dashboards/MarkdownPanel
 - project: testing
   dashboard: TimeSeriesChartPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-TimeSeriesChartPanel
+  current: http://localhost:8080/projects/testing/dashboards/TimeSeriesChartPanel
 - project: testing
   dashboard: GaugeChartPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-GaugeChartPanel
+  current: http://localhost:8080/projects/testing/dashboards/GaugeChartPanel
 - project: testing
   dashboard: StatChartPanel
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-StatChartPanel
+  current: http://localhost:8080/projects/testing/dashboards/StatChartPanel
 - project: testing
   dashboard: DuplicatePanels
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-DuplicatePanels
+  current: http://localhost:8080/projects/testing/dashboards/DuplicatePanels
 - project: testing
   dashboard: EditJson
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-EditJson
+  current: http://localhost:8080/projects/testing/dashboards/EditJson
 - project: testing
   dashboard: Defaults
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-Defaults
+  current: http://localhost:8080/projects/testing/dashboards/Defaults
 - project: testing
   dashboard: TimeSeriesChartLegends
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-TimeSeriesChartLegends
+  current: http://localhost:8080/projects/testing/dashboards/TimeSeriesChartLegends
 - project: testing
   dashboard: table
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-table
+  current: http://localhost:8080/projects/testing/dashboards/table
 - project: perses
   dashboard: NodeExporter
   preview: http://localhost:8080/projects/perses/ephemeraldashboards/pr-1664-NodeExporter
+  current: http://localhost:8080/projects/perses/dashboards/NodeExporter
 - project: testing
   dashboard: tracing
   preview: http://localhost:8080/projects/testing/ephemeraldashboards/pr-1664-tracing
+  current: http://localhost:8080/projects/testing/dashboards/tracing
 
 `,
 		},
@@ -157,7 +189,7 @@ func TestPreviewCMD(t *testing.T) {
 			APIClient:       fakeapi.New(),
 			Config:          config.Config{Dac: config.Dac{OutputFolder: "../../../../../dev/data/9-dashboard.json"}},
 			IsErrorExpected: false,
-			ExpectedMessage: `[{"project":"perses","dashboard":"Demo","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/Demo"},{"project":"perses","dashboard":"Benchmark","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/Benchmark"},{"project":"testing","dashboard":"PanelGroups","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/PanelGroups"},{"project":"testing","dashboard":"Panels","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Panels"},{"project":"testing","dashboard":"Variables","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Variables"},{"project":"testing","dashboard":"MarkdownPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/MarkdownPanel"},{"project":"testing","dashboard":"TimeSeriesChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartPanel"},{"project":"testing","dashboard":"GaugeChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/GaugeChartPanel"},{"project":"testing","dashboard":"StatChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/StatChartPanel"},{"project":"testing","dashboard":"DuplicatePanels","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/DuplicatePanels"},{"project":"testing","dashboard":"EditJson","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/EditJson"},{"project":"testing","dashboard":"Defaults","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Defaults"},{"project":"testing","dashboard":"TimeSeriesChartLegends","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartLegends"},{"project":"testing","dashboard":"table","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/table"},{"project":"perses","dashboard":"NodeExporter","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/NodeExporter"},{"project":"testing","dashboard":"tracing","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/tracing"}]
+			ExpectedMessage: `[{"project":"perses","dashboard":"Demo","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/Demo","current":"http://localhost:8080/projects/perses/dashboards/Demo"},{"project":"perses","dashboard":"Benchmark","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/Benchmark","current":"http://localhost:8080/projects/perses/dashboards/Benchmark"},{"project":"testing","dashboard":"PanelGroups","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/PanelGroups","current":"http://localhost:8080/projects/testing/dashboards/PanelGroups"},{"project":"testing","dashboard":"Panels","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Panels","current":"http://localhost:8080/projects/testing/dashboards/Panels"},{"project":"testing","dashboard":"Variables","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Variables","current":"http://localhost:8080/projects/testing/dashboards/Variables"},{"project":"testing","dashboard":"MarkdownPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/MarkdownPanel","current":"http://localhost:8080/projects/testing/dashboards/MarkdownPanel"},{"project":"testing","dashboard":"TimeSeriesChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartPanel","current":"http://localhost:8080/projects/testing/dashboards/TimeSeriesChartPanel"},{"project":"testing","dashboard":"GaugeChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/GaugeChartPanel","current":"http://localhost:8080/projects/testing/dashboards/GaugeChartPanel"},{"project":"testing","dashboard":"StatChartPanel","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/StatChartPanel","current":"http://localhost:8080/projects/testing/dashboards/StatChartPanel"},{"project":"testing","dashboard":"DuplicatePanels","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/DuplicatePanels","current":"http://localhost:8080/projects/testing/dashboards/DuplicatePanels"},{"project":"testing","dashboard":"EditJson","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/EditJson","current":"http://localhost:8080/projects/testing/dashboards/EditJson"},{"project":"testing","dashboard":"Defaults","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/Defaults","current":"http://localhost:8080/projects/testing/dashboards/Defaults"},{"project":"testing","dashboard":"TimeSeriesChartLegends","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/TimeSeriesChartLegends","current":"http://localhost:8080/projects/testing/dashboards/TimeSeriesChartLegends"},{"project":"testing","dashboard":"table","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/table","current":"http://localhost:8080/projects/testing/dashboards/table"},{"project":"perses","dashboard":"NodeExporter","preview":"http://localhost:8080/projects/perses/ephemeraldashboards/NodeExporter","current":"http://localhost:8080/projects/perses/dashboards/NodeExporter"},{"project":"testing","dashboard":"tracing","preview":"http://localhost:8080/projects/testing/ephemeraldashboards/tracing","current":"http://localhost:8080/projects/testing/dashboards/tracing"}]
 `,
 		},
 	}

--- a/pkg/client/fake/api/v1/client.go
+++ b/pkg/client/fake/api/v1/client.go
@@ -31,6 +31,10 @@ func (c *client) RESTClient() *perseshttp.RESTClient {
 	return c.restClient
 }
 
+func (c *client) Dashboard(_ string) v1.DashboardInterface {
+	return &dashboard{}
+}
+
 func (c *client) EphemeralDashboard(_ string) v1.EphemeralDashboardInterface {
 	return &ephemeralDashboard{}
 }

--- a/pkg/client/fake/api/v1/dashboard.go
+++ b/pkg/client/fake/api/v1/dashboard.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakev1
+
+import (
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type dashboard struct {
+	v1.DashboardInterface
+	project string
+}
+
+func (d *dashboard) Create(entity *modelV1.Dashboard) (*modelV1.Dashboard, error) {
+	return entity, nil
+}
+func (d *dashboard) Update(entity *modelV1.Dashboard) (*modelV1.Dashboard, error) {
+	return entity, nil
+}
+func (d *dashboard) Delete(_ string) error {
+	return nil
+}
+func (d *dashboard) Get(name string) (*modelV1.Dashboard, error) {
+	return &modelV1.Dashboard{
+
+		Kind: modelV1.KindDashboard,
+		Metadata: modelV1.ProjectMetadata{
+			Metadata: modelV1.Metadata{
+				Name: name,
+			},
+			ProjectMetadataWrapper: modelV1.ProjectMetadataWrapper{
+				Project: d.project,
+			},
+		},
+		Spec: modelV1.DashboardSpec{},
+	}, nil
+}
+func (d *dashboard) List(_ string) ([]*modelV1.Dashboard, error) {
+	return make([]*modelV1.Dashboard, 0), nil
+}


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Adding the URL of the existing dashboard, when applicable, corresponding to the preview helps the user to quickly see the before & after states, using "current" link + preview link.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
