### PR TITLE
[ENHANCEMENT] Improve the way the plugins are loaded by considering the local path where they are stored

### DIFF
--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -47,7 +47,7 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 		return nil, nil, fmt.Errorf("unable to initialize the service manager: %w", err)
 	}
 	persesAPI := NewPersesAPI(serviceManager, persistenceManager, conf)
-	persesFrontend := ui.NewPersesFrontend(conf)
+	persesFrontend := ui.NewPersesFrontend(conf, serviceManager.GetPlugin())
 	runner := app.NewRunner().WithDefaultHTTPServerAndPrometheusRegisterer(utils.MetricNamespace, registry, registry).SetBanner(banner)
 
 	// enable cleanup of the ephemeral dashboards once their ttl is reached

--- a/pkg/model/api/config/plugin.go
+++ b/pkg/model/api/config/plugin.go
@@ -101,8 +101,8 @@ func (p *PluginInDevelopment) Verify() error {
 	if len(p.Name) == 0 {
 		return errors.New("the name of the plugin in development must be set")
 	}
-	if len(p.AbsolutePath) == 0 {
-		return errors.New("the absolute path of the plugin in development must be set")
+	if len(p.AbsolutePath) == 0 && !p.DisableSchema {
+		return errors.New("the absolute path of the plugin in development must be set to load the schema. Disable the schema if you don't want to load it")
 	}
 	return nil
 }

--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -16,16 +16,19 @@ package ui
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
 	"net/http/httputil"
+	"regexp"
 	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	echoUtils "github.com/perses/common/echo"
 	apiinterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/internal/api/plugin"
 	"github.com/perses/perses/pkg/model/api/config"
 	"github.com/prometheus/common/assets"
 	"github.com/sirupsen/logrus"
@@ -44,48 +47,107 @@ var (
 		"/config",
 		"/explore",
 	}
+	capturingPluginName = regexp.MustCompile(`/plugins/([a-zA-Z0-9_-]+)/?.*`)
 )
 
 type frontend struct {
 	echoUtils.Register
-	apiPrefix            string
-	pluginsPath          string
-	pluginDevEnvironment *config.PluginDevEnvironment
+	apiPrefix     string
+	pluginService plugin.Plugin
 }
 
