### PR TITLE
[FEATURE] Perses server is able to load plugin from dev environment server

### DIFF
--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -26,13 +26,6 @@ provisioning:
   folders:
     - "dev/data"
 
-schemas:
-  panels_path: "cue/schemas/panels"
-  queries_path: "cue/schemas/queries"
-  datasources_path: "cue/schemas/datasources"
-  variables_path: "cue/schemas/variables"
-  interval: "5m"
-
 ephemeral_dashboard:
   enable: true
   cleanup_interval: 1h

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -92,7 +92,9 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 		APIRegistration(persesAPI).
 		GzipSkipper(func(c echo.Context) bool {
 			// let's skip the gzip compression when using the proxy and rely on the datasource behind.
-			return strings.HasPrefix(c.Request().URL.Path, fmt.Sprintf("%s/proxy", conf.APIPrefix))
+			return strings.HasPrefix(c.Request().URL.Path, fmt.Sprintf("%s/proxy", conf.APIPrefix)) ||
+				// When serving the plugins from a dev server, we don't want to compress the response since it's already compressed by rsbuild.
+				(conf.Plugins.DevEnvironment != nil && strings.HasPrefix(c.Request().URL.Path, fmt.Sprintf("%s/plugins", conf.APIPrefix)))
 		}).
 		Middleware(middleware.HandleError()).
 		Middleware(middleware.CheckProject(serviceManager.GetProject()))

--- a/internal/api/plugin/dev.go
+++ b/internal/api/plugin/dev.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"github.com/perses/perses/internal/api/plugin/migrate"
+	"github.com/perses/perses/internal/api/plugin/schema"
+	"github.com/perses/perses/pkg/model/api/config"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/plugin"
+	"github.com/sirupsen/logrus"
+)
+
+type pluginDev struct {
+	cfg config.PluginDevEnvironment
+	sch schema.Schema
+	mig migrate.Migration
+}
+
+func (p *pluginDev) load() []v1.PluginModule {
+	var pluginModuleList []v1.PluginModule
+	for _, plg := range p.cfg.Plugins {
+		manifest, err := ReadManifestFromNetwork(p.cfg.URL, plg.Name)
+		if err != nil {
+			logrus.WithError(err).Error("failed to load plugin manifest")
+			continue
+		}
+		npmPackageData, readErr := ReadPackageFromNetwork(p.cfg.URL, plg.Name)
+		if readErr != nil {
+			logrus.WithError(readErr).Error("failed to load plugin package")
+			continue
+		}
+		pluginModule := v1.PluginModule{
+			Kind: v1.PluginModuleKind,
+			Metadata: plugin.ModuleMetadata{
+				Name:    manifest.Name,
+				Version: manifest.Metadata.BuildInfo.Version,
+			},
+			Spec: npmPackageData.Perses,
+		}
+		if pluginSchemaLoadErr := p.sch.Load(plg.AbsolutePath, pluginModule); pluginSchemaLoadErr != nil {
+			logrus.WithError(pluginSchemaLoadErr).Error("unable to load plugin schema")
+			continue
+		}
+		if pluginMigrateLoadErr := p.mig.Load(plg.AbsolutePath, pluginModule); pluginMigrateLoadErr != nil {
+			logrus.WithError(pluginMigrateLoadErr).Error("unable to load plugin migration")
+			continue
+		}
+		pluginModuleList = append(pluginModuleList, pluginModule)
+	}
+	return pluginModuleList
+}

--- a/pkg/model/api/config/plugins.go
+++ b/pkg/model/api/config/plugins.go
@@ -13,6 +13,12 @@
 
 package config
 
