### PR TITLE
[BUGFIX] `dac preview`: fix nil pointer error for brand new dashboards

### DIFF
--- a/pkg/model/api/v1/common/url.go
+++ b/pkg/model/api/v1/common/url.go
@@ -114,3 +114,10 @@ func (u *URL) UnmarshalText(text []byte) error {
 	u.URL = urlp
 	return nil
 }
+
+func (u *URL) String() string {
+	if u == nil || u.URL == nil {
+		return ""
+	}
+	return u.URL.String()
+}


### PR DESCRIPTION
# Description

fix such issue..
```bash
time="2025-03-24T11:22:22Z" level=info msg="No dashboard node-exporter-simple found in project KubeConEurope2025, no current link to provide"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5bae0c]

goroutine 1 [running]:
net/url.(*URL).String(0xc00002aab0?)
	/opt/hostedtoolcache/go/1.23.7/x64/src/net/url/url.go:832 +0x2c
github.com/perses/perses/internal/cli/cmd/dac/preview.(*option).buildPreviewResponse(0xc000170000, 0xc00013f860?, 0xc000386340)
	/home/runner/work/perses/perses/internal/cli/cmd/dac/preview/preview.go:172 +0x3ad
github.com/perses/perses/internal/cli/cmd/dac/preview.(*option).Execute(0xc000170000)
	/home/runner/work/perses/perses/internal/cli/cmd/dac/preview/preview.go:119 +0x46b
github.com/perses/perses/internal/cli/cmd.Run({0x148f620, 0xc000170000}, 0xc00016d208, {0xc0001189c0, 0x0, 0x6})
	/home/runner/work/perses/perses/internal/cli/cmd/cmd.go:42 +0xdd
github.com/perses/perses/internal/cli/cmd/dac/preview.NewCMD.func1(0xc000142a00?, {0xc0001189c0?, 0x4?, 0x128cd55?})
	/home/runner/work/perses/perses/internal/cli/cmd/dac/preview/preview.go:194 +0x32
github.com/spf13/cobra.(*Command).execute(0xc00016d208, {0xc000118960, 0x6, 0x6})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0xc00016c008)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.main()
	/home/runner/work/perses/perses/cmd/percli/main.go:99 +0xfe
```

now: works as expected:
```bash
$ ./bin/percli dac preview -f temp.yaml 
time="2025-03-24T16:46:09+01:00" level=info msg="No dashboard myTempExampleDashboard found in project antoinethebaud, no current link to provide"
time="2025-03-24T16:46:09+01:00" level=info msg="ephemeral dashboard \"myTempExampleDashboard\" has been applied in the project \"antoinethebaud\""
- project: antoinethebaud
  dashboard: myTempExampleDashboard
  preview: https://demo.perses.dev/projects/antoinethebaud/ephemeraldashboards/myTempExampleDashboard


```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
