### PR TITLE
[ENHANCEMENT] CLI/DAC: ignore a list of pre-defined folder when building dashboard

### DIFF
--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
@@ -36,6 +37,8 @@ const (
 	goExtension  = ".go"
 	cueExtension = ".cue"
 )
+
+var folderToIgnore = []string{".git", ".github", ".idea", config.DefaultOutputFolder, "cue.mod"}
 
 type option struct {
 	persesCMD.Option
@@ -82,6 +85,9 @@ func (o *option) Execute() error {
 
 		// Process regular files only
 		if info.IsDir() {
+			if slices.Contains(folderToIgnore, info.Name()) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 


### PR DESCRIPTION
With this PR, `percli dac build` is ignoring a list of pre-defined folder where the files to be compiled must not be stored.

it fixes https://github.com/perses/perses/issues/2533.

An idea to improve this quick win would be to use the file `.gitignore` if it exists and then ignore everything listed in this file