### PR TITLE
[ENHANCEMENT]: Allow npm install flags to be passed in `make build-ui` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ build-api: generate
 
 .PHONY: build-ui
 build-ui:
-	cd ./ui && npm install && npm run build
+	cd ./ui && npm install $(NPM_INSTALL_FLAGS) && npm run build
 
 .PHONY: build-cli
 build-cli:


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

Allow npm install flags to be passed in `make build-ui`. 

For example 
`make build-ui NPM_INSTALL_FLAGS="--ignore-scripts"`  
`cd ./ui && npm install $(NPM_INSTALL_FLAGS) && npm run build`
`cd ./ui && npm install --ignore-scripts  && npm run build`

# Screenshots
N/A no UI changes were made. 

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes
[-] * No UI Changes in this PR 
- [-] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [-] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [-] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
