### PR TITLE
[IGNORE] Isolate test using cue dependencies manager

### DIFF
--- a/.github/workflows/cue.yaml
+++ b/.github/workflows/cue.yaml
@@ -1,0 +1,57 @@
+name: cue
+on:
+  push:
+    branches:
+      - main
+      - release/*
+      - snapshot/*
+    tags:
+      - v*
+  pull_request:
+    paths:
+      - '**.cue'
+      - 'internal/cli/cmd/plugin/**'
+      - 'internal/cli/cmd/dac/**'
+      - 'internal/test/cue/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
+
+jobs:
+  validate-cue-schemas:
+    name: validate CUE schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: perses/github-actions@v0.9.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+          enable_cue: true
+          cue_version: "v0.12.0"
+      - name: check cue schema
+        run: make cue-eval
+  test-cue:
+    name: "tests with cuelang"
+    runs-on: ubuntu-latest
+    services:
+      prometheus:
+        image: prom/prometheus
+        ports:
+          - '9090:9090'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: perses/github-actions@v0.9.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+          enable_cue: true # needed for DaC CLI commands unit tests
+          cue_version: "v0.12.0"
+      - name: Login to CUE's Central Registry to allow retrieving deps
+        run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
+      - name: test
+        run: make cue-test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,10 +70,6 @@ jobs:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
           cue_version: "v0.12.0"
-      - name: generate files
-        run: make generate
-      - name: Login to CUE's Central Registry to allow retrieving deps
-        run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: test
         run: make integration-test
   test-windows:
@@ -88,15 +84,10 @@ jobs:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
           cue_version: "v0.12.0"
-
       - name: "install prometheus"
         run: sh scripts/download-prometheus.sh
       - name: "start prometheus"
         run: sh scripts/run-prometheus.sh
-      - name: generate files
-        run: make generate
-      - name: Login to CUE's Central Registry to allow retrieving deps
-        run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: test
         run: make integration-test
   test-mysql:
@@ -125,10 +116,6 @@ jobs:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
           cue_version: "v0.12.0"
-      - name: generate files
-        run: make generate
-      - name: Login to CUE's Central Registry to allow retrieving deps
-        run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: test
         run: make mysql-integration-test
   golangci:
@@ -151,7 +138,7 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.62.2
           args: --timeout 5m
-  validate-cue-schemas:
+  validate-dev-data:
     name: validate CUE schemas
     runs-on: ubuntu-latest
     steps:
@@ -161,14 +148,11 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
-          enable_cue: true
-          cue_version: "v0.12.0"
-      - name: check cue schema
-        run: make cue-eval
+          enable_cue: false
       - name: download plugin
         run: make install-default-plugins
-      - name: test cue schema
-        run: make cue-test
+      - name: validate all data from dev/data
+        run: make validate-data
   check-cue-gen:
     name: "check generated CUE files"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -106,15 +106,19 @@ cue-gen:
 	cp -r cue.mod/gen/github.com/perses/perses/pkg/model/* cue/model/ && rm -r cue.mod/gen
 	find cue/model -name "*.cue" -exec sed -i 's/\"github.com\/perses\/perses\/pkg/\"github.com\/perses\/perses\/cue/g' {} \;
 
-.PHONY: cue-test
-cue-test:
-	@echo ">> test CUE schemas with json data"
-	$(GO) run ./scripts/cue-test/cue-test.go
+.PHONY: validate-data
+validate-data:
+	@echo ">> Validate all data in dev/data"
+	$(GO) run ./scripts/validate-data/validate-data.go
 
 .PHONY: test
 test: generate
 	@echo ">> running all tests"
 	$(GO) test -count=1 -v ./...
+
+.PHONY: cue-test
+cue-test: generate
+	$(GO) test -tags=cue -v -count=1 -cover -coverprofile=$(COVER_PROFILE) -coverpkg=./... ./...
 
 .PHONY: integration-test
 integration-test: generate

--- a/internal/cli/cmd/dac/build/build_test.go
+++ b/internal/cli/cmd/dac/build/build_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cue
+
 package build
 
 import (

--- a/internal/cli/cmd/plugin/build/build_test.go
+++ b/internal/cli/cmd/plugin/build/build_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cue
+
 package build
 
 import (

--- a/internal/cli/cmd/plugin/lint/lint_test.go
+++ b/internal/cli/cmd/plugin/lint/lint_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cue
+
 package lint
 
 import (

--- a/internal/test/dac/dac_cue_test.go
+++ b/internal/test/dac/dac_cue_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cue
+
 package migrate
 
 import (

--- a/scripts/validate-data/validate-data.go
+++ b/scripts/validate-data/validate-data.go
@@ -25,8 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TODO: probably doesn't make sense to keep this script in the repository. Probably we should move it to the perses/plugins repository
-
 func validateAllDashboards(sch schema.Schema) {
 	logrus.Info("validate all dashboards in dev/data")
 	data, err := os.ReadFile(filepath.Join("dev", "data", "9-dashboard.json"))


### PR DESCRIPTION
The usage of the Cuelang dependency manager required to inject a secret which is not allowed when PRs are coming from a fork.

This PR aims to isolate every tests requiring the usage of the Cuelang dependency manager. For most of the case, you don't need it.

The new workflow will only be triggered for the tests requiring it. For most of the case, the CI should not fail anymore