### PR TITLE
[ENHANCEMENT] Improve dashboard performance by reducing re-renders

### DIFF
--- a/ui/dashboards/src/context/VariableProvider/VariableProvider.tsx
+++ b/ui/dashboards/src/context/VariableProvider/VariableProvider.tsx
@@ -37,6 +37,7 @@ import {
   TextVariableDefinition,
   ListVariableDefinition,
 } from '@perses-dev/core';
+import { useShallow } from 'zustand/react/shallow';
 import { checkSavedDefaultVariableStatus, findVariableDefinitionByName, mergeVariableDefinitions } from './utils';
 import { hydrateVariableDefinitionStates as hydrateVariableDefinitionStates } from './hydrationUtils';
 import { getInitalValuesFromQueryParameters, getURLQueryParamName, useVariableQueryParams } from './query-params';
@@ -186,16 +187,19 @@ export function useVariableDefinitionActions(): {
   setVariableDefinitions: (definitions: VariableDefinition[]) => void;
 } {
   const store = useVariableDefinitionStoreCtx();
-  return useStore(store, (s) => {
-    return {
-      setVariableValue: s.setVariableValue,
-      setVariableLoading: s.setVariableLoading,
-      setVariableOptions: s.setVariableOptions,
-      setVariableDefinitions: s.setVariableDefinitions,
-      setVariableDefaultValues: s.setVariableDefaultValues,
-      getSavedVariablesStatus: s.getSavedVariablesStatus,
-    };
-  });
+  return useStore(
+    store,
+    useShallow((s) => {
+      return {
+        setVariableValue: s.setVariableValue,
+        setVariableLoading: s.setVariableLoading,
+        setVariableOptions: s.setVariableOptions,
+        setVariableDefinitions: s.setVariableDefinitions,
+        setVariableDefaultValues: s.setVariableDefaultValues,
+        getSavedVariablesStatus: s.getSavedVariablesStatus,
+      };
+    })
+  );
 }
 
 export function useVariableDefinitions(): VariableDefinition[] {
@@ -493,7 +497,9 @@ export function VariableProvider({
   externalVariableDefinitions = [],
   builtinVariableDefinitions = [],
 }: VariableProviderProps): ReactElement {
-  const [store] = useState(createVariableDefinitionStore({ initialVariableDefinitions, externalVariableDefinitions }));
+  const [store] = useState(() =>
+    createVariableDefinitionStore({ initialVariableDefinitions, externalVariableDefinitions })
+  );
 
   return (
     <VariableDefinitionStoreContext.Provider value={store}>
@@ -510,7 +516,7 @@ export function VariableProviderWithQueryParams({
 }: VariableProviderProps): ReactElement {
   const allVariableDefs = mergeVariableDefinitions(initialVariableDefinitions, externalVariableDefinitions);
   const queryParams = useVariableQueryParams(allVariableDefs);
-  const [store] = useState(
+  const [store] = useState(() =>
     createVariableDefinitionStore({ initialVariableDefinitions, externalVariableDefinitions, queryParams })
   );
 

--- a/ui/dashboards/src/context/VariableProvider/VariableProvider.tsx
+++ b/ui/dashboards/src/context/VariableProvider/VariableProvider.tsx
@@ -16,6 +16,7 @@ import { createStore, StoreApi, useStore } from 'zustand';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { immer } from 'zustand/middleware/immer';
 import { devtools } from 'zustand/middleware';
+import { shallow } from 'zustand/shallow';
 import produce from 'immer';
 import {
   VariableContext,
@@ -37,7 +38,6 @@ import {
   TextVariableDefinition,
   ListVariableDefinition,
 } from '@perses-dev/core';
-import { useShallow } from 'zustand/react/shallow';
 import { checkSavedDefaultVariableStatus, findVariableDefinitionByName, mergeVariableDefinitions } from './utils';
 import { hydrateVariableDefinitionStates as hydrateVariableDefinitionStates } from './hydrationUtils';
 import { getInitalValuesFromQueryParameters, getURLQueryParamName, useVariableQueryParams } from './query-params';
@@ -187,9 +187,9 @@ export function useVariableDefinitionActions(): {
   setVariableDefinitions: (definitions: VariableDefinition[]) => void;
 } {
   const store = useVariableDefinitionStoreCtx();
-  return useStore(
+  return useStoreWithEqualityFn(
     store,
-    useShallow((s) => {
+    (s) => {
       return {
         setVariableValue: s.setVariableValue,
         setVariableLoading: s.setVariableLoading,
@@ -198,7 +198,8 @@ export function useVariableDefinitionActions(): {
         setVariableDefaultValues: s.setVariableDefaultValues,
         getSavedVariablesStatus: s.getSavedVariablesStatus,
       };
-    })
+    },
+    shallow
   );
 }
 


### PR DESCRIPTION
# Description

Reduce unnecessary re-renders of `<DashboardApp>` component.
`DashboardApp` calls the `useDashboard()` hook, which calls `useVariableDefinitionActions()`. This function uses the store and returns **a new object every time**, invalidating the hook. By using `useShallow()`, it checks if the object actually changed or not.

However, in my opinion, it'd be best to remove this function and use `useStore(store, (s) => s.setVariableDefinitions)` instead when accessing `setVariableDefinitions` for example. What do you think?

I also updated `VariableProvider` and `VariableProviderWithQueryParams` to not create a new store every time for the initial value.

# Screenshots

Screenshots from the React Profiler while loading the node exporter dashboard:

Before: The component was rendered 9 times.
![Bildschirmfoto vom 2025-03-13 19-16-13](https://github.com/user-attachments/assets/94a3a594-54fe-4b20-bd15-5788f0f2ab4d)

After: The component is rendered 3 times.
![Bildschirmfoto vom 2025-03-13 19-17-35](https://github.com/user-attachments/assets/7485c859-0294-4bec-9c43-ab50087a3947)


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