-func NewPersesFrontend(cfg config.Config) echoUtils.Register {
+func NewPersesFrontend(cfg config.Config, pluginService plugin.Plugin) echoUtils.Register {
 	return &frontend{
-		apiPrefix:            cfg.APIPrefix,
-		pluginsPath:          cfg.Plugin.Path,
-		pluginDevEnvironment: cfg.Plugin.DevEnvironment,
+		apiPrefix:     cfg.APIPrefix,
+		pluginService: pluginService,
 	}
 }
 
 func (f *frontend) RegisterRoute(e *echo.Echo) {
 	contentRewrite := middleware.Rewrite(map[string]string{f.apiPrefix + "/*": "/app/dist/$1"})
-	e.GET(f.apiPrefix, func(c echo.Context) error {
-		return serveASTFiles(c, f.apiPrefix)
-	})
+	e.GET(f.apiPrefix, f.serveASTFiles)
 
 	// This route is serving the static files of the React app.
 	// The middleware `routerMiddleware` is here to redirect the request to the React app if the URL path is matching one of the React routes.
 	// Otherwise, the request is redirected to the `assetHandler` that is serving the static files, by changing the URL path to the correct path (with `contentRewrite`).
-	e.GET(f.apiPrefix+"/*", assetHandler(f.apiPrefix), routerMiddleware(f.apiPrefix), contentRewrite)
+	e.GET(f.apiPrefix+"/*", f.assetHandler(), f.routerMiddleware(), contentRewrite)
 
-	pluginGroup := e.Group(f.apiPrefix + "/plugins")
-	if f.pluginDevEnvironment != nil {
-		proxyMiddleware := pluginDevProxyMiddleware(*f.pluginDevEnvironment)
-		pluginGroup.Use(proxyMiddleware)
+	// This route is serving the static files of the plugins.
+	e.GET(f.apiPrefix+"/plugins/*", f.servePluginFiles)
+}
+
+func (f *frontend) servePluginFiles(c echo.Context) error {
+	// We are going to serve a plugin from a dev environment, let's set up the proxy to redirect the traffic.
+	req := c.Request()
+	res := c.Response()
+	pluginName := catchPluginName(req.URL.Path)
+	if len(pluginName) == 0 {
+		logrus.Errorf("unable to find the plugin name in the URL path: %s", req.URL.Path)
+		return apiinterface.NotFoundError
 	}
-	// This route is serving the static files of the various plugins.
-	pluginGroup.Static("/", f.pluginsPath)
+	loaded, isLoaded := f.pluginService.GetLoadedPlugin(pluginName)
+	if !isLoaded {
+		logrus.Errorf("unable to find the plugin %s", pluginName)
+		return apiinterface.NotFoundError
+	}
+	devEnvironment := loaded.DevEnvironment
+	if devEnvironment == nil {
+		// In that case, we need to read the requested files from the file system.
+		// The First thing to do is to replace the URL path with the local path of the plugin.
+		localPath := strings.Replace(req.URL.Path, fmt.Sprintf("%s/plugins/%s", f.apiPrefix, pluginName), loaded.LocalPath, 1)
+		// Then we just need to rely on the echo router to serve the file.
+		return c.File(localPath)
+	}
+	// Otherwise, it means we are in a dev environment, and we need to proxy the request to the dev server.
+	// When developing a plugin, you will be able to serve the files of the plugin using a dev server (with rsbuild).
+	var proxyErr error
+	reverseProxy := httputil.NewSingleHostReverseProxy(devEnvironment.URL.URL)
+	reverseProxy.ErrorHandler = func(_ http.ResponseWriter, _ *http.Request, err error) {
+		logrus.WithError(err).Errorf("error proxying, remote unreachable: target=%s, err=%v", devEnvironment.URL.String(), err)
+		proxyErr = err
+	}
+	if transportErr := proxyPrepareRequest(c, devEnvironment); transportErr != nil {
+		return transportErr
+	}
+	// Reverse proxy request.
+	reverseProxy.ServeHTTP(res, req)
+	// Return any error handled during proxying request.
+	if proxyErr != nil {
+		// we need to wrap the error with an Echo Error,
+		// otherwise the error will be hidden by the middleware "middleware.HandleError".
+		status := res.Status
+		if status < 400 {
+			// if there is an error and the status code doesn't match the error, then let's use a default one
+			status = 500
+		}
+		return echo.NewHTTPError(status, proxyErr.Error())
+	}
+	return nil
+}
+
+func proxyPrepareRequest(c echo.Context, devEnvironment *config.PluginInDevelopment) error {
+	req := c.Request()
+	// We have to modify the HOST of the request to match the host of the targetURL
+	// So far I'm not sure to understand exactly why. However, if you are going to remove it, be sure of what you are doing.
+	// It has been done to fix an error returned by Openshift itself saying the target doesn't exist.
+	// Since we are using HTTP/1, setting the HOST is setting also a header, so if the host and the header are different,
+	// then maybe it is blocked by the Openshift router.
+	req.Host = devEnvironment.URL.Host
+	// Fix header
+	if len(req.Header.Get(echo.HeaderXRealIP)) == 0 {
+		req.Header.Set(echo.HeaderXRealIP, c.RealIP())
+	}
+	if len(req.Header.Get(echo.HeaderXForwardedProto)) == 0 {
+		req.Header.Set(echo.HeaderXForwardedProto, c.Scheme())
+	}
+	return nil
 }
 
 // assetHandler is here to serve the static files of the React app.
 // With Webpack, we have injected the placeholder in the index.html and in every JS file that contains a route.
 // This is the only way to ensure that every asset is served with the proper prefix path.
 // So, at runtime, we need to open the JS files and then replace the placeholder with the actual API prefix.
-func assetHandler(apiPrefix string) echo.HandlerFunc {
+func (f *frontend) assetHandler() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		fileName := c.Request().URL.Path
 		assetFile, err := asts.Open(fileName)
@@ -103,78 +165,11 @@ func assetHandler(apiPrefix string) echo.HandlerFunc {
 			return apiinterface.HandleError(err)
 		}
 		if strings.Contains(fileName, ".js") {
-			data = bytes.ReplaceAll(data, []byte(prefixPathPlaceholder), []byte(apiPrefix))
+			data = bytes.ReplaceAll(data, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
 		}
 		_, err = c.Response().Write(data)
 		return apiinterface.HandleError(err)
 	}
-}
-
-// pluginDevProxyMiddleware is here to proxy the request to the dev environment.
-//
-// When developing a plugin, you will be able to serve the files of the plugin using a dev server (with rsbuild).
-// This middleware will route any request to a plugin listed in the dev environment to the dev server.
-func pluginDevProxyMiddleware(devEnvironment config.PluginDevEnvironment) echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			for _, plg := range devEnvironment.Plugins {
-				if !strings.Contains(c.Request().URL.Path, plg.Name) {
-					continue
-				}
-				// We are going to serve a plugin from a dev environment, let's set up the proxy to redirect the traffic.
-				req := c.Request()
-				res := c.Response()
-				var proxyErr error
-				// Then we need to route this request to the dev environment.
-				// We just have to replace the URL as the path should remain the same.
-				proxyURL := devEnvironment.URL
-				if plg.URL != nil {
-					proxyURL = plg.URL
-				}
-				reverseProxy := httputil.NewSingleHostReverseProxy(proxyURL.URL)
-				reverseProxy.ErrorHandler = func(_ http.ResponseWriter, _ *http.Request, err error) {
-					logrus.WithError(err).Errorf("error proxying, remote unreachable: target=%s, err=%v", devEnvironment.URL.String(), err)
-					proxyErr = err
-				}
-				if transportErr := proxyPrepareRequest(c, devEnvironment); transportErr != nil {
-					return transportErr
-				}
-				// Reverse proxy request.
-				reverseProxy.ServeHTTP(res, req)
-				// Return any error handled during proxying request.
-				if proxyErr != nil {
-					// we need to wrap the error with an Echo Error,
-					// otherwise the error will be hidden by the middleware "middleware.HandleError".
-					status := res.Status
-					if status < 400 {
-						// if there is an error and the status code doesn't match the error, then let's use a default one
-						status = 500
-					}
-					return echo.NewHTTPError(status, proxyErr.Error())
-				}
-				return nil
-			}
-			return next(c)
-		}
-	}
-}
-
-func proxyPrepareRequest(c echo.Context, devEnvironment config.PluginDevEnvironment) error {
-	req := c.Request()
-	// We have to modify the HOST of the request to match the host of the targetURL
-	// So far I'm not sure to understand exactly why. However, if you are going to remove it, be sure of what you are doing.
-	// It has been done to fix an error returned by Openshift itself saying the target doesn't exist.
-	// Since we are using HTTP/1, setting the HOST is setting also a header, so if the host and the header are different,
-	// then maybe it is blocked by the Openshift router.
-	req.Host = devEnvironment.URL.Host
-	// Fix header
-	if len(req.Header.Get(echo.HeaderXRealIP)) == 0 {
-		req.Header.Set(echo.HeaderXRealIP, c.RealIP())
-	}
-	if len(req.Header.Get(echo.HeaderXForwardedProto)) == 0 {
-		req.Header.Set(echo.HeaderXForwardedProto, c.Scheme())
-	}
-	return nil
 }
 
 // routerMiddleware is here to serve properly the React app.
