### PR TITLE
[DOC] Fix the markdown syntax in `docs/configuration/configuration.md`

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -66,8 +66,6 @@ Another example, to configure the name of the globaldatasource discovery, the en
 PERSES_GLOBAL_DATASOURCE_DISCOVERY_0_DISCOVERY_NAME="my-discovery"
 ```
 
-```bash
-
 ### Definition
 
 The file is written in YAML format, defined by the scheme described below. Brackets indicate that a parameter is optional.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This leftover line

```
  ```bash
```
starts a not existing verbatim block that is not closed and hence mixes up the markdown syntax.

This line was introduced in this commit:
https://github.com/perses/perses/commit/a0707f151dc1a4246af8f3b9c14d21b2b865f0f2#diff-17f1012e0c2fbd9bcd8dff3c23b18ff4b6676eef3beca6f8a3e72e6a36633334R69

<!-- Context useful to a reviewer -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
