### PR TITLE
[ENHANCEMENT] Panel edit mode - show actions popover button when size is too small

### DIFF
--- a/ui/dashboards/src/components/Panel/HeaderIconButton.tsx
+++ b/ui/dashboards/src/components/Panel/HeaderIconButton.tsx
@@ -1,0 +1,6 @@
+import { IconButton, styled } from '@mui/material';
+
+export const HeaderIconButton = styled(IconButton)(({ theme }) => ({
+  borderRadius: theme.shape.borderRadius,
+  padding: '4px',
+}));

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -1,0 +1,196 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Stack, styled, Box, Popover } from '@mui/material';
+import { PropsWithChildren, useMemo, useState } from 'react';
+import { InfoTooltip, combineSx } from '@perses-dev/components';
+import ArrowCollapseIcon from 'mdi-material-ui/ArrowCollapse';
+import ArrowExpandIcon from 'mdi-material-ui/ArrowExpand';
+import PencilIcon from 'mdi-material-ui/PencilOutline';
+import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import DragIcon from 'mdi-material-ui/DragVertical';
+import ContentCopyIcon from 'mdi-material-ui/ContentCopy';
+import MenuIcon from 'mdi-material-ui/Menu';
+import {
+  ARIA_LABEL_TEXT,
+  HEADER_ACTIONS_MIN_WIDTH,
+  HEADER_ACTIONS_CONTAINER_NAME,
+  TOOLTIP_TEXT,
+} from '../../constants';
+import { HeaderIconButton } from './HeaderIconButton';
+
+export interface PanelActionsProps {
+  editHandlers?: {
+    onEditPanelClick: () => void;
+    onDuplicatePanelClick: () => void;
+    onDeletePanelClick: () => void;
+  };
+  readHandlers?: {
+    isPanelViewed?: boolean;
+    onViewPanelClick: () => void;
+  };
+  extra?: React.ReactNode;
+  title: string;
+}
+
+export const PanelActions: React.FC<PanelActionsProps> = ({ editHandlers, readHandlers, extra, title }) => {
+  const readActions = useMemo(() => {
+    if (readHandlers !== undefined) {
+      return (
+        <InfoTooltip description={TOOLTIP_TEXT.viewPanel}>
+          <HeaderIconButton
+            aria-label={ARIA_LABEL_TEXT.viewPanel(title)}
+            size="small"
+            onClick={readHandlers.onViewPanelClick}
+          >
+            {readHandlers.isPanelViewed ? (
+              <ArrowCollapseIcon fontSize="inherit" />
+            ) : (
+              <ArrowExpandIcon fontSize="inherit" />
+            )}
+          </HeaderIconButton>
+        </InfoTooltip>
+      );
+    }
+    return undefined;
+  }, [readHandlers, title]);
+
+  const editActions = useMemo(() => {
+    if (editHandlers !== undefined) {
+      // If there are edit handlers, always just show the edit buttons
+      return (
+        <>
+          <InfoTooltip description={TOOLTIP_TEXT.editPanel}>
+            <HeaderIconButton
+              aria-label={ARIA_LABEL_TEXT.editPanel(title)}
+              size="small"
+              onClick={editHandlers.onEditPanelClick}
+            >
+              <PencilIcon fontSize="inherit" />
+            </HeaderIconButton>
+          </InfoTooltip>
+          <InfoTooltip description={TOOLTIP_TEXT.duplicatePanel}>
+            <HeaderIconButton
+              aria-label={ARIA_LABEL_TEXT.duplicatePanel(title)}
+              size="small"
+              onClick={editHandlers.onDuplicatePanelClick}
+            >
+              <ContentCopyIcon
+                fontSize="inherit"
+                sx={{
+                  // Shrink this icon a little bit to look more consistent
+                  // with the other icons in the header.
+                  transform: 'scale(0.925)',
+                }}
+              />
+            </HeaderIconButton>
+          </InfoTooltip>
+          <InfoTooltip description={TOOLTIP_TEXT.deletePanel}>
+            <HeaderIconButton
+              aria-label={ARIA_LABEL_TEXT.deletePanel(title)}
+              size="small"
+              onClick={editHandlers.onDeletePanelClick}
+            >
+              <DeleteIcon fontSize="inherit" />
+            </HeaderIconButton>
+          </InfoTooltip>
+        </>
+      );
+    }
+    return undefined;
+  }, [editHandlers, title]);
+
+  return (
+    <HeaderActionWrapper direction="row" spacing={0.25} alignItems="center">
+      <Box
+        sx={combineSx((theme) => ({
+          [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).up(HEADER_ACTIONS_MIN_WIDTH)]: {
+            display: 'block',
+          },
+          display: 'none',
+        }))}
+      >
+        {editHandlers === undefined && extra} {readActions} {editActions}
+      </Box>
+
+      {editActions && (
+        <Box
+          sx={combineSx((theme) => ({
+            [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).down(HEADER_ACTIONS_MIN_WIDTH)]: {
+              display: 'block',
+            },
+            display: 'none',
+          }))}
+        >
+          <ShowAction>{editActions}</ShowAction>
+        </Box>
+      )}
+
+      <InfoTooltip description={TOOLTIP_TEXT.movePanel}>
+        <HeaderIconButton aria-label={ARIA_LABEL_TEXT.movePanel(title)} size="small">
+          <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} fontSize="inherit" />
+        </HeaderIconButton>
+      </InfoTooltip>
+    </HeaderActionWrapper>
+  );
+};
+
+const HeaderActionWrapper = styled(Stack)(() => ({
+  // Adding back the negative margins from MUI's defaults for actions, so we
+  // avoid increasing the header size when actions are present while also being
+  // able to vertically center the actions.
+  // https://github.com/mui/material-ui/blob/master/packages/mui-material/src/CardHeader/CardHeader.js#L56-L58
+  marginTop: -4,
+  marginBottom: -4,
+}));
+
+const ShowAction: React.FC<PropsWithChildren> = ({ children }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>): undefined => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (): undefined => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'actions-popover' : undefined;
+
+  return (
+    <>
+      <HeaderIconButton
+        className="show-actions"
+        aria-describedby={id}
+        onClick={handleClick}
+        aria-label={ARIA_LABEL_TEXT.editPanel('expand')}
+        size="small"
+      >
+        <MenuIcon fontSize="inherit" />
+      </HeaderIconButton>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <Box sx={{ padding: '8px' }}>{children}</Box>
+      </Popover>
+    </>
+  );
+};

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -132,7 +132,7 @@ export const PanelActions: React.FC<PanelActionsProps> = ({ editHandlers, readHa
             display: 'none',
           }))}
         >
