### PR TITLE
[BUGFIX] Panel edit drawer - Update Title, description and Type on form changes

### DIFF
--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -44,6 +44,13 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
   const { plugin } = panelDefinition.spec;
   const [isDiscardDialogOpened, setDiscardDialogOpened] = useState<boolean>(false);
 
+  const { panelEditorSchema } = useValidationSchemas();
+  const form = useForm<PanelEditorValues>({
+    resolver: zodResolver(panelEditorSchema),
+    mode: 'onBlur',
+    defaultValues: initialValues,
+  });
+
   // Use common plugin editor logic even though we've split the inputs up in this form
   const pluginEditor = usePluginEditor({
     pluginTypes: ['Panel'],
@@ -62,13 +69,6 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
 
   const titleAction = getTitleAction(initialAction, true);
   const submitText = getSubmitText(initialAction, true);
-
-  const { panelEditorSchema } = useValidationSchemas();
-  const form = useForm<PanelEditorValues>({
-    resolver: zodResolver(panelEditorSchema),
-    mode: 'onBlur',
-    defaultValues: initialValues,
-  });
 
   const links = useWatch({ control: form.control, name: 'panelDefinition.spec.links' });
   useEffect(() => {
@@ -104,6 +104,10 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
     setPanelDefinition(nextPanelDef);
   };
 
+  const watchedName = useWatch({ control: form.control, name: 'panelDefinition.spec.display.name' });
+  const watchedDescription = useWatch({ control: form.control, name: 'panelDefinition.spec.display.description' });
+  const watchedPluginKind = useWatch({ control: form.control, name: 'panelDefinition.spec.plugin.kind' });
+
   return (
     <FormProvider {...form}>
       <Box
@@ -138,7 +142,7 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
                   label="Name"
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
-                  value={field.value ?? ''}
+                  value={watchedName ?? ''}
                   onChange={(event) => {
                     field.onChange(event);
                     setName(event.target.value);
@@ -184,7 +188,7 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
                   label="Description"
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
-                  value={field.value ?? ''}
+                  value={watchedDescription ?? ''}
                   onChange={(event) => {
                     field.onChange(event);
                     setDescription(event.target.value);
@@ -207,7 +211,7 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
                   disabled={pluginEditor.isLoading}
                   error={!!pluginEditor.error || !!fieldState.error}
                   helperText={pluginEditor.error?.message ?? fieldState.error?.message}
-                  value={{ type: 'Panel', kind: field.value }}
+                  value={{ type: 'Panel', kind: watchedPluginKind }}
                   onChange={(event) => {
                     field.onChange(event.kind);
                     pluginEditor.onSelectionChange(event);


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Solves https://github.com/perses/perses/issues/2791 

Changes made in the JSON will affect the top section of the edit drawer ( changes made on blur )
<!-- Context useful to a reviewer -->

# Screenshots
![Mar-18-2025 15-27-30](https://github.com/user-attachments/assets/2b831108-4937-4fc3-8d4a-c12c17432f25)



<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
