### PR TITLE
[BUGFIX] Support custom query editors

### DIFF
--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.test.tsx
@@ -117,6 +117,6 @@ describe('useQueryType', () => {
     const getQueryType = result.current;
     expect(getQueryType('PrometheusTimeSeriesQuery')).toBeUndefined();
     expect(getQueryType('TempoTraceQuery')).toBeUndefined();
-    expect(() => getQueryType('UnknownQuery')).toThrowError(`Unable to determine the query type: UnknownQuery`);
+    expect(getQueryType('UnknownQuery')).toBeUndefined();
   });
 });

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -94,7 +94,8 @@ export function useQueryType(): (pluginKind: string) => string | undefined {
           case 'TempoTraceQuery':
             return isTraceQueryPluginLoading;
         }
-        throw new Error(`Unable to determine the query type: ${pluginKind}`);
+
+        return isTraceQueryPluginLoading || isTimeSeriesQueryLoading;
       };
 
       if (isLoading(pluginKind)) {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Temporarily fix for #2697

This pull request includes a change to the `useQueryType` function in the `DataQueriesProvider` model to improve the handling of query type determination. The most important change is the modification of the function to return a combination of `isTraceQueryPluginLoading` and `isTimeSeriesQueryLoading` instead of throwing an error.

Improvements to query type determination:

* [`ui/plugin-system/src/runtime/DataQueriesProvider/model.ts`](diffhunk://#diff-762341f821e1106857e9670dc731dd98dde263e54710935a256854a850f2779cL97-R98): Modified the `useQueryType` function to return `isTraceQueryPluginLoading || isTimeSeriesQueryLoading` instead of throwing an error if the query type is not determined.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).