### PR TITLE
[ENHANCEMENT] adding extra args support dac build

### DIFF
--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -131,7 +131,7 @@ func (o *option) processFile(file string, extension string) error {
 		//      However, the cue code is (for now at least) not well packaged for such an external reuse.
 		//      See https://github.com/cue-lang/cue/blob/master/cmd/cue/cmd/eval.go#L87
 		// NB3: #nosec is needed here even if the user-fed parts of the command are sanitized upstream
-		cmd = exec.Command("cue", "eval", file, "--out", o.Output, "--concrete") // #nosec
+		cmd = exec.Command("cue", "eval", file, "--out", o.Output, "--concrete", strings.Join(o.args, " ")) // #nosec
 	} else {
 		return output.HandleString(o.writer, fmt.Sprintf("skipping %q because it is neither a `cue` or `go` file", file))
 	}

--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -44,13 +44,12 @@ type option struct {
 	opt.OutputOption
 	writer    io.Writer
 	errWriter io.Writer
+	args      []string
 	Mode      string
 }
 
 func (o *option) Complete(args []string) error {
-	if len(args) > 0 {
-		return fmt.Errorf("no args are supported by the command 'build'")
-	}
+	o.args = args
 	if outputErr := o.OutputOption.Complete(); outputErr != nil {
 		return outputErr
 	}
@@ -124,7 +123,7 @@ func (o *option) processFile(file string, extension string) error {
 		// we must be in the closest directory to the file.
 		folder := filepath.Dir(file)
 		extractedFile := filepath.Base(file)
-		cmd = exec.Command("go", "run", extractedFile, "--output", o.Output) // #nosec
+		cmd = exec.Command("go", "run", extractedFile, "--output", o.Output, strings.Join(o.args, " ")) // #nosec
 		cmd.Dir = folder
 	} else if extension == cueExtension {
 		// NB: most of the work of the `build` command is actually made by the `eval` command of the cue CLI.
@@ -218,6 +217,9 @@ percli dac build -d my_dashboards
 
 # build all the files under a given directory & deploy the resulting resources right away
 percli dac build -d my_dashboards && percli apply -d built
+
+# build a given file as JSON providing extra arguments to the Go program
+percli dac build -f main.go -ojson -- --arg1=value1 --arg2=value2
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return persesCMD.Run(o, cmd, args)

--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -131,7 +131,7 @@ func (o *option) processFile(file string, extension string) error {
 		//      However, the cue code is (for now at least) not well packaged for such an external reuse.
 		//      See https://github.com/cue-lang/cue/blob/master/cmd/cue/cmd/eval.go#L87
 		// NB3: #nosec is needed here even if the user-fed parts of the command are sanitized upstream
-		cmd = exec.Command("cue", "eval", file, "--out", o.Output, "--concrete", strings.Join(o.args, " ")) // #nosec
+		cmd = exec.Command("cue", "eval", file, "--out", o.Output, "--concrete") // #nosec
 	} else {
 		return output.HandleString(o.writer, fmt.Sprintf("skipping %q because it is neither a `cue` or `go` file", file))
 	}
@@ -218,7 +218,7 @@ percli dac build -d my_dashboards
 # build all the files under a given directory & deploy the resulting resources right away
 percli dac build -d my_dashboards && percli apply -d built
 
-# build a given file as JSON providing extra arguments to the Go program
+# build a given file as JSON providing extra arguments to the Go program (This is only applicable for Go files)
 percli dac build -f main.go -ojson -- --arg1=value1 --arg2=value2
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

This pull request introduces changes to the `internal/cli/cmd` package to support passing arguments to commands in the `build` subcommand. The most important changes include adding a new method to set arguments, updating the `option` struct to store these arguments, and modifying the command execution to include the arguments.

Enhancements to argument handling:

* [`internal/cli/cmd/cmd.go`](diffhunk://#diff-ff081a1614e8adc291f4c20213d31463eb3b63cb0ea04a80dfe3626458464973R31-R38): Added the `SetArgs` method to the `Option` interface to allow setting command arguments.

Updates to the `build` command:

* [`internal/cli/cmd/dac/build/build.go`](diffhunk://#diff-97a1ca64aa554e8fc0b8b0f14879390430207a930004b32489d5191fc381e0c4R47-L53): Updated the `option` struct to include an `args` field for storing command arguments.
* [`internal/cli/cmd/dac/build/build.go`](diffhunk://#diff-97a1ca64aa554e8fc0b8b0f14879390430207a930004b32489d5191fc381e0c4L119-R132): Modified the `processFile` method to include the arguments when executing `go run` and `cue eval` commands.
* [`internal/cli/cmd/dac/build/build.go`](diffhunk://#diff-97a1ca64aa554e8fc0b8b0f14879390430207a930004b32489d5191fc381e0c4R186-R189): Added the `SetArgs` method to the `option` struct to set the command arguments.
* [`internal/cli/cmd/dac/build/build.go`](diffhunk://#diff-97a1ca64aa554e8fc0b8b0f14879390430207a930004b32489d5191fc381e0c4R222-R224): Updated the command usage documentation to include an example of passing extra arguments to the `build` command.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
