### PR TITLE
[ENHANCEMENT] Support conditional queryOptions for panels

### DIFF
--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -76,6 +76,10 @@ export function GridItemContent(props: GridItemContentProps): ReactElement {
       spec: query.spec.plugin.spec,
     };
   });
+  const pluginQueryOptions =
+    typeof plugin?.queryOptions === 'function'
+      ? plugin?.queryOptions(panelDefinition.spec.plugin.spec)
+      : plugin?.queryOptions;
 
   return (
     <Box
@@ -87,7 +91,7 @@ export function GridItemContent(props: GridItemContentProps): ReactElement {
     >
       <DataQueriesProvider
         definitions={definitions}
-        options={{ suggestedStepMs, ...plugin?.queryOptions }}
+        options={{ suggestedStepMs, ...pluginQueryOptions }}
         queryOptions={{ enabled: inView }}
       >
         {inView && (

--- a/ui/plugin-system/src/model/panels.ts
+++ b/ui/plugin-system/src/model/panels.ts
@@ -45,7 +45,7 @@ export interface PanelPlugin<Spec = UnknownSpec, TPanelProps = PanelProps<Spec>>
    * Each {@link QueryPluginType} implementation can have its own options.
    * For example see {@link UseTimeSeriesQueryOptions} for time series queries.
    */
-  queryOptions?: QueryOptions;
+  queryOptions?: QueryOptions | ((spec: Spec) => QueryOptions);
   /**
    * If true, query editor will be hidden for panel plugin
    * @default false


### PR DESCRIPTION
# Description

For example the `Table` panel must switch between `instant` and `range` queries, depending on the cell type:
* text: `instant`, because we need a single value
* sparkline: `range`, because we need a time series

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
