### PR TITLE
[ENHANCEMENT] DaC CUE SDK: add datasource param to the var group builder

### DIFF
--- a/cue/dac-utils/variable/group/group.cue
+++ b/cue/dac-utils/variable/group/group.cue
@@ -20,6 +20,8 @@ import (
 
 #input: [...varBuilder]
 
+_datasourceName=#datasourceName?: string
+
 // For each variable, append previous variables as "dependencies" for it.
 // E.g considering 3 variables: cluster>namespace>pod, with each one depending
 // on the previous ones, the generated dependencies would be:
@@ -29,6 +31,7 @@ import (
 // this dependencies information can be used later to generate the right filter(s)
 #input: [for i, _ in #input {
 	#dependencies: [for i2, var in #input if i > i2 {var}]
+	#datasourceName: _datasourceName
 }]
 
 variables: [for i in #input {i.variable}]

--- a/docs/dac/cue/variable/group.md
+++ b/docs/dac/cue/variable/group.md
@@ -16,9 +16,10 @@ varGroupBuilder & {} // input parameters expected
 
 ## Parameters
 
-| Parameter | Type               | Mandatory/Optional | Default | Description                          |
-|-----------|--------------------|--------------------|---------|--------------------------------------|
-| `#input`  | [...<var builder>] | Mandatory          |         | The list of variables to be grouped. |
+| Parameter         | Type               | Mandatory/Optional | Default | Description                                                                                                                                                             |
+|-------------------|--------------------|--------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `#input`          | [...<var builder>] | Mandatory          |         | The list of variables to be grouped.                                                                                                                                    |
+| `#datasourceName` | string             | Optional           |         | Datasource to be used for all the variables of this group. Avoids the necessity to provide the datasource name for each variable when you want to use the same for all. |
 
 Technically the array could contain any kind of object, still it is meant to receive variables builder entries that are going to do something with the dependencies appended by the Variable Group builder.
 You can also pass to it variables for which the notion of dependencies don't/can't apply (like text variables or static lists) but that will still be used as dependencies for the following variables.

--- a/internal/test/dac/input.cue
+++ b/internal/test/dac/input.cue
@@ -31,7 +31,7 @@ import (
 )
 
 #myVarsBuilder: varGroupBuilder & {
-	#input: [for i in #input {#datasourceName: "promDemo"}]
+	#datasourceName: "promDemo"
 	#input: [
 		labelValuesVarBuilder & {
 			#name: "stack"


### PR DESCRIPTION
As you can see in the unit tests it was already possible to achieve the same result with such syntax:
```cue
#input: [for i in #input {#datasourceName: "promDemo"}]
```
Still, I expect this to be such a common pattern that adding a small helper to allow providing simply `#datasourceName: "promDemo"` is worth it imho.