### PR TITLE
[ignore] update dependabot go mod directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@
 version: 2
 updates:
 - package-ecosystem: "gomod"
-  directory: "/"
+  directories:
+    - "**/*"
   open-pull-requests-limit: 10
   schedule:
     interval: "weekly"


### PR DESCRIPTION
I am updating the dependabot config hoping afteward it will be able to update the various go.mod files we have in perses.

The various go.mod we have are using to test the plugin and dac feature.