-          <ShowAction>{editActions}</ShowAction>
+          <ShowAction title={title}>{editActions}</ShowAction>
         </Box>
       )}
 
@@ -154,7 +154,7 @@ const HeaderActionWrapper = styled(Stack)(() => ({
   marginBottom: -4,
 }));
 
-const ShowAction: React.FC<PropsWithChildren> = ({ children }) => {
+const ShowAction: React.FC<PropsWithChildren<{ title: string }>> = ({ children, title }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>): undefined => {
@@ -174,7 +174,7 @@ const ShowAction: React.FC<PropsWithChildren> = ({ children }) => {
         className="show-actions"
         aria-describedby={id}
         onClick={handleClick}
-        aria-label={ARIA_LABEL_TEXT.editPanel('expand')}
+        aria-label={ARIA_LABEL_TEXT.showPanelActions(title)}
         size="small"
       >
         <MenuIcon fontSize="inherit" />

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,62 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CardHeader, Typography, Stack, CardHeaderProps, styled, IconButton, Box } from '@mui/material';
+import { CardHeader, CardHeaderProps, Stack, Typography } from '@mui/material';
 import { InfoTooltip, combineSx } from '@perses-dev/components';
-import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
-import PencilIcon from 'mdi-material-ui/PencilOutline';
-import DeleteIcon from 'mdi-material-ui/DeleteOutline';
-import DragIcon from 'mdi-material-ui/DragVertical';
-import ArrowExpandIcon from 'mdi-material-ui/ArrowExpand';
-import ArrowCollapseIcon from 'mdi-material-ui/ArrowCollapse';
-import ContentCopyIcon from 'mdi-material-ui/ContentCopy';
-import { useReplaceVariablesInString } from '@perses-dev/plugin-system';
-import { PropsWithChildren, ReactElement, ReactNode, useState } from 'react';
 import { Link } from '@perses-dev/core';
-import MenuIcon from 'mdi-material-ui/Menu';
-import Popover from '@mui/material/Popover';
-import { ARIA_LABEL_TEXT, TOOLTIP_TEXT } from '../../constants';
+import { useReplaceVariablesInString } from '@perses-dev/plugin-system';
+import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
+import { ReactElement, ReactNode } from 'react';
+import { HEADER_ACTIONS_CONTAINER_NAME } from '../../constants';
+import { PanelActions, PanelActionsProps } from './PanelActions';
 import { PanelLinks } from './PanelLinks';
-
-const ShowAction: React.FC<PropsWithChildren> = ({ children }) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>): undefined => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = (): undefined => {
-    setAnchorEl(null);
-  };
-
-  const open = Boolean(anchorEl);
-  const id = open ? 'simple-popover' : undefined;
-
-  return (
-    <>
-      <HeaderIconButton
-        aria-describedby={id}
-        onClick={handleClick}
-        aria-label={ARIA_LABEL_TEXT.editPanel('expand')}
-        size="small"
-      >
-        <MenuIcon fontSize="inherit" />
-      </HeaderIconButton>
-      <Popover
-        id={id}
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-      >
-        <Box sx={{ padding: '8px' }}>{children}</Box>
-      </Popover>
-    </>
-  );
-};
+import { HeaderIconButton } from './HeaderIconButton';
 
 type OmittedProps = 'children' | 'action' | 'title' | 'disableTypography';
 
