### PR TITLE
BUGFIX: `percli dac setup`: fix useless requirement of go CLI when using CUE

### DIFF
--- a/internal/cli/cmd/dac/setup/setup.go
+++ b/internal/cli/cmd/dac/setup/setup.go
@@ -102,19 +102,19 @@ func (o *option) Validate() error {
 		return err
 	}
 
-	if o.language != cueLanguage && o.language != goLanguage {
+	switch o.language {
+	case cueLanguage:
+		if err := exec.Command("cue", "version").Run(); err != nil {
+			return fmt.Errorf("unable to use the required cue binary: %w", err)
+		}
+	case goLanguage:
+		if err := exec.Command("go", "version").Run(); err != nil {
+			return fmt.Errorf("unable to use the required go binary: %w", err)
+		}
+	default:
 		return fmt.Errorf("language %q is not supported", o.language)
 	}
 
-	if o.language == cueLanguage {
-		if err := exec.Command("cue", "version").Run(); err != nil {
-			return fmt.Errorf("unable to use the cue binary: %w", err)
-		}
-	}
-
-	if err := exec.Command("go", "version").Run(); err != nil {
-		return fmt.Errorf("unable to use the go binary: %w", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
# Description

`dac setup` (alternatively `dac setup --language cue`) shouldn't ask the user to install Golang, since it's not needed to work with the CUE SDK.
The issue was raised as part of https://github.com/perses/perses/issues/2533.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).