### PR TITLE
[FEATURE] Allow to configure CORS

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -151,9 +151,12 @@ encryption_key: <secret> # Optional
 
 # The path to the file containing the secret key.
 encryption_key_file: <filename> # Optional
+
+# Configuration for CORS (cross-origin resource sharing).
+cors: <CORS config> # Optional
 ```
 
-### Cookie config
+#### Cookie config
 
 ```yaml
 # Set the same_site cookie attribute and prevents the browser from sending the cookie along with cross-site requests.
@@ -349,6 +352,40 @@ actions:
 # Resource kinds that are concerned by the permission
 scopes:
   - <enum= kind | "*">
+```
+
+#### CORS config
+
+```yaml
+# Enable CORS middleware.
+# See also: https://fetch.spec.whatwg.org/#cors-protocol
+enable: <boolean> | default = false # Optional
+
+# Configure the value of the Access-Control-Allow-Origin response header.
+# The wildcard characters '*' (0+ chars) and '?' (1 char) are supported.
+# See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+allow_origins: <string[]> | default = ["*"] # Optional
+
+# Configure the value of the Access-Control-Allow-Methods response header.
+# If left empty, the header will be filled from the `Allow` header specified
+# in the request.
+# See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+allow_methods: <string[]> | default = [] # Optional
+
+# Configure the value of the Access-Control-Allow-Headers response header. 
+# See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+allow_headers: <string[]> | default = [] # Optional
+
+# Configure the value of the Access-Control-Allow-Credentials response header.
+# See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+allow_credentials: <boolean> | default = false # Optional
+
+# Configure the value of Access-Control-Expose-Headers response header.
+# See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Header
+expose_headers: <string[]> | default = [] # Optional
+
+# Configure how long (in seconds) the results of a preflight request can be cached.
+max_age: <intger> | default = 0 # Optional
 ```
 
 ### Database config

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	echoMiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/perses/common/app"
 	"github.com/perses/perses/internal/api/core/middleware"
 	"github.com/perses/perses/internal/api/dashboard"
@@ -103,6 +104,16 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 	}
 	if len(conf.APIPrefix) > 0 {
 		runner.HTTPServerBuilder().PreMiddleware(middleware.HandleAPIPrefix(conf.APIPrefix))
+	}
+	if conf.Security.CORS.Enable {
+		runner.HTTPServerBuilder().Middleware(echoMiddleware.CORSWithConfig(echoMiddleware.CORSConfig{
+			AllowOrigins:     conf.Security.CORS.AllowOrigins,
+			AllowMethods:     conf.Security.CORS.AllowMethods,
+			AllowHeaders:     conf.Security.CORS.AllowHeaders,
+			AllowCredentials: conf.Security.CORS.AllowCredentials,
+			ExposeHeaders:    conf.Security.CORS.ExposeHeaders,
+			MaxAge:           conf.Security.CORS.MaxAge,
+		}))
 	}
 	return runner, persistenceManager, nil
 }

--- a/internal/api/core/core_test.go
+++ b/internal/api/core/core_test.go
@@ -110,6 +110,7 @@ func TestCORSCustomConfig(t *testing.T) {
 		AllowMethods: []string{"OPTIONS", "GET"},
 	}
 	withServer(t, config, func(expect *httpexpect.Expect) {
+		// Test with a valid origin.
 		resp := sendPreflightRequest(expect, "https://github.com")
 		resp.Status(http.StatusNoContent)
 		resp.Header("Access-Control-Allow-Origin").IsEqual("https://github.com")
@@ -118,6 +119,12 @@ func TestCORSCustomConfig(t *testing.T) {
 		resp = sendRequest(expect, "https://github.com")
 		resp.Status(http.StatusOK)
 		resp.Header("Access-Control-Allow-Origin").IsEqual("https://github.com")
+
+		// Test with an invalid origin.
+		resp = sendPreflightRequest(expect, "https://google.com")
+		resp.Status(http.StatusNoContent)
+		resp.Header("Access-Control-Allow-Origin").IsEmpty()
+		resp.Header("Access-Control-Allow-Methods").IsEmpty()
 
 		resp = sendRequest(expect, "https://google.com")
 		resp.Status(http.StatusOK)

--- a/internal/api/core/core_test.go
+++ b/internal/api/core/core_test.go
@@ -1,0 +1,126 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/perses/perses/internal/api/utils"
+	"github.com/perses/perses/internal/test"
+	apiConfig "github.com/perses/perses/pkg/model/api/config"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+// We cannot reuse in this package what is inside internal/api/e2e because it would create a
+// circular dependency. There is hence some test code duplication between both packages.
+func defaultConfig() apiConfig.Config {
+	projectPath := test.GetRepositoryPath()
+	return apiConfig.Config{
+		Security: apiConfig.Security{
+			Readonly:      false,
+			EnableAuth:    false,
+			EncryptionKey: secret.Hidden(hex.EncodeToString([]byte("=tW$56zytgB&3jN2E%7-+qrGZE?v6LCc"))),
+		},
+		Plugin: apiConfig.Plugin{
+			Path:        filepath.Join(projectPath, "plugins"),
+			ArchivePath: filepath.Join(projectPath, "plugins-archive"),
+		},
+		Database: apiConfig.Database{
+			File: &apiConfig.File{
+				Folder:        "./test",
+				Extension:     apiConfig.JSONExtension,
+				CaseSensitive: true,
+			},
+		},
+	}
+}
+
+func withServer(t *testing.T, config apiConfig.Config, testFunc func(*httpexpect.Expect)) {
+	runner, persistenceManager, err := New(config, false, prometheus.NewRegistry(), "")
+	assert.NoError(t, err)
+
+	handler, err := runner.HTTPServerBuilder().BuildHandler()
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(handler)
+
+	defer persistenceManager.GetPersesDAO().Close()
+	defer server.Close()
+
+	expect := httpexpect.WithConfig(httpexpect.Config{
+		BaseURL:  server.URL,
+		Reporter: httpexpect.NewAssertReporter(t),
+	})
+	testFunc(expect)
+}
+
+func sendPreflightRequest(expect *httpexpect.Expect, origin string) *httpexpect.Response {
+	return expect.OPTIONS(fmt.Sprintf("%s/projects", utils.APIV1Prefix)).
+		WithHeader("Origin", origin).
+		Expect()
+}
+
+func sendRequest(expect *httpexpect.Expect, origin string) *httpexpect.Response {
+	return expect.GET(fmt.Sprintf("%s/projects", utils.APIV1Prefix)).
+		WithHeader("Origin", origin).
+		Expect()
+}
+
+func TestCORSDefaultConfig(t *testing.T) {
+	config := defaultConfig()
+	config.Security.CORS = apiConfig.CORSConfig{
+		Enable: true,
+	}
+	withServer(t, config, func(expect *httpexpect.Expect) {
+		resp := sendPreflightRequest(expect, "https://github.com")
+		resp.Status(http.StatusNoContent)
+		resp.Header("Access-Control-Allow-Origin").IsEqual("*")
+		resp.Header("Access-Control-Allow-Methods").IsEqual("OPTIONS, GET, POST")
+
+		resp = sendRequest(expect, "https://github.com")
+		resp.Status(http.StatusOK)
+		resp.Header("Access-Control-Allow-Origin").IsEqual("*")
+	})
+}
+
+func TestCORSCustomConfig(t *testing.T) {
+	config := defaultConfig()
+	config.Security.CORS = apiConfig.CORSConfig{
+		Enable:       true,
+		AllowOrigins: []string{"https://gitlab.com", "https://github.com"},
+		AllowMethods: []string{"OPTIONS", "GET"},
+	}
+	withServer(t, config, func(expect *httpexpect.Expect) {
+		resp := sendPreflightRequest(expect, "https://github.com")
+		resp.Status(http.StatusNoContent)
+		resp.Header("Access-Control-Allow-Origin").IsEqual("https://github.com")
+		resp.Header("Access-Control-Allow-Methods").IsEqual("OPTIONS,GET")
+
+		resp = sendRequest(expect, "https://github.com")
+		resp.Status(http.StatusOK)
+		resp.Header("Access-Control-Allow-Origin").IsEqual("https://github.com")
+
+		resp = sendRequest(expect, "https://google.com")
+		resp.Status(http.StatusOK)
+		resp.Header("Access-Control-Allow-Origin").IsEmpty()
+	})
+}

--- a/internal/cli/cmd/conf/conf_test.go
+++ b/internal/cli/cmd/conf/conf_test.go
@@ -47,6 +47,8 @@ func TestConfigCMD(t *testing.T) {
     cookie:
         secure: false
     enable_auth: true
+    cors:
+        enable: false
 
 `,
 		},

