### PR TITLE
[BUGFIX] ListVariable: fix autocomplete when 'All' is selected

### DIFF
--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -18,7 +18,6 @@ import {
   ListVariableDefinition,
   ListVariableSpec,
   TextVariableDefinition,
-  UnknownSpec,
   VariableName,
   VariableValue,
 } from '@perses-dev/core';
@@ -58,7 +57,7 @@ export function Variable({ name, source }: VariableProps): ReactElement {
 }
 
 export function useListVariableState(
-  spec: ListVariableSpec<UnknownSpec> | undefined,
+  spec: ListVariableSpec | undefined,
   state: VariableState | undefined,
   variablesOptionsQuery: Partial<UseQueryResult<VariableOption[]>>
 ): {
@@ -190,7 +189,6 @@ function ListVariable({ name, source }: VariableProps): ReactElement {
     ctx.state,
     variablesOptionsQuery
   );
-  const [inputValue, setInputValue] = useState<string>('');
   const [inputWidth, setInputWidth] = useState(MIN_VARIABLE_WIDTH);
 
   const title = definition?.spec.display?.name ?? name;
@@ -226,7 +224,7 @@ function ListVariable({ name, source }: VariableProps): ReactElement {
         limitTags={3}
         size="small"
         disableClearable
-        PopperComponent={StyledPopper}
+        slots={{ popper: StyledPopper }}
         renderInput={(params) => {
           return allowMultiple ? (
             <TextField {...params} label={title} />
@@ -250,9 +248,7 @@ function ListVariable({ name, source }: VariableProps): ReactElement {
             setVariableValue(name, variableOptionToVariableValue(value), source);
           }
         }}
-        inputValue={inputValue}
         onInputChange={(_, newInputValue) => {
-          setInputValue(newInputValue);
           if (!allowMultiple) {
             setInputWidth(getWidthPx(newInputValue, 'list'));
           }
@@ -287,8 +283,10 @@ function TextVariable({ name, source }: VariableProps): ReactElement {
       onBlur={() => setVariableValue(name, tempValue, source)}
       placeholder={name}
       label={definition?.spec.display?.name ?? name}
-      InputProps={{
-        readOnly: definition?.spec.constant ?? false,
+      slotProps={{
+        input: {
+          readOnly: definition?.spec.constant ?? false,
+        },
       }}
       sx={{
         width: `${inputWidth}px`,


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Close #2277. Found other issue when testing the fix: dropdown position changing when removing change from All to an item

# Screenshots
![output](https://github.com/user-attachments/assets/4494c1d1-de08-4944-ad45-7cf6a76f1728)

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