@@ -76,15 +30,8 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
   description?: string;
   links?: Link[];
   extra?: ReactNode;
-  readHandlers?: {
-    isPanelViewed?: boolean;
-    onViewPanelClick: () => void;
-  };
-  editHandlers?: {
-    onEditPanelClick: () => void;
-    onDuplicatePanelClick: () => void;
-    onDeletePanelClick: () => void;
-  };
+  readHandlers?: PanelActionsProps['readHandlers'];
+  editHandlers?: PanelActionsProps['editHandlers'];
 }
 
 export function PanelHeader({
@@ -103,67 +50,6 @@ export function PanelHeader({
 
   const title = useReplaceVariablesInString(rawTitle) as string;
   const description = useReplaceVariablesInString(rawDescription);
-
-  let readActions: CardHeaderProps['action'] = undefined;
-  if (readHandlers !== undefined) {
-    readActions = (
-      <InfoTooltip description={TOOLTIP_TEXT.viewPanel}>
-        <HeaderIconButton
-          aria-label={ARIA_LABEL_TEXT.viewPanel(title)}
-          size="small"
-          onClick={readHandlers.onViewPanelClick}
-        >
-          {readHandlers.isPanelViewed ? (
-            <ArrowCollapseIcon fontSize="inherit" />
-          ) : (
-            <ArrowExpandIcon fontSize="inherit" />
-          )}
-        </HeaderIconButton>
-      </InfoTooltip>
-    );
-  }
-  let editActions: CardHeaderProps['action'] = undefined;
-  if (editHandlers !== undefined) {
-    // If there are edit handlers, always just show the edit buttons
-    editActions = (
-      <>
-        <InfoTooltip description={TOOLTIP_TEXT.editPanel}>
-          <HeaderIconButton
-            aria-label={ARIA_LABEL_TEXT.editPanel(title)}
-            size="small"
-            onClick={editHandlers.onEditPanelClick}
-          >
-            <PencilIcon fontSize="inherit" />
-          </HeaderIconButton>
-        </InfoTooltip>
-        <InfoTooltip description={TOOLTIP_TEXT.duplicatePanel}>
-          <HeaderIconButton
-            aria-label={ARIA_LABEL_TEXT.duplicatePanel(title)}
-            size="small"
-            onClick={editHandlers.onDuplicatePanelClick}
-          >
-            <ContentCopyIcon
-              fontSize="inherit"
-              sx={{
-                // Shrink this icon a little bit to look more consistent
-                // with the other icons in the header.
-                transform: 'scale(0.925)',
-              }}
-            />
-          </HeaderIconButton>
-        </InfoTooltip>
-        <InfoTooltip description={TOOLTIP_TEXT.deletePanel}>
-          <HeaderIconButton
-            aria-label={ARIA_LABEL_TEXT.deletePanel(title)}
-            size="small"
-            onClick={editHandlers.onDeletePanelClick}
-          >
-            <DeleteIcon fontSize="inherit" />
-          </HeaderIconButton>
-        </InfoTooltip>
-      </>
-    );
-  }
 
   return (
     <CardHeader
@@ -205,51 +91,11 @@ export function PanelHeader({
           {links !== undefined && links.length > 0 && <PanelLinks links={links} />}
         </Stack>
       }
-      action={
-        <HeaderActionWrapper
-          sx={combineSx((theme) => {
-            theme.containerQueries('primary').up(200);
-            return {};
-          })}
-          direction="row"
-          spacing={0.25}
-          alignItems="center"
-        >
-          <Box
-            sx={{
-              '@container responsiveBox (min-width: 200px)': {
-                display: 'block',
-              },
-              display: 'none',
-            }}
-          >
-            {editHandlers === undefined && extra} {readActions} {editActions}
-          </Box>
-          {editActions && (
-            <>
-              <Box
-                sx={{
-                  '@container responsiveBox (max-width: 200px)': {
-                    display: 'block',
-                  },
-                  display: 'none',
-                }}
-              >
-                <ShowAction>{editActions}</ShowAction>
-              </Box>
-              <InfoTooltip description={TOOLTIP_TEXT.movePanel}>
-                <HeaderIconButton aria-label={ARIA_LABEL_TEXT.movePanel(title)} size="small">
-                  <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} fontSize="inherit" />
-                </HeaderIconButton>
-              </InfoTooltip>
-            </>
-          )}
-        </HeaderActionWrapper>
-      }
+      action={<PanelActions title={title} readHandlers={readHandlers} editHandlers={editHandlers} extra={extra} />}
       sx={combineSx(
         (theme) => ({
           containerType: 'inline-size',
-          containerName: 'responsiveBox',
+          containerName: HEADER_ACTIONS_CONTAINER_NAME,
           padding: theme.spacing(1),
           borderBottom: `solid 1px ${theme.palette.divider}`,
           '.MuiCardHeader-content': {
@@ -269,17 +115,3 @@ export function PanelHeader({
     />
   );
 }
-
-const HeaderIconButton = styled(IconButton)(({ theme }) => ({
-  borderRadius: theme.shape.borderRadius,
-  padding: '4px',
-}));
-
-const HeaderActionWrapper = styled(Stack)(() => ({
-  // Adding back the negative margins from MUI's defaults for actions, so we
-  // avoid increasing the header size when actions are present while also being
-  // able to vertically center the actions.
-  // https://github.com/mui/material-ui/blob/master/packages/mui-material/src/CardHeader/CardHeader.js#L56-L58
-  marginTop: -4,
-  marginBottom: -4,
-}));

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CardHeader, Typography, Stack, CardHeaderProps, styled, IconButton } from '@mui/material';
+import { CardHeader, Typography, Stack, CardHeaderProps, styled, IconButton, Box } from '@mui/material';
 import { InfoTooltip, combineSx } from '@perses-dev/components';
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
@@ -21,10 +21,53 @@ import ArrowExpandIcon from 'mdi-material-ui/ArrowExpand';
 import ArrowCollapseIcon from 'mdi-material-ui/ArrowCollapse';
 import ContentCopyIcon from 'mdi-material-ui/ContentCopy';
 import { useReplaceVariablesInString } from '@perses-dev/plugin-system';
-import { ReactElement, ReactNode } from 'react';
+import { PropsWithChildren, ReactElement, ReactNode, useState } from 'react';
 import { Link } from '@perses-dev/core';
+import MenuIcon from 'mdi-material-ui/Menu';
+import Popover from '@mui/material/Popover';
 import { ARIA_LABEL_TEXT, TOOLTIP_TEXT } from '../../constants';
 import { PanelLinks } from './PanelLinks';
+
+const ShowAction: React.FC<PropsWithChildren> = ({ children }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>): undefined => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (): undefined => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
+
+  return (
+    <>
+      <HeaderIconButton
+        aria-describedby={id}
+        onClick={handleClick}
+        aria-label={ARIA_LABEL_TEXT.editPanel('expand')}
+        size="small"
+      >
+        <MenuIcon fontSize="inherit" />
+      </HeaderIconButton>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <Box sx={{ padding: '8px' }}>{children}</Box>
+      </Popover>
+    </>
+  );
+};
+
 type OmittedProps = 'children' | 'action' | 'title' | 'disableTypography';
 
 export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
@@ -118,11 +161,6 @@ export function PanelHeader({
             <DeleteIcon fontSize="inherit" />
           </HeaderIconButton>
         </InfoTooltip>
-        <InfoTooltip description={TOOLTIP_TEXT.movePanel}>
-          <HeaderIconButton aria-label={ARIA_LABEL_TEXT.movePanel(title)} size="small">
-            <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} fontSize="inherit" />
-          </HeaderIconButton>
-        </InfoTooltip>
       </>
     );
   }
@@ -168,12 +206,50 @@ export function PanelHeader({
         </Stack>
       }
       action={
-        <HeaderActionWrapper direction="row" spacing={0.25} alignItems="center">
-          {editHandlers === undefined && extra} {readActions} {editActions}
+        <HeaderActionWrapper
+          sx={combineSx((theme) => {
+            theme.containerQueries('primary').up(200);
+            return {};
+          })}
+          direction="row"
+          spacing={0.25}
+          alignItems="center"
+        >
+          <Box
+            sx={{
+              '@container responsiveBox (min-width: 200px)': {
+                display: 'block',
+              },
+              display: 'none',
+            }}
+          >
+            {editHandlers === undefined && extra} {readActions} {editActions}
+          </Box>
+          {editActions && (
+            <>
+              <Box
+                sx={{
+                  '@container responsiveBox (max-width: 200px)': {
+                    display: 'block',
+                  },
+                  display: 'none',
+                }}
+              >
+                <ShowAction>{editActions}</ShowAction>
+              </Box>
+              <InfoTooltip description={TOOLTIP_TEXT.movePanel}>
+                <HeaderIconButton aria-label={ARIA_LABEL_TEXT.movePanel(title)} size="small">
+                  <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} fontSize="inherit" />
+                </HeaderIconButton>
+              </InfoTooltip>
+            </>
+          )}
         </HeaderActionWrapper>
       }
       sx={combineSx(
         (theme) => ({
+          containerType: 'inline-size',
+          containerName: 'responsiveBox',
           padding: theme.spacing(1),
           borderBottom: `solid 1px ${theme.palette.divider}`,
           '.MuiCardHeader-content': {

--- a/ui/dashboards/src/constants/styles.ts
+++ b/ui/dashboards/src/constants/styles.ts
@@ -23,3 +23,6 @@ export const editButtonStyle: SxProps<Theme> = {
 
 export const MIN_VARIABLE_WIDTH = 120;
 export const MAX_VARIABLE_WIDTH = 500;
+
+export const HEADER_ACTIONS_MIN_WIDTH = 200;
+export const HEADER_ACTIONS_CONTAINER_NAME = 'header-actions-container';

--- a/ui/dashboards/src/constants/user-interface-text.ts
+++ b/ui/dashboards/src/constants/user-interface-text.ts
@@ -49,5 +49,6 @@ export const ARIA_LABEL_TEXT = {
   editPanel: (panelName: string): string => `edit panel ${panelName}`,
   duplicatePanel: (panelName: string): string => `duplicate panel ${panelName}`,
   deletePanel: (panelName: string): string => `delete panel ${panelName}`,
+  showPanelActions: (panelName: string): string => `show panel actions for ${panelName} `,
   movePanel: (panelName: string): string => `move panel ${panelName}`,
 };

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -20,6 +20,7 @@ This package contains end-to-end tests for Perses written using [Playwright](htt
 
 Tests are run during local development using the configuration in `local.playwright.config.ts`. The tests depend on the local development servers (backend and UI) to test against. By default, locally run tests will not take screenshots for visual testing.
 
+- Update the configuration at `dev/config.yaml` to `enable_auth: false` as the end-to-end tests do not use auth.
 - Start the backend server from the project root: `./scripts/api_backend_dev.sh`
 - Change to the `ui` directory.
 - Start the UI server: `npm start`
@@ -30,7 +31,7 @@ Tests are run during local development using the configuration in `local.playwri
 
 ### Locally with screenshots (maintainers only)
 
-*This option is limited to maintainers because it requires access to secrets in the Happo account.*
+_This option is limited to maintainers because it requires access to secrets in the Happo account._
 
 Occasionally, you may want to generate screenshots locally to debug an issue with visual tests.
 

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -20,8 +20,7 @@ This package contains end-to-end tests for Perses written using [Playwright](htt
 
 Tests are run during local development using the configuration in `local.playwright.config.ts`. The tests depend on the local development servers (backend and UI) to test against. By default, locally run tests will not take screenshots for visual testing.
 
-- Update the configuration at `dev/config.yaml` to `enable_auth: false` as the end-to-end tests do not use auth.
-- Start the backend server from the project root: `./scripts/api_backend_dev.sh`
+- Start the backend server from the project root and disable authentication: `./scripts/api_backend_dev.sh --e2e`.
 - Change to the `ui` directory.
 - Start the UI server: `npm start`
   - Important to ensure libraries are built since e2e imports from other Perses packages

--- a/ui/e2e/src/pages/Panel.ts
+++ b/ui/e2e/src/pages/Panel.ts
@@ -28,6 +28,7 @@ export class Panel {
   readonly editButton: Locator;
   readonly deleteButton: Locator;
   readonly duplicateButton: Locator;
+  readonly showActionsButton: Locator;
 
   readonly resizeHandle: Locator;
 
@@ -50,6 +51,9 @@ export class Panel {
     });
     this.duplicateButton = this.container.getByRole('button', {
       name: 'duplicate panel',
+    });
+    this.showActionsButton = this.container.getByRole('button', {
+      name: 'show panel actions',
     });
 
     // Need to look up to panel draggable parent first to get the resize handle.

--- a/ui/e2e/src/tests/panels.spec.ts
+++ b/ui/e2e/src/tests/panels.spec.ts
@@ -96,6 +96,7 @@ test.describe('Dashboard: Panels', () => {
     const smallerSize = await panel.getBounds();
     expect(smallerSize.width / originalSize.width).toBeCloseTo(smallMultiplier, 1);
     expect(smallerSize.height / originalSize.height).toBeCloseTo(smallMultiplier, 1);
+    await expect(panel.container.locator('button.show-actions')).toBeVisible();
 
     // Resize bigger
     const largeMultiplier = 1.5;
@@ -106,6 +107,7 @@ test.describe('Dashboard: Panels', () => {
     const largerSize = await panel.getBounds();
     expect(largerSize.width / originalSize.width).toBeCloseTo(largeMultiplier, 1);
     expect(largerSize.height / originalSize.height).toBeCloseTo(largeMultiplier, 1);
+    await expect(panel.container.locator('button.show-actions')).toBeHidden();
   });
 
   // There was previously a bug related to going to a smaller screen and back to

--- a/ui/e2e/src/tests/panels.spec.ts
+++ b/ui/e2e/src/tests/panels.spec.ts
@@ -96,7 +96,7 @@ test.describe('Dashboard: Panels', () => {
     const smallerSize = await panel.getBounds();
     expect(smallerSize.width / originalSize.width).toBeCloseTo(smallMultiplier, 1);
     expect(smallerSize.height / originalSize.height).toBeCloseTo(smallMultiplier, 1);
-    await expect(panel.container.locator('button.show-actions')).toBeVisible();
+    await expect(panel.showActionsButton).toBeVisible();
 
     // Resize bigger
     const largeMultiplier = 1.5;
@@ -107,7 +107,7 @@ test.describe('Dashboard: Panels', () => {
     const largerSize = await panel.getBounds();
     expect(largerSize.width / originalSize.width).toBeCloseTo(largeMultiplier, 1);
     expect(largerSize.height / originalSize.height).toBeCloseTo(largeMultiplier, 1);
-    await expect(panel.container.locator('button.show-actions')).toBeHidden();
+    await expect(panel.showActionsButton).toBeHidden();
   });
 
   // There was previously a bug related to going to a smaller screen and back to


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
fixes https://github.com/perses/perses/issues/2595
### In edit mode
- conditionally show a menu button and hide the edit actions to make them usable when the panel is very small
- always show drag handle

### changes made
- refactor actions from `PanelHeader` to `PanelActions` ( main bulk of the change )
- Added a step in the e2e to check the visibility of the button depending on size
- Added `ShowActions` component and required constants
- Update e2e `README.md` to instruct how to run the back-end so the tests will run locally

<!-- Context useful to a reviewer -->

# Screenshots before
<img width="345" alt="image" src="https://github.com/user-attachments/assets/113f8172-981b-4251-96a7-24e11d52bdd2" />

- panels 1 & 2 , cannot be moved ( unlike panel 3 )

# Screenshots after
<img width="328" alt="image" src="https://github.com/user-attachments/assets/e8d62588-611e-4f52-b03b-6417c1101a96" />

- example of small sizes

![Feb-02-2025 20-57-32](https://github.com/user-attachments/assets/8dd433de-09ef-4c39-b3d5-c1013c1fb78f)

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
