### PR TITLE
[FEATURE] PromQL Debugger: individual query per node

### DIFF
--- a/ui/prometheus-plugin/src/components/PromQLEditor.tsx
+++ b/ui/prometheus-plugin/src/components/PromQLEditor.tsx
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/prometheus-plugin/src/components/PromQLEditor.tsx
+++ b/ui/prometheus-plugin/src/components/PromQLEditor.tsx
@@ -22,7 +22,7 @@ import CloseIcon from 'mdi-material-ui/Close';
 import { useReplaceVariablesInString } from '@perses-dev/plugin-system';
 import { PrometheusDatasourceSelector } from '../model';
 import { replacePromBuiltinVariables } from '../plugins/prometheus-time-series-query/replace-prom-builtin-variables';
-import { useParseQuery } from './parse';
+import { useParseQuery } from './query';
 import TreeNode from './TreeNode';
 
 const treeViewStr = 'Tree View';
@@ -138,7 +138,7 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
                   {isLoading ? (
                     <CircularProgress />
                   ) : parseQueryResponse?.data ? (
-                    <TreeNode node={parseQueryResponse.data} reverse={false} />
+                    <TreeNode node={parseQueryResponse.data} reverse={false} childIdx={0} datasource={datasource} />
                   ) : null}
                 </div>
               )}

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -337,8 +337,16 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
                       </ListItem>
                     ))}
                     {cnt > maxLabelValues && (
-                      <ListItem>
-                        <Typography variant="body2">...</Typography>
+                      <ListItem
+                        sx={{
+                          display: 'flex',
+                          gap: 1,
+                          py: 0,
+                          px: 0.5,
+                        }}
+                      >
+                        <CircleIcon sx={{ fontSize: 8 }} />
+                        <Typography variant="body2">. . .</Typography>
                       </ListItem>
                     )}
                   </List>
@@ -361,7 +369,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
             </Tooltip>
           ))}
           {resultStats.sortedLabelCards.length > maxLabelNames ? (
-            <Typography>...{resultStats.sortedLabelCards.length - maxLabelNames} more...</Typography>
+            <Typography variant="body2">...{resultStats.sortedLabelCards.length - maxLabelNames} more...</Typography>
           ) : null}
         </Stack>
       )}

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -56,14 +56,15 @@ interface TreeNodeProps {
   node: ASTNode;
   // The parent element of this node.
   parentEl?: HTMLDivElement | null;
-  // used to compute the position of the connector line between this node and its parent.
+  // Used to compute the position of the connector line between this node and its parent.
   reverse: boolean;
-  // The index of this node in its parent's children.
-  // used to render the node's individual query
+  // Datasource used for the node's individual query.
   datasource: PrometheusDatasourceSelector;
-  // used to render the node's individual query
+  // The index of this node in its parent's children.
+  // Used to render the node's individual query.
   childIdx: number;
-  // used to render the node's individual query
+  // Function to report the node state to the parent.
+  // Used to render the node's individual query.
   reportNodeState?: (childIdx: number, state: NodeState) => void;
 }
 

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -78,7 +78,6 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
   const [nodeEl, setNodeEl] = useState<HTMLDivElement | null>(null);
   const nodeRef = useCallback((node: HTMLDivElement) => setNodeEl(node), []);
 
