### PR TITLE
[BUGFIX] CLI/plugin: Improve error returned when files are missing in a plugin and fix loading default config file

### DIFF
--- a/internal/api/plugin/plugin.go
+++ b/internal/api/plugin/plugin.go
@@ -110,12 +110,8 @@ func (p *pluginFile) Load() error {
 			continue
 		}
 		pluginPath := filepath.Join(p.path, file.Name())
-		if valid, validErr := IsRequiredFileExists(pluginPath, pluginPath, pluginPath); !valid || validErr != nil {
-			if validErr != nil {
-				logrus.WithError(validErr).Error("unable to check if the plugin is valid")
-			} else {
-				logrus.Debugf("folder %q is not a valide plugin and is skept. Missing mandatory files", file.Name())
-			}
+		if validErr := IsRequiredFileExists(pluginPath, pluginPath, pluginPath); validErr != nil {
+			logrus.WithError(validErr).Errorf("folder %q is not a valid plugin and is skipped. Missing mandatory files", file.Name())
 			// We can ignore this folder, it's not a plugin, or the plugin is invalid.
 			continue
 		}

--- a/internal/api/plugin/validate.go
+++ b/internal/api/plugin/validate.go
@@ -14,6 +14,7 @@
 package plugin
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/perses/perses/internal/cli/file"
@@ -26,25 +27,31 @@ import (
 // distFolder is the folder where the result of the build of the frontend is stored.
 // In case the plugin is coming from the archive built in a previous stage, then all paths will have the same value.
 // In case we are validating a plugin in its repository, then the various folders in parameter will have different values depending on the struct of the repository.
-func IsRequiredFileExists(frontendFolder string, schemaFolder string, distFolder string) (bool, error) {
+func IsRequiredFileExists(frontendFolder string, schemaFolder string, distFolder string) error {
 	// check if the manifest file exists
 	exist, err := file.Exists(filepath.Join(distFolder, ManifestFileName))
-	if !exist || err != nil {
-		return false, err
+	if err != nil {
+		return err
+	}
+	if !exist {
+		return fmt.Errorf("the manifest file %s is missing", filepath.Join(distFolder, ManifestFileName))
 	}
 	// check if the package.json file exists
 	npmPackageData, readErr := ReadPackage(frontendFolder)
 	if readErr != nil {
-		return false, err
+		return err
 	}
 	// check if the schema folder exists only if it requires schema
 	if IsSchemaRequired(npmPackageData.Perses) {
 		exist, err = file.Exists(schemaFolder)
-		if !exist || err != nil {
-			return false, err
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return fmt.Errorf("the schema folder %s is missing", schemaFolder)
 		}
 	}
-	return true, nil
+	return nil
 }
 
 // IsSchemaRequired check if any plugins described in the module require a schema

--- a/internal/cli/cmd/plugin/build/build.go
+++ b/internal/cli/cmd/plugin/build/build.go
@@ -155,7 +155,7 @@ func NewCMD() *cobra.Command {
 	}
 	cmd.Flags().StringVar((*string)(&o.archiveFormat), "archive-format", string(archive.TARgz), "The archive format. Supported format are: tar.gz, tar, zip")
 	cmd.Flags().BoolVar(&o.skipNPMBuild, "skip-npm-build", false, "")
-	cmd.Flags().StringVar(&o.cfgPath, "config", "perses_plugin_config.yaml", "Path to the configuration file")
+	cmd.Flags().StringVar(&o.cfgPath, "config", "", "Path to the configuration file. By default, the command will look for a file named 'perses_plugin_config.yaml'")
 
 	return cmd
 }

--- a/internal/cli/cmd/plugin/build/build.go
+++ b/internal/cli/cmd/plugin/build/build.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 
 	"github.com/mholt/archives"
 	"github.com/perses/perses/internal/api/archive"
@@ -58,7 +59,7 @@ func (o *option) Validate() error {
 		return fmt.Errorf("archive format %q not managed", o.archiveFormat)
 	}
 	// Check if the required files are present
-	if exist, err := plugin.IsRequiredFileExists(o.cfg.FrontendPath, o.cfg.SchemasPath, o.cfg.DistPath); err != nil || !exist {
+	if err := plugin.IsRequiredFileExists(o.cfg.FrontendPath, o.cfg.SchemasPath, o.cfg.DistPath); err != nil {
 		return fmt.Errorf("required files are missing: %w", err)
 	}
 	if _, err := os.Stat("cue.mod"); os.IsNotExist(err) {
@@ -108,7 +109,7 @@ func (o *option) computeArchiveFiles() ([]archives.FileInfo, error) {
 		list[license] = license
 	}
 	// add the package.json file required to get the type of the plugin.
-	list[path.Join(o.cfg.FrontendPath, plugin.PackageJSONFile)] = plugin.PackageJSONFile
+	list[filepath.Join(o.cfg.FrontendPath, plugin.PackageJSONFile)] = plugin.PackageJSONFile
 
 	// Add the dist content at the root of the archive (saying differently, dist folder should not appear in the archive)
 	distFiles, err := os.ReadDir(o.cfg.DistPath)
@@ -116,7 +117,7 @@ func (o *option) computeArchiveFiles() ([]archives.FileInfo, error) {
 		return nil, fmt.Errorf("unable to read 'dist' directory: %w", err)
 	}
 	for _, f := range distFiles {
-		list[path.Join(o.cfg.DistPath, f.Name())] = f.Name()
+		list[filepath.Join(o.cfg.DistPath, f.Name())] = f.Name()
 	}
 
 	// Do the same for the Cuelang schemas
@@ -125,7 +126,7 @@ func (o *option) computeArchiveFiles() ([]archives.FileInfo, error) {
 		return nil, fmt.Errorf("unable to read 'schema' directory: %w", err)
 	}
 	for _, f := range cueFiles {
-		list[path.Join(o.cfg.SchemasPath, f.Name())] = path.Join("schemas", f.Name())
+		list[filepath.Join(o.cfg.SchemasPath, f.Name())] = path.Join("schemas", f.Name())
 	}
 
 	// Add the cue.mod folder at the root of the archive

--- a/internal/cli/cmd/plugin/config/config.go
+++ b/internal/cli/cmd/plugin/config/config.go
@@ -13,7 +13,14 @@
 
 package config
 
-import "github.com/perses/common/config"
+import (
+	"github.com/perses/common/config"
+	"github.com/perses/perses/internal/cli/file"
+)
+
+const (
+	DefaultConfigFile = "perses_plugin_config.yaml"
+)
 
 type PluginConfig struct {
 	// DistPath is the path to the folder containing the files built by npm
@@ -35,9 +42,15 @@ func (c *PluginConfig) Verify() error {
 }
 
 func Resolve(configFile string) (PluginConfig, error) {
+	cfgPath := configFile
 	c := PluginConfig{}
+	if len(cfgPath) == 0 {
+		if exist, err := file.Exists(DefaultConfigFile); err == nil && exist {
+			cfgPath = DefaultConfigFile
+		}
+	}
 	return c, config.NewResolver[PluginConfig]().
-		SetConfigFile(configFile).
+		SetConfigFile(cfgPath).
 		SetEnvPrefix("PERSES_PLUGIN_CONFIG").
 		Resolve(&c).
 		Verify()

--- a/internal/cli/cmd/plugin/config/config.go
+++ b/internal/cli/cmd/plugin/config/config.go
@@ -24,7 +24,7 @@ type PluginConfig struct {
 	SchemasPath string `json:"schemas_path" yaml:"schemas_path"`
 }
 
-func (c *PluginConfig) Validate() error {
+func (c *PluginConfig) Verify() error {
 	if len(c.DistPath) == 0 {
 		c.DistPath = "dist"
 	}

--- a/internal/cli/cmd/plugin/lint/lint.go
+++ b/internal/cli/cmd/plugin/lint/lint.go
@@ -91,7 +91,7 @@ func NewCMD() *cobra.Command {
 			return persesCMD.Run(o, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&o.cfgPath, "config", "perses_plugin_config.yaml", "Path to the configuration file")
+	cmd.Flags().StringVar(&o.cfgPath, "config", "", "Path to the configuration file. By default, the command will look for a file named 'perses_plugin_config.yaml'")
 
 	return cmd
 }

--- a/internal/cli/cmd/plugin/lint/lint.go
+++ b/internal/cli/cmd/plugin/lint/lint.go
@@ -49,7 +49,7 @@ func (o *option) Complete(args []string) error {
 }
 
 func (o *option) Validate() error {
-	if exist, err := plugin.IsRequiredFileExists(o.cfg.FrontendPath, o.cfg.SchemasPath, o.cfg.DistPath); err != nil || !exist {
+	if err := plugin.IsRequiredFileExists(o.cfg.FrontendPath, o.cfg.SchemasPath, o.cfg.DistPath); err != nil {
 		return fmt.Errorf("required files are missing: %w", err)
 	}
 	if _, err := os.Stat("cue.mod"); os.IsNotExist(err) {


### PR DESCRIPTION
When we are building the archive for a plugin, we are checking a list of mandatory files. If they are missing the error returned was not understandable.

This PR aims to improve the error returned.