### PR TITLE
[IGNORE] fix goreleaser archive format field used

### DIFF
--- a/scripts/generate-goreleaser/.goreleaser.base.yaml
+++ b/scripts/generate-goreleaser/.goreleaser.base.yaml
@@ -35,7 +35,8 @@ archives:
     builds:
       - "perses"
       - "percli"
-    format: "tar.gz"
+    formats:
+      - "tar.gz"
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
from the logs:

```
  • setting defaults
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```

I am applying what is describing in the goreleaser documentation.