### PR TITLE
[BUGFIX] Format expireAt with ISOString to fix EphemeralDashboard view crash

### DIFF
--- a/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardList.tsx
+++ b/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardList.tsx
@@ -67,7 +67,7 @@ export function EphemeralDashboardList(props: EphemeralDashboardListProperties):
     return add(
       ephemeralDashboard.metadata.updatedAt ? new Date(ephemeralDashboard.metadata.updatedAt) : new Date(),
       parseDurationString(ephemeralDashboard.spec.ttl)
-    ).toLocaleString();
+    ).toISOString();
   }, []);
 
   const rows = useMemo(() => {


### PR DESCRIPTION

# Description
`expireAt` field in the Ephemeral Dashboard view is formatted as `localeString` whereas the rendering logic relies on it being in ISO format. This causes a crash while trying to view the Ephemeral dashboard. 
Fix for #2777 and #2063 

# Screenshots

![image](https://github.com/user-attachments/assets/452ae5a0-54f0-4d52-8e3c-2cdddc216552)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
