### PR TITLE
[IGNORE] Home page: Add error boundary around recently viewed dashboards

### DIFF
--- a/ui/app/src/views/home/RecentDashboards.tsx
+++ b/ui/app/src/views/home/RecentDashboards.tsx
@@ -14,6 +14,7 @@
 import { Card, Stack } from '@mui/material';
 import HistoryIcon from 'mdi-material-ui/History';
 import { ReactElement } from 'react';
+import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { RecentDashboardList } from '../../components/DashboardList/RecentDashboardList';
 import { useRecentDashboardList } from '../../model/dashboard-client';
 
@@ -27,7 +28,9 @@ export function RecentDashboards(): ReactElement {
         <h2>Recently Viewed Dashboards</h2>
       </Stack>
       <Card id="recent-dashboard-list">
-        <RecentDashboardList dashboardList={data} isLoading={isLoading} />
+        <ErrorBoundary FallbackComponent={ErrorAlert}>
+          <RecentDashboardList dashboardList={data} isLoading={isLoading} />
+        </ErrorBoundary>
       </Card>
     </Stack>
   );


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Add an error boundary around recently view dashboard. Some user are affect by an unknown issue #2559. It will mitigate the error on the home page. But it will still throw error on dashboards, I think

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

