### PR TITLE
[BUGFIX] Uses pkg filepath instead of path when manipulating file access

### DIFF
--- a/internal/api/database/file/file.go
+++ b/internal/api/database/file/file.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -33,9 +32,9 @@ import (
 func generateID(kind modelV1.Kind, metadata modelAPI.Metadata) (string, error) {
 	switch m := metadata.(type) {
 	case *modelV1.ProjectMetadata:
-		return path.Join(modelV1.PluralKindMap[kind], m.Project, m.Name), nil
+		return filepath.Join(modelV1.PluralKindMap[kind], m.Project, m.Name), nil
 	case *modelV1.Metadata:
-		return path.Join(modelV1.PluralKindMap[kind], m.Name), nil
+		return filepath.Join(modelV1.PluralKindMap[kind], m.Name), nil
 	}
 	return "", fmt.Errorf("metadata %T not managed", metadata)
 }
@@ -299,7 +298,7 @@ func (d *DAO) upsert(key string, entity modelAPI.Entity) error {
 }
 
 func (d *DAO) buildPath(key string) string {
-	return path.Join(d.Folder, fmt.Sprintf("%s.%s", key, d.Extension))
+	return filepath.Join(d.Folder, fmt.Sprintf("%s.%s", key, d.Extension))
 }
 
 func (d *DAO) unmarshal(data []byte, entity interface{}) error {

--- a/internal/api/database/file/query.go
+++ b/internal/api/database/file/query.go
@@ -16,25 +16,22 @@ package databasefile
 import (
 	"fmt"
 	"os"
-	"path"
-
-	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
-
+	"path/filepath"
 	"strings"
-
-	"github.com/perses/perses/internal/api/interface/v1/globalrole"
-	"github.com/perses/perses/internal/api/interface/v1/globalrolebinding"
-	"github.com/perses/perses/internal/api/interface/v1/role"
-	"github.com/perses/perses/internal/api/interface/v1/rolebinding"
 
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
+	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
 	"github.com/perses/perses/internal/api/interface/v1/folder"
 	"github.com/perses/perses/internal/api/interface/v1/globaldatasource"
+	"github.com/perses/perses/internal/api/interface/v1/globalrole"
+	"github.com/perses/perses/internal/api/interface/v1/globalrolebinding"
 	"github.com/perses/perses/internal/api/interface/v1/globalsecret"
 	"github.com/perses/perses/internal/api/interface/v1/globalvariable"
 	"github.com/perses/perses/internal/api/interface/v1/project"
+	"github.com/perses/perses/internal/api/interface/v1/role"
+	"github.com/perses/perses/internal/api/interface/v1/rolebinding"
 	"github.com/perses/perses/internal/api/interface/v1/secret"
 	"github.com/perses/perses/internal/api/interface/v1/user"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
@@ -57,13 +54,13 @@ func isFolderExist(folder string) (bool, error) {
 func (d *DAO) generateProjectResourceQuery(kind v1.Kind, project string) string {
 	if len(project) == 0 {
 		// It's used when we query a list of object. It can happen that the project is empty.
-		return path.Join(d.Folder, v1.PluralKindMap[kind])
+		return filepath.Join(d.Folder, v1.PluralKindMap[kind])
 	}
-	return path.Join(d.Folder, v1.PluralKindMap[kind], project)
+	return filepath.Join(d.Folder, v1.PluralKindMap[kind], project)
 }
 
 func (d *DAO) generateResourceQuery(kind v1.Kind) string {
-	return path.Join(d.Folder, v1.PluralKindMap[kind])
+	return filepath.Join(d.Folder, v1.PluralKindMap[kind])
 }
 
 func (d *DAO) buildQuery(query databaseModel.Query) (pathFolder string, prefix string, isExist bool, err error) {

--- a/internal/api/plugin/archive.go
+++ b/internal/api/plugin/archive.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/mholt/archives"
 	"github.com/perses/perses/internal/api/archive"
@@ -54,7 +54,7 @@ func (a *arch) unzip(archiveFileName string) error {
 		return nil
 	}
 	logrus.Debugf("unzipping archive %s", archiveFileName)
-	archiveFile := path.Join(a.folder, archiveFileName)
+	archiveFile := filepath.Join(a.folder, archiveFileName)
 	stream, archiveOpenErr := os.Open(archiveFile)
 	defer func() {
 		if closeErr := stream.Close(); closeErr != nil {
@@ -81,8 +81,8 @@ func (a *arch) extractArchiveFileHandler(_ context.Context, f archives.FileInfo)
 	if f.IsDir() {
 		return nil
 	}
-	currentDir, _ := path.Split(f.NameInArchive)
-	if mkdirErr := os.MkdirAll(path.Join(a.targetFolder, currentDir), os.ModePerm); mkdirErr != nil {
+	currentDir, _ := filepath.Split(f.NameInArchive)
+	if mkdirErr := os.MkdirAll(filepath.Join(a.targetFolder, currentDir), os.ModePerm); mkdirErr != nil {
 		return fmt.Errorf("unable to create directory %q: %w", currentDir, mkdirErr)
 	}
 	stream, openErr := f.Open()
@@ -98,7 +98,7 @@ func (a *arch) extractArchiveFileHandler(_ context.Context, f archives.FileInfo)
 	if err != nil {
 		return fmt.Errorf("unable to read the file %q: %w", f.NameInArchive, err)
 	}
-	if writeErr := os.WriteFile(path.Join(a.targetFolder, f.NameInArchive), respBytes, 0644); writeErr != nil { // nolint: gosec
+	if writeErr := os.WriteFile(filepath.Join(a.targetFolder, f.NameInArchive), respBytes, 0644); writeErr != nil { // nolint: gosec
 		return fmt.Errorf("unable to write the file %q: %w", f.NameInArchive, writeErr)
 	}
 	return nil

--- a/internal/api/plugin/npm.go
+++ b/internal/api/plugin/npm.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/plugin"
@@ -51,7 +51,7 @@ type NPMManifest struct {
 }
 
 func ReadManifest(pluginPath string) (*NPMManifest, error) {
-	manifestFilePath := path.Join(pluginPath, ManifestFileName)
+	manifestFilePath := filepath.Join(pluginPath, ManifestFileName)
 	manifestData := &NPMManifest{}
 	return manifestData, readFile(manifestFilePath, manifestData)
 }
@@ -62,7 +62,7 @@ func ReadManifestFromNetwork(url *common.URL, pluginName string) (*NPMManifest, 
 }
 
 func ReadPackage(pluginPath string) (*NPMPackage, error) {
-	packageFilePath := path.Join(pluginPath, PackageJSONFile)
+	packageFilePath := filepath.Join(pluginPath, PackageJSONFile)
 	packageData := &NPMPackage{}
 	return packageData, readFile(packageFilePath, packageData)
 }

--- a/internal/api/plugin/schema/schema.go
+++ b/internal/api/plugin/schema/schema.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -61,7 +60,7 @@ func Load(pluginPath string, moduleSpec plugin.ModuleSpec) ([]LoadSchema, error)
 				return nil
 			}
 		}
-		currentDir, _ := path.Split(currentPath)
+		currentDir, _ := filepath.Split(currentPath)
 		name, instance, schemaErr := LoadModelSchema(currentDir)
 		if schemaErr != nil {
 			return schemaErr

--- a/internal/cli/cmd/dac/build/testdata/go/go.mod
+++ b/internal/cli/cmd/dac/build/testdata/go/go.mod
@@ -13,9 +13,7 @@
 
 module dac
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.23.4
 
 replace github.com/perses/perses => ../../../../../../../ // Use current version
 

--- a/scripts/cue-test/cue-test.go
+++ b/scripts/cue-test/cue-test.go
@@ -16,7 +16,7 @@ package main
 import (
 	"encoding/json"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/perses/perses/internal/api/plugin"
 	"github.com/perses/perses/internal/api/plugin/schema"
@@ -30,7 +30,7 @@ import (
 
 func validateAllDashboards(sch schema.Schema) {
 	logrus.Info("validate all dashboards in dev/data")
-	data, err := os.ReadFile(path.Join("dev", "data", "9-dashboard.json"))
+	data, err := os.ReadFile(filepath.Join("dev", "data", "9-dashboard.json"))
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func validateAllDashboards(sch schema.Schema) {
 
 func validateAllDatasources(sch schema.Schema) {
 	logrus.Info("validate all datasources in dev/data")
-	data, err := os.ReadFile(path.Join("dev", "data", "8-datasource.json"))
+	data, err := os.ReadFile(filepath.Join("dev", "data", "8-datasource.json"))
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func validateAllDatasources(sch schema.Schema) {
 
 func validateAllGlobalDatasources(sch schema.Schema) {
 	logrus.Info("validate all globalDatasources in dev/data")
-	data, err := os.ReadFile(path.Join("dev", "data", "4-globaldatasource.json"))
+	data, err := os.ReadFile(filepath.Join("dev", "data", "4-globaldatasource.json"))
 	if err != nil {
 		logrus.Fatal(err)
 	}


### PR DESCRIPTION
We are using in various places `path.Join` or `path.Split` while using file access path that works everywhere than on windows. 

This PR aims to fix that by using the pkg `filepath` that will handle the windows file system.