### PR TITLE
[DOC] Add (back) common package doc

### DIFF
--- a/docs/plugins/common.md
+++ b/docs/plugins/common.md
@@ -1,0 +1,74 @@
+# Common definitions
+
+Standard definitions that plugins can use.
+
+## Calculation specification
+
+Calculation is defined as:
+
+```yaml
+<enum = "first" | "last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"> # "last" is the default
+```
+
+## Format specification
+
+The format spec is defined as:
+
+```yaml
+<enum = <Time format> | <Percent format> | <Decimal format> | <Bytes format> | <Throughput format>>
+```
+
+### Time format
+
+```yaml
+unit: <enum = "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years">
+decimalPlaces: <int> # Optional
+```
+
+### Percent format
+
+```yaml
+unit: <enum =  "percent" | "percent-decimal">
+decimalPlaces: <int> # Optional
+```
+
+### Decimal format
+
+```yaml
+unit: "decimal"
+decimalPlaces: <int> # Optional
+shortValues: <boolean> | default = false # Optional
+```
+
+### Bytes format
+
+```yaml
+unit: "bytes"
+decimalPlaces: <int> # Optional
+shortValues: <boolean> | default = false # Optional
+```
+
+### Throughput format
+
+```yaml
+unit: < enum = "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec">
+decimalPlaces: <int> # Optional
+shortValues: <boolean> | default = false # Optional
+```
+
+## Thresholds specification
+
+```yaml
+mode: <enum = "percent" | "absolute"> # Optional
+defaultColor: string # Optional
+steps:
+  - <Step specification> # Optional
+```
+
+### Step specification
+
+```yaml
+value: <int>
+color: <string> # Optional
+name: <string> # Optional
+```


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Since the `common` package used by plugins is defined in perses/perses, its documentation should remain there (previously part of panels.md)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
