### PR TITLE
[ENHANCEMENT] CLI/plugin: Improve the way to vendor cue dependencies and rely on cue default caching

### DIFF
--- a/.github/workflows/cue.yaml
+++ b/.github/workflows/cue.yaml
@@ -56,7 +56,15 @@ jobs:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
           cue_version: "v0.12.0"
+      - name: cache cue deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/cue
+          key: ${{ runner.os }}-cue-${{ hashFiles('**/module.cue') }}
+          restore-keys: |
+            ${{ runner.os }}-cue-
       - name: Login to CUE's Central Registry to allow retrieving deps
+        if: ${{ github.secret_source == 'Actions' }}
         run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: test
         run: make cue-test

--- a/internal/cli/cmd/plugin/build/build.go
+++ b/internal/cli/cmd/plugin/build/build.go
@@ -14,37 +14,21 @@
 package build
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 
-	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/format"
-	"cuelang.org/go/cue/load"
 	"github.com/mholt/archives"
 	"github.com/perses/perses/internal/api/archive"
 	"github.com/perses/perses/internal/api/plugin"
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/cmd/plugin/config"
-	"github.com/perses/perses/internal/cli/file"
 	"github.com/perses/perses/internal/cli/output"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-)
-
-const (
-	vendorDir        = "pkg"
-	vendorDirBackup  = vendorDir + ".bak"
-	moduleFile       = "module.cue"
-	moduleFileBackup = moduleFile + ".bak"
 )
 
 type option struct {
@@ -58,10 +42,7 @@ type option struct {
 	pluginPath                string
 	isSchemaRequired          bool
 	schemaPathFromPackageJSON string
-	moduleFilePath            string
-	moduleFileBackupPath      string
-	vendorDirPath             string
-	vendorDirBackupPath       string
+	cueVendor                 *cueVendor
 	writer                    io.Writer
 	errWriter                 io.Writer
 }
@@ -81,10 +62,12 @@ func (o *option) Complete(args []string) error {
 	o.cfg.FrontendPath = filepath.Join(o.pluginPath, o.cfg.FrontendPath)
 	o.cfg.SchemasPath = filepath.Join(o.pluginPath, o.cfg.SchemasPath)
 	// Set the different path variables needed for the CUE part
-	o.moduleFilePath = filepath.Join(o.pluginPath, plugin.CuelangModuleFolder, moduleFile)
-	o.moduleFileBackupPath = filepath.Join(o.pluginPath, moduleFileBackup)
-	o.vendorDirPath = filepath.Join(o.pluginPath, plugin.CuelangModuleFolder, vendorDir)
-	o.vendorDirBackupPath = filepath.Join(o.pluginPath, vendorDirBackup)
+	o.cueVendor = &cueVendor{
+		pluginPath:           o.pluginPath,
+		moduleFilePath:       filepath.Join(o.pluginPath, plugin.CuelangModuleFolder, moduleFile),
+		moduleFileBackupPath: filepath.Join(o.pluginPath, moduleFileBackup),
+		vendorDirPath:        filepath.Join(o.pluginPath, plugin.CuelangModuleFolder, vendorDir),
+	}
 	return nil
 }
 
@@ -122,7 +105,7 @@ func (o *option) Execute() error {
 
 	// If the schema is required, we need to prepare the CUE files for the archive
 	if o.isSchemaRequired {
-		restoreInitialState, cueErr := o.prepareCueFiles()
+		restoreInitialState, cueErr := o.cueVendor.vendorCueDependencies()
 		if restoreInitialState != nil {
 			defer restoreInitialState()
 		}
@@ -146,242 +129,6 @@ func (o *option) Execute() error {
 		return fmt.Errorf("archive creation failed: %w", archiveBuildErr)
 	}
 	return output.HandleString(o.writer, fmt.Sprintf("%s built successfully", manifest.Name))
-}
-
-func (o *option) executeNPMSteps() error {
-	if err := o.executeNPMInstall(); err != nil {
-		return err
-	}
-	return o.executeNPMBuild()
-}
-
-func (o *option) executeNPMInstall() error {
-	if o.skipNPMInstall {
-		return nil
-	}
-	if _, err := os.Stat(filepath.Join(o.cfg.FrontendPath, "node_modules")); os.IsNotExist(err) {
-		// Then run `npm ci` to install the dependencies
-		cmd := exec.Command("npm", "ci")
-		cmd.Dir = o.cfg.FrontendPath
-		// to get a more comprehensive error message, we need to capture the stdout & stderr.
-		var stdoutBuffer bytes.Buffer
-		cmd.Stdout = &stdoutBuffer
-		var stderrBuffer bytes.Buffer
-		cmd.Stderr = &stderrBuffer
-		cmd.Dir = o.cfg.FrontendPath
-		if execErr := cmd.Run(); execErr != nil {
-			return fmt.Errorf("unable to install the frontend dependencies: %w, stdout: %s, stderr: %s", execErr, stdoutBuffer.String(), stderrBuffer.String())
-		}
-	}
-	return nil
-}
-
-func (o *option) executeNPMBuild() error {
-	if o.skipNPMBuild {
-		return nil
-	}
-	cmd := exec.Command("npm", "run", "build")
-	// to get a more comprehensive error message, we need to capture the stdout & stderr.
-	var stdoutBuffer bytes.Buffer
-	cmd.Stdout = &stdoutBuffer
-	var stderrBuffer bytes.Buffer
-	cmd.Stderr = &stderrBuffer
-	cmd.Dir = o.cfg.FrontendPath
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("unable to build the frontend: %w, stdout: %s, stderr: %s", err, stdoutBuffer.String(), stderrBuffer.String())
-	}
-	return nil
-}
-
-// prepareCueFiles "prepares" the CUE files for the plugin packaging.
-// More precisely, it does the necessary to rely on the "old" modules resolution, so that the plugin archive
-// is fully "self-contained" and schema evaluation doesn't need to fetch dependencies from an OCI registry.
-func (o *option) prepareCueFiles() (func(), error) {
-	// Check if we need to vendor the dependencies
-	// - Parse the module file into a CUE instance
-	ctx := cuecontext.New()
-	insts := load.Instances([]string{o.moduleFilePath}, nil)
-	module := ctx.BuildInstance(insts[0])
-	if err := module.Err(); err != nil {
-		return nil, fmt.Errorf("failed to load plugin module file: %w", err)
-	}
-
-	// - if no `deps` are present, skip vendoring
-	deps := module.LookupPath(cue.ParsePath("deps"))
-	if deps.Err() != nil {
-		logrus.Debugf("`deps` not found, no CUE dependencies to vendor")
-		return nil, nil
-	}
-
-	// Backup the original state of cue.mod/pkg if it exists*, and restore the original state on exit.
-	// *: even if a given plugin relies on new dependency management, it may also rely on other dependencies
-	// managed the old way. This is technically possible & supported by CUE, thus we want to handle this case.
-	var restoreVendorDir func()
-	if _, err := os.Stat(o.vendorDirPath); err == nil {
-		if copyErr := file.CopyDir(o.vendorDirPath, o.vendorDirBackupPath); copyErr != nil {
-			return nil, fmt.Errorf("failed to backup original %s: %w", o.vendorDirPath, copyErr)
-		}
-		restoreVendorDir = func() {
-			if removeErr := os.RemoveAll(o.vendorDirPath); removeErr != nil {
-				logrus.WithError(removeErr).Errorf("failed to cleanup alterated %s", o.vendorDirPath)
-			}
-			if renameErr := os.Rename(o.vendorDirBackupPath, o.vendorDirPath); renameErr != nil {
-				logrus.WithError(renameErr).Errorf("failed to restore original %s", o.vendorDirPath)
-			}
-		}
-	} else {
-		restoreVendorDir = func() {
-			if removeErr := os.RemoveAll(o.vendorDirPath); removeErr != nil {
-				logrus.WithError(removeErr).Errorf("failed to cleanup %s", o.vendorDirPath)
-			}
-		}
-	}
-
-	// Vendor the dependencies
-	if err := o.vendorCueDependencies(); err != nil {
-		return restoreVendorDir, fmt.Errorf("failed to vendor CUE dependencies: %w", err)
-	}
-
-	// Alter the module file
-	restoreModuleFile, err := o.alterCueModule(ctx, module)
-	restore := func() {
-		if restoreModuleFile != nil {
-			restoreModuleFile()
-		}
-		restoreVendorDir()
-	}
-
-	if err != nil {
-		return restore, fmt.Errorf("failed to alter module file: %w", err)
-	}
-
-	return restore, nil
-}
-
-// vendorCueDependencies does a home-made vendoring of CUE dependencies
-// ---
-// Full explanation:
-//
-// Following the move to CUE native dependency management, the deps of the plugin are no longer vendored under cue.mod/pkg.
-// Letting things in this state would imply that, at runtime, the Perses server should have access to an OCI registry - thus
-// either access to the internet OR to a custom registry set up by users in their private network - to be able to evaluate a plugin
-// schema that imports packages - like the `common` package of Perses.
-//
-// As we consider this constraint a no-go in our case, We looked for solutions to that problem... After asking to CUE maintainers
-// it seems our long-term solution would be https://github.com/cue-lang/cue/issues/3328. For the time being we thus have to
-// reproduce the vendoring structure of the "old modules" (https://cuelang.org/docs/concept/faq/new-modules-vs-old-modules/) with
-// custom code.
-//
-// More precisely the steps are:
-// - set the `CUE_CACHE_DIR` env var to a local temp folder
-// - evaluate the schemas to trigger the retrieval of dependencies
-// - move the dependencies to `cue.mod/pkg`
-// - remove the version in the name of the last directory generated from the module path (= rename `cue@vX.Y.Z` to `cue`)
-func (o *option) vendorCueDependencies() error {
-	// Define a temporary folder where to store the CUE dependencies
-	tempDir, err := os.MkdirTemp("", "cue_cache")
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory for CUE cache: %w", err)
-	}
-	defer os.RemoveAll(tempDir) // Ensure cleanup
-	if err := os.Setenv("CUE_CACHE_DIR", tempDir); err != nil {
-		return fmt.Errorf("failed to set CUE_CACHE_DIR: %w", err)
-	}
-
-	// Run `cue mod tidy` to fetch the dependencies
-	cmd := exec.Command("cue", "mod", "tidy") // nolint: gosec
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	cmd.Dir = o.pluginPath // the command has to be run from the plugin path
-	if cmdErr := cmd.Run(); cmdErr != nil {
-		return fmt.Errorf("cue mod tidy failed: %w, stderr: %s", cmdErr, stderr.String())
-	}
-
-	// Move dependencies to cue.mod/pkg
-	// NB we copy with file.CopyDir instead of moving with os.Rename because the latter was causing issues on Windows when `pkg` already exists
-	if copyErr := file.CopyDir(filepath.Join(tempDir, "mod", "extract"), o.vendorDirPath); copyErr != nil {
-		return fmt.Errorf("failed to move dependencies: %w", copyErr)
-	}
-
-	// At this point, the folder structure is like: cue.mod/pkg/github.com/perses/perses/cue@vX.Y.Z
-	// we need to change it to: cue.mod/pkg/github.com/perses/perses/cue in order to have the "old" modules
-	// resolution working.
-	// See https://cuelang.org/docs/concept/faq/new-modules-vs-old-modules/
-	//
-	// NB: Since "github.com/perses/perses/cue" may not be the only dependency, we walk through all
-	// directories under cue.mod/pkg
-	err = filepath.WalkDir(o.vendorDirPath, func(path string, d os.DirEntry, err error) error {
-		logrus.Debugf("Walking through %s", path)
-		if err != nil {
-			return fmt.Errorf("error walking through %s: %w", path, err)
-		}
-
-		if d.IsDir() {
-			// Rename the directory if it has a version in its name (e.g cue@vX.Y.Z)
-			parts := strings.Split(path, "@")
-			if len(parts) == 2 {
-				renamedDir := parts[0]
-
-				// Ensure we don't overwrite existing directories
-				if _, osErr := os.Stat(renamedDir); !os.IsNotExist(osErr) {
-					return fmt.Errorf("directory already exists: %s", renamedDir)
-				}
-
-				// Rename the directory
-				if osErr := os.Rename(path, renamedDir); osErr != nil {
-					return fmt.Errorf("failed to rename directory %s to %s: %w", path, renamedDir, osErr)
-				}
-
-				logrus.Debugf("Renamed %s to %s\n", path, renamedDir)
-				return filepath.SkipDir
-			}
-		}
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to walk through %s: %w", o.vendorDirPath, err)
-	}
-
-	return nil
-}
-
-// alterCueModule alters the module file to remove the `deps` section, so that schema evaluation will resolve
-// dependencies from the local vendor dir instead of from an OCI registry.
-// To achieve this we parse the module file into a Value & iteratively copy the fields, skipping the `deps` field.
-// That's the easier way we can do in the current state of the CUE lib.
-func (o *option) alterCueModule(ctx *cue.Context, module cue.Value) (func(), error) {
-	// restore the original state when finished
-	restoreInitialModule := func() {
-		if err := os.Rename(o.moduleFileBackupPath, o.moduleFilePath); err != nil {
-			logrus.WithError(err).Errorf("failed to restore original module file")
-		}
-	}
-
-	if err := os.Rename(o.moduleFilePath, o.moduleFileBackupPath); err != nil {
-		return restoreInitialModule, fmt.Errorf("failed to backup original module file: %v", err)
-	}
-
-	newModule := ctx.CompileString("{}")
-	iter, _ := module.Fields()
-	for iter.Next() {
-		if iter.Selector().String() == "deps" {
-			continue
-		}
-		newModule = newModule.FillPath(cue.MakePath(iter.Selector()), iter.Value())
-	}
-
-	cueBytes, err := format.Node(newModule.Syntax())
-	if err != nil {
-		return restoreInitialModule, fmt.Errorf("Failed to format new module.cue: %v", err)
-	}
-
-	err = os.WriteFile(o.moduleFilePath, cueBytes, 0644) // nolint: gosec
-	if err != nil {
-		return restoreInitialModule, fmt.Errorf("Failed to write module.cue: %v", err)
-	}
-
-	return restoreInitialModule, nil
 }
 
 func (o *option) computeArchiveFiles() ([]archives.FileInfo, error) {

--- a/internal/cli/cmd/plugin/build/cue.go
+++ b/internal/cli/cmd/plugin/build/cue.go
@@ -97,7 +97,7 @@ type cueVendor struct {
 // - Parse the module.cue file containing the dependencies
 // - if no `deps` are present, skip vendoring
 // - if there is already a vendor directory, skip vendoring
-// - Loop other the dependencies and for each:
+// - Loop over the dependencies and for each:
 //   - Look if the dependency is already present in the CUE cache
 //   - If not, download the dependency
 //   - Copy the dependency from the CUE cache to the vendor directory. During this process, we remove the version in the name of the last directory generated from the module path (= rename `cue@vX.Y.Z` to `cue`)

--- a/internal/cli/cmd/plugin/build/cue.go
+++ b/internal/cli/cmd/plugin/build/cue.go
@@ -1,0 +1,259 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/cue/load"
+	"github.com/perses/perses/internal/cli/file"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	vendorDir        = "pkg"
+	vendorDirBackup  = vendorDir + ".bak"
+	moduleFile       = "module.cue"
+	moduleFileBackup = moduleFile + ".bak"
+)
+
+// cacheDir is partially inspired from the CUE source code available at https://github.com/cue-lang/cue/blob/c479844b8d7a75403ab488080e7ba7808b5caaa2/internal/cueconfig/config.go#L67-L76
+// The code has been copied and adapted as we cannot import code from the internal package.
+func cacheDir() (string, error) {
+	if dir := os.Getenv("CUE_CACHE_DIR"); dir != "" {
+		return dir, nil
+	}
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine system cache directory: %v", err)
+	}
+	return filepath.Join(dir, "cue"), nil
+}
+
+type cueDep struct {
+	// moduleName is the name of the module (e.g github.com/perses/perses/cue@v0)
+	moduleName               string
+	modulePathInCueCaching   string
+	modulePathWithoutVersion string
+	version                  string
+}
+
+func (d *cueDep) generateModulePath() error {
+	p := d.moduleName
+	if filepath.Separator != '/' {
+		p = strings.Replace(d.moduleName, "/", string(filepath.Separator), -1)
+	}
+	parts := strings.Split(p, "@")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid module name %s", d.moduleName)
+	}
+	d.modulePathWithoutVersion = parts[0]
+	d.modulePathInCueCaching = fmt.Sprintf("%s@%s", parts[0], d.version)
+	return nil
+}
+
+type cueVendor struct {
+	pluginPath           string
+	moduleFilePath       string
+	moduleFileBackupPath string
+	vendorDirPath        string
+}
+
+// vendorCueDependencies does a home-made vendoring of CUE dependencies
+// ---
+// Full explanation:
+//
+// Following the move to CUE native dependency management, the deps of the plugin are no longer vendored under cue.mod/pkg.
+// Letting things in this state would imply that, at runtime, the Perses server should have access to an OCI registry - thus
+// either access to the internet OR to a custom registry set up by users in their private network - to be able to evaluate a plugin
+// schema that imports packages - like the `common` package of Perses.
+//
+// As we consider this constraint a no-go in our case, we asked to CUE maintainers.
+// It seems our long-term solution would be https://github.com/cue-lang/cue/issues/3328. For the time being, we thus have to
+// reproduce the vendoring structure of the "old modules" (https://cuelang.org/docs/concept/faq/new-modules-vs-old-modules/) with
+// custom code.
+//
+// More precisely, the steps are:
+// - Parse the module.cue file containing the dependencies
+// - if no `deps` are present, skip vendoring
+// - if there is already a vendor directory, skip vendoring
+// - Loop other the dependencies and for each:
+//   - Look if the dependency is already present in the CUE cache
+//   - If not, download the dependency
+//   - Copy the dependency from the CUE cache to the vendor directory. During this process, we remove the version in the name of the last directory generated from the module path (= rename `cue@vX.Y.Z` to `cue`)
+//
+// - Once all dependencies have been copied, we are modifying the module file to remove the `deps` section, so that schema evaluation will resolve dependencies from the local vendor dir instead of from an OCI registry.
+func (c *cueVendor) vendorCueDependencies() (func(), error) {
+	exist, err := file.Exists(c.vendorDirPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if %s exists: %w", c.vendorDirPath, err)
+	}
+	if exist {
+		// Then, there is already a vendor directory.
+		// To avoid collision and merge issue by importing the data from the Cuelang cache to vendor directory,
+		// we are considering that the current vendor directory already contains all required deps.
+		return nil, nil
+	}
+	deps, moduleInstance := c.getDependency()
+	if len(deps) == 0 {
+		// There is no dependency to vendor, we can skip this step
+		return nil, nil
+	}
+
+	cueCacheDir, err := cacheDir()
+	if err != nil {
+		return nil, err
+	}
+	cueCacheDir = filepath.Join(cueCacheDir, "mod", "extract")
+	cleanUpFunc := func() {
+		if removeErr := os.RemoveAll(c.vendorDirPath); removeErr != nil {
+			logrus.WithError(removeErr).Errorf("failed to cleanup %s", c.vendorDirPath)
+		}
+	}
+
+	for _, dep := range deps {
+		depExist, depErr := file.Exists(filepath.Join(cueCacheDir, dep.modulePathInCueCaching))
+		if depErr != nil {
+			return cleanUpFunc, fmt.Errorf("failed to check if %s exists: %w", dep.modulePathInCueCaching, depErr)
+		}
+		if !depExist {
+			if downloadErr := c.downloadCueDeps(); downloadErr != nil {
+				return cleanUpFunc, downloadErr
+			}
+		}
+		// At this point, all dependencies have been downloaded. So we can copy the content of the CUE cache to the vendor directory.
+		// First, we need to create the dependency folder in the vendor directory.
+		if mkdirErr := os.MkdirAll(filepath.Join(c.vendorDirPath, dep.modulePathWithoutVersion), 0777); mkdirErr != nil {
+			return cleanUpFunc, fmt.Errorf("failed to create directory %s: %w", dep.modulePathWithoutVersion, mkdirErr)
+		}
+		// Then, we copy the content of the CUE cache to the target directory created above.
+		if copyErr := file.CopyDir(filepath.Join(cueCacheDir, dep.modulePathInCueCaching), filepath.Join(c.vendorDirPath, dep.modulePathWithoutVersion)); copyErr != nil {
+			return cleanUpFunc, fmt.Errorf("failed to copy the dependency %q", dep.modulePathWithoutVersion)
+		}
+	}
+	// At this point, all dependencies have been copied. We can now remove the `deps` section from the module file.
+	restoreModuleFileFunc, err := c.alterCueModule(moduleInstance)
+	restoreFunc := func() {
+		if restoreModuleFileFunc != nil {
+			restoreModuleFileFunc()
+		}
+		cleanUpFunc()
+	}
+	return restoreFunc, err
+}
+
+func (c *cueVendor) downloadCueDeps() error {
+	cmd := exec.Command("cue", "mod", "tidy") // nolint: gosec
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Dir = c.pluginPath // the command has to be run from the plugin path
+	if cmdErr := cmd.Run(); cmdErr != nil {
+		return fmt.Errorf("cue mod tidy failed: %w, stderr: %s", cmdErr, stderr.String())
+	}
+	return nil
+}
+
+func (c *cueVendor) getDependency() ([]cueDep, *build.Instance) {
+	ctx := cuecontext.New()
+	instance := load.Instances([]string{c.moduleFilePath}, nil)
+	module := ctx.BuildInstance(instance[0])
+	deps := module.LookupPath(cue.ParsePath("deps"))
+	if deps.Err() != nil {
+		logrus.WithError(deps.Err()).Debugf("`deps` not found, no CUE dependencies to vendor")
+		return nil, nil
+	}
+	if deps.Kind() != cue.StructKind {
+		logrus.Debugf("`deps` is not a CUE dependency")
+		return nil, nil
+	}
+	var depList []cueDep
+	it, _ := deps.Fields()
+	for it.Next() {
+		moduleName := it.Selector()
+		if moduleName.LabelType() != cue.StringLabel {
+			logrus.Debugf("module name %s is not a string", moduleName)
+			continue
+		}
+		moduleValue := it.Value()
+		if moduleValue.Kind() != cue.StructKind {
+			logrus.Debugf("module %s is not a struct", moduleName)
+			continue
+		}
+		version := moduleValue.LookupPath(cue.ParsePath("v"))
+		if version.Err() != nil || version.Kind() != cue.StringKind {
+			logrus.Debugf("version not found for module %s", moduleName)
+			continue
+		}
+		versionAsString, _ := version.String()
+		d := cueDep{
+			moduleName: moduleName.Unquoted(),
+			version:    versionAsString,
+		}
+		if err := d.generateModulePath(); err != nil {
+			logrus.Debug(err)
+			continue
+		}
+		depList = append(depList, d)
+	}
+	return depList, instance[0]
+}
+
+// alterCueModule alters the module file to remove the `deps` section, so that schema evaluation will resolve
+// dependencies from the local vendor dir instead of from an OCI registry.
+// To achieve this, we parse the module file into a Value & iteratively copy the fields, skipping the `deps` field.
+// That's the easier way we can do in the current state of the CUE lib.
+func (c *cueVendor) alterCueModule(moduleInstance *build.Instance) (func(), error) {
+	ctx := cuecontext.New()
+	module := ctx.BuildInstance(moduleInstance)
+	// restore the original state when finished
+	restoreInitialModule := func() {
+		if err := os.Rename(c.moduleFileBackupPath, c.moduleFilePath); err != nil {
+			logrus.WithError(err).Errorf("failed to restore original module file")
+		}
+	}
+
+	if err := os.Rename(c.moduleFilePath, c.moduleFileBackupPath); err != nil {
+		return restoreInitialModule, fmt.Errorf("failed to backup original module file: %v", err)
+	}
+
+	newModule := ctx.CompileString("{}")
+	iter, _ := module.Fields()
+	for iter.Next() {
+		if iter.Selector().String() == "deps" {
+			continue
+		}
+		newModule = newModule.FillPath(cue.MakePath(iter.Selector()), iter.Value())
+	}
+
+	cueBytes, err := format.Node(newModule.Syntax())
+	if err != nil {
+		return restoreInitialModule, fmt.Errorf("failed to format new module.cue: %v", err)
+	}
+
+	err = os.WriteFile(c.moduleFilePath, cueBytes, 0644) // nolint: gosec
+	if err != nil {
+		return restoreInitialModule, fmt.Errorf("failed to write module.cue: %v", err)
+	}
+
+	return restoreInitialModule, nil
+}

