### PR TITLE
[ENHANCEMENT] : percli plugin lint: improve the way to find the schema files

### DIFF
--- a/internal/cli/cmd/dac/build/testdata/go/go.mod
+++ b/internal/cli/cmd/dac/build/testdata/go/go.mod
@@ -13,7 +13,9 @@
 
 module dac
 
-go 1.22.5
+go 1.23.0
+
+toolchain go1.23.4
 
 replace github.com/perses/perses => ../../../../../../../ // Use current version
 


### PR DESCRIPTION
This PR is reflecting the introduction of the plugin module from https://github.com/perses/plugins/pull/16.

The folder `schema` can contains multiple cuelang schema representing the sub plugin module. This PR is aiming to find whatever the folder struct is the different schema files. Like that we are not forcing people to have a special folder struct for their plugins.

With this change, we should be able to validate our own plugin.