### PR TITLE
[IGNORE] DatasourceSelect: support OutlinedSelectProps

### DIFF
--- a/ui/plugin-system/src/components/DatasourceSelect.tsx
+++ b/ui/plugin-system/src/components/DatasourceSelect.tsx
@@ -12,7 +12,19 @@
 // limitations under the License.
 
 import OpenInNewIcon from 'mdi-material-ui/OpenInNew';
-import { Select, SelectProps, MenuItem, Stack, Divider, ListItemText, Chip, IconButton, Box } from '@mui/material';
+import {
+  Select,
+  SelectProps,
+  MenuItem,
+  Stack,
+  Divider,
+  ListItemText,
+  Chip,
+  IconButton,
+  Box,
+  OutlinedSelectProps,
+  BaseSelectProps,
+} from '@mui/material';
 import { DatasourceSelector } from '@perses-dev/core';
 import { ReactElement, useMemo } from 'react';
 import { DatasourceSelectItemSelector, useListDatasourceSelectItems } from '../runtime';
@@ -21,7 +33,7 @@ import { DatasourceSelectItemSelector, useListDatasourceSelectItems } from '../r
 // this component
 type OmittedMuiProps = 'children' | 'value' | 'onChange';
 
-export interface DatasourceSelectProps extends Omit<SelectProps<string>, OmittedMuiProps> {
+export interface DatasourceSelectProps extends Omit<OutlinedSelectProps & BaseSelectProps<string>, OmittedMuiProps> {
   value: DatasourceSelector;
   onChange: (next: DatasourceSelector) => void;
   datasourcePluginKind: string;


### PR DESCRIPTION
# Description

Explicitly use `OutlinedSelectProps` as the parent interface, otherwise we cannot use the `notched` property in https://github.com/perses/plugins/pull/73.

Not 100% sure why it's required, `SelectProps` is a type union:
```
export type SelectProps<Value = unknown> =
  | (FilledSelectProps & BaseSelectProps<Value>)
  | (StandardSelectProps & BaseSelectProps<Value>)
  | (OutlinedSelectProps & BaseSelectProps<Value>);
```

And the inheritance with `interface DatasourceSelectProps extends Omit<SelectProps<string>, OmittedMuiProps>` doesn't work otherwise.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