--- a/internal/cli/cmd/plugin/build/cue_test.go
+++ b/internal/cli/cmd/plugin/build/cue_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDependency(t *testing.T) {
+	testSuite := []struct {
+		name       string
+		modulePath string
+		expected   []cueDep
+	}{
+		{
+			name:       "no dependency",
+			modulePath: filepath.Join("testdata", "emptydeps", "cue.mod", "module.cue"),
+		},
+		{
+			name:       "single dependency",
+			modulePath: filepath.Join("testdata", "barchart", "cue.mod", "module.cue"),
+			expected: []cueDep{
+				{
+					moduleName:               "github.com/perses/perses/cue@v0",
+					modulePathInCueCaching:   filepath.Join("github.com", "perses", "perses", "cue@v0.0.2-test"),
+					modulePathWithoutVersion: filepath.Join("github.com", "perses", "perses", "cue"),
+					version:                  "v0.0.2-test",
+				},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.name, func(t *testing.T) {
+			c := &cueVendor{
+				moduleFilePath: test.modulePath,
+			}
+			deps, _ := c.getDependency()
+			assert.Equal(t, test.expected, deps)
+		})
+	}
+}

--- a/internal/cli/cmd/plugin/build/npm.go
+++ b/internal/cli/cmd/plugin/build/npm.go
@@ -1,0 +1,67 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func (o *option) executeNPMSteps() error {
+	if err := o.executeNPMInstall(); err != nil {
+		return err
+	}
+	return o.executeNPMBuild()
+}
+
+func (o *option) executeNPMInstall() error {
+	if o.skipNPMInstall {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(o.cfg.FrontendPath, "node_modules")); os.IsNotExist(err) {
+		// Then run `npm ci` to install the dependencies
+		cmd := exec.Command("npm", "ci")
+		cmd.Dir = o.cfg.FrontendPath
+		// to get a more comprehensive error message, we need to capture the stdout & stderr.
+		var stdoutBuffer bytes.Buffer
+		cmd.Stdout = &stdoutBuffer
+		var stderrBuffer bytes.Buffer
+		cmd.Stderr = &stderrBuffer
+		cmd.Dir = o.cfg.FrontendPath
+		if execErr := cmd.Run(); execErr != nil {
+			return fmt.Errorf("unable to install the frontend dependencies: %w, stdout: %s, stderr: %s", execErr, stdoutBuffer.String(), stderrBuffer.String())
+		}
+	}
+	return nil
+}
+
+func (o *option) executeNPMBuild() error {
+	if o.skipNPMBuild {
+		return nil
+	}
+	cmd := exec.Command("npm", "run", "build")
+	// to get a more comprehensive error message, we need to capture the stdout & stderr.
+	var stdoutBuffer bytes.Buffer
+	cmd.Stdout = &stdoutBuffer
+	var stderrBuffer bytes.Buffer
+	cmd.Stderr = &stderrBuffer
+	cmd.Dir = o.cfg.FrontendPath
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("unable to build the frontend: %w, stdout: %s, stderr: %s", err, stdoutBuffer.String(), stderrBuffer.String())
+	}
+	return nil
+}

--- a/internal/cli/cmd/plugin/build/testdata/emptydeps/cue.mod/module.cue
+++ b/internal/cli/cmd/plugin/build/testdata/emptydeps/cue.mod/module.cue
@@ -1,0 +1,7 @@
+module: "github.com/perses/plugins/markdownchart@v0"
+language: {
+	version: "v0.12.0"
+}
+source: {
+	kind: "git"
+}


### PR DESCRIPTION
This PR is changing the way we are vendoring the Cuelang dependency.

Before we were setting a temporary folder that was used as cache folder to download the Cuelang dependency.

Now we are not altering the default caching folder of Cuelang. The code is looking at the dependency file and then based on them, it will copy one by one the dependency from the caching folder to the vendor folder.

If one dependency is not found, then the code is calling cuelang to download it.