### PR TITLE
[FEATURE] add remote loader for runtime plugins

### DIFF
--- a/internal/api/plugin/npm.go
+++ b/internal/api/plugin/npm.go
@@ -25,7 +25,7 @@ const (
 )
 
 type NPMPerses struct {
-	PluginType string `json:"pluginType"`
+	Plugins []PluginMetadata `json:"plugins"`
 }
 
 type NPMPackage struct {
@@ -39,14 +39,14 @@ type BuildInfo struct {
 	Name    string `json:"buildName"`
 }
 
-type Metadata struct {
+type ManifetsMetadata struct {
 	BuildInfo BuildInfo `json:"buildInfo"`
 }
 
 type NPMManifest struct {
-	ID       string   `json:"id"`
-	Name     string   `json:"name"`
-	Metadata Metadata `json:"metaData"`
+	ID       string           `json:"id"`
+	Name     string           `json:"name"`
+	Metadata ManifetsMetadata `json:"metaData"`
 }
 
 func ReadManifest(pluginPath string) (*NPMManifest, error) {

--- a/internal/api/plugin/npm.go
+++ b/internal/api/plugin/npm.go
@@ -17,6 +17,8 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
 const (
@@ -24,14 +26,10 @@ const (
 	PackageJSONFile  = "package.json"
 )
 
-type NPMPerses struct {
-	Plugins []PluginMetadata `json:"plugins"`
-}
-
 type NPMPackage struct {
-	Author  string    `json:"author"`
-	Version string    `json:"version"`
-	Perses  NPMPerses `json:"perses"`
+	Author  string              `json:"author"`
+	Version string              `json:"version"`
+	Perses  v1.PluginModuleSpec `json:"perses"`
 }
 
 type BuildInfo struct {

--- a/internal/api/plugin/plugin.go
+++ b/internal/api/plugin/plugin.go
@@ -17,18 +17,39 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/perses/perses/pkg/model/api/config"
 	"github.com/sirupsen/logrus"
 )
 
-const pluginFileName = "plugin.json"
+const (
+	PluginModuleKind = "PluginModule"
+	pluginFileName   = "plugin-modules.json"
+)
 
-type Info struct {
+type PluginMetadata struct {
+	PluginType string `json:"pluginType"`
+	Kind       string `json:"kind"`
+	Display    struct {
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+	} `json:"display"`
+}
+
+type PluginModuleSpec struct {
+	Plugins []PluginMetadata `json:"plugins"`
+}
+
+type PluginModuleMetadata struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
-	Type    string `json:"type"`
+}
+
+type PluginModule struct {
+	Kind     string               `json:"kind"`
+	Metadata PluginModuleMetadata `json:"metadata"`
+	Spec     PluginModuleSpec     `json:"spec"`
 }
 
 type Plugin interface {
@@ -52,7 +73,7 @@ type plugin struct {
 }
 
 func (p *plugin) List() ([]byte, error) {
-	pluginFilePath := path.Join(p.path, pluginFileName)
+	pluginFilePath := filepath.Join(p.path, pluginFileName)
 	if _, osErr := os.Stat(pluginFilePath); errors.Is(osErr, os.ErrNotExist) {
 		if generateErr := p.generatePluginListFile(); generateErr != nil {
 			return nil, generateErr
@@ -72,40 +93,45 @@ func (p *plugin) generatePluginListFile() error {
 	if err != nil {
 		return err
 	}
-	var pluginList []Info
+	var pluginModuleList []PluginModule
 	for _, file := range files {
 		if !file.IsDir() {
 			// we are only interested in the plugin folder, so any files at the root of the plugin folder can be skipped
 			continue
 		}
 		// now we need to read the manifest file to extract the info we are interested
-		if _, osErr := os.Stat(path.Join(p.path, file.Name(), ManifestFileName)); errors.Is(osErr, os.ErrNotExist) {
+		if _, osErr := os.Stat(filepath.Join(p.path, file.Name(), ManifestFileName)); errors.Is(osErr, os.ErrNotExist) {
 			// The manifest doesn't exist, so we can ignore this folder, it's not a plugin, or the plugin is invalid.
 			logrus.Debugf("folder %q does not contain file mf-manifest.json, skipping it as it does not match the plugin architecture", file.Name())
 			continue
 		}
-		manifest, readErr := ReadManifest(path.Join(p.path, file.Name()))
+		manifest, readErr := ReadManifest(filepath.Join(p.path, file.Name()))
 		if readErr != nil {
 			logrus.WithError(readErr).Error("unable to read plugin manifest")
 			continue
 		}
-		npmPackageData, readErr := ReadPackage(path.Join(p.path, file.Name()))
+		npmPackageData, readErr := ReadPackage(filepath.Join(p.path, file.Name()))
 		if readErr != nil {
 			logrus.WithError(readErr).Error("unable to read plugin package.json")
 			continue
 		}
-		pluginList = append(pluginList, Info{
-			Name:    manifest.Name,
-			Version: manifest.Metadata.BuildInfo.Version,
-			Type:    npmPackageData.Perses.PluginType,
+		pluginModuleList = append(pluginModuleList, PluginModule{
+			Kind: PluginModuleKind,
+			Metadata: PluginModuleMetadata{
+				Name:    manifest.Name,
+				Version: manifest.Metadata.BuildInfo.Version,
+			},
+			Spec: PluginModuleSpec{
+				Plugins: npmPackageData.Perses.Plugins,
+			},
 		})
 	}
-	if len(pluginList) == 0 {
-		pluginList = make([]Info, 0)
+	if len(pluginModuleList) == 0 {
+		pluginModuleList = make([]PluginModule, 0)
 	}
-	marshalData, marshalErr := json.Marshal(pluginList)
+	marshalData, marshalErr := json.Marshal(pluginModuleList)
 	if marshalErr != nil {
 		return marshalErr
 	}
-	return os.WriteFile(path.Join(p.path, pluginFileName), marshalData, 0644) // nolint: gosec
+	return os.WriteFile(filepath.Join(p.path, pluginFileName), marshalData, 0644) // nolint: gosec
 }

--- a/pkg/model/api/v1/plugin.go
+++ b/pkg/model/api/v1/plugin.go
@@ -1,0 +1,43 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "github.com/perses/perses/pkg/model/api/v1/common"
+
+const PluginModuleKind = "PluginModule"
+
+type PluginSpec struct {
+	Display *common.Display `json:"display"`
+	Name    string          `json:"name"`
+}
+
+type Plugin struct {
+	Kind string     `json:"kind"`
+	Spec PluginSpec `json:"spec"`
+}
+
+type PluginModuleSpec struct {
+	Plugins []Plugin `json:"plugins"`
+}
+
+type PluginModuleMetadata struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type PluginModule struct {
+	Kind     string               `json:"kind"`
+	Metadata PluginModuleMetadata `json:"metadata"`
+	Spec     PluginModuleSpec     `json:"spec"`
+}

--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Datasource, DatasourceDefinition } from '@perses-dev/core';
-import { ReactElement, useState } from 'react';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { Datasource, DatasourceDefinition } from '@perses-dev/core';
+import { remotePluginLoader } from '@perses-dev/plugin-runtime';
 import { DatasourceEditorForm, PluginRegistry, ValidationProvider } from '@perses-dev/plugin-system';
-import { bundledPluginLoader } from '../../model/bundled-plugins';
-import { DrawerProps } from '../form-drawers';
+import { ReactElement, useState } from 'react';
 import { DeleteResourceDialog } from '../dialogs';
+import { DrawerProps } from '../form-drawers';
 
 interface DatasourceDrawerProps<T extends Datasource> extends DrawerProps<T> {
   datasource: T;
@@ -52,7 +52,7 @@ export function DatasourceDrawer<T extends Datasource>({
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <PluginRegistry pluginLoader={bundledPluginLoader}>
+        <PluginRegistry pluginLoader={remotePluginLoader()}>
           <ValidationProvider>
             {isOpen && (
               <DatasourceEditorForm

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -11,21 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Variable, VariableDefinition, getVariableProject } from '@perses-dev/core';
-import React, { ReactElement, useEffect, useMemo, useState } from 'react';
-import { DatasourceStoreProvider, VariableProviderWithQueryParams } from '@perses-dev/dashboards';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { Variable, VariableDefinition, getVariableProject } from '@perses-dev/core';
+import { DatasourceStoreProvider, VariableProviderWithQueryParams } from '@perses-dev/dashboards';
+import { remotePluginLoader } from '@perses-dev/plugin-runtime';
 import {
   PluginRegistry,
   TimeRangeProviderWithQueryParams,
+  ValidationProvider,
   VariableEditorForm,
   useInitialTimeRange,
-  ValidationProvider,
 } from '@perses-dev/plugin-system';
-import { bundledPluginLoader } from '../../model/bundled-plugins';
+import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../model/datasource-api';
-import { DrawerProps } from '../form-drawers';
 import { DeleteResourceDialog } from '../dialogs';
+import { DrawerProps } from '../form-drawers';
 
 interface VariableDrawerProps<T extends Variable> extends DrawerProps<T> {
   variable: T;
@@ -76,7 +76,7 @@ export function VariableDrawer<T extends Variable>({
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="variable-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <PluginRegistry pluginLoader={bundledPluginLoader}>
+        <PluginRegistry pluginLoader={remotePluginLoader()}>
           <ValidationProvider>
             <DatasourceStoreProvider datasourceApi={datasourceApi} projectName={projectName}>
               <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>

--- a/ui/app/src/model/bundled-plugins.ts
+++ b/ui/app/src/model/bundled-plugins.ts
@@ -19,6 +19,7 @@ import { PluginLoader, PluginModuleResource, dynamicImportPluginLoader } from '@
 /**
  * A PluginLoader that includes all the "built-in" plugins that are bundled with Perses by default.
  */
+// TODO: this can be removed when all plugins are loaded dynamically
 export const bundledPluginLoader: PluginLoader = dynamicImportPluginLoader([
   {
     resource: prometheusResource as PluginModuleResource,

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -12,18 +12,18 @@
 // limitations under the License.
 
 import { Box, CircularProgress, Stack } from '@mui/material';
-import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard } from '@perses-dev/dashboards';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { PluginRegistry, UsageMetricsProvider, ValidationProvider } from '@perses-dev/plugin-system';
 import { DashboardResource, EphemeralDashboardResource, getResourceDisplayName } from '@perses-dev/core';
+import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard } from '@perses-dev/dashboards';
+import { remotePluginLoader } from '@perses-dev/plugin-runtime';
+import { PluginRegistry, UsageMetricsProvider, ValidationProvider } from '@perses-dev/plugin-system';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
-import { bundledPluginLoader } from '../../../model/bundled-plugins';
-import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasource-api';
-import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
-import { useVariableList } from '../../../model/variable-client';
-import { useGlobalVariableList } from '../../../model/global-variable-client';
 import ProjectBreadcrumbs from '../../../components/breadcrumbs/ProjectBreadcrumbs';
+import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasource-api';
+import { useGlobalVariableList } from '../../../model/global-variable-client';
 import { useProject } from '../../../model/project-client';
+import { useVariableList } from '../../../model/variable-client';
+import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
 
 export interface GenericDashboardViewProps {
   dashboardResource: DashboardResource | EphemeralDashboardResource;
@@ -81,7 +81,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
     >
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry
-          pluginLoader={bundledPluginLoader}
+          pluginLoader={remotePluginLoader()}
           defaultPluginKinds={{
             Panel: 'TimeSeriesChart',
             TimeSeriesQuery: 'PrometheusTimeSeriesQuery',

--- a/ui/app/src/views/projects/explore/ProjectExploreView.tsx
+++ b/ui/app/src/views/projects/explore/ProjectExploreView.tsx
@@ -11,17 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { CircularProgress, Stack } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { PluginRegistry, ProjectStoreProvider, useProjectStore } from '@perses-dev/plugin-system';
-import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 import { ViewExplore } from '@perses-dev/explore';
-import { CircularProgress, Stack } from '@mui/material';
+import { remotePluginLoader } from '@perses-dev/plugin-runtime';
+import { PluginRegistry, ProjectStoreProvider, useProjectStore } from '@perses-dev/plugin-system';
+import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../../model/datasource-api';
 import { useGlobalVariableList } from '../../../model/global-variable-client';
 import { useVariableList } from '../../../model/variable-client';
 import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
-import { bundledPluginLoader } from '../../../model/bundled-plugins';
 
 export interface ProjectExploreViewProps {
   exploreTitleComponent?: React.ReactNode;
@@ -71,7 +71,7 @@ function HelperExploreView(props: ProjectExploreViewProps): ReactElement {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
-      <PluginRegistry pluginLoader={bundledPluginLoader}>
+      <PluginRegistry pluginLoader={remotePluginLoader()}>
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <ViewExplore
             datasourceApi={datasourceApi}

--- a/ui/dashboards/src/components/DynamicPanel/DynamicPanelContent.tsx
+++ b/ui/dashboards/src/components/DynamicPanel/DynamicPanelContent.tsx
@@ -29,7 +29,7 @@ export function DynamicPanelContent({ definition, contentDimensions }: DynamicPa
       plugin={{
         // Panel plugins are always loaded from its own module
         // TODO: adjust the plugin spec to include the module name
-        kind: definition.spec.plugin.kind,
+        name: definition.spec.plugin.kind,
         moduleName: definition.spec.plugin.kind,
       }}
       props={{ definition, contentDimensions }}

--- a/ui/dashboards/src/components/DynamicPanel/DynamicPanelContent.tsx
+++ b/ui/dashboards/src/components/DynamicPanel/DynamicPanelContent.tsx
@@ -27,8 +27,10 @@ export function DynamicPanelContent({ definition, contentDimensions }: DynamicPa
   return (
     <PluginLoader<DynamicPanelContentProps>
       plugin={{
-        name: definition.spec.plugin.kind,
-        moduleName: 'Chart',
+        // Panel plugins are always loaded from its own module
+        // TODO: adjust the plugin spec to include the module name
+        kind: definition.spec.plugin.kind,
+        moduleName: definition.spec.plugin.kind,
       }}
       props={{ definition, contentDimensions }}
     />

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -99,7 +99,7 @@ export function DashboardProvider(props: DashboardProviderProps): ReactElement {
 
   useEffect(() => {
     if (plugin === undefined) return;
-    const defaultPanelSpec = plugin.createInitialOptions();
+    const defaultPanelSpec = plugin.createInitialOptions ? plugin.createInitialOptions() : {};
     // set default panel kind, spec, and queries for add panel editor
     store.setState({
       initialValues: {

--- a/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
@@ -33,7 +33,7 @@ import {
 } from '@perses-dev/core';
 
 const PROJECT = 'perses';
-const FAKE_PLUGIN_KIND = 'FakeDatasourcePluginKind';
+const FAKE_PLUGIN_NAME = 'FakeDatasourcePlugin';
 
 const FakeDataSourcePlugin: DatasourcePlugin = {
   createClient: jest.fn().mockReturnValue(undefined),
@@ -44,8 +44,8 @@ const FakeDataSourcePlugin: DatasourcePlugin = {
 };
 
 const MOCK_DS_PLUGIN: MockPlugin = {
-  pluginType: 'Datasource',
-  kind: FAKE_PLUGIN_KIND,
+  kind: 'Datasource',
+  spec: { name: FAKE_PLUGIN_NAME },
   plugin: FakeDataSourcePlugin,
 };
 
@@ -65,14 +65,14 @@ interface TestData {
 }
 
 function definedInDashboard(props: { default: boolean }): DatasourceSpec {
-  return { default: props.default, plugin: { kind: FAKE_PLUGIN_KIND, spec: {} } };
+  return { default: props.default, plugin: { kind: FAKE_PLUGIN_NAME, spec: {} } };
 }
 
 function definedInProject(props: { name: string; default: boolean }): DatasourceResource {
   return {
     kind: 'Datasource',
     metadata: { name: props.name, project: PROJECT },
-    spec: { default: props.default, plugin: { kind: FAKE_PLUGIN_KIND, spec: {} } },
+    spec: { default: props.default, plugin: { kind: FAKE_PLUGIN_NAME, spec: {} } },
   };
 }
 
@@ -80,7 +80,7 @@ function definedGlobally(props: { name: string; default: boolean }): GlobalDatas
   return {
     kind: 'GlobalDatasource',
     metadata: { name: props.name },
-    spec: { default: props.default, plugin: { kind: FAKE_PLUGIN_KIND, spec: {} } },
+    spec: { default: props.default, plugin: { kind: FAKE_PLUGIN_NAME, spec: {} } },
   };
 }
 
@@ -114,12 +114,12 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
         result: [
           {
             editLink: undefined,
-            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_NAME}`,
             items: [
               {
                 name: 'Default (localDatasourceA from dashboard)',
                 selector: {
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                 },
               },
             ],
@@ -134,7 +134,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 saved: true,
                 selector: {
                   group: 'dashboard',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'localDatasourceA',
                 },
               },
@@ -149,7 +149,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overridden: false,
                 selector: {
                   group: 'project',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'projectDatasourceA',
                 },
               },
@@ -164,7 +164,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overridden: false,
                 selector: {
                   group: 'global',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'globalDatasourceA',
                 },
               },
@@ -186,12 +186,12 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
         result: [
           {
             editLink: undefined,
-            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_NAME}`,
             items: [
               {
                 name: 'Default (datasourceA from global)',
                 selector: {
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                 },
               },
             ],
@@ -205,7 +205,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overridden: false,
                 selector: {
                   group: 'global',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'datasourceA',
                 },
               },
@@ -229,12 +229,12 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
         result: [
           {
             editLink: undefined,
-            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_NAME}`,
             items: [
               {
                 name: 'Default (localDatasourceA from dashboard)',
                 selector: {
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                 },
               },
             ],
@@ -249,7 +249,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 saved: true,
                 selector: {
                   group: 'dashboard',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'localDatasourceA',
                 },
               },
@@ -264,7 +264,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overridden: false,
                 selector: {
                   group: 'project',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'projectDatasourceA',
                 },
               },
@@ -279,7 +279,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overridden: false,
                 selector: {
                   group: 'global',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'globalDatasourceA',
                 },
               },
@@ -301,13 +301,13 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
         result: [
           {
             editLink: undefined,
-            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_NAME}`,
             items: [
               {
                 // This is the default datasource because first of the list
                 name: 'Default (datasourceA from project)',
                 selector: {
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                 },
               },
             ],
@@ -322,7 +322,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overriding: true,
                 selector: {
                   group: 'project',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'datasourceA',
                 },
               },
@@ -338,7 +338,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overriding: true, // Oddity coming from the algorithm. Not harmful as overriding is not checked if overridden is true
                 selector: {
                   group: 'global',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'datasourceA',
                 },
               },
@@ -365,12 +365,12 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
       expected: {
         result: [
           {
-            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_NAME}`,
             items: [
               {
                 name: 'Default (defaultDatasource from global)',
                 selector: {
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                 },
               },
             ],
@@ -386,7 +386,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 saved: true,
                 selector: {
                   group: 'dashboard',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'datasourceA',
                 },
               },
@@ -402,7 +402,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overriding: true,
                 selector: {
                   group: 'project',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'datasourceB',
                 },
               },
@@ -417,7 +417,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overridden: false,
                 selector: {
                   group: 'global',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'defaultDatasource',
                 },
               },
@@ -427,7 +427,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overriding: true, // Oddity coming from the algorithm. Not harmful as overriding is not checked if overridden is true
                 selector: {
                   group: 'global',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'datasourceB',
                 },
               },
@@ -437,7 +437,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 overriding: true, // Oddity coming from the algorithm. Not harmful as overriding is not checked if overridden is true
                 selector: {
                   group: 'global',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'datasourceA',
                 },
               },
@@ -462,12 +462,12 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
         result: [
           {
             editLink: undefined,
-            group: `Default Datasource Plugin for ${FAKE_PLUGIN_KIND}`,
+            group: `Default Datasource Plugin for ${FAKE_PLUGIN_NAME}`,
             items: [
               {
                 name: 'Default (localDatasourceA from dashboard)',
                 selector: {
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                 },
               },
             ],
@@ -482,7 +482,7 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
                 saved: false,
                 selector: {
                   group: 'dashboard',
-                  kind: FAKE_PLUGIN_KIND,
+                  kind: FAKE_PLUGIN_NAME,
                   name: 'localDatasourceA',
                 },
               },
@@ -521,7 +521,9 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
         </PluginRegistry>
       );
     };
-    const { result } = renderHook(() => useListDatasourceSelectItems(FAKE_PLUGIN_KIND), { wrapper });
+    const { result } = renderHook(() => useListDatasourceSelectItems(FAKE_PLUGIN_NAME), { wrapper });
+
+    console.log(result.current);
 
     await waitFor(() => expect(result.current.data).toBeDefined());
     expect(result.current.data).toEqual(data.expected.result);

--- a/ui/dashboards/src/context/DatasourceStoreProvider.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.tsx
@@ -144,27 +144,27 @@ export function DatasourceStoreProvider(props: DatasourceStoreProviderProps): Re
   );
 
   const listDatasourceSelectItems = useEvent(
-    async (datasourcePluginKind: string): Promise<DatasourceSelectItemGroup[]> => {
+    async (datasourcePluginName: string): Promise<DatasourceSelectItemGroup[]> => {
       const [pluginMetadata, datasources, globalDatasources] = await Promise.all([
         listPluginMetadata(['Datasource']),
-        project ? datasourceApi.listDatasources(project, datasourcePluginKind) : [],
-        datasourceApi.listGlobalDatasources(datasourcePluginKind),
+        project ? datasourceApi.listDatasources(project, datasourcePluginName) : [],
+        datasourceApi.listGlobalDatasources(datasourcePluginName),
       ]);
 
       // Find the metadata for the plugin type they asked for, so we can use it for the name of the default datasource
-      const datasourcePluginMetadata = pluginMetadata.find((metadata) => metadata.kind === datasourcePluginKind);
+      const datasourcePluginMetadata = pluginMetadata.find((metadata) => metadata.spec.name === datasourcePluginName);
       if (datasourcePluginMetadata === undefined) {
-        throw new Error(`Could not find a Datasource plugin with kind '${datasourcePluginKind}'`);
+        throw new Error(`Could not find a Datasource plugin with kind '${datasourcePluginName}'`);
       }
 
       // Get helper for computing results properly
-      const { results, addItem } = buildDatasourceSelectItemGroups(datasourcePluginMetadata.display.name);
+      const { results, addItem } = buildDatasourceSelectItemGroups(datasourcePluginMetadata.spec.display.name);
 
       // Start with dashboard datasources with the highest precedence
       if (dashboardResource?.spec.datasources) {
         for (const selectorName in dashboardResource.spec.datasources) {
           const spec = dashboardResource.spec.datasources[selectorName];
-          if (spec === undefined || spec.plugin.kind !== datasourcePluginKind) continue;
+          if (spec === undefined || spec.plugin.kind !== datasourcePluginName) continue;
 
           const saved = selectorName in savedDatasources;
           addItem({ spec, selectorName, selectorGroup: 'dashboard', saved });

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -33,8 +33,8 @@ const FakeTimeSeriesPlugin: PanelPlugin<UnknownSpec> = {
 };
 
 const MOCK_TIME_SERIES_PANEL: MockPlugin = {
-  pluginType: 'Panel',
-  kind: 'TimeSeriesChart',
+  kind: 'Panel',
+  spec: { name: 'TimeSeriesChart' },
   plugin: FakeTimeSeriesPlugin,
 };
 

--- a/ui/explore/package.json
+++ b/ui/explore/package.json
@@ -33,6 +33,7 @@
     "@perses-dev/dashboards": "0.49.0",
     "@perses-dev/panels-plugin": "0.49.0",
     "@perses-dev/plugin-system": "0.49.0",
+    "@perses-dev/plugin-runtime": "0.49.0",
     "@perses-dev/prometheus-plugin": "0.49.0",
     "@types/react-grid-layout": "^1.3.2",
     "date-fns": "^2.28.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -229,6 +229,7 @@
         "@perses-dev/core": "0.49.0",
         "@perses-dev/dashboards": "0.49.0",
         "@perses-dev/panels-plugin": "0.49.0",
+        "@perses-dev/plugin-runtime": "0.49.0",
         "@perses-dev/plugin-system": "0.49.0",
         "@perses-dev/prometheus-plugin": "0.49.0",
         "@types/react-grid-layout": "^1.3.2",
@@ -32332,7 +32333,8 @@
       "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@module-federation/enhanced": "^0.1.21"
+        "@module-federation/enhanced": "^0.1.21",
+        "@perses-dev/plugin-system": "0.49.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.3",

--- a/ui/panels-plugin/plugin.json
+++ b/ui/panels-plugin/plugin.json
@@ -6,99 +6,123 @@
   "spec": {
     "plugins": [
       {
-        "pluginType": "Panel",
-        "kind": "TimeSeriesChart",
-        "display": {
-          "name": "Time Series Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "TimeSeriesChart",
+          "display": {
+            "name": "Time Series Chart",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "Table",
-        "display": {
+        "kind": "Panel",
+        "spec": {
           "name": "Table",
-          "description": ""
+          "display": {
+            "name": "Table",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "TimeSeriesTable",
-        "display": {
-          "name": "Time Series Table",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "TimeSeriesTable",
+          "display": {
+            "name": "Time Series Table",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "BarChart",
-        "display": {
-          "name": "Bar Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "BarChart",
+          "display": {
+            "name": "Bar Chart",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "PieChart",
-        "display": {
-          "name": "Pie Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "PieChart",
+          "display": {
+            "name": "Pie Chart",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "StatChart",
-        "display": {
-          "name": "Stat Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "StatChart",
+          "display": {
+            "name": "Stat Chart",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "GaugeChart",
-        "display": {
-          "name": "Gauge Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "GaugeChart",
+          "display": {
+            "name": "Gauge Chart",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "MarkdownChart",
-        "display": {
-          "name": "Markdown",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "MarkdownChart",
+          "display": {
+            "name": "Markdown",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "ScatterChart",
-        "display": {
-          "name": "Scatter Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "ScatterChart",
+          "display": {
+            "name": "Scatter Chart",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "TraceTable",
-        "display": {
-          "name": "Trace Table",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "TraceTable",
+          "display": {
+            "name": "Trace Table",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "TracingGanttChart",
-        "display": {
-          "name": "Tracing Gantt Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "TracingGanttChart",
+          "display": {
+            "name": "Tracing Gantt Chart",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "StatusHistoryChart",
-        "display": {
-          "name": "Status History Chart",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "StatusHistoryChart",
+          "display": {
+            "name": "Status History Chart",
+            "description": ""
+          }
         }
       }
     ]

--- a/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/scatterplot/ScatterChartPanel.test.tsx
@@ -46,8 +46,8 @@ const FakeTraceQueryPlugin: TraceQueryPlugin<UnknownSpec> = {
 };
 
 const MOCK_TRACE_QUERY_PLUGIN: MockPlugin = {
-  pluginType: 'TraceQuery',
-  kind: 'TempoTraceQuery',
+  kind: 'TraceQuery',
+  spec: { name: 'TempoTraceQuery' },
   plugin: FakeTraceQueryPlugin,
 };
 

--- a/ui/panels-plugin/src/plugins/table/TablePanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/table/TablePanel.test.tsx
@@ -49,8 +49,8 @@ function buildFakeTimeSeriesQuery(data: TimeSeriesData): TimeSeriesQueryPlugin<U
 
 function buildMockQueryPlugin(data: TimeSeriesData): MockPlugin {
   return {
-    pluginType: 'TimeSeriesQuery',
-    kind: 'PrometheusTimeSeriesQuery',
+    kind: 'TimeSeriesQuery',
+    spec: { name: 'PrometheusTimeSeriesQuery' },
     plugin: buildFakeTimeSeriesQuery(data),
   };
 }

--- a/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-chart/TimeSeriesChartPanel.test.tsx
@@ -45,8 +45,8 @@ const FakeTimeSeriesQuery: TimeSeriesQueryPlugin<UnknownSpec> = {
 };
 
 const MOCK_PROM_QUERY_PLUGIN: MockPlugin = {
-  pluginType: 'TimeSeriesQuery',
-  kind: 'PrometheusTimeSeriesQuery',
+  kind: 'TimeSeriesQuery',
+  spec: { name: 'PrometheusTimeSeriesQuery' },
   plugin: FakeTimeSeriesQuery,
 };
 

--- a/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/time-series-table/TimeSeriesTablePanel.test.tsx
@@ -56,8 +56,8 @@ function buildFakeTimeSeriesQuery(data: TimeSeriesData): TimeSeriesQueryPlugin {
 
 function buildMockQueryPlugin(data: TimeSeriesData): MockPlugin {
   return {
-    pluginType: 'TimeSeriesQuery',
-    kind: 'PrometheusTimeSeriesQuery',
+    kind: 'TimeSeriesQuery',
+    spec: { name: 'PrometheusTimeSeriesQuery' },
     plugin: buildFakeTimeSeriesQuery(data),
   };
 }

--- a/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.test.tsx
+++ b/ui/panels-plugin/src/plugins/trace-table/TraceTablePanel.test.tsx
@@ -47,8 +47,8 @@ function buildFakeTraceQuery(): TraceQueryPlugin {
 
 function buildMockQueryPlugin(): MockPlugin {
   return {
-    pluginType: 'TraceQuery',
-    kind: 'TempoTraceQuery',
+    kind: 'TraceQuery',
+    spec: { name: 'TempoTraceQuery' },
     plugin: buildFakeTraceQuery(),
   };
 }

--- a/ui/plugin-runtime/package.json
+++ b/ui/plugin-runtime/package.json
@@ -28,7 +28,8 @@
     "lint:fix": "eslint --fix src --ext .ts,.tsx"
   },
   "dependencies": {
-    "@module-federation/enhanced": "^0.1.21"
+    "@module-federation/enhanced": "^0.1.21",
+    "@perses-dev/plugin-system": "0.49.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.11.3",

--- a/ui/plugin-runtime/src/PersesPlugin.types.ts
+++ b/ui/plugin-runtime/src/PersesPlugin.types.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 export interface PersesPlugin {
-  kind: string;
+  name: string;
   moduleName: string;
   baseURL?: string;
 }

--- a/ui/plugin-runtime/src/PersesPlugin.types.ts
+++ b/ui/plugin-runtime/src/PersesPlugin.types.ts
@@ -12,13 +12,9 @@
 // limitations under the License.
 
 export interface PersesPlugin {
-  name: string;
+  kind: string;
   moduleName: string;
   baseURL?: string;
 }
 
-export interface PersesPluginModule {
-  default: unknown;
-}
-
-export type PersesPluginType = 'panel';
+export type RemotePluginModule = Record<string, unknown>;

--- a/ui/plugin-runtime/src/PluginLoader.test.tsx
+++ b/ui/plugin-runtime/src/PluginLoader.test.tsx
@@ -56,7 +56,7 @@ class SimpleErrorBoundary extends React.Component<React.PropsWithChildren, { err
 
 describe('PluginLoader', () => {
   const mockPlugin: PersesPlugin = {
-    kind: 'test-plugin',
+    name: 'test-plugin',
     moduleName: 'test-module',
     baseURL: 'https://example.com',
   };

--- a/ui/plugin-runtime/src/PluginLoader.test.tsx
+++ b/ui/plugin-runtime/src/PluginLoader.test.tsx
@@ -14,7 +14,7 @@
 import { FederationHost } from '@module-federation/enhanced/runtime';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { PersesPluginModule } from './PersesPlugin.types';
+import { PersesPlugin, RemotePluginModule } from './PersesPlugin.types';
 import { PluginLoader } from './PluginLoader';
 import * as PluginRuntime from './PluginRuntime';
 
@@ -55,8 +55,8 @@ class SimpleErrorBoundary extends React.Component<React.PropsWithChildren, { err
 }
 
 describe('PluginLoader', () => {
-  const mockPlugin = {
-    name: 'test-plugin',
+  const mockPlugin: PersesPlugin = {
+    kind: 'test-plugin',
     moduleName: 'test-module',
     baseURL: 'https://example.com',
   };
@@ -65,7 +65,8 @@ describe('PluginLoader', () => {
     const mockPluginModule = jest.fn(() => <div>Mock Plugin Component</div>);
 
     jest.spyOn(PluginRuntime, 'usePluginRuntime').mockImplementation(() => ({
-      load: (): Promise<{ default: unknown }> => Promise.resolve({ default: mockPluginModule }),
+      loadPlugin: (): Promise<{ 'test-plugin': () => React.ReactNode }> =>
+        Promise.resolve({ 'test-plugin': mockPluginModule }),
       pluginRuntime: {} as FederationHost,
     }));
 
@@ -80,11 +81,11 @@ describe('PluginLoader', () => {
     expect(screen.getByText('Mock Plugin Component')).toBeInTheDocument();
   });
 
-  it('should throw an error if the plugin module does not have a default export', async () => {
+  it('should throw an error if the plugin module does not have a named export', async () => {
     const mockPluginModule = jest.fn(() => <div>Mock Plugin Component</div>);
 
     jest.spyOn(PluginRuntime, 'usePluginRuntime').mockImplementation(() => ({
-      load: (): Promise<PersesPluginModule> => Promise.resolve({ mockPluginModule } as unknown as PersesPluginModule),
+      loadPlugin: (): Promise<RemotePluginModule> => Promise.resolve({ mockPluginModule } as RemotePluginModule),
       pluginRuntime: {} as FederationHost,
     }));
 
@@ -97,14 +98,14 @@ describe('PluginLoader', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('PluginLoader: Plugin module does not have a default export')).toBeInTheDocument();
+      expect(screen.getByText('PluginLoader: Plugin module does not have a test-plugin export')).toBeInTheDocument();
     });
   });
 
-  it('should throw an error if the plugin module default export is not a function', async () => {
+  it('should throw an error if the plugin module named export is not a function', async () => {
     jest.spyOn(PluginRuntime, 'usePluginRuntime').mockImplementation(() => ({
-      load: (): Promise<PersesPluginModule> =>
-        Promise.resolve({ default: 'not a function' } as unknown as PersesPluginModule),
+      loadPlugin: (): Promise<RemotePluginModule> =>
+        Promise.resolve({ 'test-plugin': 'not a function' } as unknown as RemotePluginModule),
       pluginRuntime: {} as FederationHost,
     }));
 
@@ -117,7 +118,7 @@ describe('PluginLoader', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('PluginLoader: Plugin module default export is not a function')).toBeInTheDocument();
+      expect(screen.getByText('PluginLoader: Plugin test-plugin export is not a function')).toBeInTheDocument();
     });
   });
 });

--- a/ui/plugin-runtime/src/PluginLoader.tsx
+++ b/ui/plugin-runtime/src/PluginLoader.tsx
@@ -31,7 +31,7 @@ export function PluginLoader<P>({ plugin, props }: PluginLoaderProps<P>): JSX.El
   const [pluginModule, setPluginModule] = useState<RemotePluginModule | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
-  const name = `${plugin.moduleName}-${plugin.kind}`;
+  const name = `${plugin.moduleName}-${plugin.name}`;
   const previousPluginName = useRef<string>(name);
 
   useEffect(() => {
@@ -44,8 +44,8 @@ export function PluginLoader<P>({ plugin, props }: PluginLoaderProps<P>): JSX.El
       })
       .catch((error) => {
         setPluginModule(null);
-        console.error(`PluginLoader: Error loading plugin ${plugin.kind} from module ${plugin.moduleName}:`, error);
-        setError(new Error(`PluginLoader: Error loading plugin ${plugin.kind} from module ${plugin.moduleName}`));
+        console.error(`PluginLoader: Error loading plugin ${plugin.name} from module ${plugin.moduleName}:`, error);
+        setError(new Error(`PluginLoader: Error loading plugin ${plugin.name} from module ${plugin.moduleName}`));
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name]);
@@ -58,14 +58,14 @@ export function PluginLoader<P>({ plugin, props }: PluginLoaderProps<P>): JSX.El
     return null;
   }
 
-  const pluginFunction = pluginModule[plugin.kind];
+  const pluginFunction = pluginModule[plugin.name];
 
   if (!pluginFunction) {
-    throw new Error(`PluginLoader: Plugin module does not have a ${plugin.kind} export`);
+    throw new Error(`PluginLoader: Plugin module does not have a ${plugin.name} export`);
   }
 
   if (typeof pluginFunction !== 'function') {
-    throw new Error(`PluginLoader: Plugin ${plugin.kind} export is not a function`);
+    throw new Error(`PluginLoader: Plugin ${plugin.name} export is not a function`);
   }
 
   // make sure to re mount the plugin when changes, to avoid mismatch in hooks ordering when re rendering

--- a/ui/plugin-runtime/src/PluginLoader.tsx
+++ b/ui/plugin-runtime/src/PluginLoader.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { useEffect, useRef, useState } from 'react';
-import { PersesPlugin, PersesPluginModule } from './PersesPlugin.types';
+import { PersesPlugin, RemotePluginModule } from './PersesPlugin.types';
 import { usePluginRuntime } from './PluginRuntime';
 
 interface PluginLoaderProps<P> {
@@ -27,25 +27,25 @@ function PluginContainer<P>({ pluginFn, props }: { pluginFn: Function; props: P 
 }
 
 export function PluginLoader<P>({ plugin, props }: PluginLoaderProps<P>): JSX.Element | null {
-  const { load } = usePluginRuntime({ moduleName: plugin.moduleName, baseURL: plugin.baseURL });
-  const [pluginModule, setPluginModule] = useState<PersesPluginModule | null>(null);
+  const { loadPlugin } = usePluginRuntime({ plugin });
+  const [pluginModule, setPluginModule] = useState<RemotePluginModule | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
-  const name = `${plugin.name}-${plugin.moduleName}`;
+  const name = `${plugin.moduleName}-${plugin.kind}`;
   const previousPluginName = useRef<string>(name);
 
   useEffect(() => {
     previousPluginName.current = name;
     setError(null);
 
-    load(plugin.name)
+    loadPlugin()
       .then((module) => {
         setPluginModule(module);
       })
       .catch((error) => {
         setPluginModule(null);
-        console.error(`PluginLoader: Error loading plugin ${plugin.name}:`, error);
-        setError(new Error(`PluginLoader: Error loading plugin ${plugin.name}`));
+        console.error(`PluginLoader: Error loading plugin ${plugin.kind} from module ${plugin.moduleName}:`, error);
+        setError(new Error(`PluginLoader: Error loading plugin ${plugin.kind} from module ${plugin.moduleName}`));
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name]);
@@ -58,12 +58,14 @@ export function PluginLoader<P>({ plugin, props }: PluginLoaderProps<P>): JSX.El
     return null;
   }
 
-  if (!pluginModule.default) {
-    throw new Error('PluginLoader: Plugin module does not have a default export');
+  const pluginFunction = pluginModule[plugin.kind];
+
+  if (!pluginFunction) {
+    throw new Error(`PluginLoader: Plugin module does not have a ${plugin.kind} export`);
   }
 
-  if (typeof pluginModule.default !== 'function') {
-    throw new Error('PluginLoader: Plugin module default export is not a function');
+  if (typeof pluginFunction !== 'function') {
+    throw new Error(`PluginLoader: Plugin ${plugin.kind} export is not a function`);
   }
 
   // make sure to re mount the plugin when changes, to avoid mismatch in hooks ordering when re rendering
@@ -71,5 +73,5 @@ export function PluginLoader<P>({ plugin, props }: PluginLoaderProps<P>): JSX.El
     return null;
   }
 
-  return <PluginContainer key={name} pluginFn={pluginModule.default} props={props} />;
+  return <PluginContainer key={name} pluginFn={pluginFunction} props={props} />;
 }

--- a/ui/plugin-runtime/src/PluginRuntime.tsx
+++ b/ui/plugin-runtime/src/PluginRuntime.tsx
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { init, loadRemote } from '@module-federation/enhanced/runtime';
+import { FederationHost, init, loadRemote } from '@module-federation/enhanced/runtime';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { PersesPluginModule } from './PersesPlugin.types';
+import { PersesPlugin, RemotePluginModule } from './PersesPlugin.types';
 
 export const pluginRuntime = init({
   name: '@perses/perses-ui-host',
@@ -25,7 +25,7 @@ export const pluginRuntime = init({
       lib: () => React,
       shareConfig: {
         singleton: true,
-        requiredVersion: '18.2.0',
+        requiredVersion: '^18.2.0',
       },
     },
     'react-dom': {
@@ -33,7 +33,7 @@ export const pluginRuntime = init({
       lib: () => ReactDOM,
       shareConfig: {
         singleton: true,
-        requiredVersion: '18.2.0',
+        requiredVersion: '^18.2.0',
       },
     },
     echarts: {
@@ -45,19 +45,19 @@ export const pluginRuntime = init({
       },
     },
     '@perses-dev/components': {
-      version: '0.46.0',
+      version: '0.49.0',
       lib: () => require('@perses-dev/components'),
       shareConfig: {
         singleton: true,
-        requiredVersion: '^0.46.0',
+        requiredVersion: '^0.49.0',
       },
     },
     '@perses-dev/plugin-system': {
-      version: '0.46.0',
+      version: '0.49.0',
       lib: () => require('@perses-dev/plugin-system'),
       shareConfig: {
         singleton: true,
-        requiredVersion: '^0.46.0',
+        requiredVersion: '^0.49.0',
       },
     },
     // Below are the shared modules that are used by the plugins, this can be part of the SDK
@@ -70,11 +70,11 @@ export const pluginRuntime = init({
       },
     },
     'date-fns-tz': {
-      version: '1.3.7',
+      version: '1.3.8',
       lib: () => require('date-fns-tz'),
       shareConfig: {
         singleton: true,
-        requiredVersion: '^1.3.7',
+        requiredVersion: '^1.3.8',
       },
     },
     lodash: {
@@ -101,7 +101,6 @@ export const pluginRuntime = init({
         requiredVersion: '^11.11.0',
       },
     },
-
     '@hookform/resolvers/zod': {
       version: '3.3.4',
       lib: () => require('@hookform/resolvers/zod'),
@@ -110,35 +109,55 @@ export const pluginRuntime = init({
         requiredVersion: '^3.3.4',
       },
     },
+    'use-resize-observer': {
+      version: '9.1.0',
+      lib: () => require('use-resize-observer'),
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^9.1.0',
+      },
+    },
+    'mdi-material-ui': {
+      version: '7.4.0',
+      lib: () => require('mdi-material-ui'),
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^7.4.0',
+      },
+    },
   },
 });
 
-export function usePluginRuntime({ moduleName, baseURL }: { moduleName: string; baseURL?: string }): {
-  pluginRuntime: typeof pluginRuntime;
-  load: (name: string) => Promise<PersesPluginModule | null>;
+const registerRemote = (name: string, baseURL?: string): void => {
+  const existingRemote = pluginRuntime.options.remotes.find((remote) => remote.name === name);
+  if (!existingRemote) {
+    const remoteEntryURL = baseURL ? `${baseURL}/${name}/mf-manifest.json` : `/plugins/${name}/mf-manifest.json`;
+    pluginRuntime.registerRemotes([
+      {
+        name,
+        entry: remoteEntryURL,
+        alias: name,
+      },
+    ]);
+  }
+};
+
+export const loadPlugin = async (
+  pluginName: string,
+  moduleName: string,
+  baseURL?: string
+): Promise<RemotePluginModule | null> => {
+  registerRemote(pluginName, baseURL);
+
+  return loadRemote<RemotePluginModule>(`${pluginName}/${moduleName}`);
+};
+
+export function usePluginRuntime({ plugin }: { plugin: PersesPlugin }): {
+  pluginRuntime: FederationHost;
+  loadPlugin: () => Promise<RemotePluginModule | null>;
 } {
-  const registerRemote = (name: string): void => {
-    const existingRemote = pluginRuntime.options.remotes.find((remote) => remote.name === name);
-    if (!existingRemote) {
-      const remoteEntryURL = baseURL ? `${baseURL}/${name}/mf-manifest.json` : `/plugins/${name}/mf-manifest.json`;
-      pluginRuntime.registerRemotes([
-        {
-          name,
-          entry: remoteEntryURL,
-          alias: name,
-        },
-      ]);
-    }
-  };
-
-  const load = async (name: string): Promise<PersesPluginModule | null> => {
-    registerRemote(name);
-
-    return loadRemote<PersesPluginModule>(`${name}/${moduleName}`);
-  };
-
   return {
     pluginRuntime,
-    load,
+    loadPlugin: () => loadPlugin(plugin.moduleName, plugin.kind, plugin.baseURL),
   };
 }

--- a/ui/plugin-runtime/src/PluginRuntime.tsx
+++ b/ui/plugin-runtime/src/PluginRuntime.tsx
@@ -143,13 +143,13 @@ const registerRemote = (name: string, baseURL?: string): void => {
 };
 
 export const loadPlugin = async (
-  pluginName: string,
   moduleName: string,
+  pluginName: string,
   baseURL?: string
 ): Promise<RemotePluginModule | null> => {
-  registerRemote(pluginName, baseURL);
+  registerRemote(moduleName, baseURL);
 
-  return loadRemote<RemotePluginModule>(`${pluginName}/${moduleName}`);
+  return loadRemote<RemotePluginModule>(`${moduleName}/${pluginName}`);
 };
 
 export function usePluginRuntime({ plugin }: { plugin: PersesPlugin }): {
@@ -158,6 +158,6 @@ export function usePluginRuntime({ plugin }: { plugin: PersesPlugin }): {
 } {
   return {
     pluginRuntime,
-    loadPlugin: () => loadPlugin(plugin.moduleName, plugin.kind, plugin.baseURL),
+    loadPlugin: () => loadPlugin(plugin.moduleName, plugin.name, plugin.baseURL),
   };
 }

--- a/ui/plugin-runtime/src/index.ts
+++ b/ui/plugin-runtime/src/index.ts
@@ -13,3 +13,4 @@
 
 export * from './PluginLoader';
 export * from './PluginRuntime';
+export * from './remotePluginLoader';

--- a/ui/plugin-runtime/src/remotePluginLoader.ts
+++ b/ui/plugin-runtime/src/remotePluginLoader.ts
@@ -19,12 +19,11 @@ const isPluginMetadata = (plugin: unknown): plugin is PluginMetadata => {
   return (
     typeof plugin === 'object' &&
     plugin !== null &&
-    'pluginType' in plugin &&
     'kind' in plugin &&
-    'display' in plugin &&
-    typeof plugin.display === 'object' &&
-    plugin.display !== null &&
-    'name' in plugin.display
+    'spec' in plugin &&
+    typeof plugin.spec === 'object' &&
+    plugin.spec !== null &&
+    'name' in plugin.spec
   );
 };
 
@@ -69,13 +68,13 @@ export const remotePluginLoader = (baseURL?: string): PluginLoader => {
       const pluginModule: RemotePluginModule = {};
 
       for (const plugin of resource.spec.plugins) {
-        const remotePluginModule = await loadPlugin(pluginModuleName, plugin.kind);
+        const remotePluginModule = await loadPlugin(pluginModuleName, plugin.spec.name);
 
-        const remotePlugin = remotePluginModule?.[plugin.kind];
+        const remotePlugin = remotePluginModule?.[plugin.spec.name];
         if (remotePlugin) {
-          pluginModule[plugin.kind] = remotePlugin;
+          pluginModule[plugin.spec.name] = remotePlugin;
         } else {
-          console.error(`RemotePluginLoader: Error loading plugin ${plugin.kind}`);
+          console.error(`RemotePluginLoader: Error loading plugin ${plugin.spec.name}`);
         }
       }
 

--- a/ui/plugin-runtime/src/remotePluginLoader.ts
+++ b/ui/plugin-runtime/src/remotePluginLoader.ts
@@ -1,0 +1,85 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PluginLoader, PluginMetadata, PluginModuleResource } from '@perses-dev/plugin-system';
+import { RemotePluginModule } from './PersesPlugin.types';
+import { loadPlugin } from './PluginRuntime';
+
+const isPluginMetadata = (plugin: unknown): plugin is PluginMetadata => {
+  return (
+    typeof plugin === 'object' &&
+    plugin !== null &&
+    'pluginType' in plugin &&
+    'kind' in plugin &&
+    'display' in plugin &&
+    typeof plugin.display === 'object' &&
+    plugin.display !== null &&
+    'name' in plugin.display
+  );
+};
+
+const isPluginModuleResource = (pluginModule: unknown): pluginModule is PluginModuleResource => {
+  return (
+    typeof pluginModule === 'object' &&
+    pluginModule !== null &&
+    'metadata' in pluginModule &&
+    'spec' in pluginModule &&
+    typeof pluginModule.spec === 'object' &&
+    pluginModule.spec !== null &&
+    'plugins' in pluginModule.spec &&
+    Array.isArray(pluginModule.spec.plugins) &&
+    pluginModule.spec.plugins.every(isPluginMetadata)
+  );
+};
+
+export const remotePluginLoader = (baseURL?: string): PluginLoader => {
+  return {
+    getInstalledPlugins: async (): Promise<PluginModuleResource[]> => {
+      const pluginsResponse = await fetch(`${baseURL ? baseURL : ''}/api/v1/plugins`);
+
+      const plugins = await pluginsResponse.json();
+
+      let pluginModules: PluginModuleResource[] = [];
+
+      if (Array.isArray(plugins)) {
+        pluginModules = plugins.filter(isPluginModuleResource);
+      } else {
+        console.error('RemotePluginLoader: Error loading plugins, response is not an array');
+      }
+
+      if (!pluginModules.length) {
+        console.error('RemotePluginLoader: No valid plugins found');
+      }
+
+      return pluginModules;
+    },
+    importPluginModule: async (resource): Promise<RemotePluginModule> => {
+      const pluginModuleName = resource.metadata.name;
+
+      const pluginModule: RemotePluginModule = {};
+
+      for (const plugin of resource.spec.plugins) {
+        const remotePluginModule = await loadPlugin(pluginModuleName, plugin.kind);
+
+        const remotePlugin = remotePluginModule?.[plugin.kind];
+        if (remotePlugin) {
+          pluginModule[plugin.kind] = remotePlugin;
+        } else {
+          console.error(`RemotePluginLoader: Error loading plugin ${plugin.kind}`);
+        }
+      }
+
+      return pluginModule;
+    },
+  };
+};

--- a/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
@@ -36,7 +36,7 @@ function useDefaultQueryDefinition(queryTypes: QueryPluginType[]): QueryDefiniti
   // Use as default the plugin kind explicitly set as default or the first in the list
   const { data: queryPlugins } = useListPluginMetadata(queryTypes);
   const { defaultPluginKinds } = usePluginRegistry();
-  const defaultQueryKind = defaultPluginKinds?.[defaultQueryType] ?? queryPlugins?.[0]?.kind ?? '';
+  const defaultQueryKind = defaultPluginKinds?.[defaultQueryType] ?? queryPlugins?.[0]?.spec.name ?? '';
 
   const { data: defaultQueryPlugin } = usePlugin(defaultQueryType, defaultQueryKind, {
     useErrorBoundary: true,

--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
@@ -47,7 +47,7 @@ export const PluginKindSelect = forwardRef((props: PluginKindSelectProps, ref): 
         return '';
       }
       const selectedValue = optionValueToSelection(selected as string);
-      return data?.find((v) => v.pluginType === selectedValue.type && v.kind === selectedValue.kind)?.display.name;
+      return data?.find((v) => v.kind === selectedValue.type && v.spec.name === selectedValue.kind)?.spec.display.name;
     },
     [data]
   );
@@ -68,10 +68,10 @@ export const PluginKindSelect = forwardRef((props: PluginKindSelectProps, ref): 
       {data?.map((metadata) => (
         <MenuItem
           data-testid="option"
-          key={metadata.pluginType + metadata.kind}
-          value={selectionToOptionValue({ type: metadata.pluginType, kind: metadata.kind })}
+          key={metadata.kind + metadata.spec.name}
+          value={selectionToOptionValue({ type: metadata.kind, kind: metadata.spec.name })}
         >
-          {metadata.display.name}
+          {metadata.spec.display.name}
         </MenuItem>
       ))}
     </TextField>

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.test.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.test.tsx
@@ -98,11 +98,11 @@ const MetadataConsumer = (props: { pluginType: PluginType }): ReactElement | nul
     <table>
       <tbody>
         {pluginMetadata.map((item) => (
-          <tr key={item.kind}>
-            <td>{item.pluginType}</td>
+          <tr key={item.spec.name}>
             <td>{item.kind}</td>
-            <td>{item.display.name}</td>
-            <td>{item.display.description}</td>
+            <td>{item.spec.name}</td>
+            <td>{item.spec.display.name}</td>
+            <td>{item.spec.display.description}</td>
           </tr>
         ))}
       </tbody>

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -89,7 +89,7 @@ export function PluginRegistry(props: PluginRegistryProps): ReactElement {
   );
 
   const listPluginMetadata = useCallback(
-    async (pluginTypes: PluginType[]) => {
+    async (pluginTypes: string[]) => {
       const pluginIndexes = await getPluginIndexes();
       return pluginTypes.flatMap((type) => pluginIndexes.pluginMetadataByType.get(type) ?? []);
     },

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -61,25 +61,25 @@ export function PluginRegistry(props: PluginRegistryProps): ReactElement {
   });
 
   const getPlugin = useCallback(
-    async <T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>> => {
+    async <T extends PluginType>(kind: T, name: string): Promise<PluginImplementation<T>> => {
       // Get the indexes of the installed plugins
       const pluginIndexes = await getPluginIndexes();
 
       // Figure out what module the plugin is in by looking in the index
-      const typeAndKindKey = getTypeAndKindKey(pluginType, kind);
-      const resource = pluginIndexes.pluginResourcesByTypeAndKind.get(typeAndKindKey);
+      const typeAndKindKey = getTypeAndKindKey(kind, name);
+      const resource = pluginIndexes.pluginResourcesByNameAndKind.get(typeAndKindKey);
       if (resource === undefined) {
-        throw new Error(`A ${pluginType} plugin for kind '${kind}' is not installed`);
+        throw new Error(`A ${name} plugin for kind '${kind}' is not installed`);
       }
 
       // Treat the plugin module as a bunch of named exports that have plugins
       const pluginModule = (await loadPluginModule(resource)) as Record<string, Plugin<UnknownSpec>>;
 
       // We currently assume that plugin modules will have named exports that match the kinds they handle
-      const plugin = pluginModule[kind];
+      const plugin = pluginModule[name];
       if (plugin === undefined) {
         throw new Error(
-          `The ${pluginType} plugin for kind '${kind}' is missing from the ${resource.metadata.name} plugin module`
+          `The ${name} plugin for kind '${kind}' is missing from the ${resource.metadata.name} plugin module`
         );
       }
 
@@ -91,7 +91,7 @@ export function PluginRegistry(props: PluginRegistryProps): ReactElement {
   const listPluginMetadata = useCallback(
     async (pluginTypes: string[]) => {
       const pluginIndexes = await getPluginIndexes();
-      return pluginTypes.flatMap((type) => pluginIndexes.pluginMetadataByType.get(type) ?? []);
+      return pluginTypes.flatMap((type) => pluginIndexes.pluginMetadataByKind.get(type) ?? []);
     },
     [getPluginIndexes]
   );

--- a/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
+++ b/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
@@ -19,7 +19,7 @@ export interface PluginIndexes {
   // Plugin resources by plugin type and kind (i.e. look up what module a plugin type and kind is in)
   pluginResourcesByTypeAndKind: Map<string, PluginModuleResource>;
   // Plugin metadata by plugin type
-  pluginMetadataByType: Map<PluginType, PluginMetadata[]>;
+  pluginMetadataByType: Map<string, PluginMetadata[]>;
 }
 
 /**

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -11,22 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Metadata, UnknownSpec } from '@perses-dev/core';
-import { TimeSeriesQueryPlugin } from './time-series-queries';
-import { PanelPlugin } from './panels';
-import { VariablePlugin } from './variables';
+import { UnknownSpec } from '@perses-dev/core';
 import { DatasourcePlugin } from './datasource';
+import { PanelPlugin } from './panels';
 import { Plugin } from './plugin-base';
+import { TimeSeriesQueryPlugin } from './time-series-queries';
 import { TraceQueryPlugin } from './trace-queries';
-
-/**
- * Information about a module/package that contains plugins.
- */
-export interface PluginModuleResource {
-  kind: 'PluginModule';
-  metadata: Metadata;
-  spec: PluginSpec;
-}
+import { VariablePlugin } from './variables';
 
 export interface PluginSpec {
   plugins: PluginMetadata[];
@@ -42,6 +33,23 @@ export interface PluginMetadata {
     name: string;
     description?: string;
   };
+}
+
+/**
+ * Metadata about a module/package that contains plugins.
+ */
+export interface PluginModuleMetadata {
+  name: string;
+  version: string;
+}
+
+/**
+ * Information about a module/package that contains plugins.
+ */
+export interface PluginModuleResource {
+  kind: 'PluginModule';
+  metadata: PluginModuleMetadata;
+  spec: PluginSpec;
 }
 
 /**

--- a/ui/plugin-system/src/model/plugins.ts
+++ b/ui/plugin-system/src/model/plugins.ts
@@ -19,7 +19,7 @@ import { TimeSeriesQueryPlugin } from './time-series-queries';
 import { TraceQueryPlugin } from './trace-queries';
 import { VariablePlugin } from './variables';
 
-export interface PluginSpec {
+export interface PluginModuleSpec {
   plugins: PluginMetadata[];
 }
 
@@ -27,11 +27,13 @@ export interface PluginSpec {
  * Metadata about an individual plugin that's part of a PluginModule.
  */
 export interface PluginMetadata {
-  pluginType: PluginType;
-  kind: string;
-  display: {
+  kind: PluginType;
+  spec: {
     name: string;
-    description?: string;
+    display: {
+      name: string;
+      description?: string;
+    };
   };
 }
 
@@ -49,7 +51,7 @@ export interface PluginModuleMetadata {
 export interface PluginModuleResource {
   kind: 'PluginModule';
   metadata: PluginModuleMetadata;
-  spec: PluginSpec;
+  spec: PluginModuleSpec;
 }
 
 /**

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
@@ -30,18 +30,22 @@ jest.mock('../plugin-registry', () => ({
   useListPluginMetadata: jest.fn().mockImplementation(() => ({
     data: [
       {
-        display: {
-          name: 'Prometheus Query',
+        spec: {
+          display: {
+            name: 'Prometheus Query',
+          },
+          name: 'PrometheusTimeSeriesQuery',
         },
-        kind: 'PrometheusTimeSeriesQuery',
-        pluginType: 'TimeSeriesQuery',
+        kind: 'TimeSeriesQuery',
       },
       {
-        display: {
-          name: 'Tempo Query',
+        spec: {
+          display: {
+            name: 'Tempo Query',
+          },
+          name: 'TempoTraceQuery',
         },
-        kind: 'TempoTraceQuery',
-        pluginType: 'TraceQuery',
+        kind: 'TraceQuery',
       },
     ],
     isLoading: false,

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -73,13 +73,13 @@ export function useQueryType(): (pluginKind: string) => string | undefined {
 
     if (timeSeriesQueryPlugins) {
       timeSeriesQueryPlugins.forEach((plugin) => {
-        map[plugin.pluginType]?.push(plugin.kind);
+        map[plugin.kind]?.push(plugin.spec.name);
       });
     }
 
     if (traceQueryPlugins) {
       traceQueryPlugins.forEach((plugin) => {
-        map[plugin.pluginType]?.push(plugin.kind);
+        map[plugin.kind]?.push(plugin.spec.name);
       });
     }
     return map;

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -27,7 +27,7 @@ export interface DatasourceStore {
   /**
    * Gets a list of datasource selection items for a plugin kind.
    */
-  listDatasourceSelectItems(datasourcePluginKind: string): Promise<DatasourceSelectItemGroup[]>;
+  listDatasourceSelectItems(datasourcePluginName: string): Promise<DatasourceSelectItemGroup[]>;
 
   /**
    * Gets the list of datasources defined in the dashboard
@@ -90,13 +90,13 @@ export function useDatasourceStore(): DatasourceStore {
  * Returns a list, with all information that can be used in a datasource selection context (group, name, selector, kind, ...)
  */
 export function useListDatasourceSelectItems(
-  datasourcePluginKind: string,
+  datasourcePluginName: string,
   project?: string
 ): UseQueryResult<DatasourceSelectItemGroup[]> {
   const { listDatasourceSelectItems } = useDatasourceStore();
   return useQuery<DatasourceSelectItemGroup[]>({
-    queryKey: ['listDatasourceSelectItems', datasourcePluginKind, project],
-    queryFn: () => listDatasourceSelectItems(datasourcePluginKind),
+    queryKey: ['listDatasourceSelectItems', datasourcePluginName, project],
+    queryFn: () => listDatasourceSelectItems(datasourcePluginName),
   });
 }
 

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -18,7 +18,7 @@ import { DefaultPluginKinds, PluginImplementation, PluginMetadata, PluginType } 
 
 export interface PluginRegistryContextType {
   getPlugin<T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>>;
-  listPluginMetadata(pluginTypes: PluginType[]): Promise<PluginMetadata[]>;
+  listPluginMetadata(pluginTypes: string[]): Promise<PluginMetadata[]>;
   defaultPluginKinds?: DefaultPluginKinds;
 }
 
@@ -83,7 +83,7 @@ export function usePlugins<T extends PluginType>(
 
 // Allow consumers to pass useQuery options from react-query when listing metadata
 type UseListPluginMetadataOptions = Omit<
-  UseQueryOptions<PluginMetadata[], Error, PluginMetadata[], [string, PluginType[]]>,
+  UseQueryOptions<PluginMetadata[], Error, PluginMetadata[], [string, string[]]>,
   'queryKey' | 'queryFn'
 >;
 
@@ -91,7 +91,7 @@ type UseListPluginMetadataOptions = Omit<
  * Gets a list of plugin metadata for the specified plugin type and returns it, along with loading/error state.
  */
 export function useListPluginMetadata(
-  pluginTypes: PluginType[],
+  pluginTypes: string[],
   options?: UseListPluginMetadataOptions
 ): UseQueryResult<PluginMetadata[]> {
   const { listPluginMetadata } = usePluginRegistry();

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -17,7 +17,7 @@ import { BuiltinVariableDefinition } from '@perses-dev/core';
 import { DefaultPluginKinds, PluginImplementation, PluginMetadata, PluginType } from '../model';
 
 export interface PluginRegistryContextType {
-  getPlugin<T extends PluginType>(pluginType: T, kind: string): Promise<PluginImplementation<T>>;
+  getPlugin<T extends PluginType>(kind: T, name: string): Promise<PluginImplementation<T>>;
   listPluginMetadata(pluginTypes: string[]): Promise<PluginMetadata[]>;
   defaultPluginKinds?: DefaultPluginKinds;
 }
@@ -109,10 +109,10 @@ export function usePluginBuiltinVariableDefinitions(): UseQueryResult<BuiltinVar
     queryKey: ['usePluginBuiltinVariableDefinitions'],
     queryFn: async () => {
       const datasources = await listPluginMetadata(['Datasource']);
-      const datasourceKinds = new Set(datasources.map((datasource) => datasource.kind));
+      const datasourceNames = new Set(datasources.map((datasource) => datasource.spec.name));
       const result: BuiltinVariableDefinition[] = [];
-      for (const kind of datasourceKinds) {
-        const plugin = await getPlugin('Datasource', kind);
+      for (const name of datasourceNames) {
+        const plugin = await getPlugin('Datasource', name);
         if (plugin.getBuiltinVariableDefinitions) {
           plugin.getBuiltinVariableDefinitions().forEach((definition) => result.push(definition));
         }

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithPluginSystemDatasourceStore.tsx
@@ -73,8 +73,8 @@ export const WithPluginSystemDatasourceStore = (Story: StoryFn, context: StoryCo
       }
       throw new Error(`WithDatasourceStore is not configured to support kind: ${selector.kind}`);
     },
-    listDatasourceSelectItems: async (datasourcePluginKind): Promise<DatasourceSelectItemGroup[]> => {
-      if (datasourcePluginKind === 'PrometheusDatasource') {
+    listDatasourceSelectItems: async (datasourcePluginName): Promise<DatasourceSelectItemGroup[]> => {
+      if (datasourcePluginName === 'PrometheusDatasource') {
         return Promise.resolve([
           {
             items: [
@@ -86,7 +86,7 @@ export const WithPluginSystemDatasourceStore = (Story: StoryFn, context: StoryCo
           },
         ]);
       }
-      throw new Error(`WithDatasourceStore is not configured to support kind: ${datasourcePluginKind}`);
+      throw new Error(`WithDatasourceStore is not configured to support kind: ${datasourcePluginName}`);
     },
     getSavedDatasources: (): Record<string, DatasourceSpec> => {
       return {};

--- a/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
+++ b/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
@@ -17,8 +17,8 @@ import { PluginModuleResource, Plugin, PluginLoader, PluginImplementation, Plugi
 
 export type MockPlugin = {
   [T in PluginType]: {
-    pluginType: T;
-    kind: string;
+    kind: T;
+    spec: { name: string };
     plugin: PluginImplementation<T>;
   };
 }[PluginType];
@@ -36,11 +36,13 @@ export function mockPluginRegistry(...mockPlugins: MockPlugin[]): Omit<PluginReg
     },
     spec: {
       // Add metadata for all mock plugins
-      plugins: mockPlugins.map(({ pluginType, kind }) => ({
-        pluginType,
+      plugins: mockPlugins.map(({ kind, spec: { name } }) => ({
         kind,
-        display: {
-          name: getMockPluginName(pluginType, kind),
+        spec: {
+          name,
+          display: {
+            name: getMockPluginName(kind, name),
+          },
         },
       })),
     },
@@ -49,7 +51,7 @@ export function mockPluginRegistry(...mockPlugins: MockPlugin[]): Omit<PluginReg
   const mockPluginModule: Record<string, Plugin<UnknownSpec>> = {};
   for (const mockPlugin of mockPlugins) {
     // "Export" on the module under the same name as the kind the plugin handles
-    mockPluginModule[mockPlugin.kind] = mockPlugin.plugin;
+    mockPluginModule[mockPlugin.spec.name] = mockPlugin.plugin;
   }
 
   const pluginLoader: PluginLoader = {
@@ -73,6 +75,6 @@ export function mockPluginRegistry(...mockPlugins: MockPlugin[]): Omit<PluginReg
  * The function that's used to generate the display name of mocked plugins in mockPluginRegistry. Can be useful if you
  * need to interact with some UI component that's displaying it.
  */
-export function getMockPluginName(pluginType: PluginType, kind: string): string {
-  return `${pluginType} Plugin for ${kind}`;
+export function getMockPluginName(kind: PluginType, name: string): string {
+  return `${kind} Plugin for ${name}`;
 }

--- a/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
+++ b/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
@@ -32,9 +32,7 @@ export function mockPluginRegistry(...mockPlugins: MockPlugin[]): Omit<PluginReg
     kind: 'PluginModule',
     metadata: {
       name: 'Fake Plugin Module for Tests',
-      createdAt: '',
-      updatedAt: '',
-      version: 0,
+      version: '0',
     },
     spec: {
       // Add metadata for all mock plugins

--- a/ui/plugin-system/src/test/test-plugins/bert/plugin.json
+++ b/ui/plugin-system/src/test/test-plugins/bert/plugin.json
@@ -4,27 +4,33 @@
   "spec": {
     "plugins": [
       {
-        "pluginType": "Panel",
-        "kind": "BertPanel1",
-        "display": {
-          "name": "Bert Panel 1",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "BertPanel1",
+          "display": {
+            "name": "Bert Panel 1",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Panel",
-        "kind": "BertPanel2",
-        "display": {
-          "name": "Bert Panel 2",
-          "description": ""
+        "kind": "Panel",
+        "spec": {
+          "name": "BertPanel2",
+          "display": {
+            "name": "Bert Panel 2",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Variable",
-        "kind": "BertVariable",
-        "display": {
-          "name": "Bert Variable",
-          "description": ""
+        "kind": "Variable",
+        "spec": {
+          "name": "BertVariable",
+          "display": {
+            "name": "Bert Variable",
+            "description": ""
+          }
         }
       }
     ]

--- a/ui/plugin-system/src/test/test-plugins/ernie/plugin.json
+++ b/ui/plugin-system/src/test/test-plugins/ernie/plugin.json
@@ -4,27 +4,33 @@
   "spec": {
     "plugins": [
       {
-        "pluginType": "Variable",
-        "kind": "ErnieVariable1",
-        "display": {
-          "name": "Ernie Variable 1",
-          "description": "A variable plugin that exists in the plugin module"
+        "kind": "Variable",
+        "spec": {
+          "name": "ErnieVariable1",
+          "display": {
+            "name": "Ernie Variable 1",
+            "description": "A variable plugin that exists in the plugin module"
+          }
         }
       },
       {
-        "pluginType": "Variable",
-        "kind": "ErnieVariable2",
-        "display": {
-          "name": "Ernie Variable 2",
-          "description": "A variable plugin that exists in the plugin module"
+        "kind": "Variable",
+        "spec": {
+          "name": "ErnieVariable2",
+          "display": {
+            "name": "Ernie Variable 2",
+            "description": "A variable plugin that exists in the plugin module"
+          }
         }
       },
       {
-        "pluginType": "Variable",
-        "kind": "MissingErnieVariable",
-        "display": {
-          "name": "Ernie Variable",
-          "description": "A variable plugin that exists here in the metadata, but is not in the plugin module"
+        "kind": "Variable",
+        "spec": {
+          "name": "MissingErnieVariable",
+          "display": {
+            "name": "Ernie Variable",
+            "description": "A variable plugin that exists here in the metadata, but is not in the plugin module"
+          }
         }
       }
     ]

--- a/ui/prometheus-plugin/plugin.json
+++ b/ui/prometheus-plugin/plugin.json
@@ -6,51 +6,63 @@
   "spec": {
     "plugins": [
       {
-        "pluginType": "Variable",
-        "kind": "StaticListVariable",
-        "display": {
-          "name": "[Static] Custom List",
-          "description": "Static list variables allow you to define an array of values"
+        "kind": "Variable",
+        "spec": {
+          "name": "StaticListVariable",
+          "display": {
+            "name": "[Static] Custom List",
+            "description": "Static list variables allow you to define an array of values"
+          }
         }
       },
       {
-        "pluginType": "Variable",
-        "kind": "PrometheusLabelValuesVariable",
-        "display": {
-          "name": "[Prometheus] Label Values",
-          "description": ""
+        "kind": "Variable",
+        "spec": {
+          "name": "PrometheusLabelValuesVariable",
+          "display": {
+            "name": "[Prometheus] Label Values",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Variable",
-        "kind": "PrometheusLabelNamesVariable",
-        "display": {
-          "name": "[Prometheus] Label Names",
-          "description": ""
+        "kind": "Variable",
+        "spec": {
+          "name": "PrometheusLabelNamesVariable",
+          "display": {
+            "name": "[Prometheus] Label Names",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Variable",
-        "kind": "PrometheusPromQLVariable",
-        "display": {
-          "name": "[Prometheus] PromQL Result Values",
-          "description": ""
+        "kind": "Variable",
+        "spec": {
+          "name": "PrometheusPromQLVariable",
+          "display": {
+            "name": "[Prometheus] PromQL Result Values",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "TimeSeriesQuery",
-        "kind": "PrometheusTimeSeriesQuery",
-        "display": {
-          "name": "Prometheus Query",
-          "description": ""
+        "kind": "TimeSeriesQuery",
+        "spec": {
+          "name": "PrometheusTimeSeriesQuery",
+          "display": {
+            "name": "Prometheus Query",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Datasource",
-        "kind": "PrometheusDatasource",
-        "display": {
-          "name": "Prometheus Datasource",
-          "description": ""
+        "kind": "Datasource",
+        "spec": {
+          "name": "PrometheusDatasource",
+          "display": {
+            "name": "Prometheus Datasource",
+            "description": ""
+          }
         }
       }
     ]

--- a/ui/tempo-plugin/plugin.json
+++ b/ui/tempo-plugin/plugin.json
@@ -6,19 +6,23 @@
   "spec": {
     "plugins": [
       {
-        "pluginType": "TraceQuery",
-        "kind": "TempoTraceQuery",
-        "display": {
-          "name": "Tempo Trace Query",
-          "description": ""
+        "kind": "TraceQuery",
+        "spec": {
+          "name": "TempoTraceQuery",
+          "display": {
+            "name": "Tempo Trace Query",
+            "description": ""
+          }
         }
       },
       {
-        "pluginType": "Datasource",
-        "kind": "TempoDatasource",
-        "display": {
-          "name": "Tempo Datasource",
-          "description": ""
+        "kind": "Datasource",
+        "spec": {
+          "name": "TempoDatasource",
+          "display": {
+            "name": "Tempo Datasource",
+            "description": ""
+          }
         }
       }
     ]


### PR DESCRIPTION
# Description

This PR uses the remote plugin loader to load all types of plugins at runtime, based on the installed plugins fetched from `api/v1/plugins`

This will work in conjunction with https://github.com/perses/plugins/pull/16 and https://github.com/perses/plugins/pull/18