### PR TITLE
[BUGFIX] StatChart: remove unneccessary scrollbars due to rounding

### DIFF
--- a/ui/components/src/StatChart/StatChart.tsx
+++ b/ui/components/src/StatChart/StatChart.tsx
@@ -169,7 +169,9 @@ export const StatChart: FC<StatChartProps> = (props) => {
         <EChart
           sx={{
             width: '100%',
-            height: height - seriesNameHeight - valueFontHeight,
+            // ECharts rounds the height to the nearest integer by default.
+            // This can cause unneccessary scrollbars when the total height of this chart exceeds the 'height' prop.
+            height: Math.floor(height - seriesNameHeight - valueFontHeight),
           }}
           option={option}
           theme={chartsTheme.echartsTheme}


### PR DESCRIPTION
# Description

ECharts rounds the height to the nearest integer by default. This can cause unneccessary scrollbars when the total height of this chart exceeds the 'height' prop.

For example:
height = 74px
font height = 18.5px
computed chart height = 55.5px

55.5px is rounded up to 56px in ECharts (or MUI?), and then 56px (chart) + 18.5px (font) > 74px, causing the rendering of scrollbars.

# Screenshots

Before:
![Bildschirmfoto vom 2025-03-31 20-44-13](https://github.com/user-attachments/assets/c1635d3d-1eb6-48ce-918c-f2da4b7dba64)

After:
![Bildschirmfoto vom 2025-03-31 20-44-22](https://github.com/user-attachments/assets/f15c9e82-b46c-4854-90d6-f6f977dc20a5)

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
