### PR TITLE
[BUGFIX] Grafana migration: Fix variable allValue migration

### DIFF
--- a/internal/api/plugin/migrate/variable.go
+++ b/internal/api/plugin/migrate/variable.go
@@ -103,13 +103,17 @@ func (m *mig) migrateListVariable(v TemplateVar) dashboard.Variable {
 				Description: v.Description,
 				Hidden:      v.Hide > 0,
 			},
-			AllowAllValue:  v.IncludeAll,
-			AllowMultiple:  v.Multi,
-			CustomAllValue: v.AllValue,
-			DefaultValue:   v.getDefaultValue(),
-			Sort:           grafanaMappingSort(v.Sort),
+			AllowAllValue: v.IncludeAll,
+			AllowMultiple: v.Multi,
+			DefaultValue:  v.getDefaultValue(),
+			Sort:          grafanaMappingSort(v.Sort),
 		},
 		Name: v.Name,
+	}
+
+	// Only set CusomAllValue if IncludeAll is enabled for panel
+	if v.IncludeAll {
+		spec.CustomAllValue = v.AllValue
 	}
 
 	i := 0


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR addresses an issue with the migration of allValue from Grafana dashboards to Perses. Currently, Perses validation does not allow `allValue` (or `CustomAllValue` in perses) to be set when `AllowAllValue` is `false`. However, this is a valid use case in Grafana, which causes the migration of certain Grafana dashboards to fail.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