--- a/pkg/model/api/config/config_test.go
+++ b/pkg/model/api/config/config_test.go
@@ -54,6 +54,9 @@ func TestJSONMarshalConfig(t *testing.T) {
       "providers": {
         "enable_native": false
       }
+    },
+    "cors": {
+      "enable": false
     }
   },
   "database": {},
@@ -117,6 +120,9 @@ func TestJSONMarshalConfig(t *testing.T) {
       "providers": {
         "enable_native": false
       }
+    },
+    "cors": {
+      "enable": false
     }
   },
   "database": {
@@ -223,6 +229,15 @@ func TestUnmarshalJSONConfig(t *testing.T) {
           ]
         }
       ]
+    },
+    "cors": {
+      "enable": true,
+      "allow_origins": ["https://github.com"],
+      "allow_methods": ["GET", "POST"],
+      "allow_headers": ["X-Custom-Header"],
+      "allow_credentials": true,
+      "expose_headers": ["Content-Encoding"],
+      "max_age": 60
     }
   },
   "database": {
@@ -286,6 +301,15 @@ func TestUnmarshalJSONConfig(t *testing.T) {
 								},
 							},
 						},
+					},
+					CORS: CORSConfig{
+						Enable:           true,
+						AllowOrigins:     []string{"https://github.com"},
+						AllowMethods:     []string{"GET", "POST"},
+						AllowHeaders:     []string{"X-Custom-Header"},
+						AllowCredentials: true,
+						ExposeHeaders:    []string{"Content-Encoding"},
+						MaxAge:           60,
 					},
 				},
 				Database: Database{
@@ -363,6 +387,19 @@ security:
           - create
         scopes:
           - Project
+  cors:
+    enable: true
+    allow_origins:
+      - https://github.com
+    allow_methods:
+      - GET
+      - POST
+    allow_headers:
+      - X-Custom-Header
+    allow_credentials: true
+    expose_headers:
+      - Content-Encoding
+    max_age: 60
 
 database:
   file:
@@ -431,6 +468,15 @@ plugin:
 						Providers: AuthProviders{
 							EnableNative: true,
 						},
+					},
+					CORS: CORSConfig{
+						Enable:           true,
+						AllowOrigins:     []string{"https://github.com"},
+						AllowMethods:     []string{"GET", "POST"},
+						AllowHeaders:     []string{"X-Custom-Header"},
+						AllowCredentials: true,
+						ExposeHeaders:    []string{"Content-Encoding"},
+						MaxAge:           60,
 					},
 				},
 				Database: Database{

--- a/pkg/model/api/config/security.go
+++ b/pkg/model/api/config/security.go
@@ -129,6 +129,16 @@ type Cookie struct {
 	Secure bool `json:"secure" yaml:"secure"`
 }
 
+type CORSConfig struct {
+	Enable           bool     `json:"enable" yaml:"enable"`
+	AllowOrigins     []string `json:"allow_origins,omitempty" yaml:"allow_origins,omitempty"`
+	AllowMethods     []string `json:"allow_methods,omitempty" yaml:"allow_methods,omitempty"`
+	AllowHeaders     []string `json:"allow_headers,omitempty" yaml:"allow_headers,omitempty"`
+	AllowCredentials bool     `json:"allow_credentials,omitempty" yaml:"allow_credentials,omitempty"`
+	ExposeHeaders    []string `json:"expose_headers,omitempty" yaml:"expose_headers,omitempty"`
+	MaxAge           int      `json:"max_age,omitempty" yaml:"max_age,omitempty"`
+}
+
 type Security struct {
 	// Readonly will deactivate any HTTP POST, PUT, DELETE endpoint
 	Readonly bool `json:"readonly" yaml:"readonly"`
@@ -149,6 +159,8 @@ type Security struct {
 	Authorization AuthorizationConfig `json:"authorization,omitempty" yaml:"authorization,omitempty"`
 	// Authentication contains configuration regarding management of access/refresh token
 	Authentication AuthenticationConfig `json:"authentication,omitempty" yaml:"authentication,omitempty"`
+	// Configuration for the CORS middleware.
+	CORS CORSConfig `json:"cors,omitempty" yaml:"cors"`
 }
 
 func (s *Security) Verify() error {


### PR DESCRIPTION
# Description

CORS is needed in order to host the frontend independently from the backend. This change adds the ability to configure the [CORS middleware](https://echo.labstack.com/docs/middleware/cors) in the config file.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).