### PR TITLE
[DOC] Refactor and improve the doc about how to load a plugin

### DIFF
--- a/docs/configuration/load-plugin.md
+++ b/docs/configuration/load-plugin.md
@@ -1,0 +1,50 @@
+How to load a plugin
+====================
+
+Before being able to use a plugin, it must be recognized and loaded by the Perses backend.
+
+When the Perses backend is starting, it will look at a specific folder that should contain any plugin archive file. This
+folder can be set using the following configuration:
+
+```yaml
+plugin:
+  archive_path: /path/to/archive/folder
+```
+
+Note: to know how to build a plugin archive, please refer to the [plugin structure documentation](../plugins/structure.md).
+
+By default, the plugin archive folder is set to `plugins-archive` or to `/etc/perses/plugins-archive` if it's running in
+a container.
+
+Perses will extract every archive contained in this folder and will put the data into another folder. This folder can be
+set using the following configuration:
+
+```yaml
+plugin:
+  path: /path/to/plugin/folder
+```
+
+By default, the plugin folder is set to `plugins` or to `/etc/perses/plugins` if it's running in a container.
+
+Finally, Perses will look at any folder contained in the plugin folder and will load in memory every schema contained.
+It will also generate a file `plugin-module.json` at the root of the plugin folder.
+This file contains the list of the plugins that can be used by the frontend.
+
+This file is used to serve the HTTP endpoint `/api/v1/plugins`. The frontend calls this endpoint to get the list of the
+plugins to be loaded.
+
+## Load plugin in development mode
+
+While you are implementing a plugin, you probably would like to see it alive in Perses using the dev server of `rsbuild`.
+
+Perses is able to load a plugin served by the `rsbuild` dev server. To do so, you need to set the following configuration:
+
+```yaml
+plugin:
+  dev_environment:
+    plugins:
+      - name: <plugin_module_name> # Like Prometheus
+        url: http://localhost:3005 # The URL of the rsbuild dev server
+        disable_schema: false # If you want to disable the schema loading
+        absolute_path: "/path/to/plugin/folder" # The absolute path of the plugin folder. Required if disable_schema is false
+```

--- a/docs/plugins/structure.md
+++ b/docs/plugins/structure.md
@@ -1,5 +1,5 @@
-Loading plugins
-======================
+Plugin structure
+================
 
 In Perses, each plugin must be provided as an archive file containing the plugin's frontend and backend parts.
 
@@ -38,39 +38,3 @@ The archive must have the following structure:
 The CLI can help you to respect and verify this structure with the commands `percli plugin build` and
 `percli plugin validate`.
 Check the associated [documentation](../cli.md) for more details.
-
-## Backend side
-
-Before being able to use a plugin, it must be recognized and loaded by the Perses backend.
-
-When the Perses backend is starting, it will look at a specific folder that should contain any plugin archive file. This
-folder can be set using the following configuration:
-
-```yaml
-plugin:
-  archive_path: /path/to/archive/folder
-```
-
-By default, the plugin archive folder is set to `plugins-archive` or to `/etc/perses/plugins-archive` if it's running in
-a container.
-
-Perses will extract every archive contained in this folder and will put the data into another folder. This folder can be
-set using the following configuration:
-
-```yaml
-plugin:
-  path: /path/to/plugin/folder
-```
-
-By default, the plugin folder is set to `plugins` or to `/etc/perses/plugins` if it's running in a container.
-
-Finally, Perses will look at any folder contained in the plugin folder and will load in memory every schema contained.
-It will also generate a file `plugin-module.json` at the root of the plugin folder.
-This file contains the list of the plugins that can be used by the frontend.
-
-This file is used to serve the HTTP endpoint `/api/v1/plugins`. The frontend calls this endpoint to get the list of the
-plugins to be loaded.
-
-## Frontend side
-
-TODO


### PR DESCRIPTION
I have split the initial doc about how a plugin is loaded. I think it makes more sense like that. 