### PR TITLE
[FEATURE] Add support for external changes to the ViewDashboard component

### DIFF
--- a/ui/core/src/utils/assign-ref.ts
+++ b/ui/core/src/utils/assign-ref.ts
@@ -1,0 +1,16 @@
+import { MutableRef } from './types';
+
+/**
+ * Utility to assign a value to a React ref regardless of its type (callback or object ref)
+ * @param ref The React ref to assign to
+ * @param value The value to assign to the ref
+ */
+export function assignRef<T>(ref: MutableRef<T> | null | undefined, value: T): void {
+  if (ref) {
+    if (typeof ref === 'function') {
+      ref(value);
+    } else {
+      ref.current = value;
+    }
+  }
+}

--- a/ui/core/src/utils/assign-ref.ts
+++ b/ui/core/src/utils/assign-ref.ts
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { MutableRef } from './types';
 
 /**

--- a/ui/core/src/utils/index.ts
+++ b/ui/core/src/utils/index.ts
@@ -22,3 +22,4 @@ export * from './transform-data';
 export * from './value-mapping';
 export * from './types';
 export * from './regexp';
+export * from './assign-ref';

--- a/ui/core/src/utils/types.ts
+++ b/ui/core/src/utils/types.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export type DispatchWithPromise<A> = (value: A) => Promise<void>;
+export type MutableRef<T> = React.RefCallback<T> | React.MutableRefObject<T | null> | null;

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -76,7 +76,7 @@ export interface DashboardStoreProps {
 
 export interface DashboardProviderProps {
   initialState: DashboardStoreProps;
-  dashboardStoreApiRef?: MutableRef<StoreApi<DashboardStoreState>>;
+  dashboardStoreApiRef?: MutableRef<DashboardStoreState>;
   children?: ReactNode;
 }
 
@@ -101,7 +101,7 @@ export function DashboardProvider({ dashboardStoreApiRef, ...props }: DashboardP
   const [store] = useState(() => {
     const newStore = createDashboardStore(props);
 
-    assignRef(dashboardStoreApiRef, newStore);
+    assignRef(dashboardStoreApiRef, newStore.getState());
 
     return newStore;
   }); // prevent calling createDashboardStore every time it rerenders

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx
@@ -26,6 +26,8 @@ import {
   DEFAULT_REFRESH_INTERVAL,
   DatasourceSpec,
   EphemeralDashboardResource,
+  MutableRef,
+  assignRef,
 } from '@perses-dev/core';
 import { usePlugin, usePluginRegistry } from '@perses-dev/plugin-system';
 import { createPanelGroupEditorSlice, PanelGroupEditorSlice } from './panel-group-editor-slice';
@@ -74,6 +76,7 @@ export interface DashboardStoreProps {
 
 export interface DashboardProviderProps {
   initialState: DashboardStoreProps;
+  dashboardStoreApiRef?: MutableRef<StoreApi<DashboardStoreState>>;
   children?: ReactNode;
 }
 
@@ -87,7 +90,7 @@ export function useDashboardStore<T>(selector: (state: DashboardStoreState) => T
   return useStoreWithEqualityFn(store, selector, shallow);
 }
 
-export function DashboardProvider(props: DashboardProviderProps): ReactElement {
+export function DashboardProvider({ dashboardStoreApiRef, ...props }: DashboardProviderProps): ReactElement {
   const createDashboardStore = useCallback(initStore, [props]);
 
   // load plugin to retrieve initial spec if default panel kind is defined
@@ -95,11 +98,18 @@ export function DashboardProvider(props: DashboardProviderProps): ReactElement {
   const defaultPanelKind = defaultPluginKinds?.['Panel'] ?? '';
   const { data: plugin } = usePlugin('Panel', defaultPanelKind);
 
-  const [store] = useState(createDashboardStore(props)); // prevent calling createDashboardStore every time it rerenders
+  const [store] = useState(() => {
+    const newStore = createDashboardStore(props);
+
+    assignRef(dashboardStoreApiRef, newStore);
+
+    return newStore;
+  }); // prevent calling createDashboardStore every time it rerenders
 
   useEffect(() => {
     if (plugin === undefined) return;
     const defaultPanelSpec = plugin.createInitialOptions ? plugin.createInitialOptions() : {};
+
     // set default panel kind, spec, and queries for add panel editor
     store.setState({
       initialValues: {

--- a/ui/dashboards/src/context/DashboardProvider/DashboardProviderWithQueryParams.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/DashboardProviderWithQueryParams.tsx
@@ -15,7 +15,11 @@ import { StringParam, useQueryParam } from 'use-query-params';
 import { ReactElement } from 'react';
 import { DashboardProvider, DashboardProviderProps } from './DashboardProvider';
 
-export function DashboardProviderWithQueryParams({ children, initialState }: DashboardProviderProps): ReactElement {
+export function DashboardProviderWithQueryParams({
+  children,
+  initialState,
+  dashboardStoreApiRef,
+}: DashboardProviderProps): ReactElement {
   const [viewPanelRef, setViewPanelRef] = useQueryParam('viewPanelRef', StringParam);
 
   return (
@@ -25,6 +29,7 @@ export function DashboardProviderWithQueryParams({ children, initialState }: Das
         setViewPanelRef: setViewPanelRef,
         ...initialState,
       }}
+      dashboardStoreApiRef={dashboardStoreApiRef}
     >
       {children}
     </DashboardProvider>

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -47,7 +47,7 @@ export interface PanelEditorSlice {
   /**
    * Opens the editor for adding a new Panel to a panel group.
    */
