### PR TITLE
[IGNORE] Restore panel icon hover behavior

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -108,7 +108,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
           height: '100%',
           display: 'flex',
           flexFlow: 'column nowrap',
-          ':hover': { '--panel-hover': 'true' },
+          ':hover': { '--panel-hover': 'block' },
         },
         sx
       )}

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Stack, Box, Popover, CircularProgress, styled } from '@mui/material';
-import { isValidElement, PropsWithChildren, useMemo, useState } from 'react';
+import { isValidElement, PropsWithChildren, ReactNode, useMemo, useState } from 'react';
 import { InfoTooltip } from '@perses-dev/components';
 import ArrowCollapseIcon from 'mdi-material-ui/ArrowCollapse';
 import ArrowExpandIcon from 'mdi-material-ui/ArrowExpand';
@@ -195,6 +195,14 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
 
   const divider = <Box sx={{ flexGrow: 1 }}></Box>;
 
+  // if the panel is in non-editing, non-fullscreen mode, show certain icons only on hover
+  const OnHover = ({ children }: PropsWithChildren): ReactNode =>
+    editHandlers === undefined && !readHandlers?.isPanelViewed ? (
+      <Box sx={{ display: 'var(--panel-hover, none)' }}>{children}</Box>
+    ) : (
+      <>{children}</>
+    );
+
   return (
     <>
       {/* small panel width: move all icons except move/grab to overflow menu */}
@@ -218,7 +226,8 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           },
         })}
       >
-        {descriptionAction} {linksAction} {divider} {queryStateIndicator} {extraActions} {readActions}
+        <OnHover>{descriptionAction}</OnHover> {linksAction} {divider} {queryStateIndicator} {extraActions}
+        <OnHover>{readActions}</OnHover>
         <OverflowMenu title={title}>{editActions}</OverflowMenu>
         {moveAction}
       </ConditionalBox>
@@ -231,7 +240,8 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).down(HEADER_MEDIUM_WIDTH)]: { display: 'none' },
         })}
       >
-        {descriptionAction} {linksAction} {divider} {queryStateIndicator} {extraActions} {readActions} {editActions}
+        <OnHover>{descriptionAction}</OnHover> {linksAction} {divider} {queryStateIndicator} {extraActions}
+        <OnHover>{readActions}</OnHover> {editActions}
         {moveAction}
       </ConditionalBox>
     </>

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Stack, Box, Popover, CircularProgress, styled } from '@mui/material';
+import { Stack, Box, Popover, CircularProgress, styled, PopoverPosition } from '@mui/material';
 import { isValidElement, PropsWithChildren, ReactNode, useMemo, useState } from 'react';
 import { InfoTooltip } from '@perses-dev/components';
 import ArrowCollapseIcon from 'mdi-material-ui/ArrowCollapse';
@@ -212,10 +212,12 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         })}
       >
         {divider}
-        <OverflowMenu title={title}>
-          {descriptionAction} {linksAction} {queryStateIndicator} {extraActions} {readActions} {editActions}
-        </OverflowMenu>
-        {moveAction}
+        <OnHover>
+          <OverflowMenu title={title}>
+            {descriptionAction} {linksAction} {queryStateIndicator} {extraActions} {readActions} {editActions}
+          </OverflowMenu>
+          {moveAction}
+        </OnHover>
       </ConditionalBox>
 
       {/* medium panel width: move edit icons to overflow menu */}
@@ -226,10 +228,15 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           },
         })}
       >
-        <OnHover>{descriptionAction}</OnHover> {linksAction} {divider} {queryStateIndicator} {extraActions}
-        <OnHover>{readActions}</OnHover>
-        <OverflowMenu title={title}>{editActions}</OverflowMenu>
-        {moveAction}
+        <OnHover>
+          {descriptionAction} {linksAction}
+        </OnHover>
+        {divider} {queryStateIndicator}
+        <OnHover>
+          {extraActions} {readActions}
+          <OverflowMenu title={title}>{editActions}</OverflowMenu>
+          {moveAction}
+        </OnHover>
       </ConditionalBox>
 
       {/* large panel width: show all icons in panel header */}
@@ -240,16 +247,20 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           [theme.containerQueries(HEADER_ACTIONS_CONTAINER_NAME).down(HEADER_MEDIUM_WIDTH)]: { display: 'none' },
         })}
       >
-        <OnHover>{descriptionAction}</OnHover> {linksAction} {divider} {queryStateIndicator} {extraActions}
-        <OnHover>{readActions}</OnHover> {editActions}
-        {moveAction}
+        <OnHover>
+          {descriptionAction} {linksAction}
+        </OnHover>
+        {divider} {queryStateIndicator}
+        <OnHover>
+          {extraActions} {readActions} {editActions} {moveAction}
+        </OnHover>
       </ConditionalBox>
     </>
   );
 };
 
 const OverflowMenu: React.FC<PropsWithChildren<{ title: string }>> = ({ children, title }) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [anchorPosition, setAnchorPosition] = useState<PopoverPosition>();
 
   // do not show overflow menu if there is no content (for example, edit actions are hidden)
   const hasContent = isValidElement(children) || (Array.isArray(children) && children.some(isValidElement));
@@ -258,14 +269,14 @@ const OverflowMenu: React.FC<PropsWithChildren<{ title: string }>> = ({ children
   }
 
   const handleClick = (event: React.MouseEvent<HTMLElement>): undefined => {
-    setAnchorEl(event.currentTarget);
+    setAnchorPosition(event.currentTarget.getBoundingClientRect());
   };
 
   const handleClose = (): undefined => {
-    setAnchorEl(null);
+    setAnchorPosition(undefined);
   };
 
-  const open = Boolean(anchorEl);
+  const open = Boolean(anchorPosition);
   const id = open ? 'actions-menu' : undefined;
 
   return (
@@ -282,7 +293,8 @@ const OverflowMenu: React.FC<PropsWithChildren<{ title: string }>> = ({ children
       <Popover
         id={id}
         open={open}
-        anchorEl={anchorEl}
+        anchorReference="anchorPosition"
+        anchorPosition={anchorPosition}
         onClose={handleClose}
         anchorOrigin={{
           vertical: 'bottom',


### PR DESCRIPTION
# Description

Restore panel icon hover behavior (ref. https://github.com/perses/perses/pull/2635#discussion_r1970392400)

In non-editing, non-fullscreen mode, some panel icons are only visible on mouse hover:
* info icon (panel description)
* fullscreen icon

To be discussed:
* should the menu also be visible on hover, or always?

cc @galangel 

# Screenshots

https://github.com/user-attachments/assets/96b7bc4c-b1be-4e1e-8ff8-3415cb1afec7

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
