### PR TITLE
[ENHANCEMENT] schemas are required for specific plugin kind

### DIFF
--- a/cue/model/api/v1/plugin/plugin_go_gen.cue
+++ b/cue/model/api/v1/plugin/plugin_go_gen.cue
@@ -6,13 +6,24 @@ package plugin
 
 import "github.com/perses/perses/cue/model/api/v1/common"
 
-#KindVariable:        "Variable"
-#KindDatasource:      "Datasource"
-#KindPanel:           "Panel"
-#KindTimeSeriesQuery: "TimeSeriesQuery"
-#KindTraceQuery:      "TraceQuery"
-#KindQuery:           "Query"
-#KindExplore:         "Explore"
+#Kind: string // #enumKind
+
+#enumKind:
+	#KindVariable |
+	#KindDatasource |
+	#KindPanel |
+	#KindTimeSeriesQuery |
+	#KindTraceQuery |
+	#KindQuery |
+	#KindExplore
+
+#KindVariable:        #Kind & "Variable"
+#KindDatasource:      #Kind & "Datasource"
+#KindPanel:           #Kind & "Panel"
+#KindTimeSeriesQuery: #Kind & "TimeSeriesQuery"
+#KindTraceQuery:      #Kind & "TraceQuery"
+#KindQuery:           #Kind & "Query"
+#KindExplore:         #Kind & "Explore"
 
 #Spec: {
 	display?: null | common.#Display @go(Display,*common.Display)

--- a/cue/model/api/v1/plugin/plugin_patch.cue
+++ b/cue/model/api/v1/plugin/plugin_patch.cue
@@ -22,6 +22,6 @@
 package plugin
 
 #Plugin: {
-	kind: string @go(Kind)
+	kind: #enumKind @go(Kind)
 	spec: #Spec  @go(Spec)
 }

--- a/internal/api/plugin/dev.go
+++ b/internal/api/plugin/dev.go
@@ -49,6 +49,10 @@ func (p *pluginDev) load() []v1.PluginModule {
 			},
 			Spec: npmPackageData.Perses,
 		}
+		if !IsSchemaRequired(pluginModule.Spec) {
+			logrus.Debugf("plugin %q does not require schema, so it will be skipped", pluginModule.Metadata.Name)
+			continue
+		}
 		if pluginSchemaLoadErr := p.sch.Load(plg.AbsolutePath, pluginModule); pluginSchemaLoadErr != nil {
 			logrus.WithError(pluginSchemaLoadErr).Error("unable to load plugin schema")
 			continue

--- a/internal/api/plugin/migrate/migrate.go
+++ b/internal/api/plugin/migrate/migrate.go
@@ -115,7 +115,7 @@ func isPackageMigrate(file string) (bool, error) {
 	return strings.Contains(string(data), "package migrate"), nil
 }
 
-func getPluginKind(migrateFile string) (string, error) {
+func getPluginKind(migrateFile string) (plugin.Kind, error) {
 	data, err := os.ReadFile(migrateFile)
 	if err != nil {
 		return "", err

--- a/internal/api/plugin/plugin.go
+++ b/internal/api/plugin/plugin.go
@@ -123,9 +123,10 @@ func (p *pluginFile) Load() error {
 			},
 			Spec: npmPackageData.Perses,
 		}
-		// TODO with this current implementation, we cannot load a plugin that does not have a schema.
-		//  We should probably add a flag to the plugin to indicate if it has a schema or not.
-		//  Actually we already know what plugin type should have a schema or not. So we simply have to determinate based on the plugin type which one should have a schema or not.
+		if !IsSchemaRequired(pluginModule.Spec) {
+			logrus.Debugf("plugin %q does not require schema, so it will be skipped", pluginModule.Metadata.Name)
+			continue
+		}
 		if pluginSchemaLoadErr := p.sch.Load(pluginPath, pluginModule); pluginSchemaLoadErr != nil {
 			logrus.WithError(pluginSchemaLoadErr).Error("unable to load plugin schema")
 			continue

--- a/internal/api/plugin/schema/schema.go
+++ b/internal/api/plugin/schema/schema.go
@@ -31,7 +31,7 @@ import (
 )
 
 type LoadSchema struct {
-	Kind     string
+	Kind     plugin.Kind
 	Name     string
 	Instance *build.Instance
 }

--- a/internal/cli/cmd/plugin/lint/lint.go
+++ b/internal/cli/cmd/plugin/lint/lint.go
@@ -63,11 +63,13 @@ func (o *option) Execute() error {
 	if readErr != nil {
 		return fmt.Errorf("unable to read plugin package.json: %w", readErr)
 	}
-	if _, err := schema.Load("", npmPackageData.Perses); err != nil {
-		return err
-	}
-	if _, err := migrate.Load("", npmPackageData.Perses); err != nil {
-		return err
+	if plugin.IsSchemaRequired(npmPackageData.Perses) {
+		if _, err := schema.Load("", npmPackageData.Perses); err != nil {
+			return err
+		}
+		if _, err := migrate.Load("", npmPackageData.Perses); err != nil {
+			return err
+		}
 	}
 	return output.HandleString(o.writer, "current plugin is valid")
 }

--- a/pkg/model/api/v1/plugin/plugin.go
+++ b/pkg/model/api/v1/plugin/plugin.go
@@ -20,14 +20,16 @@ import (
 	"github.com/perses/perses/pkg/model/api/v1/common"
 )
 
+type Kind string
+
 const (
-	KindVariable        = "Variable"
-	KindDatasource      = "Datasource"
-	KindPanel           = "Panel"
-	KindTimeSeriesQuery = "TimeSeriesQuery"
-	KindTraceQuery      = "TraceQuery"
-	KindQuery           = "Query"
-	KindExplore         = "Explore"
+	KindVariable        Kind = "Variable"
+	KindDatasource      Kind = "Datasource"
+	KindPanel           Kind = "Panel"
+	KindTimeSeriesQuery Kind = "TimeSeriesQuery"
+	KindTraceQuery      Kind = "TraceQuery"
+	KindQuery           Kind = "Query"
+	KindExplore         Kind = "Explore"
 )
 
 type Spec struct {
@@ -36,8 +38,8 @@ type Spec struct {
 }
 
 type Plugin struct {
-	Kind string `json:"kind" yaml:"kind"`
-	Spec Spec   `json:"spec" yaml:"spec"`
+	Kind Kind `json:"kind" yaml:"kind"`
+	Spec Spec `json:"spec" yaml:"spec"`
 }
 
 func (p *Plugin) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
Based on the plugin Kind, we are able to detect if the plugin needs a schema or not.

That should help to support and load the `explorer` plugin and latter the plugin like in the PR https://github.com/perses/perses/pull/2530