-  openAddPanel: (panelGroupId?: PanelGroupId) => void;
+  openAddPanel: (panelGroupId?: PanelGroupId, panelDefinition?: PanelEditorValues['panelDefinition']) => void;
 }
 
 export interface PanelEditorState {
@@ -163,7 +163,7 @@ export function createPanelEditorSlice(): StateCreator<
       });
     },
 
-    openAddPanel(panelGroupId): void {
+    openAddPanel(panelGroupId, panelDefinition): void {
       // If a panel group isn't supplied, add to the first group or create a group if there aren't any
       let newGroup: PanelGroupDefinition | undefined = undefined;
       panelGroupId ??= get().panelGroupOrder[0];
@@ -177,7 +177,7 @@ export function createPanelEditorSlice(): StateCreator<
         mode: 'create',
         initialValues: {
           groupId: panelGroupId,
-          panelDefinition: get().initialValues?.panelDefinition ?? createPanelDefinition(),
+          panelDefinition: panelDefinition ?? get().initialValues?.panelDefinition ?? createPanelDefinition(),
         },
         applyChanges: (next) => {
           const name = next.panelDefinition.spec.display.name;

--- a/ui/dashboards/src/test/plugin-registry.tsx
+++ b/ui/dashboards/src/test/plugin-registry.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { UnknownSpec } from '@perses-dev/core';
-import { PanelPlugin, MockPlugin } from '@perses-dev/plugin-system';
+import { PanelPlugin, MockPlugin, TimeSeriesQueryPlugin } from '@perses-dev/plugin-system';
 import { ReactElement } from 'react';
 
 const FakeTimeSeriesChartOptionEditor = (): ReactElement => {
@@ -39,5 +39,19 @@ const MOCK_TIME_SERIES_PANEL: MockPlugin = {
   plugin: FakeTimeSeriesPlugin,
 };
 
+const FakeTimeSeriesQuery: TimeSeriesQueryPlugin = {
+  createInitialOptions: () => ({}),
+  getTimeSeriesData: async () => ({ series: [] }),
+  OptionsEditorComponent: () => {
+    return <div>TimeSeriesQuery options</div>;
+  },
+};
+
+const MOCK_TIME_SERIES_QUERY: MockPlugin = {
+  kind: 'TimeSeriesQuery',
+  spec: { name: 'PrometheusTimeSeriesQuery' },
+  plugin: FakeTimeSeriesQuery,
+};
+
 // Array of default mock plugins added to the PluginRegistry during test renders
-export const MOCK_PLUGINS: MockPlugin[] = [MOCK_TIME_SERIES_PANEL];
+export const MOCK_PLUGINS: MockPlugin[] = [MOCK_TIME_SERIES_PANEL, MOCK_TIME_SERIES_QUERY];

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -26,6 +26,7 @@ import {
   DatasourceStoreProvider,
   VariableProviderProps,
   VariableProviderWithQueryParams,
+  DashboardProviderProps,
 } from '../../context';
 import { DashboardProviderWithQueryParams } from '../../context/DashboardProvider/DashboardProviderWithQueryParams';
 import { DashboardApp, DashboardAppProps } from './DashboardApp';
@@ -35,6 +36,7 @@ export interface ViewDashboardProps extends Omit<BoxProps, 'children'>, Dashboar
   externalVariableDefinitions?: VariableProviderProps['externalVariableDefinitions'];
   isEditing?: boolean;
   isCreating?: boolean;
+  dashboardStoreApiRef?: DashboardProviderProps['dashboardStoreApiRef'];
 }
 
 /**
@@ -56,6 +58,7 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
     isEditing,
     isCreating,
     sx,
+    dashboardStoreApiRef,
     ...others
   } = props;
   const { spec } = dashboardResource;
@@ -107,6 +110,7 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
           dashboardResource,
           isEditMode: !!isEditing,
         }}
+        dashboardStoreApiRef={dashboardStoreApiRef}
       >
         <TimeRangeProviderWithQueryParams
           initialTimeRange={initialTimeRange}

--- a/ui/dashboards/src/views/ViewDashboard/tests/ViewDashboard.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/ViewDashboard.test.tsx
@@ -1,0 +1,69 @@
+import { screen, waitFor } from '@testing-library/dom';
+import { getMockPluginName, ValidationProvider } from '@perses-dev/plugin-system';
+import { renderHook } from '@testing-library/react';
+import { act, useRef } from 'react';
+import { StoreApi } from 'zustand';
+import { PanelDefinition } from '@perses-dev/core';
+import { defaultDatasourceProps, getTestDashboard, renderWithContext } from '../../../test';
+import { ViewDashboard, ViewDashboardProps } from '../ViewDashboard';
+import { DashboardStoreState } from '../../../context';
+
+describe('View Dashboard', () => {
+  const dashboardResource = getTestDashboard();
+  const renderDashboard = (props?: Partial<ViewDashboardProps>): void => {
+    renderWithContext(
+      <ValidationProvider>
+        <ViewDashboard
+          dashboardResource={dashboardResource}
+          datasourceApi={defaultDatasourceProps.datasourceApi}
+          isReadonly={false}
+          isVariableEnabled={true}
+          isDatasourceEnabled={true}
+          {...props}
+        />
+      </ValidationProvider>
+    );
+  };
+
+  it('should render component', () => {
+    renderDashboard();
+    const dashboardName = dashboardResource.metadata.name;
+
+    expect(screen.getByText(dashboardName)).toBeInTheDocument();
+  });
+
+  it('should allow external access to the dashboardStoreState and trigger panel editor actions', async () => {
+    const dashboardStoreApiRef = renderHook(() => useRef<StoreApi<DashboardStoreState>>(null)).result.current;
+
+    renderDashboard({ dashboardStoreApiRef });
+
+    // Ensure the store is initialized
+    await waitFor(() => expect(dashboardStoreApiRef.current).toBeDefined());
+
+    const CUSTOM_DISPLAY_NAME = 'Custom Display Name';
+
+    const panelDefinitionMock: PanelDefinition = {
+      ...dashboardResource.spec.panels.memory!,
+      spec: {
+        ...dashboardResource.spec.panels.memory!.spec,
+        display: {
+          name: CUSTOM_DISPLAY_NAME,
+        },
+      },
+    };
+
+    // Trigger the panel editor open action using the external store reference
+    act(() => {
+      dashboardStoreApiRef.current?.getState().openAddPanel(undefined, panelDefinitionMock);
+    });
+
+    // Verify that the panel editor is open and displays the expected content
+    await waitFor(() => {
+      expect(screen.getByText('Add Panel')).toBeInTheDocument();
+      expect(screen.getByText(panelDefinitionMock.spec.display.name)).toBeInTheDocument();
+      expect(screen.getAllByText(getMockPluginName('TimeSeriesQuery', 'PrometheusTimeSeriesQuery'))).toHaveLength(
+        panelDefinitionMock.spec!.queries!.length
+      );
+    });
+  });
+});

--- a/ui/dashboards/src/views/ViewDashboard/tests/ViewDashboard.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/ViewDashboard.test.tsx
@@ -15,7 +15,6 @@ import { screen, waitFor } from '@testing-library/dom';
 import { getMockPluginName, ValidationProvider } from '@perses-dev/plugin-system';
 import { renderHook } from '@testing-library/react';
 import { act, useRef } from 'react';
-import { StoreApi } from 'zustand';
 import { PanelDefinition } from '@perses-dev/core';
 import { defaultDatasourceProps, getTestDashboard, renderWithContext } from '../../../test';
 import { ViewDashboard, ViewDashboardProps } from '../ViewDashboard';
@@ -46,7 +45,7 @@ describe('View Dashboard', () => {
   });
 
   it('should allow external access to the dashboardStoreState and trigger panel editor actions', async () => {
-    const dashboardStoreApiRef = renderHook(() => useRef<StoreApi<DashboardStoreState>>(null)).result.current;
+    const dashboardStoreApiRef = renderHook(() => useRef<DashboardStoreState>(null)).result.current;
 
     renderDashboard({ dashboardStoreApiRef });
 
@@ -67,7 +66,7 @@ describe('View Dashboard', () => {
 
     // Trigger the panel editor open action using the external store reference
     act(() => {
-      dashboardStoreApiRef.current?.getState().openAddPanel(undefined, panelDefinitionMock);
+      dashboardStoreApiRef.current?.openAddPanel(undefined, panelDefinitionMock);
     });
 
     // Verify that the panel editor is open and displays the expected content

--- a/ui/dashboards/src/views/ViewDashboard/tests/ViewDashboard.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/ViewDashboard.test.tsx
@@ -1,3 +1,16 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { screen, waitFor } from '@testing-library/dom';
 import { getMockPluginName, ValidationProvider } from '@perses-dev/plugin-system';
 import { renderHook } from '@testing-library/react';

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -62,6 +62,7 @@ export function useQueryType(): (pluginKind: string) => string | undefined {
   const { data: timeSeriesQueryPlugins, isLoading: isTimeSeriesQueryLoading } = useListPluginMetadata([
     'TimeSeriesQuery',
   ]);
+
   const { data: traceQueryPlugins, isLoading: isTraceQueryPluginLoading } = useListPluginMetadata(['TraceQuery']);
 
   // For example, `map: {"TimeSeriesQuery":["PrometheusTimeSeriesQuery"],"TraceQuery":["TempoTraceQuery"]}`

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -62,7 +62,6 @@ export function useQueryType(): (pluginKind: string) => string | undefined {
   const { data: timeSeriesQueryPlugins, isLoading: isTimeSeriesQueryLoading } = useListPluginMetadata([
     'TimeSeriesQuery',
   ]);
-
   const { data: traceQueryPlugins, isLoading: isTraceQueryPluginLoading } = useListPluginMetadata(['TraceQuery']);
 
   // For example, `map: {"TimeSeriesQuery":["PrometheusTimeSeriesQuery"],"TraceQuery":["TempoTraceQuery"]}`

--- a/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
+++ b/ui/plugin-system/src/test-utils/mock-plugin-registry.tsx
@@ -67,6 +67,7 @@ export function mockPluginRegistry(...mockPlugins: MockPlugin[]): Omit<PluginReg
     pluginLoader,
     defaultPluginKinds: {
       TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+      Panel: 'TimeSeriesChart',
     },
   };
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Solves https://github.com/perses/perses/issues/2796

This pull request includes several changes to enhance the flexibility and functionality of the dashboard provider and its related components. The most important changes include the addition of a utility function to handle React refs, the introduction of a new `MutableRef` type, and modifications to the `DashboardProvider` to support external access to the store API.

### Utility Functions and Types:
* Added `assignRef` utility function to handle assignment to React refs of different types (`ui/core/src/utils/assign-ref.ts`).
* Introduced `MutableRef` type to represent a React ref that can be either a callback or an object ref (`ui/core/src/utils/types.ts`).

### Dashboard Provider Enhancements:
* Updated `DashboardProvider` and related components to accept a `dashboardStoreApiRef` prop, allowing external access to the dashboard store API (`ui/dashboards/src/context/DashboardProvider/DashboardProvider.tsx`). [[1]](diffhunk://#diff-7a305cb3218f85265712a33f4bb8c101c830a46c8347474c51534eb51f02de1cR29-R30) [[2]](diffhunk://#diff-7a305cb3218f85265712a33f4bb8c101c830a46c8347474c51534eb51f02de1cR79) [[3]](diffhunk://#diff-7a305cb3218f85265712a33f4bb8c101c830a46c8347474c51534eb51f02de1cL90-R112)
* Modified `DashboardProviderWithQueryParams` to pass the `dashboardStoreApiRef` prop to `DashboardProvider` (`ui/dashboards/src/context/DashboardProvider/DashboardProviderWithQueryParams.tsx`). [[1]](diffhunk://#diff-273db30af981e576e775b10803f2a42eb245da5b29f021e61bab0abef615da88L18-R22) [[2]](diffhunk://#diff-273db30af981e576e775b10803f2a42eb245da5b29f021e61bab0abef615da88R32)
* Enhanced `ViewDashboard` to support the `dashboardStoreApiRef` prop, enabling external manipulation of the dashboard store (`ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx`). [[1]](diffhunk://#diff-c0ba305500622558fed229dd3de12d65cd637758e027a83be96d0fe4a27cf938R29) [[2]](diffhunk://#diff-c0ba305500622558fed229dd3de12d65cd637758e027a83be96d0fe4a27cf938R39) [[3]](diffhunk://#diff-c0ba305500622558fed229dd3de12d65cd637758e027a83be96d0fe4a27cf938R61) [[4]](diffhunk://#diff-c0ba305500622558fed229dd3de12d65cd637758e027a83be96d0fe4a27cf938R113)

### Panel Editor Improvements:
* Updated `openAddPanel` method in `panel-editor-slice` to accept an optional `panelDefinition` parameter, providing more flexibility when adding new panels (`ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts`). [[1]](diffhunk://#diff-50d50bc6b2e5f15c22c1575366a61cd091cf9f01510f126cb6f3134262f03a83L50-R50) [[2]](diffhunk://#diff-50d50bc6b2e5f15c22c1575366a61cd091cf9f01510f126cb6f3134262f03a83L166-R166) [[3]](diffhunk://#diff-50d50bc6b2e5f15c22c1575366a61cd091cf9f01510f126cb6f3134262f03a83L180-R180)

### Testing Enhancements:
* Added tests for the `ViewDashboard` component to verify external access to the dashboard store state and panel editor actions (`ui/dashboards/src/views/ViewDashboard/tests/ViewDashboard.test.tsx`).

<!-- Context useful to a reviewer -->

# Screenshots
- Automatically load up an editor with predefined options whenever accessing a dashboard

```typescript
  const [externalStore, setExternalStore] = useState<DashboardStoreState | null>(null);

  useEffect(() => {
    if (externalStore) {
      externalStore.openAddPanel(undefined, panelDefinitionMock);
    }
  }, [externalStore]);

<ViewDashboard 
   {...props}
   dashboardStoreApiRef={setExternalStore}
/>
```

![perses example usage](https://github.com/user-attachments/assets/d71fec4a-c9c6-4cd1-aede-8c80a0014ba1)

- Open up the editor with predefined options using ref

```typescript
  const externalStoreApiRef = useRef<DashboardStoreState | null>(null);

<Box>
      <Button onClick={() => externalStoreApiRef.current?.openAddPanel(undefined, panelDefinitionMock)}>
        I am an external button!
      </Button>
      <ViewDashboard 
        {...props}
        dashboardStoreApiRef={externalStoreApiRef}
      />
      // Rest of the code...
</Box>
```

![using ref](https://github.com/user-attachments/assets/891e8532-607b-48c0-9fa1-01483ab39fc5)

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