+import (
+	"errors"
+
+	"github.com/perses/perses/pkg/model/api/v1/common"
+)
+
 const (
 	DefaultPluginPath        = "plugins"
 	DefaultArchivePluginPath = "plugins-archive"
@@ -31,6 +37,37 @@ func (f *Plugins) Verify() error {
 // TODO : how to avoid user to know where the plugins are stored in the docker image
 type Plugins struct {
 	// Path is the path to the directory containing the runtime plugins
-	Path        string `json:"path,omitempty" yaml:"path,omitempty"`
-	ArchivePath string `json:"archive_path,omitempty" yaml:"archive_path,omitempty"`
+	Path           string                `json:"path,omitempty" yaml:"path,omitempty"`
+	ArchivePath    string                `json:"archive_path,omitempty" yaml:"archive_path,omitempty"`
+	DevEnvironment *PluginDevEnvironment `json:"dev_environment,omitempty" yaml:"dev_environment,omitempty"`
+}
+
+type PluginDevEnvironment struct {
+	URL     *common.URL           `json:"url,omitempty" yaml:"url,omitempty"`
+	Plugins []PluginInDevelopment `json:"plugins" yaml:"plugins"`
+}
+
+func (p *PluginDevEnvironment) Verify() error {
+	if p.URL == nil {
+		p.URL = common.MustParseURL("http://localhost:3005")
+	}
+	if len(p.Plugins) == 0 {
+		return errors.New("no plugins defined")
+	}
+	return nil
+}
+
+type PluginInDevelopment struct {
+	Name         string `json:"name" yaml:"name"`
+	AbsolutePath string `json:"absolute_path" yaml:"absolute_path"`
+}
+
+func (p *PluginInDevelopment) Verify() error {
+	if len(p.Name) == 0 {
+		return errors.New("the name of the plugin in development must be set")
+	}
+	if len(p.AbsolutePath) == 0 {
+		return errors.New("the absolute path of the plugin in development must be set")
+	}
+	return nil
 }

--- a/pkg/model/api/config/plugins.go
+++ b/pkg/model/api/config/plugins.go
@@ -58,8 +58,9 @@ func (p *PluginDevEnvironment) Verify() error {
 }
 
 type PluginInDevelopment struct {
-	Name         string `json:"name" yaml:"name"`
-	AbsolutePath string `json:"absolute_path" yaml:"absolute_path"`
+	Name         string      `json:"name" yaml:"name"`
+	URL          *common.URL `json:"url,omitempty" yaml:"url,omitempty"`
+	AbsolutePath string      `json:"absolute_path" yaml:"absolute_path"`
 }
 
 func (p *PluginInDevelopment) Verify() error {

--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -127,7 +127,11 @@ func pluginDevProxyMiddleware(devEnvironment config.PluginDevEnvironment) echo.M
 				var proxyErr error
 				// Then we need to route this request to the dev environment.
 				// We just have to replace the URL as the path should remain the same.
-				reverseProxy := httputil.NewSingleHostReverseProxy(devEnvironment.URL.URL)
+				proxyURL := devEnvironment.URL
+				if plg.URL != nil {
+					proxyURL = plg.URL
+				}
+				reverseProxy := httputil.NewSingleHostReverseProxy(proxyURL.URL)
 				reverseProxy.ErrorHandler = func(_ http.ResponseWriter, _ *http.Request, err error) {
 					logrus.WithError(err).Errorf("error proxying, remote unreachable: target=%s, err=%v", devEnvironment.URL.String(), err)
 					proxyErr = err

--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/http/httputil"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -47,14 +48,16 @@ var (
 
 type frontend struct {
 	echoUtils.Register
-	apiPrefix   string
-	pluginsPath string
+	apiPrefix            string
+	pluginsPath          string
+	pluginDevEnvironment *config.PluginDevEnvironment
 }
 
 func NewPersesFrontend(cfg config.Config) echoUtils.Register {
 	return &frontend{
-		apiPrefix:   cfg.APIPrefix,
-		pluginsPath: cfg.Plugins.Path,
+		apiPrefix:            cfg.APIPrefix,
+		pluginsPath:          cfg.Plugins.Path,
+		pluginDevEnvironment: cfg.Plugins.DevEnvironment,
 	}
 }
 
@@ -69,8 +72,13 @@ func (f *frontend) RegisterRoute(e *echo.Echo) {
 	// Otherwise, the request is redirected to the `assetHandler` that is serving the static files, by changing the URL path to the correct path (with `contentRewrite`).
 	e.GET(f.apiPrefix+"/*", assetHandler(f.apiPrefix), routerMiddleware(f.apiPrefix), contentRewrite)
 
+	pluginGroup := e.Group(f.apiPrefix + "/plugins")
+	if f.pluginDevEnvironment != nil {
+		proxyMiddleware := pluginDevProxyMiddleware(*f.pluginDevEnvironment)
+		pluginGroup.Use(proxyMiddleware)
+	}
 	// This route is serving the static files of the various plugins.
-	e.Static(f.apiPrefix+"/plugins", f.pluginsPath)
+	pluginGroup.Static("/", f.pluginsPath)
 }
 
 // assetHandler is here to serve the static files of the React app.
@@ -100,6 +108,69 @@ func assetHandler(apiPrefix string) echo.HandlerFunc {
 		_, err = c.Response().Write(data)
 		return apiinterface.HandleError(err)
 	}
+}
+
+// pluginDevProxyMiddleware is here to proxy the request to the dev environment.
+//
+// When developing a plugin, you will be able to serve the files of the plugin using a dev server (with rsbuild).
+// This middleware will route any request to a plugin listed in the dev environment to the dev server.
+func pluginDevProxyMiddleware(devEnvironment config.PluginDevEnvironment) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			for _, plg := range devEnvironment.Plugins {
+				if !strings.Contains(c.Request().URL.Path, plg.Name) {
+					continue
+				}
+				// We are going to serve a plugin from a dev environment, let's set up the proxy to redirect the traffic.
+				req := c.Request()
+				res := c.Response()
+				var proxyErr error
+				// Then we need to route this request to the dev environment.
+				// We just have to replace the URL as the path should remain the same.
+				reverseProxy := httputil.NewSingleHostReverseProxy(devEnvironment.URL.URL)
+				reverseProxy.ErrorHandler = func(_ http.ResponseWriter, _ *http.Request, err error) {
+					logrus.WithError(err).Errorf("error proxying, remote unreachable: target=%s, err=%v", devEnvironment.URL.String(), err)
+					proxyErr = err
+				}
+				if transportErr := proxyPrepareRequest(c, devEnvironment); transportErr != nil {
+					return transportErr
+				}
+				// Reverse proxy request.
+				reverseProxy.ServeHTTP(res, req)
+				// Return any error handled during proxying request.
+				if proxyErr != nil {
+					// we need to wrap the error with an Echo Error,
+					// otherwise the error will be hidden by the middleware "middleware.HandleError".
+					status := res.Status
+					if status < 400 {
+						// if there is an error and the status code doesn't match the error, then let's use a default one
+						status = 500
+					}
+					return echo.NewHTTPError(status, proxyErr.Error())
+				}
+				return nil
+			}
+			return next(c)
+		}
+	}
+}
+
+func proxyPrepareRequest(c echo.Context, devEnvironment config.PluginDevEnvironment) error {
+	req := c.Request()
+	// We have to modify the HOST of the request to match the host of the targetURL
+	// So far I'm not sure to understand exactly why. However, if you are going to remove it, be sure of what you are doing.
+	// It has been done to fix an error returned by Openshift itself saying the target doesn't exist.
+	// Since we are using HTTP/1, setting the HOST is setting also a header, so if the host and the header are different,
+	// then maybe it is blocked by the Openshift router.
+	req.Host = devEnvironment.URL.Host
+	// Fix header
+	if len(req.Header.Get(echo.HeaderXRealIP)) == 0 {
+		req.Header.Set(echo.HeaderXRealIP, c.RealIP())
+	}
+	if len(req.Header.Get(echo.HeaderXForwardedProto)) == 0 {
+		req.Header.Set(echo.HeaderXForwardedProto, c.Scheme())
+	}
+	return nil
 }
 
 // routerMiddleware is here to serve properly the React app.


### PR DESCRIPTION
Here a proposition to let the Perses server to read plugin serving by the dev server from `rsbuild`.

You just need to configure in Perses the dev environment and then it will read the schema and refresh the list of module available on `/api/v1/plugins`.

It will also forward the request to the dev server when needed. 

To be used like that: 

```yaml
plugins:
  dev_environment:
    url: "http://localhost:3005"
    plugins:
      - name: TimeSeriesChart
        absolute_path: "/Users/ahusson/workspace/go/src/perses/plugins/TimeSeriesChart"
```

I am just wondering if it's a good idea to have this configuration in the global config of Perses or if we should have it in a different file.
On the other hand, if someone want to split the Perses config in different files, there are tools for that that will compute and merge multiple files to a single one. That's what we are using to build the perses demo config. 

There is a based config file versioned on the repo `perses/website` and then there is another file directly on the VM where you have all the secret. Then these files are merged to give the final config.

So probably it's fine.

Related to the issue https://github.com/perses/plugins/issues/34