### PR TITLE
[BUGFIX] fix rspack dev server on Node.js v22

### DIFF
--- a/ui/app/rspack.config.mjs
+++ b/ui/app/rspack.config.mjs
@@ -11,19 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import rspack from '@rspack/core';
 import refreshPlugin from '@rspack/plugin-react-refresh';
 import TerserPlugin from 'terser-webpack-plugin';
 import { defineConfig } from '@rspack/cli';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV === 'development';
 
 export default defineConfig({
   output: {
-    path: resolve(__dirname, './dist'),
+    path: resolve(import.meta.dirname, './dist'),
     publicPath: isDev ? undefined : 'PREFIX_PATH_PLACEHOLDER/',
   },
   mode: isDev ? 'development' : 'production',

--- a/ui/app/rspack.config.mjs
+++ b/ui/app/rspack.config.mjs
@@ -11,16 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import rspack from '@rspack/core';
 import refreshPlugin from '@rspack/plugin-react-refresh';
 import TerserPlugin from 'terser-webpack-plugin';
 import { defineConfig } from '@rspack/cli';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV === 'development';
 
 export default defineConfig({
   output: {
-    path: './dist',
+    path: resolve(__dirname, './dist'),
     publicPath: isDev ? undefined : 'PREFIX_PATH_PLACEHOLDER/',
   },
   mode: isDev ? 'development' : 'production',


### PR DESCRIPTION
# Description

Fixes the following error when starting rspack dev server on Node.js v22:
```
/home/agerstmayr/redhat/dev/perses/perses/ui/node_modules/@rspack/core/dist/index.js:12602
  throw new Error(
        ^
Error: ./dist is neither a posix nor a windows path, and there is no 'dirname' method defined in the file system
    at dirname2 (/home/agerstmayr/redhat/dev/perses/perses/ui/node_modules/@rspack/core/dist/index.js:12602:9)
    at /home/agerstmayr/redhat/dev/perses/perses/ui/node_modules/@rspack/core/dist/index.js:12610:21
    at Immediate.<anonymous> (/home/agerstmayr/redhat/dev/perses/perses/ui/node_modules/webpack-dev-server/node_modules/memfs/src/volume.ts:588:9)
    at processImmediate (node:internal/timers:491:21)
```
Resolves: #2776

@Nexucis could you check if that change works for your env so we're not regressing #2758?
I tried it with Node.js v23.9.0 on Linux and it does work here.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
