### PR TITLE
[ignore] fix release condition for  cue sdk

### DIFF
--- a/.github/workflows/cue.yaml
+++ b/.github/workflows/cue.yaml
@@ -73,7 +73,7 @@ jobs:
     name: "publish module to Central Registry"
     needs: "validate-schemas"
     runs-on: ubuntu-latest
-    if: ${{ github.event.release.tag_name && startsWith(github.ref_name, 'v')}} 
+    if: ${{ github.event_name == 'push' && startsWith(github.ref_name, 'v') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The job has been skipped during the the release because the event check is not the accurate one. Before it was looking for the event matching the creating of release in GitHub. But the process in Perses is to actually create a tag. The CI is then triggered when the tag is created (with a push). 

This PR is fixing it