### PR TITLE
[ENHANCEMENT] Improve panel hover behavior and adjust header styling for better visibility

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -100,6 +100,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
           height: '100%',
           display: 'flex',
           flexFlow: 'column nowrap',
+          ':hover': { '--panel-hover': 'true' },
         },
         sx
       )}

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -111,36 +111,42 @@ export const PanelActions: React.FC<PanelActionsProps> = ({ editHandlers, readHa
   }, [editHandlers, title]);
 
   return (
-    <HeaderActionWrapper direction="row" spacing={0.25} alignItems="center">
-      <Box
-        sx={combineSx((theme) => ({
-          display: 'block',
-          [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).down(HEADER_ACTIONS_MIN_WIDTH)]: {
-            display: 'none',
-          },
-        }))}
-      >
-        {editHandlers === undefined && extra} {readActions} {editActions}
-      </Box>
-
+    <HeaderActionWrapper
+      direction="row"
+      spacing={0.25}
+      alignItems="center"
+      sx={{ display: editHandlers !== undefined || readHandlers?.isPanelViewed ? 'flex' : 'var(--panel-hover, none)' }}
+    >
+      {editHandlers === undefined && extra} {readActions}
       {editActions && (
-        <Box
-          sx={combineSx((theme) => ({
-            display: 'block',
-            [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).up(HEADER_ACTIONS_MIN_WIDTH)]: {
-              display: 'none',
-            },
-          }))}
-        >
-          <ShowAction title={title}>{editActions}</ShowAction>
-        </Box>
+        <>
+          <Box
+            sx={combineSx((theme) => ({
+              display: 'block',
+              [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).down(HEADER_ACTIONS_MIN_WIDTH)]: {
+                display: 'none',
+              },
+            }))}
+          >
+            {editActions}
+          </Box>
+          <Box
+            sx={combineSx((theme) => ({
+              display: 'block',
+              [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).up(HEADER_ACTIONS_MIN_WIDTH)]: { display: 'none' },
+            }))}
+          >
+            <ShowAction title={title}>{editActions}</ShowAction>
+          </Box>
+        </>
       )}
-
-      <InfoTooltip description={TOOLTIP_TEXT.movePanel}>
-        <HeaderIconButton aria-label={ARIA_LABEL_TEXT.movePanel(title)} size="small">
-          <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} fontSize="inherit" />
-        </HeaderIconButton>
-      </InfoTooltip>
+      {editActions && (
+        <InfoTooltip description={TOOLTIP_TEXT.movePanel}>
+          <HeaderIconButton aria-label={ARIA_LABEL_TEXT.movePanel(title)} size="small">
+            <DragIcon className="drag-handle" sx={{ cursor: 'grab' }} fontSize="inherit" />
+          </HeaderIconButton>
+        </InfoTooltip>
+      )}
     </HeaderActionWrapper>
   );
 };

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CardHeader, CardHeaderProps, Stack, Typography } from '@mui/material';
+import { Box, CardHeader, CardHeaderProps, Stack, Typography } from '@mui/material';
 import { InfoTooltip, combineSx } from '@perses-dev/components';
 import { Link } from '@perses-dev/core';
 import { useReplaceVariablesInString } from '@perses-dev/plugin-system';
@@ -67,7 +67,7 @@ export function PanelHeader({
               // `minHeight` guarantees that the header has the correct height
               // when there is no title (i.e. in the preview)
               lineHeight: '24px',
-              minHeight: '24px',
+              minHeight: '26px',
               whiteSpace: 'nowrap',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
@@ -77,16 +77,18 @@ export function PanelHeader({
           </Typography>
           {/* Show the info tooltip when description is defined and is not all whitespace */}
           {description !== undefined && description.trim().length > 0 && (
-            <InfoTooltip id={descriptionTooltipId} description={description} enterDelay={100}>
-              <HeaderIconButton aria-label="panel description" size="small">
-                <InformationOutlineIcon
-                  aria-describedby="info-tooltip"
-                  aria-hidden={false}
-                  fontSize="inherit"
-                  sx={{ color: (theme) => theme.palette.text.secondary }}
-                />
-              </HeaderIconButton>
-            </InfoTooltip>
+            <Box sx={{ display: editHandlers === undefined ? 'var(--panel-hover, none)' : 'flex' }}>
+              <InfoTooltip id={descriptionTooltipId} description={description} enterDelay={100}>
+                <HeaderIconButton aria-label="panel description" size="small">
+                  <InformationOutlineIcon
+                    aria-describedby="info-tooltip"
+                    aria-hidden={false}
+                    fontSize="inherit"
+                    sx={{ color: (theme) => theme.palette.text.secondary }}
+                  />
+                </HeaderIconButton>
+              </InfoTooltip>
+            </Box>
           )}
           {links !== undefined && links.length > 0 && <PanelLinks links={links} />}
         </Stack>


### PR DESCRIPTION
# Description
Solves https://github.com/perses/perses/issues/2602

- Updated the panels to show header actions only when hovering the panel or when the panel is expanded
- show drag handle only in edit mode

<!-- Context useful to a reviewer -->

# Screenshots
![Feb-04-2025 22-11-20](https://github.com/user-attachments/assets/3d6c3901-5d96-45e8-a856-82f17d8b8be8)
<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
