### PR TITLE
[BUGFIX] Fixes tooltip display in EDGE / IE

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -93,7 +93,24 @@ type ZREventProperties = {
   zrByTouch?: boolean;
 };
 
-export type ZRRawMouseEvent = MouseEvent & ZREventProperties;
+export type ZRRawMouseEvent = (MouseEvent | PointerEvent) & ZREventProperties;
+
+type ZRBrowser = {
+  ie: RegExpMatchArray | null;
+  edge: RegExpMatchArray | null;
+};
+
+export const browser: ZRBrowser = {
+  // IE 11 Trident/7.0; rv:11.0
+  ie: navigator.userAgent.match(/MSIE\s([\d.]+)/) || navigator.userAgent.match(/Trident\/.+?rv:(([\d.]+))/),
+  // IE 12 and 12+
+  edge: navigator.userAgent.match(/Edge?\/([\d.]+)/),
+};
+
+export const pointerEventsSupported =
+  'onpointerdown' in window && (browser.edge || (browser.ie && browser.ie[1] && +browser.ie[1] >= 11));
+
+export const trackingEventName = pointerEventsSupported ? 'pointermove' : 'mousemove';
 
 export const useMousePosition = (): CursorData['coords'] => {
   const [coords, setCoords] = useState<CursorData['coords']>(null);
@@ -120,10 +137,14 @@ export const useMousePosition = (): CursorData['coords'] => {
         target: e.target,
       });
     };
-    window.addEventListener('mousemove', setFromEvent);
+
+    // Devices that both enabled touch and mouse don't trigger touch events correctly
+    // which leads to missing zrender mousemove coordinates
+    // {@link https://github.com/ecomfe/zrender/blob/ae8cfaae186e6c1bf66b5dc431b2cdda5e67dacf/src/dom/HandlerProxy.ts#L423-L428 }
+    window.addEventListener(trackingEventName, setFromEvent);
 
     return (): void => {
-      window.removeEventListener('mousemove', setFromEvent);
+      window.removeEventListener(trackingEventName, setFromEvent);
     };
   }, []);
 


### PR DESCRIPTION
# Description

Perses is refactoring tooltip logic from eCharts, it’s important to note that the zRender library used by eCharts handles window events differently for touch devices and browsers. Specifically, `zrX` and `zrY` properties on event objects are only available on the `PointerMove` event for Edge browsers, while other browsers use the standard `MouseEvent`. This discrepancy means we cannot rely solely on `MouseEvent` for consistent event handling.

Unfortunately, `zRender` does not provide any public API or methods to detect how it patches events, leaving us without a straightforward way to accommodate these differences.

To address this, similar logic from `zRender` has been incorporated directly into the project, with slight modifications to minimize boilerplate code and improve maintainability.

Reference to core logic in `zRender` where event patching occurs:
[zRender patch and fix explanation](https://github.com/ecomfe/zrender/blob/ae8cfaae186e6c1bf66b5dc431b2cdda5e67dacf/src/dom/HandlerProxy.ts#L423-L428)

fixes #2401

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