-  const [responseTime, setResponseTime] = useState<number>(0);
   const [resultStats, setResultStats] = useState<{
     numSeries: number;
     labelExamples: Record<string, Array<{ value: string; count: number }>>;
@@ -118,7 +117,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
     data: instantQueryResponse,
     isLoading,
     error,
-  } = useInstantQuery(serializeNode(queryNode) ?? '', datasource, mergedChildState === 'success', setResponseTime);
+  } = useInstantQuery(serializeNode(queryNode) ?? '', datasource, mergedChildState === 'success');
 
   // report the node state to the parent
   useEffect(() => {
@@ -299,7 +298,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
           <Typography variant="body2" component="span" sx={{ color: (theme) => theme.palette.grey[500] }}>
             {resultStats.numSeries} result{resultStats.numSeries !== 1 && 's'}
             &nbsp;&nbsp;–&nbsp;&nbsp;
-            {responseTime}ms
+            {instantQueryResponse.responseTime}ms
             {resultStats.sortedLabelCards.length > 0 && <>&nbsp;&nbsp;–</>}
           </Typography>
           {resultStats.sortedLabelCards.slice(0, maxLabelNames).map(([ln, cnt]) => (

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -124,7 +124,7 @@ export default function TreeNode({
   // Individual query for the current node
   const {
     data: instantQueryResponse,
-    isLoading,
+    isFetching,
     error,
   } = useInstantQuery(serializeNode(queryNode) ?? '', datasource, mergedChildState === 'success');
 
@@ -133,11 +133,11 @@ export default function TreeNode({
     if (reportNodeState) {
       if (mergedChildState === 'error' || error) {
         reportNodeState(childIdx, 'error');
-      } else if (isLoading) {
+      } else if (isFetching) {
         reportNodeState(childIdx, 'running');
       }
     }
-  }, [mergedChildState, error, isLoading, reportNodeState, childIdx]);
+  }, [mergedChildState, error, isFetching, reportNodeState, childIdx]);
 
   // This function is passed down to the child nodes so they can report their state.
   const childReportNodeState = useCallback(
@@ -266,7 +266,7 @@ export default function TreeNode({
       {/* The node's individual query: */}
       <QueryStatus
         mergedChildState={mergedChildState}
-        isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         resultStats={resultStats}
         responseTime={instantQueryResponse?.responseTime}
@@ -323,7 +323,7 @@ export default function TreeNode({
 
 interface QueryStatusProps {
   mergedChildState: NodeState;
-  isLoading: boolean;
+  isFetching: boolean;
   error: StatusError | null;
   resultStats: {
     numSeries: number;
@@ -335,31 +335,17 @@ interface QueryStatusProps {
 
 function QueryStatus({
   mergedChildState,
-  isLoading,
+  isFetching,
   error,
   resultStats,
   responseTime,
 }: QueryStatusProps): ReactElement {
   if (mergedChildState === 'waiting') {
-    return (
-      <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
-        <CircularProgress size={16} color="inherit" />
-        <Typography variant="body2" color="text.secondary">
-          Waiting for child query
-        </Typography>
-      </Box>
-    );
+    return <ProgressState text="Waiting for child query" />;
   }
 
   if (mergedChildState === 'running') {
-    return (
-      <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
-        <CircularProgress size={16} />
-        <Typography variant="body2" color="primary">
-          Running...
-        </Typography>
-      </Box>
-    );
+    return <ProgressState text="Running" />;
   }
 
   if (mergedChildState === 'error') {
@@ -371,15 +357,8 @@ function QueryStatus({
     );
   }
 
-  if (isLoading) {
-    return (
-      <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
-        <CircularProgress size={16} color="secondary" />
-        <Typography variant="body2" color="text.secondary">
-          Loading...
-        </Typography>
-      </Box>
-    );
+  if (isFetching) {
+    return <ProgressState text="Loading" />;
   }
 
   if (error) {
@@ -478,5 +457,16 @@ function QueryStatus({
         <Typography variant="body2">...{resultStats.sortedLabelCards.length - maxLabelNames} more...</Typography>
       ) : null}
     </Stack>
+  );
+}
+
+function ProgressState({ text }: { text: string }): ReactElement {
+  return (
+    <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
+      <CircularProgress size={16} color="secondary" />
+      <Typography variant="body2" color="text.secondary">
+        {text}...
+      </Typography>
+    </Box>
   );
 }

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -183,7 +183,9 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
       return;
     }
 
-    reportNodeState && reportNodeState(childIdx, 'success');
+    if (reportNodeState) {
+      reportNodeState(childIdx, 'success');
+    }
 
     let resultSeries = 0;
     const labelValuesByName: Record<string, Record<string, number>> = {};
@@ -226,7 +228,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
   }, [instantQueryResponse, reportNodeState, childIdx]);
 
   const innerNode = (
-    <Stack gap={2}>
+    <Stack direction="row" gap={2}>
       <Box
         ref={nodeRef}
         sx={{
@@ -271,14 +273,14 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
           </Typography>
         </Stack>
       ) : (
-        <Stack>
+        <Stack direction="row" gap={1}>
           <Typography>
             {resultStats.numSeries} result{resultStats.numSeries !== 1 && 's'}
             &nbsp;&nbsp;–&nbsp;&nbsp;
             {responseTime}ms
             {resultStats.sortedLabelCards.length > 0 && <>&nbsp;&nbsp;–&nbsp;&nbsp;</>}
           </Typography>
-          <Stack>
+          <Stack direction="row" gap={1}>
             {resultStats.sortedLabelCards.slice(0, maxLabelNames).map(([ln, cnt]) => (
               <Tooltip
                 key={ln}
@@ -318,7 +320,9 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
                 arrow
               >
                 <span style={{ cursor: 'pointer', whiteSpace: 'nowrap' }}>
-                  <Typography variant="body2">{ln}</Typography>
+                  <Typography variant="body2" component="span">
+                    {ln}
+                  </Typography>
                   <Typography variant="body2" component="span" color="text.secondary">
                     : {cnt}
                   </Typography>

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -255,23 +255,44 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
       </Box>
       {/* The node's individual query: */}
       {mergedChildState === 'waiting' ? (
-        <CircularProgress /* TODO: put something different than running state like in Prom UI? */ />
+        <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
+          <CircularProgress size={16} color="inherit" />
+          <Typography variant="body2" color="text.secondary">
+            Waiting for child query
+          </Typography>
+        </Box>
       ) : mergedChildState === 'running' ? (
-        <CircularProgress />
+        <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
+          <CircularProgress size={16} />
+          <Typography variant="body2" color="primary">
+            Running...
+          </Typography>
+        </Box>
       ) : mergedChildState === 'error' ? (
         <Stack>
           <AlertCircle />
           Blocked on child query error
         </Stack>
       ) : isLoading ? (
-        <CircularProgress /* TODO: put something different than running state like in Prom UI? */ />
+        <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
+          <CircularProgress size={16} color="secondary" />
+          <Typography variant="body2" color="text.secondary">
+            Loading...
+          </Typography>
+        </Box>
       ) : error ? (
-        <Stack>
+        <Box
+          display="flex"
+          alignItems="center"
+          gap={1}
+          sx={{ color: (theme) => theme.palette.error.main }}
+          marginBottom={1.5}
+        >
           <AlertCircle />
-          <Typography>
+          <Typography variant="body2">
             <strong>Error executing query:</strong> {error.message}
           </Typography>
-        </Stack>
+        </Box>
       ) : (
         <Stack direction="row" gap={1} alignItems="center" marginBottom={1.5}>
           <Typography variant="body2" component="span" sx={{ color: (theme) => theme.palette.grey[500] }}>

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -253,7 +253,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
         {/* The node (visible box) itself. */}
         {formatNode(node, false, 1)}
       </Box>
-      {/* The node's individual query */}
+      {/* The node's individual query: */}
       {mergedChildState === 'waiting' ? (
         <CircularProgress /* TODO: put something different than running state like in Prom UI? */ />
       ) : mergedChildState === 'running' ? (
@@ -273,66 +273,68 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
           </Typography>
         </Stack>
       ) : (
-        <Stack direction="row" gap={1}>
-          <Typography>
+        <Stack direction="row" gap={1} alignItems="center" marginBottom={1.5}>
+          <Typography variant="body2" component="span" sx={{ color: (theme) => theme.palette.grey[500] }}>
             {resultStats.numSeries} result{resultStats.numSeries !== 1 && 's'}
             &nbsp;&nbsp;–&nbsp;&nbsp;
             {responseTime}ms
-            {resultStats.sortedLabelCards.length > 0 && <>&nbsp;&nbsp;–&nbsp;&nbsp;</>}
+            {resultStats.sortedLabelCards.length > 0 && <>&nbsp;&nbsp;–</>}
           </Typography>
-          <Stack direction="row" gap={1}>
-            {resultStats.sortedLabelCards.slice(0, maxLabelNames).map(([ln, cnt]) => (
-              <Tooltip
-                key={ln}
-                title={
-                  <Box sx={{ p: 1, bgcolor: 'grey.900', color: 'grey.100' }}>
-                    <List dense>
-                      {resultStats.labelExamples[ln]?.map(({ value, count }) => (
-                        <ListItem
-                          key={value}
+          {resultStats.sortedLabelCards.slice(0, maxLabelNames).map(([ln, cnt]) => (
+            <Tooltip
+              key={ln}
+              title={
+                <Box sx={{ p: 1, bgcolor: 'grey.900', color: 'grey.100' }}>
+                  <List dense>
+                    {resultStats.labelExamples[ln]?.map(({ value, count }) => (
+                      <ListItem
+                        key={value}
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          py: 0.5,
+                        }}
+                      >
+                        <Chip
+                          label={escapeString(value)}
                           sx={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            py: 0.5,
+                            color: 'red',
+                            bgcolor: 'grey.800',
+                            fontFamily: 'monospace',
                           }}
-                        >
-                          <Chip
-                            label={escapeString(value)}
-                            sx={{
-                              color: 'red',
-                              bgcolor: 'grey.800',
-                              fontFamily: 'monospace',
-                            }}
-                          />
-                          <Typography variant="body2" component="span">
-                            ({count}x)
-                          </Typography>
-                        </ListItem>
-                      ))}
-                      {cnt > maxLabelValues && (
-                        <ListItem>
-                          <Typography variant="body2">...</Typography>
-                        </ListItem>
-                      )}
-                    </List>
-                  </Box>
-                }
-                arrow
-              >
-                <span style={{ cursor: 'pointer', whiteSpace: 'nowrap' }}>
-                  <Typography variant="body2" component="span">
-                    {ln}
-                  </Typography>
-                  <Typography variant="body2" component="span" color="text.secondary">
-                    : {cnt}
-                  </Typography>
-                </span>
-              </Tooltip>
-            ))}
-            {resultStats.sortedLabelCards.length > maxLabelNames ? (
-              <Typography>...{resultStats.sortedLabelCards.length - maxLabelNames} more...</Typography>
-            ) : null}
-          </Stack>
+                        />
+                        <Typography variant="body2" component="span">
+                          ({count}x)
+                        </Typography>
+                      </ListItem>
+                    ))}
+                    {cnt > maxLabelValues && (
+                      <ListItem>
+                        <Typography variant="body2">...</Typography>
+                      </ListItem>
+                    )}
+                  </List>
+                </Box>
+              }
+              arrow
+            >
+              <span style={{ cursor: 'pointer', whiteSpace: 'nowrap' }}>
+                <Typography
+                  variant="body2"
+                  component="span"
+                  sx={{ fontFamily: 'monospace', color: (theme) => theme.palette.success.main }}
+                >
+                  {ln}
+                </Typography>
+                <Typography variant="body2" component="span" sx={{ color: (theme) => theme.palette.grey[500] }}>
+                  : {cnt}
+                </Typography>
+              </span>
+            </Tooltip>
+          ))}
+          {resultStats.sortedLabelCards.length > maxLabelNames ? (
+            <Typography>...{resultStats.sortedLabelCards.length - maxLabelNames} more...</Typography>
+          ) : null}
         </Stack>
       )}
     </Stack>

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -18,7 +18,7 @@ import CircleIcon from 'mdi-material-ui/Circle';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import AlertCircle from 'mdi-material-ui/AlertCircle';
 import { StatusError } from '@perses-dev/core';
-import { MonitoredInstantQueryResponse, PrometheusDatasourceSelector } from '../model';
+import { PrometheusDatasourceSelector } from '../model';
 import ASTNode, { nodeType } from './promql/ast';
 import { escapeString, getNodeChildren } from './promql/utils';
 import { formatNode } from './promql/format';

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -15,7 +15,7 @@
 
 import { Box, CircularProgress, List, ListItem, Stack, Tooltip, Typography, useTheme } from '@mui/material';
 import CircleIcon from 'mdi-material-ui/Circle';
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { ReactElement, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import AlertCircle from 'mdi-material-ui/AlertCircle';
 import { StatusError } from '@perses-dev/core';
 import { PrometheusDatasourceSelector } from '../model';
@@ -68,7 +68,14 @@ interface TreeNodeProps {
   reportNodeState?: (childIdx: number, state: NodeState) => void;
 }
 
-const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource, childIdx, reportNodeState }) => {
+export default function TreeNode({
+  node,
+  parentEl,
+  reverse,
+  datasource,
+  childIdx,
+  reportNodeState,
+}: TreeNodeProps): ReactElement {
   const theme = useTheme();
   const children = getNodeChildren(node);
 
@@ -312,9 +319,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
       ))}
     </div>
   );
-};
-
-export default TreeNode;
+}
 
 interface QueryStatusProps {
   mergedChildState: NodeState;
@@ -328,7 +333,13 @@ interface QueryStatusProps {
   responseTime?: number;
 }
 
-const QueryStatus: React.FC<QueryStatusProps> = ({ mergedChildState, isLoading, error, resultStats, responseTime }) => {
+function QueryStatus({
+  mergedChildState,
+  isLoading,
+  error,
+  resultStats,
+  responseTime,
+}: QueryStatusProps): ReactElement {
   if (mergedChildState === 'waiting') {
     return (
       <Box display="flex" alignItems="center" gap={1} marginBottom={1.5}>
@@ -468,4 +479,4 @@ const QueryStatus: React.FC<QueryStatusProps> = ({ mergedChildState, isLoading, 
       ) : null}
     </Stack>
   );
-};
+}

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -13,7 +13,8 @@
 
 // Forked from https://github.com/prometheus/prometheus/blob/65f610353919b1c7b42d3776c3a95b68046a6bba/web/ui/mantine-ui/src/pages/query/TreeNode.tsx
 
-import { Box, Chip, CircularProgress, List, ListItem, Stack, Tooltip, Typography, useTheme } from '@mui/material';
+import { Box, CircularProgress, List, ListItem, Stack, Tooltip, Typography, useTheme } from '@mui/material';
+import CircleIcon from 'mdi-material-ui/Circle';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import AlertCircle from 'mdi-material-ui/AlertCircle';
 import { PrometheusDatasourceSelector } from '../model';
@@ -305,25 +306,32 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource
             <Tooltip
               key={ln}
               title={
-                <Box sx={{ p: 1, bgcolor: 'grey.900', color: 'grey.100' }}>
+                <Box>
                   <List dense>
                     {resultStats.labelExamples[ln]?.map(({ value, count }) => (
                       <ListItem
                         key={value}
                         sx={{
                           display: 'flex',
-                          justifyContent: 'space-between',
-                          py: 0.5,
+                          gap: 1,
+                          py: 0,
+                          px: 0.5,
                         }}
                       >
-                        <Chip
-                          label={escapeString(value)}
+                        <CircleIcon sx={{ fontSize: 8 }} />
+                        <Typography
+                          variant="body2"
+                          component="span"
                           sx={{
-                            color: 'red',
-                            bgcolor: 'grey.800',
+                            color: (theme) =>
+                              theme.palette.mode === 'dark' // TODO we shouldnt have to do that I guess
+                                ? theme.palette.warning.dark
+                                : theme.palette.warning.main,
                             fontFamily: 'monospace',
                           }}
-                        />
+                        >
+                          {escapeString(value)}
+                        </Typography>
                         <Typography variant="body2" component="span">
                           ({count}x)
                         </Typography>

--- a/ui/prometheus-plugin/src/components/TreeNode.tsx
+++ b/ui/prometheus-plugin/src/components/TreeNode.tsx
@@ -13,15 +13,41 @@
 
 // Forked from https://github.com/prometheus/prometheus/blob/65f610353919b1c7b42d3776c3a95b68046a6bba/web/ui/mantine-ui/src/pages/query/TreeNode.tsx
 
-import { Box, useTheme } from '@mui/material';
-import { useCallback, useLayoutEffect, useState } from 'react';
+import { Box, Chip, CircularProgress, List, ListItem, Stack, Tooltip, Typography, useTheme } from '@mui/material';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import AlertCircle from 'mdi-material-ui/AlertCircle';
+import { PrometheusDatasourceSelector } from '../model';
 import ASTNode, { nodeType } from './promql/ast';
-import { getNodeChildren } from './promql/utils';
+import { escapeString, getNodeChildren } from './promql/utils';
 import { formatNode } from './promql/format';
+import serializeNode from './promql/serialize';
+import { functionSignatures } from './promql/functionSignatures';
+import { useInstantQuery } from './query';
 
 // The indentation factor for each level of the tree.
 const nodeIndent = 5;
 const connectorWidth = nodeIndent * 5;
+
+// max number of label names and values to show in the individual query status
+const maxLabelNames = 10;
+const maxLabelValues = 10;
+
+type NodeState = 'waiting' | 'running' | 'error' | 'success';
+
+// mergeChildStates basically returns the "worst" state found among the children.
+const mergeChildStates = (states: NodeState[]): NodeState => {
+  if (states.includes('error')) {
+    return 'error';
+  }
+  if (states.includes('waiting')) {
+    return 'waiting';
+  }
+  if (states.includes('running')) {
+    return 'running';
+  }
+
+  return 'success';
+};
 
 interface TreeNodeProps {
   // The AST node to render.
@@ -30,9 +56,16 @@ interface TreeNodeProps {
   parentEl?: HTMLDivElement | null;
   // used to compute the position of the connector line between this node and its parent.
   reverse: boolean;
+  // The index of this node in its parent's children.
+  // used to render the node's individual query
+  datasource: PrometheusDatasourceSelector;
+  // used to render the node's individual query
+  childIdx: number;
+  // used to render the node's individual query
+  reportNodeState?: (childIdx: number, state: NodeState) => void;
 }
 
-const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse }) => {
+const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse, datasource, childIdx, reportNodeState }) => {
   const theme = useTheme();
   const children = getNodeChildren(node);
 
@@ -44,6 +77,17 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse }) => {
   const [nodeEl, setNodeEl] = useState<HTMLDivElement | null>(null);
   const nodeRef = useCallback((node: HTMLDivElement) => setNodeEl(node), []);
 
+  const [responseTime, setResponseTime] = useState<number>(0);
+  const [resultStats, setResultStats] = useState<{
+    numSeries: number;
+    labelExamples: Record<string, Array<{ value: string; count: number }>>;
+    sortedLabelCards: Array<[string, number]>;
+  }>({
+    numSeries: 0,
+    labelExamples: {},
+    sortedLabelCards: [],
+  });
+
   const [connectorStyle, setConnectorStyle] = useState({
     borderColor: theme.palette.grey['500'],
     borderLeftStyle: 'solid',
@@ -51,6 +95,52 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse }) => {
     width: connectorWidth,
     left: -connectorWidth,
   });
+
+  const [childStates, setChildStates] = useState<NodeState[]>(children.map(() => 'waiting'));
+  const mergedChildState = useMemo(() => mergeChildStates(childStates), [childStates]);
+
+  // Optimize range vector selector fetches to give us the info we're looking for
+  // more cheaply. E.g. 'foo[7w]' can be expensive to fully fetch, but wrapping it
+  // in 'last_over_time(foo[7w])' is cheaper and also gives us all the info we
+  // need (number of series and labels).
+  let queryNode = node;
+  if (queryNode.type === nodeType.matrixSelector) {
+    queryNode = {
+      type: nodeType.call,
+      func: functionSignatures.last_over_time!,
+      args: [node],
+    };
+  }
+
+  // Individual query for the current node
+  const {
+    data: instantQueryResponse,
+    isLoading,
+    error,
+  } = useInstantQuery(serializeNode(queryNode) ?? '', datasource, mergedChildState === 'success', setResponseTime);
+
+  // report the node state to the parent
+  useEffect(() => {
+    if (reportNodeState) {
+      if (mergedChildState === 'error' || error) {
+        reportNodeState(childIdx, 'error');
+      } else if (isLoading) {
+        reportNodeState(childIdx, 'running');
+      }
+    }
+  }, [mergedChildState, error, isLoading, reportNodeState, childIdx]);
+
+  // This function is passed down to the child nodes so they can report their state.
+  const childReportNodeState = useCallback(
+    (childIdx: number, state: NodeState) => {
+      setChildStates((prev) => {
+        const newStates = [...prev];
+        newStates[childIdx] = state;
+        return newStates;
+      });
+    },
+    [setChildStates]
+  );
 
   // Update the size and position of tree connector lines based on the node's and its parent's position.
   useLayoutEffect(() => {
@@ -87,42 +177,186 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse }) => {
     }
   }, [parentEl, nodeEl, reverse, nodeRef, setConnectorStyle]);
 
+  // Update the node info state based on the query result.
+  useEffect(() => {
+    if (instantQueryResponse?.status !== 'success') {
+      return;
+    }
+
+    reportNodeState && reportNodeState(childIdx, 'success');
+
+    let resultSeries = 0;
+    const labelValuesByName: Record<string, Record<string, number>> = {};
+    const { resultType, result } = instantQueryResponse.data;
+
+    if (resultType === 'scalar' || resultType === 'string') {
+      resultSeries = 1;
+    } else if (result && result.length > 0) {
+      resultSeries = result.length;
+      // TODO comment
+      result.forEach((s) => {
+        Object.entries(s.metric).forEach(([ln, lv]) => {
+          // TODO: If we ever want to include __name__ here again, we cannot use the
+          // last_over_time(foo[7d]) optimization since that removes the metric name.
+          if (ln !== '__name__') {
+            labelValuesByName[ln] = labelValuesByName[ln] ?? {};
+            labelValuesByName[ln]![lv] = (labelValuesByName[ln]![lv] ?? 0) + 1;
+          }
+        });
+      });
+    }
+
+    // TODO comment
+    const labelCardinalities: Record<string, number> = {};
+    const labelExamples: Record<string, Array<{ value: string; count: number }>> = {};
+    Object.entries(labelValuesByName).forEach(([ln, lvs]) => {
+      labelCardinalities[ln] = Object.keys(lvs).length;
+      // Sort label values by their number of occurrences within this label name.
+      labelExamples[ln] = Object.entries(lvs)
+        .sort(([, aCnt], [, bCnt]) => bCnt - aCnt)
+        .slice(0, maxLabelValues)
+        .map(([lv, cnt]) => ({ value: lv, count: cnt }));
+    });
+
+    setResultStats({
+      numSeries: resultSeries,
+      sortedLabelCards: Object.entries(labelCardinalities).sort((a, b) => b[1] - a[1]),
+      labelExamples,
+    });
+  }, [instantQueryResponse, reportNodeState, childIdx]);
+
   const innerNode = (
-    <Box
-      ref={nodeRef}
-      sx={{
-        position: 'relative',
-        display: 'inline-block',
-        padding: 1,
-        marginBottom: 1.5,
-        borderRadius: 2,
-        backgroundColor: theme.palette.background.code,
-      }}
-    >
-      {parentEl !== undefined && (
-        // Connector line between this node and its parent.
-        <Box
-          sx={{
-            position: 'absolute',
-            display: 'inline-block',
-            ...connectorStyle,
-          }}
-        />
+    <Stack gap={2}>
+      <Box
+        ref={nodeRef}
+        sx={{
+          position: 'relative',
+          display: 'inline-block',
+          padding: 1,
+          marginBottom: 1.5,
+          borderRadius: 2,
+          backgroundColor: theme.palette.background.code,
+        }}
+      >
+        {parentEl !== undefined && (
+          // Connector line between this node and its parent.
+          <Box
+            sx={{
+              position: 'absolute',
+              display: 'inline-block',
+              ...connectorStyle,
+            }}
+          />
+        )}
+        {/* The node (visible box) itself. */}
+        {formatNode(node, false, 1)}
+      </Box>
+      {/* The node's individual query */}
+      {mergedChildState === 'waiting' ? (
+        <CircularProgress /* TODO: put something different than running state like in Prom UI? */ />
+      ) : mergedChildState === 'running' ? (
+        <CircularProgress />
+      ) : mergedChildState === 'error' ? (
+        <Stack>
+          <AlertCircle />
+          Blocked on child query error
+        </Stack>
+      ) : isLoading ? (
+        <CircularProgress /* TODO: put something different than running state like in Prom UI? */ />
+      ) : error ? (
+        <Stack>
+          <AlertCircle />
+          <Typography>
+            <strong>Error executing query:</strong> {error.message}
+          </Typography>
+        </Stack>
+      ) : (
+        <Stack>
+          <Typography>
+            {resultStats.numSeries} result{resultStats.numSeries !== 1 && 's'}
+            &nbsp;&nbsp;–&nbsp;&nbsp;
+            {responseTime}ms
+            {resultStats.sortedLabelCards.length > 0 && <>&nbsp;&nbsp;–&nbsp;&nbsp;</>}
+          </Typography>
+          <Stack>
+            {resultStats.sortedLabelCards.slice(0, maxLabelNames).map(([ln, cnt]) => (
+              <Tooltip
+                key={ln}
+                title={
+                  <Box sx={{ p: 1, bgcolor: 'grey.900', color: 'grey.100' }}>
+                    <List dense>
+                      {resultStats.labelExamples[ln]?.map(({ value, count }) => (
+                        <ListItem
+                          key={value}
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            py: 0.5,
+                          }}
+                        >
+                          <Chip
+                            label={escapeString(value)}
+                            sx={{
+                              color: 'red',
+                              bgcolor: 'grey.800',
+                              fontFamily: 'monospace',
+                            }}
+                          />
+                          <Typography variant="body2" component="span">
+                            ({count}x)
+                          </Typography>
+                        </ListItem>
+                      ))}
+                      {cnt > maxLabelValues && (
+                        <ListItem>
+                          <Typography variant="body2">...</Typography>
+                        </ListItem>
+                      )}
+                    </List>
+                  </Box>
+                }
+                arrow
+              >
+                <span style={{ cursor: 'pointer', whiteSpace: 'nowrap' }}>
+                  <Typography variant="body2">{ln}</Typography>
+                  <Typography variant="body2" component="span" color="text.secondary">
+                    : {cnt}
+                  </Typography>
+                </span>
+              </Tooltip>
+            ))}
+            {resultStats.sortedLabelCards.length > maxLabelNames ? (
+              <Typography>...{resultStats.sortedLabelCards.length - maxLabelNames} more...</Typography>
+            ) : null}
+          </Stack>
+        </Stack>
       )}
-      {/* The node (visible box) itself. */}
-      {formatNode(node, false, 1)}
-    </Box>
+    </Stack>
   );
 
   if (node.type === nodeType.binaryExpr) {
     return (
       <div>
         <Box ml={nodeIndent}>
-          <TreeNode node={children[0]!} parentEl={nodeEl} reverse={true} />
+          <TreeNode
+            node={children[0]!}
+            parentEl={nodeEl}
+            reverse={true}
+            datasource={datasource}
+            childIdx={0}
+            reportNodeState={childReportNodeState}
+          />
         </Box>
         {innerNode}
         <Box ml={nodeIndent}>
-          <TreeNode node={children[1]!} parentEl={nodeEl} reverse={false} />
+          <TreeNode
+            node={children[1]!}
+            parentEl={nodeEl}
+            reverse={false}
+            datasource={datasource}
+            childIdx={1}
+            reportNodeState={childReportNodeState}
+          />
         </Box>
       </div>
     );
@@ -133,7 +367,14 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, parentEl, reverse }) => {
       {innerNode}
       {children.map((child, idx) => (
         <Box ml={nodeIndent} key={idx}>
-          <TreeNode node={child} parentEl={nodeEl} reverse={false} />
+          <TreeNode
+            node={child}
+            parentEl={nodeEl}
+            reverse={false}
+            datasource={datasource}
+            childIdx={idx}
+            reportNodeState={childReportNodeState}
+          />
         </Box>
       ))}
     </div>

--- a/ui/prometheus-plugin/src/components/promql/functionSignatures.ts
+++ b/ui/prometheus-plugin/src/components/promql/functionSignatures.ts
@@ -1,0 +1,185 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Forked from https://github.com/prometheus/prometheus/blob/65f610353919b1c7b42d3776c3a95b68046a6bba/web/ui/mantine-ui/src/promql/functionSignatures.ts
+
+import { valueType, Func } from './ast';
+
+export const functionSignatures: Record<string, Func> = {
+  abs: { name: 'abs', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  absent: { name: 'absent', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  absent_over_time: {
+    name: 'absent_over_time',
+    argTypes: [valueType.matrix],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  acos: { name: 'acos', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  acosh: { name: 'acosh', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  asin: { name: 'asin', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  asinh: { name: 'asinh', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  atan: { name: 'atan', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  atanh: { name: 'atanh', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  avg_over_time: { name: 'avg_over_time', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  ceil: { name: 'ceil', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  changes: { name: 'changes', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  clamp: {
+    name: 'clamp',
+    argTypes: [valueType.vector, valueType.scalar, valueType.scalar],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  clamp_max: {
+    name: 'clamp_max',
+    argTypes: [valueType.vector, valueType.scalar],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  clamp_min: {
+    name: 'clamp_min',
+    argTypes: [valueType.vector, valueType.scalar],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  cos: { name: 'cos', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  cosh: { name: 'cosh', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  count_over_time: { name: 'count_over_time', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  day_of_month: { name: 'day_of_month', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+  day_of_week: { name: 'day_of_week', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+  day_of_year: { name: 'day_of_year', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+  days_in_month: { name: 'days_in_month', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+  deg: { name: 'deg', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  delta: { name: 'delta', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  deriv: { name: 'deriv', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  exp: { name: 'exp', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  floor: { name: 'floor', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  histogram_avg: { name: 'histogram_avg', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  histogram_count: { name: 'histogram_count', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  histogram_fraction: {
+    name: 'histogram_fraction',
+    argTypes: [valueType.scalar, valueType.scalar, valueType.vector],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  histogram_quantile: {
+    name: 'histogram_quantile',
+    argTypes: [valueType.scalar, valueType.vector],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  histogram_stddev: {
+    name: 'histogram_stddev',
+    argTypes: [valueType.vector],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  histogram_stdvar: {
+    name: 'histogram_stdvar',
+    argTypes: [valueType.vector],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  histogram_sum: { name: 'histogram_sum', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  double_exponential_smoothing: {
+    name: 'double_exponential_smoothing',
+    argTypes: [valueType.matrix, valueType.scalar, valueType.scalar],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  hour: { name: 'hour', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+  idelta: { name: 'idelta', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  increase: { name: 'increase', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  irate: { name: 'irate', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  label_join: {
+    name: 'label_join',
+    argTypes: [valueType.vector, valueType.string, valueType.string, valueType.string],
+    variadic: -1,
+    returnType: valueType.vector,
+  },
+  label_replace: {
+    name: 'label_replace',
+    argTypes: [valueType.vector, valueType.string, valueType.string, valueType.string, valueType.string],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  last_over_time: { name: 'last_over_time', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  ln: { name: 'ln', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  log10: { name: 'log10', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  log2: { name: 'log2', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  mad_over_time: { name: 'mad_over_time', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  max_over_time: { name: 'max_over_time', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  min_over_time: { name: 'min_over_time', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  minute: { name: 'minute', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+  month: { name: 'month', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+  pi: { name: 'pi', argTypes: [], variadic: 0, returnType: valueType.scalar },
+  predict_linear: {
+    name: 'predict_linear',
+    argTypes: [valueType.matrix, valueType.scalar],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  present_over_time: {
+    name: 'present_over_time',
+    argTypes: [valueType.matrix],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  quantile_over_time: {
+    name: 'quantile_over_time',
+    argTypes: [valueType.scalar, valueType.matrix],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  rad: { name: 'rad', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  rate: { name: 'rate', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  resets: { name: 'resets', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  round: { name: 'round', argTypes: [valueType.vector, valueType.scalar], variadic: 1, returnType: valueType.vector },
+  scalar: { name: 'scalar', argTypes: [valueType.vector], variadic: 0, returnType: valueType.scalar },
+  sgn: { name: 'sgn', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  sin: { name: 'sin', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  sinh: { name: 'sinh', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  sort: { name: 'sort', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  sort_by_label: {
+    name: 'sort_by_label',
+    argTypes: [valueType.vector, valueType.string],
+    variadic: -1,
+    returnType: valueType.vector,
+  },
+  sort_by_label_desc: {
+    name: 'sort_by_label_desc',
+    argTypes: [valueType.vector, valueType.string],
+    variadic: -1,
+    returnType: valueType.vector,
+  },
+  sort_desc: { name: 'sort_desc', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  sqrt: { name: 'sqrt', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  stddev_over_time: {
+    name: 'stddev_over_time',
+    argTypes: [valueType.matrix],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  stdvar_over_time: {
+    name: 'stdvar_over_time',
+    argTypes: [valueType.matrix],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
+  sum_over_time: { name: 'sum_over_time', argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
+  tan: { name: 'tan', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  tanh: { name: 'tanh', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  time: { name: 'time', argTypes: [], variadic: 0, returnType: valueType.scalar },
+  timestamp: { name: 'timestamp', argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  vector: { name: 'vector', argTypes: [valueType.scalar], variadic: 0, returnType: valueType.vector },
+  year: { name: 'year', argTypes: [valueType.vector], variadic: 1, returnType: valueType.vector },
+};

--- a/ui/prometheus-plugin/src/components/promql/serialize.ts
+++ b/ui/prometheus-plugin/src/components/promql/serialize.ts
@@ -1,0 +1,145 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Forked from https://github.com/prometheus/prometheus/blob/65f610353919b1c7b42d3776c3a95b68046a6bba/web/ui/mantine-ui/src/promql/serialize.ts
+
+import { formatDuration, msToPrometheusDuration } from '@perses-dev/core';
+import ASTNode, {
+  VectorSelector,
+  matchType,
+  vectorMatchCardinality,
+  nodeType,
+  StartOrEnd,
+  MatrixSelector,
+} from './ast';
+import { aggregatorsWithParam, maybeParenthesizeBinopChild, escapeString } from './utils';
+
+const serializeAtAndOffset = (timestamp: number | null, startOrEnd: StartOrEnd, offset: number): string =>
+  `${timestamp !== null ? ` @ ${(timestamp / 1000).toFixed(3)}` : startOrEnd !== null ? ` @ ${startOrEnd}()` : ''}${
+    offset === 0
+      ? ''
+      : offset > 0
+        ? ` offset ${formatDuration(msToPrometheusDuration(offset))}`
+        : ` offset -${formatDuration(msToPrometheusDuration(-offset))}`
+  }`;
+
+const serializeSelector = (node: VectorSelector | MatrixSelector): string => {
+  const matchers = node.matchers
+    .filter((m) => !(m.name === '__name__' && m.type === matchType.equal && m.value === node.name))
+    .map((m) => `${m.name}${m.type}"${escapeString(m.value)}"`);
+
+  const range = node.type === nodeType.matrixSelector ? `[${formatDuration(msToPrometheusDuration(node.range))}]` : '';
+  const atAndOffset = serializeAtAndOffset(node.timestamp, node.startOrEnd, node.offset);
+
+  return `${node.name}${matchers.length > 0 ? `{${matchers.join(',')}}` : ''}${range}${atAndOffset}`;
+};
+
+const serializeNode = (node: ASTNode, indent = 0, pretty = false, initialIndent = true): string => {
+  const childListSeparator = pretty ? '\n' : '';
+  const childSeparator = pretty ? '\n' : ' ';
+  const childIndent = indent + 2;
+  const ind = pretty ? ' '.repeat(indent) : '';
+  // Needed for unary operators.
+  const initialInd = initialIndent ? ind : '';
+
+  switch (node.type) {
+    case nodeType.aggregation:
+      return `${initialInd}${node.op}${
+        node.without
+          ? ` without(${node.grouping.join(', ')}) `
+          : node.grouping.length > 0
+            ? ` by(${node.grouping.join(', ')}) `
+            : ''
+      }(${childListSeparator}${
+        aggregatorsWithParam.includes(node.op) && node.param !== null
+          ? `${serializeNode(node.param, childIndent, pretty)},${childSeparator}`
+          : ''
+      }${serializeNode(node.expr, childIndent, pretty)}${childListSeparator}${ind})`;
+
+    case nodeType.subquery:
+      return `${initialInd}${serializeNode(node.expr, indent, pretty)}[${formatDuration(msToPrometheusDuration(node.range))}:${
+        node.step !== 0 ? formatDuration(msToPrometheusDuration(node.step)) : ''
+      }]${serializeAtAndOffset(node.timestamp, node.startOrEnd, node.offset)}`;
+
+    case nodeType.parenExpr:
+      return `${initialInd}(${childListSeparator}${serializeNode(
+        node.expr,
+        childIndent,
+        pretty
+      )}${childListSeparator}${ind})`;
+
+    case nodeType.call: {
+      const sep = node.args.length > 0 ? childListSeparator : '';
+
+      return `${initialInd}${node.func.name}(${sep}${node.args
+        .map((arg) => serializeNode(arg, childIndent, pretty))
+        .join(',' + childSeparator)}${sep}${node.args.length > 0 ? ind : ''})`;
+    }
+
+    case nodeType.matrixSelector:
+      return `${initialInd}${serializeSelector(node)}`;
+
+    case nodeType.vectorSelector:
+      return `${initialInd}${serializeSelector(node)}`;
+
+    case nodeType.numberLiteral:
+      return `${initialInd}${node.val}`;
+
+    case nodeType.stringLiteral:
+      return `${initialInd}"${escapeString(node.val)}"`;
+
+    case nodeType.unaryExpr:
+      return `${initialInd}${node.op}${serializeNode(node.expr, indent, pretty, false)}`;
+
+    case nodeType.binaryExpr: {
+      let matching = '';
+      let grouping = '';
+      const vm = node.matching;
+      if (vm !== null && (vm.labels.length > 0 || vm.on)) {
+        if (vm.on) {
+          matching = ` on(${vm.labels.join(', ')})`;
+        } else {
+          matching = ` ignoring(${vm.labels.join(', ')})`;
+        }
+
+        if (vm.card === vectorMatchCardinality.manyToOne || vm.card === vectorMatchCardinality.oneToMany) {
+          grouping = ` group_${vm.card === vectorMatchCardinality.manyToOne ? 'left' : 'right'}(${vm.include.join(',')})`;
+        }
+      }
+
+      return `${serializeNode(maybeParenthesizeBinopChild(node.op, node.lhs), childIndent, pretty)}${childSeparator}${ind}${
+        node.op
+      }${node.bool ? ' bool' : ''}${matching}${grouping}${childSeparator}${serializeNode(
+        maybeParenthesizeBinopChild(node.op, node.rhs),
+        childIndent,
+        pretty
+      )}`;
+    }
+
+    case nodeType.placeholder:
+      // TODO: Should we just throw an error when trying to serialize an AST containing a placeholder node?
+      // (that would currently break editing-as-text of ASTs that contain placeholders)
+      return `${initialInd}…${
+        node.children.length > 0
+          ? `(${childListSeparator}${node.children
+              .map((child) => serializeNode(child, childIndent, pretty))
+              .join(',' + childSeparator)}${childListSeparator}${ind})`
+          : ''
+      }`;
+
+    default:
+      throw new Error('unsupported node type');
+  }
+};
+
+export default serializeNode;

--- a/ui/prometheus-plugin/src/components/promql/utils.ts
+++ b/ui/prometheus-plugin/src/components/promql/utils.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/prometheus-plugin/src/components/promql/utils.ts
+++ b/ui/prometheus-plugin/src/components/promql/utils.ts
@@ -77,6 +77,8 @@ export const getNodeChildren = (node: ASTNode): ASTNode[] => {
   }
 };
 
+export const aggregatorsWithParam = ['topk', 'bottomk', 'quantile', 'count_values', 'limitk', 'limit_ratio'];
+
 export const escapeString = (str: string): string => {
   return str.replace(/([\\"])/g, '\\$1');
 };

--- a/ui/prometheus-plugin/src/components/query.ts
+++ b/ui/prometheus-plugin/src/components/query.ts
@@ -1,7 +1,7 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain TQueryFnData extends any = unknownany = unknown at
+// You may obtain a copy of the License at
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
@@ -40,7 +40,6 @@ export function useParseQuery(
   });
 }
 
-// TODO replace setter by return val
 export function useInstantQuery(
   content: string,
   datasource: DatasourceSelector,

--- a/ui/prometheus-plugin/src/components/query.ts
+++ b/ui/prometheus-plugin/src/components/query.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// You may obtain TQueryFnData extends any = unknownany = unknown at
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
@@ -14,7 +14,13 @@
 import { useDatasourceClient } from '@perses-dev/plugin-system';
 import { DatasourceSelector, StatusError } from '@perses-dev/core';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
-import { ParseQueryRequestParameters, ParseQueryResponse, PrometheusClient } from '../model';
+import {
+  InstantQueryRequestParameters,
+  InstantQueryResponse,
+  ParseQueryRequestParameters,
+  ParseQueryResponse,
+  PrometheusClient,
+} from '../model';
 
 export function useParseQuery(
   content: string,
@@ -30,6 +36,27 @@ export function useParseQuery(
       const params: ParseQueryRequestParameters = { query: content };
 
       return await client!.parseQuery(params);
+    },
+  });
+}
+
+export function useInstantQuery(
+  content: string,
+  datasource: DatasourceSelector,
+  enabled?: boolean,
+  recordResponseTime?: (time: number) => void
+): UseQueryResult<InstantQueryResponse, StatusError> {
+  const { data: client } = useDatasourceClient<PrometheusClient>(datasource);
+
+  return useQuery<InstantQueryResponse, StatusError>({
+    enabled: !!client && enabled,
+    queryKey: ['instantQuery', content, 'datasource', datasource],
+    queryFn: async () => {
+      const params: InstantQueryRequestParameters = { query: content };
+      const startTime = performance.now();
+      const response = await client!.instantQuery(params);
+      recordResponseTime && recordResponseTime(performance.now() - startTime);
+      return response;
     },
   });
 }

--- a/ui/prometheus-plugin/src/components/query.ts
+++ b/ui/prometheus-plugin/src/components/query.ts
@@ -40,6 +40,7 @@ export function useParseQuery(
   });
 }
 
+// TODO replace setter by return val
 export function useInstantQuery(
   content: string,
   datasource: DatasourceSelector,

--- a/ui/prometheus-plugin/src/components/query.ts
+++ b/ui/prometheus-plugin/src/components/query.ts
@@ -49,7 +49,8 @@ export function useInstantQuery(
 
   return useQuery<MonitoredInstantQueryResponse, StatusError>({
     enabled: !!client && enabled,
-    queryKey: ['instantQuery', content, 'datasource', datasource],
+    // TODO: for some reason the caching is not working: identical nodes still fire their requests after each change made to the promQL
+    queryKey: ['instantQuery', content, 'datasource', datasource.kind],
     queryFn: async () => {
       const params: InstantQueryRequestParameters = { query: content };
       const startTime = performance.now();

--- a/ui/prometheus-plugin/src/components/query.ts
+++ b/ui/prometheus-plugin/src/components/query.ts
@@ -16,7 +16,7 @@ import { DatasourceSelector, StatusError } from '@perses-dev/core';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import {
   InstantQueryRequestParameters,
-  InstantQueryResponse,
+  MonitoredInstantQueryResponse,
   ParseQueryRequestParameters,
   ParseQueryResponse,
   PrometheusClient,
@@ -44,20 +44,20 @@ export function useParseQuery(
 export function useInstantQuery(
   content: string,
   datasource: DatasourceSelector,
-  enabled?: boolean,
-  recordResponseTime?: (time: number) => void
-): UseQueryResult<InstantQueryResponse, StatusError> {
+  enabled?: boolean
+): UseQueryResult<MonitoredInstantQueryResponse, StatusError> {
   const { data: client } = useDatasourceClient<PrometheusClient>(datasource);
 
-  return useQuery<InstantQueryResponse, StatusError>({
+  return useQuery<MonitoredInstantQueryResponse, StatusError>({
     enabled: !!client && enabled,
     queryKey: ['instantQuery', content, 'datasource', datasource],
     queryFn: async () => {
       const params: InstantQueryRequestParameters = { query: content };
       const startTime = performance.now();
       const response = await client!.instantQuery(params);
-      recordResponseTime && recordResponseTime(performance.now() - startTime);
-      return response;
+      const responseTime = performance.now() - startTime;
+
+      return { ...response, responseTime };
     },
   });
 }

--- a/ui/prometheus-plugin/src/model/api-types.ts
+++ b/ui/prometheus-plugin/src/model/api-types.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/prometheus-plugin/src/model/api-types.ts
+++ b/ui/prometheus-plugin/src/model/api-types.ts
@@ -62,13 +62,21 @@ export interface ScalarData {
   result: ValueTuple;
 }
 
+export interface StringData {
+  resultType: 'string';
+  result: ValueTuple;
+}
+
 export interface InstantQueryRequestParameters {
   query: string;
   time?: UnixTimestampSeconds;
   timeout?: DurationString;
 }
 
-export type InstantQueryResponse = ApiResponse<MatrixData | VectorData | ScalarData>;
+export type InstantQueryResultType = MatrixData | VectorData | ScalarData | StringData;
+
+// Ref https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+export type InstantQueryResponse = ApiResponse<InstantQueryResultType>;
 
 export interface RangeQueryRequestParameters {
   query: string;

--- a/ui/prometheus-plugin/src/model/api-types.ts
+++ b/ui/prometheus-plugin/src/model/api-types.ts
@@ -78,6 +78,10 @@ export type InstantQueryResultType = MatrixData | VectorData | ScalarData | Stri
 // Ref https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
 export type InstantQueryResponse = ApiResponse<InstantQueryResultType>;
 
+export type MonitoredInstantQueryResponse = InstantQueryResponse & {
+  responseTime: number;
+};
+
 export interface RangeQueryRequestParameters {
   query: string;
   start: UnixTimestampSeconds;

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/ui/prometheus-plugin/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -31,6 +31,7 @@ import {
   MatrixData,
   VectorData,
   ScalarData,
+  InstantQueryResultType,
 } from '../../model';
 import { getFormattedPrometheusSeriesName } from '../../utils';
 import { DEFAULT_SCRAPE_INTERVAL, PrometheusDatasourceSpec } from '../types';
@@ -130,7 +131,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
     timeRange: { start: fromUnixTime(start), end: fromUnixTime(end) },
     stepMs: step * 1000,
 
-    series: buildTimeSeries(result, query, seriesNameFormat),
+    series: buildTimeSeries(query, result, seriesNameFormat),
     metadata: {
       notices,
       executedQueryString: query,
@@ -140,7 +141,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   return chartData;
 };
 
-function buildVectorData(data: VectorData, query: string, seriesNameFormat: string | undefined): TimeSeries[] {
+function buildVectorData(query: string, data: VectorData, seriesNameFormat: string | undefined): TimeSeries[] {
   return data.result.map((res) => {
     const { metric, value } = res;
 
@@ -156,7 +157,7 @@ function buildVectorData(data: VectorData, query: string, seriesNameFormat: stri
   });
 }
 
-function buildMatrixData(data: MatrixData, query: string, seriesNameFormat: string | undefined): TimeSeries[] {
+function buildMatrixData(query: string, data: MatrixData, seriesNameFormat: string | undefined): TimeSeries[] {
   return data.result.map((res) => {
     const { metric, values } = res;
 
@@ -172,7 +173,7 @@ function buildMatrixData(data: MatrixData, query: string, seriesNameFormat: stri
   });
 }
 
-function buildScalarData(data: ScalarData, query: string, seriesNameFormat: string | undefined): TimeSeries[] {
+function buildScalarData(query: string, data: ScalarData, seriesNameFormat: string | undefined): TimeSeries[] {
   const { name, formattedName } = getFormattedPrometheusSeriesName(query, {}, seriesNameFormat);
   return [
     {
@@ -183,11 +184,7 @@ function buildScalarData(data: ScalarData, query: string, seriesNameFormat: stri
   ];
 }
 
-function buildTimeSeries(
-  data: MatrixData | VectorData | ScalarData | undefined,
-  query: string,
-  seriesNameFormat?: string
-): TimeSeries[] {
+function buildTimeSeries(query: string, data?: InstantQueryResultType, seriesNameFormat?: string): TimeSeries[] {
   if (!data) {
     return [];
   }
@@ -196,11 +193,11 @@ function buildTimeSeries(
 
   switch (resultType) {
     case 'vector':
-      return buildVectorData(data, query, seriesNameFormat);
+      return buildVectorData(query, data, seriesNameFormat);
     case 'matrix':
-      return buildMatrixData(data, query, seriesNameFormat);
+      return buildMatrixData(query, data, seriesNameFormat);
     case 'scalar':
-      return buildScalarData(data, query, seriesNameFormat);
+      return buildScalarData(query, data, seriesNameFormat);
     default:
       console.warn('Unknown result type', resultType, data);
       return [];


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR implements this item of https://github.com/perses/perses/issues/2355:
- **Sub-queries aside each node, with details about each label/dimension available & eventual error state**

# Screenshots

![image](https://github.com/user-attachments/assets/a6e2deb7-c66f-4974-b575-42cf746cb9cb)

![2025-01-24_17h07_05](https://github.com/user-attachments/assets/eb10b2a5-3b22-49e2-9bd9-df155c3e5efa)

![Screenshot 2025-01-24 170805](https://github.com/user-attachments/assets/7f67ffc4-e6a5-418a-bb5f-88626e0ca743)

NB: The tooltip in dark mode is kinda ugly, but there is something to fix about tooltips in dark mode in general that goes beyond this PR. To be tackled independently.
![image](https://github.com/user-attachments/assets/2bbccefe-b665-459c-9698-8f849cdc52d8)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
