### PR TITLE
[ENHANCEMENT] make proxy authorization optional

### DIFF
--- a/pkg/model/api/v1/secret.go
+++ b/pkg/model/api/v1/secret.go
@@ -58,11 +58,8 @@ func (s *SecretSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (s *SecretSpec) validate() error {
-	if s.BasicAuth == nil && s.Authorization == nil {
-		return fmt.Errorf("at most one of basicAuth and authorization must be configured")
-	}
-	if s.BasicAuth != nil && s.Authorization != nil {
-		return fmt.Errorf("basicAuth and authorization are mutually exclusive, use one of them")
+	if s.BasicAuth != nil && s.Authorization != nil && s.OAuth != nil {
+		return fmt.Errorf("basicAuth, authorization and oauth are mutually exclusive, use one of them")
 	}
 	return nil
 }

--- a/ui/app/src/components/secrets/SecretDataGrid.tsx
+++ b/ui/app/src/components/secrets/SecretDataGrid.tsx
@@ -30,6 +30,7 @@ const MemoizedColumnHeaders = memo(GridColumnHeaders);
 
 export interface Row extends CommonRow {
   project: string;
+  noAuth: boolean;
   basicAuth: boolean;
   authorization: boolean;
   tlsConfig: boolean;

--- a/ui/app/src/components/secrets/SecretEditorForm.tsx
+++ b/ui/app/src/components/secrets/SecretEditorForm.tsx
@@ -35,6 +35,7 @@ import TrashIcon from 'mdi-material-ui/TrashCan';
 import PlusIcon from 'mdi-material-ui/Plus';
 import { FormEditorProps } from '../form-drawers';
 
+const noAuthIndex = 'noAuth';
 const basicAuthIndex = 'basicAuth';
 const authorizationIndex = 'authorization';
 
@@ -98,7 +99,11 @@ export function SecretEditorForm({
   }, [form.formState.isValid]);
 
   const [tabValue, setTabValue] = useState<string>(
-    initialSecretClean.spec.basicAuth ? basicAuthIndex : authorizationIndex
+    initialSecretClean.spec.basicAuth
+      ? basicAuthIndex
+      : initialSecretClean.spec.authorization
+        ? authorizationIndex
+        : noAuthIndex
   );
 
   const handleTabChange = (event: SyntheticEvent, newValue: string): void => {
@@ -111,7 +116,10 @@ export function SecretEditorForm({
 
     setTabValue(newValue);
 
-    if (newValue === basicAuthIndex) {
+    if (newValue === noAuthIndex) {
+      form.setValue('spec.authorization', undefined);
+      form.setValue('spec.basicAuth', undefined);
+    } else if (newValue === basicAuthIndex) {
       form.setValue('spec.authorization', undefined);
     } else if (newValue === authorizationIndex) {
       form.setValue('spec.basicAuth', undefined);
@@ -177,6 +185,12 @@ export function SecretEditorForm({
           >
             <FormControl>
               <RadioGroup row value={tabValue} onChange={handleTabChange} aria-labelledby="Secret Authorization Setup">
+                <FormControlLabel
+                  disabled={isReadonly}
+                  value={noAuthIndex}
+                  control={<Radio />}
+                  label="No Authorization"
+                />
                 <FormControlLabel
                   disabled={isReadonly}
                   value={basicAuthIndex}

--- a/ui/app/src/components/secrets/SecretList.tsx
+++ b/ui/app/src/components/secrets/SecretList.tsx
@@ -75,6 +75,7 @@ export function SecretList<T extends Secret>({
           version: secret.metadata.version,
           createdAt: secret.metadata.createdAt,
           updatedAt: secret.metadata.updatedAt,
+          noAuth: !secret.spec.basicAuth && !secret.spec.authorization,
         }) as Row
     );
   }, [data]);
@@ -170,13 +171,20 @@ export function SecretList<T extends Secret>({
         ),
       },
       {
+        field: 'noAuth',
+        headerName: 'No Authorization',
+        type: 'boolean',
+        flex: 3,
+        minWidth: 150,
+      },
+      {
         field: 'basicAuth',
         headerName: 'Basic Auth',
         type: 'boolean',
         flex: 3,
         minWidth: 150,
       },
-      { field: 'authorization', headerName: 'Authorization', type: 'boolean', flex: 3, minWidth: 150 },
+      { field: 'authorization', headerName: 'Custom Authorization', type: 'boolean', flex: 3, minWidth: 150 },
       { field: 'tlsConfig', headerName: 'TLS Config', type: 'boolean', flex: 3, minWidth: 150 },
       VERSION_COL_DEF,
       CREATED_AT_COL_DEF,

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -290,13 +290,7 @@ function TabButton({ index, ...props }: TabButtonProps): ReactElement {
               metadata: {
                 name: 'NewSecret',
               },
-              spec: {
-                basicAuth: {
-                  username: '',
-                  password: '',
-                  passwordFile: '',
-                },
-              },
+              spec: {},
             }}
             isOpen={isSecretDrawerOpened}
             action="create"

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -331,13 +331,7 @@ function TabButton({ index, projectName, ...props }: TabButtonProps): ReactEleme
                 name: 'NewSecret',
                 project: projectName,
               },
-              spec: {
-                basicAuth: {
-                  username: '',
-                  password: '',
-                  passwordFile: '',
-                },
-              },
+              spec: {},
             }}
             isOpen={isSecretDrawerOpened}
             action="create"

--- a/ui/e2e/src/pages/SecretEditor.ts
+++ b/ui/e2e/src/pages/SecretEditor.ts
@@ -46,4 +46,9 @@ export class SecretEditor {
     await this.basicAuthPasswordInput.clear();
     await this.basicAuthPasswordInput.type(password);
   }
+
+  async clickRadioOption(tabKey: string): Promise<void> {
+    const radioOption = this.container.locator(`input[type="radio"][value="${tabKey}"]`);
+    await radioOption.check();
+  }
 }

--- a/ui/e2e/src/tests/projectView.spec.ts
+++ b/ui/e2e/src/tests/projectView.spec.ts
@@ -91,6 +91,7 @@ test.describe('ProjectView', () => {
 
     await projectPage.addSecretButton.click();
     const secretEditor = projectPage.getSecretEditor();
+    await secretEditor.clickRadioOption('basicAuth');
     await secretEditor.setName('mysupersecret');
     await secretEditor.setBasicAuthUsername('mysuperusername');
     await secretEditor.setBasicAuthPassword('mysuperpassword');


### PR DESCRIPTION
# Description

This PR makes the authorization options for a secret optional. This will allow clients using the proxy to pass their own Authorization header in cases this Header is available from the client or is dynamic and cannot be set to a specific value.

# UI changes

updated the secrets table to include the "No Authorization" option

<img width="1196" alt="Screenshot 2025-03-20 at 10 59 02" src="https://github.com/user-attachments/assets/95fee980-db2e-40da-8386-4f1a6d1dc194" />

updated the secrets form to include the "No Authorization" option

<img width="1071" alt="Screenshot 2025-03-20 at 10 59 10" src="https://github.com/user-attachments/assets/6e03fcd1-3092-467d-9cd3-a4feb8528196" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).