### PR TITLE
[BUGFIX] Fix OAuth struct parse errors + typo in json

### DIFF
--- a/pkg/model/api/v1/secret/oauth.go
+++ b/pkg/model/api/v1/secret/oauth.go
@@ -103,7 +103,7 @@ func (o *OAuth) GetClientSecret() (string, error) {
 }
 
 func (o *OAuth) validate() error {
-	if len(o.ClientID) == 0 || len(o.ClientSecret) == 0 || len(o.ClientSecretFile) == 0 && len(o.TokenURL) == 0 {
+	if len(o.ClientID) == 0 || (len(o.ClientSecret) == 0 && len(o.ClientSecretFile) == 0) || len(o.TokenURL) == 0 {
 		return fmt.Errorf("when using oauth, clientID, clientSecret/clientSecretFile, and tokenURL cannot be empty")
 	}
 	if len(o.ClientSecret) > 0 && len(o.ClientSecretFile) > 0 {

--- a/pkg/model/api/v1/secret/oauth.go
+++ b/pkg/model/api/v1/secret/oauth.go
@@ -50,7 +50,7 @@ type OAuth struct {
 	ClientID string `json:"clientID" yaml:"clientID"`
 	// ClientSecret is the application's secret.
 	ClientSecret     string `json:"clientSecret" yaml:"clientSecret"`
-	ClientSecretFile string `json:"clientSecretfile" yaml:"clientSecretFile"`
+	ClientSecretFile string `json:"clientSecretFile" yaml:"clientSecretFile"`
 	// TokenURL is the resource server's token endpoint
 	// URL. This is a constant specific to each server.
 	TokenURL string `json:"tokenURL" yaml:"tokenURL"`
@@ -94,7 +94,7 @@ func (o *OAuth) GetClientSecret() (string, error) {
 	if len(o.ClientSecretFile) > 0 {
 		clientSecret, err := os.ReadFile(o.ClientSecretFile)
 		if err != nil {
-			return "", fmt.Errorf("failed to read client_secret_file: %w", err)
+			return "", fmt.Errorf("failed to read clientSecretFile: %w", err)
 		}
 		return string(clientSecret), nil
 	}
@@ -104,10 +104,10 @@ func (o *OAuth) GetClientSecret() (string, error) {
 
 func (o *OAuth) validate() error {
 	if len(o.ClientID) == 0 || len(o.ClientSecret) == 0 || len(o.ClientSecretFile) == 0 && len(o.TokenURL) == 0 {
-		return fmt.Errorf("when using oauth, client_id, client_secret/client_secret_file, and token_url cannot be empty")
+		return fmt.Errorf("when using oauth, clientID, clientSecret/clientSecretFile, and tokenURL cannot be empty")
 	}
 	if len(o.ClientSecret) > 0 && len(o.ClientSecretFile) > 0 {
-		return fmt.Errorf("at most one of oauth client_secret & client_secret_file must be configured")
+		return fmt.Errorf("at most one of oauth clientSecret & clientSecretFile must be configured")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

- Updated the error messages
- Fixed a typo into the json struct tag
- Fixed the conditions to be valid client credentials (results in the table means "return an error"
![image](https://github.com/user-attachments/assets/28acd90e-1c1a-4116-9a13-34a5ec2e32e5)


# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
