### PR TITLE
[IGNORE] add <PanelPluginLoader> component to simplify embedding panels

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -55,6 +55,11 @@ export type PanelExtraProps = {
 
 /**
  * Renders a PanelDefinition's content inside of a Card.
+ *
+ * Internal structure:
+ * <Panel>            // renders an entire panel, incl. header and action buttons
+ *   <PanelContent>   // renders loading, error or panel based on the queries' status
+ *     <PanelPlugin>  // loads a panel plugin from the plugin registry and renders the PanelComponent with the given data
  */
 export const Panel = memo(function Panel(props: PanelProps) {
   const {

--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -57,9 +57,9 @@ export type PanelExtraProps = {
  * Renders a PanelDefinition's content inside of a Card.
  *
  * Internal structure:
- * <Panel>            // renders an entire panel, incl. header and action buttons
- *   <PanelContent>   // renders loading, error or panel based on the queries' status
- *     <PanelPlugin>  // loads a panel plugin from the plugin registry and renders the PanelComponent with the given data
+ * <Panel>                  // renders an entire panel, incl. header and action buttons
+ *   <PanelContent>         // renders loading, error or panel based on the queries' status
+ *     <PanelPluginLoader>  // loads a panel plugin from the plugin registry and renders the PanelComponent with data from props.queryResults
  */
 export const Panel = memo(function Panel(props: PanelProps) {
   const {

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { usePlugin, PanelProps, QueryData, PanelPlugin } from '@perses-dev/plugin-system';
+import { usePlugin, PanelProps, QueryData, PanelPlugin as IPanelPlugin } from '@perses-dev/plugin-system';
 import { UnknownSpec, PanelDefinition, QueryDataType } from '@perses-dev/core';
 import { ReactElement } from 'react';
 import { LoadingOverlay } from '@perses-dev/components';
@@ -80,7 +80,7 @@ export function PanelContent(props: PanelContentProps): ReactElement {
 }
 
 interface PanelLoadingProps extends Pick<PanelContentProps, 'spec' | 'definition' | 'contentDimensions'> {
-  plugin?: PanelPlugin<UnknownSpec, PanelProps<UnknownSpec, QueryDataType>>;
+  plugin?: IPanelPlugin<UnknownSpec, PanelProps<UnknownSpec, QueryDataType>>;
 }
 
 function PanelLoading({ plugin, spec, definition, contentDimensions }: PanelLoadingProps): ReactElement {

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { usePlugin, PanelProps, QueryData, PanelPlugin as IPanelPlugin } from '@perses-dev/plugin-system';
+import { usePlugin, PanelProps, QueryData, PanelPlugin } from '@perses-dev/plugin-system';
 import { UnknownSpec, PanelDefinition, QueryDataType } from '@perses-dev/core';
 import { ReactElement } from 'react';
 import { LoadingOverlay } from '@perses-dev/components';
 import { Skeleton } from '@mui/material';
-import { PanelPlugin } from './PanelPlugin';
+import { PanelPluginLoader } from './PanelPluginLoader';
 
 export interface PanelContentProps extends Omit<PanelProps<UnknownSpec>, 'queryResults'> {
   panelPluginKind: string;
@@ -51,7 +51,7 @@ export function PanelContent(props: PanelContentProps): ReactElement {
   );
   if (queryResultsWithData.length > 0 || queryResults.length === 0) {
     return (
-      <PanelPlugin
+      <PanelPluginLoader
         kind={panelPluginKind}
         spec={spec}
         contentDimensions={contentDimensions}
@@ -80,7 +80,7 @@ export function PanelContent(props: PanelContentProps): ReactElement {
 }
 
 interface PanelLoadingProps extends Pick<PanelContentProps, 'spec' | 'definition' | 'contentDimensions'> {
-  plugin?: IPanelPlugin<UnknownSpec, PanelProps<UnknownSpec, QueryDataType>>;
+  plugin?: PanelPlugin<UnknownSpec, PanelProps<UnknownSpec, QueryDataType>>;
 }
 
 function PanelLoading({ plugin, spec, definition, contentDimensions }: PanelLoadingProps): ReactElement {

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -16,6 +16,7 @@ import { UnknownSpec, PanelDefinition, QueryDataType } from '@perses-dev/core';
 import { ReactElement } from 'react';
 import { LoadingOverlay } from '@perses-dev/components';
 import { Skeleton } from '@mui/material';
+import { PanelPlugin } from './PanelPlugin';
 
 export interface PanelContentProps extends Omit<PanelProps<UnknownSpec>, 'queryResults'> {
   panelPluginKind: string;
@@ -24,15 +25,12 @@ export interface PanelContentProps extends Omit<PanelProps<UnknownSpec>, 'queryR
 }
 
 /**
- * A small wrapper component that renders the appropriate PanelComponent from a Panel plugin based on the panel
- * definition's kind. Used so that an ErrorBoundary can be wrapped around this.
+ * Based on the status of the queries (loading, error or data available), this component renders a
+ * loading overlay, throws an error, or renders the panel content.
  */
 export function PanelContent(props: PanelContentProps): ReactElement {
   const { panelPluginKind, definition, queryResults, spec, contentDimensions } = props;
   const { data: plugin, isLoading: isPanelLoading } = usePlugin('Panel', panelPluginKind, { throwOnError: true });
-
-  const PanelComponent = plugin?.PanelComponent;
-  const supportedQueryTypes = plugin?.supportedQueryTypes || [];
 
   // Show fullsize skeleton if the panel plugin is loading.
   if (isPanelLoading) {
@@ -46,18 +44,6 @@ export function PanelContent(props: PanelContentProps): ReactElement {
     );
   }
 
-  if (PanelComponent === undefined) {
-    throw new Error(`Missing PanelComponent from panel plugin for kind '${panelPluginKind}'`);
-  }
-
-  for (const queryResult of queryResults) {
-    if (!supportedQueryTypes.includes(queryResult.definition.kind)) {
-      throw new Error(
-        `This panel does not support queries of type '${queryResult.definition.kind}'. Supported query types: ${supportedQueryTypes.join(', ')}.`
-      );
-    }
-  }
-
   // Render the panel if any query has data, or the panel doesn't have a query attached (for example MarkdownPanel).
   // Loading indicator or errors of other queries are shown in the panel header.
   const queryResultsWithData = queryResults.flatMap((q) =>
@@ -65,7 +51,8 @@ export function PanelContent(props: PanelContentProps): ReactElement {
   );
   if (queryResultsWithData.length > 0 || queryResults.length === 0) {
     return (
-      <PanelComponent
+      <PanelPlugin
+        kind={panelPluginKind}
         spec={spec}
         contentDimensions={contentDimensions}
         definition={definition}

--- a/ui/dashboards/src/components/Panel/PanelPlugin.tsx
+++ b/ui/dashboards/src/components/Panel/PanelPlugin.tsx
@@ -1,0 +1,65 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { usePlugin, PanelProps } from '@perses-dev/plugin-system';
+import { UnknownSpec, QueryDataType } from '@perses-dev/core';
+import { ReactElement } from 'react';
+import { Skeleton } from '@mui/material';
+
+interface PanelPluginProps extends PanelProps<UnknownSpec, QueryDataType> {
+  kind: string;
+}
+
+/**
+ * PanelPlugin loads the panel plugin specified by the 'kind' prop from the plugin registry and
+ * renders its PanelComponent.
+ */
+export function PanelPlugin(props: PanelPluginProps): ReactElement {
+  const { kind, spec, contentDimensions, definition, queryResults } = props;
+  const { data: plugin, isLoading: isPanelLoading } = usePlugin('Panel', kind, { throwOnError: true });
+  const PanelComponent = plugin?.PanelComponent;
+  const supportedQueryTypes = plugin?.supportedQueryTypes || [];
+
+  // Show fullsize skeleton if the panel plugin is loading.
+  if (isPanelLoading) {
+    return (
+      <Skeleton
+        variant="rectangular"
+        width={contentDimensions?.width}
+        height={contentDimensions?.height}
+        aria-label="Loading..."
+      />
+    );
+  }
+
+  if (PanelComponent === undefined) {
+    throw new Error(`Missing PanelComponent from panel plugin for kind '${kind}'`);
+  }
+
+  for (const queryResult of queryResults) {
+    if (!supportedQueryTypes.includes(queryResult.definition.kind)) {
+      throw new Error(
+        `This panel does not support queries of type '${queryResult.definition.kind}'. Supported query types: ${supportedQueryTypes.join(', ')}.`
+      );
+    }
+  }
+
+  return (
+    <PanelComponent
+      spec={spec}
+      contentDimensions={contentDimensions}
+      definition={definition}
+      queryResults={queryResults}
+    />
+  );
+}

--- a/ui/dashboards/src/components/Panel/PanelPluginLoader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelPluginLoader.tsx
@@ -21,10 +21,10 @@ interface PanelPluginProps extends PanelProps<UnknownSpec, QueryDataType> {
 }
 
 /**
- * PanelPlugin loads the panel plugin specified by the 'kind' prop from the plugin registry and
+ * PanelPluginLoader loads the panel plugin specified by the 'kind' prop from the plugin registry and
  * renders its PanelComponent.
  */
-export function PanelPlugin(props: PanelPluginProps): ReactElement {
+export function PanelPluginLoader(props: PanelPluginProps): ReactElement {
   const { kind, spec, contentDimensions, definition, queryResults } = props;
   const { data: plugin, isLoading: isPanelLoading } = usePlugin('Panel', kind, { throwOnError: true });
   const PanelComponent = plugin?.PanelComponent;

--- a/ui/dashboards/src/components/Panel/index.ts
+++ b/ui/dashboards/src/components/Panel/index.ts
@@ -12,4 +12,4 @@
 // limitations under the License.
 
 export * from './Panel';
-export * from './PanelPlugin';
+export * from './PanelPluginLoader';

--- a/ui/dashboards/src/components/Panel/index.ts
+++ b/ui/dashboards/src/components/Panel/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './Panel';
+export * from './PanelPlugin';


### PR DESCRIPTION
# Description

This component wraps loading a panel plugin from the registry and rendering its PanelComponent. Example usage:

```
<PanelPluginLoader
  kind="StatChart"
  spec={{
    calculation: 'last-number',
    format: {
      unit: 'decimal',
    },
    sparkline: {},
  }}
  contentDimensions={{ width: 300, height: 100 }}
  queryResults={[
    { definition: { kind: 'TimeSeriesQuery', spec: { plugin: { kind: '', spec: {} } } }, data: tsData },
  ]}
/>
```

This is useful e.g. in the Table panel, when rendering Panels in a table cell.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
