### PR TITLE
[DOC] Add HTTP Proxy documentation

### DIFF
--- a/docs/plugins/common.md
+++ b/docs/plugins/common.md
@@ -56,6 +56,19 @@ decimalPlaces: <int> # Optional
 shortValues: <boolean> | default = false # Optional
 ```
 
+
+## Mapping specification
+
+```yaml
+# TODO
+```
+
+## Proxy specification
+
+```yaml
+# TODO
+```
+
 ## Thresholds specification
 
 ```yaml
@@ -71,4 +84,10 @@ steps:
 value: <int>
 color: <string> # Optional
 name: <string> # Optional
+```
+
+## Transform specification
+
+```yaml
+# TODO
 ```

--- a/docs/plugins/common.md
+++ b/docs/plugins/common.md
@@ -65,8 +65,34 @@ shortValues: <boolean> | default = false # Optional
 
 ## Proxy specification
 
+### HTTP Proxy specification
+
 ```yaml
-# TODO
+kind: "HTTPProxy"
+spec:
+  # URL is the url of datasource. It is not the url of the proxy.
+  url: <url>
+
+  # It is a tuple list of http methods and http endpoints that will be accessible.
+  # Leave it empty if you don't want to restrict the access to the datasource.
+  allowedEndpoints:
+    - <Allowed Endpoints specification> # Optional
+
+  # It can be used to provide additional headers that need to be forwarded when requesting the datasource
+  headers:
+    <string>: <string> # Optional
+
+  # This is the name of the secret that should be used for the proxy or discovery configuration
+  # It will contain any sensitive information such as password, token, certificate.
+  # Please read the documentation about secrets to understand how to create one
+  secret: <string> # Optional
+```
+
+#### Allowed Endpoints specification
+
+```yaml
+endpointPattern: <RegExp>
+method: <enum | possibleValue = 'POST' | 'PUT' | 'PATCH' | 'GET' | 'DELETE'>
 ```
 
 ## Thresholds specification

--- a/docs/plugins/common.md
+++ b/docs/plugins/common.md
@@ -15,7 +15,7 @@ Calculation is defined as:
 The format spec is defined as:
 
 ```yaml
-<enum = <Time format> | <Percent format> | <Decimal format> | <Bytes format> | <Throughput format>>
+<anyOf = Time format | Percent format | Decimal format | Bytes format | Throughput format>
 ```
 
 ### Time format
@@ -60,7 +60,7 @@ shortValues: <boolean> | default = false # Optional
 
 ```yaml
 mode: <enum = "percent" | "absolute"> # Optional
-defaultColor: string # Optional
+defaultColor: <string> # Optional
 steps:
   - <Step specification> # Optional
 ```


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Moving HTTP proxy doc (back) to perses/perses to reference it both in prometheus & tempo docs.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
