### PR TITLE
[IGNORE] Run cue tests when go.mod and plugins are modified

### DIFF
--- a/.github/workflows/cue.yaml
+++ b/.github/workflows/cue.yaml
@@ -13,6 +13,10 @@ on:
       - 'internal/cli/cmd/plugin/**'
       - 'internal/cli/cmd/dac/**'
       - 'internal/test/cue/**'
+      - 'go.mod'
+      - 'internal/**/go.mod'
+      - 'go-sdk/test/go.mod'
+      - 'scripts/plugin/**'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
when `go.mod` or the list of the plugin is modified, we should run all test to be sure aspect of the code is covered and the update of dependencies doesn't break anything