### PR TITLE
[ENHANCEMENT] allow scoped datasource proxies to use global secrets

### DIFF
--- a/internal/api/impl/proxy/localdatasource.go
+++ b/internal/api/impl/proxy/localdatasource.go
@@ -29,7 +29,11 @@ func (e *endpoint) proxyDashboardDatasource(ctx echo.Context, projectName, dtsNa
 	path := ctx.Param("*")
 
 	pr, err := newProxy(spec, path, e.crypto, func(name string) (*v1.SecretSpec, error) {
-		return e.getProjectSecret(projectName, dtsName, name)
+		secret, err := e.getProjectSecret(projectName, dtsName, name)
+		if err != nil {
+			return e.getGlobalSecret(dtsName, name)
+		}
+		return secret, nil
 	})
 	if err != nil {
 		return err

--- a/internal/api/impl/proxy/projectdatasource.go
+++ b/internal/api/impl/proxy/projectdatasource.go
@@ -28,7 +28,11 @@ import (
 func (e *endpoint) proxyProjectDatasource(ctx echo.Context, projectName, dtsName string, spec v1.DatasourceSpec) error {
 	path := ctx.Param("*")
 	pr, err := newProxy(spec, path, e.crypto, func(name string) (*v1.SecretSpec, error) {
-		return e.getProjectSecret(projectName, dtsName, name)
+		secret, err := e.getProjectSecret(projectName, dtsName, name)
+		if err != nil {
+			return e.getGlobalSecret(dtsName, name)
+		}
+		return secret, nil
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

When using datasources with TLS, CAs can be defined globally to verify datasource backends. This PR allows proxies to use global secrets in addition to project scoped secrets

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).