### PR TITLE
[BUGFIX] HTTPSettingsEditor: remove directUrl/proxy of previous value

### DIFF
--- a/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
+++ b/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
@@ -440,10 +440,18 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
   const handleModeChange = (v: number): void => {
     if (tabs[v]?.label === strDirect) {
       setPreviousSpecProxy(value);
-      onChange({ ...value, directUrl: previousSpecDirect.directUrl });
+
+      // Copy all settings (for example, scrapeInterval), except 'proxy'
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { proxy, ...newValue } = value;
+      onChange({ ...newValue, directUrl: previousSpecDirect.directUrl });
     } else if (tabs[v]?.label === strProxy) {
       setPreviousSpecDirect(value);
-      onChange({ ...value, proxy: previousSpecProxy.proxy });
+
+      // Copy all settings (for example, scrapeInterval), except 'directUrl'
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { directUrl, ...newValue } = value;
+      onChange({ ...newValue, proxy: previousSpecProxy.proxy });
     }
   };
 


### PR DESCRIPTION
# Description

When switching between directUrl and proxy, copy all values (e.g. scrapeInterval) except for directUrl / proxy.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