@@ -202,33 +197,41 @@ func proxyPrepareRequest(c echo.Context, devEnvironment config.PluginDevEnvironm
 // - /api/v1/projects/perses/dashboards/* will be served by the first route
 // - /api/v1/projects/test will be served by the second route
 // - /api/v1/foo will be served by the last route.
-func routerMiddleware(apiPrefix string) echo.MiddlewareFunc {
+func (f *frontend) routerMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			for _, route := range reactRoutes {
-				if !strings.HasPrefix(c.Request().URL.Path, apiPrefix+route) {
+				if !strings.HasPrefix(c.Request().URL.Path, f.apiPrefix+route) {
 					continue
 				}
-				return serveASTFiles(c, apiPrefix)
+				return f.serveASTFiles(c)
 			}
 			return next(c)
 		}
 	}
 }
 
-func serveASTFiles(c echo.Context, apiPrefix string) error {
-	f, err := asts.Open("/app/dist/index.html")
+func (f *frontend) serveASTFiles(c echo.Context) error {
+	fileOpened, err := asts.Open("/app/dist/index.html")
 	if err != nil {
 		logrus.WithError(err).Error("Unable to open the React index.html")
 		return apiinterface.HandleError(err)
 	}
-	defer f.Close()
-	idx, err := io.ReadAll(f)
+	defer fileOpened.Close()
+	idx, err := io.ReadAll(fileOpened)
 	if err != nil {
 		logrus.WithError(err).Error("Error reading React index.html")
 		return apiinterface.HandleError(err)
 	}
-	idx = bytes.ReplaceAll(idx, []byte(prefixPathPlaceholder), []byte(apiPrefix))
+	idx = bytes.ReplaceAll(idx, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
 	_, err = c.Response().Write(idx)
 	return apiinterface.HandleError(err)
+}
+
+func catchPluginName(path string) string {
+	c := capturingPluginName.FindStringSubmatch(path)
+	if len(c) != 2 {
+		return ""
+	}
+	return c[1]
 }


### PR DESCRIPTION
The goal of this PR is to store the actual path where a plugin is located and associated it to it's name. Doing that allows to remove the constraint to have the folder in the archive named exactly like the plugin.

It will allow us to rename every plugin folder in `perses/plugins` and solve the issue https://github.com/perses/plugins/issues/43

As a side note, it is also fixing what URL is used for a plugin in development. Before it wasn't considering the URL written in the local config.

It is also fixing when the schema is not required, the plugins are still loaded. Before when schema was not required, the whole plugin was skipped and so not in the list of the plugin loaded.