### PR TITLE
[BUGFIX] Use plugin URL override

### DIFF
--- a/internal/api/plugin/dev.go
+++ b/internal/api/plugin/dev.go
@@ -31,12 +31,17 @@ type pluginDev struct {
 func (p *pluginDev) load() []v1.PluginModule {
 	var pluginModuleList []v1.PluginModule
 	for _, plg := range p.cfg.Plugins {
-		manifest, err := ReadManifestFromNetwork(p.cfg.URL, plg.Name)
+		urlToUse := p.cfg.URL
+		if plg.URL != nil {
+			urlToUse = plg.URL
+		}
+
+		manifest, err := ReadManifestFromNetwork(urlToUse, plg.Name)
 		if err != nil {
 			logrus.WithError(err).Error("failed to load plugin manifest")
 			continue
 		}
-		npmPackageData, readErr := ReadPackageFromNetwork(p.cfg.URL, plg.Name)
+		npmPackageData, readErr := ReadPackageFromNetwork(urlToUse, plg.Name)
 		if readErr != nil {
 			logrus.WithError(readErr).Error("failed to load plugin package")
 			continue


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

The struct definition of `PluginInDevelopment` allows for a URL override but wasn't used in the code 

```go
type PluginInDevelopment struct {
	// The name of the plugin in development
	Name string `json:"name" yaml:"name"`
	// DisableSchema is used to disable the schema validation of the plugin.
	// It is useful when the plugin is in development and the schema is not yet defined.
	DisableSchema bool `json:"disable_schema,omitempty" yaml:"disable_schema,omitempty"`
	// The URL of the development server hosting the plugin.
	// It is usually created by the command `rsbuild dev`.
	// If defined, it will override the URL defined in the `PluginDevEnvironment`.
	URL *common.URL `json:"url,omitempty" yaml:"url,omitempty"`
	// The absolute path to the plugin repository
	AbsolutePath string `json:"absolute_path" yaml:"absolute_path"`
}
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A