### PR TITLE
[IGNORE] Fix flaky StatChart panel e2e test

### DIFF
--- a/dev/data/9-dashboard.json
+++ b/dev/data/9-dashboard.json
@@ -2594,16 +2594,16 @@
               {
                 "x": 0,
                 "y": 0,
-                "width": 5,
+                "width": 7,
                 "height": 7,
                 "content": {
                   "$ref": "#/spec/panels/SingleStat"
                 }
               },
               {
-                "x": 5,
+                "x": 7,
                 "y": 0,
-                "width": 5,
+                "width": 7,
                 "height": 7,
                 "content": {
                   "$ref": "#/spec/panels/SingleStat-1"


### PR DESCRIPTION
# Description

Due to the size of the StatChart panel in the example dashboard, the edit button was in the action menu.
Unfortunately locating elements in the MaterialUI `<Popover>` element is unstable at times, therefore let's just increase the StatChart panel width for the e2e test, so the edit button is directly in the Panel header instead of the MUI `<Popover>` element.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
