### PR TITLE
[BUGFIX] CUE SDK: fix "cannot reference optional field" error

### DIFF
--- a/cue/dac-utils/variable/list/list.cue
+++ b/cue/dac-utils/variable/list/list.cue
@@ -34,7 +34,6 @@ varBuilder
 #capturingRegexp?: string
 #sort?:            v1Variable.#Sort
 #pluginKind:       string
-#datasourceName:   string
 
 variable: {
 	kind: #kind


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This fixes one of the errors we are getting in some cases with DaC following the bump to CUE [v0.12.0](https://github.com/cue-lang/cue/releases/tag/v0.12.0) that includes this:
> ⚠️ [CL 1206950](https://cuelang.org/cl/1206950) fixes an issue where incomplete errors were not being reported by `cue eval` and `cue vet`.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
