### PR TITLE
[BUGFIX] Read clientSecretFile when configuring rest client with oauth

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -151,9 +151,13 @@ func NewRESTClient(config RestConfigClient) (*perseshttp.RESTClient, error) {
 		roundTripper = transport.New(config.URL, roundTripper, *config.NativeAuth)
 	}
 	if config.OAuth != nil {
+		clientSecret, clientSecretErr := config.OAuth.GetClientSecret()
+		if clientSecretErr != nil {
+			return nil, clientSecretErr
+		}
 		oauthConfig := &clientcredentials.Config{
 			ClientID:     config.OAuth.ClientID,
-			ClientSecret: config.OAuth.ClientSecret,
+			ClientSecret: clientSecret,
 			TokenURL:     config.OAuth.TokenURL,
 			Scopes:       config.OAuth.Scopes,
 			AuthStyle:    oauth2.AuthStyle(config.OAuth.AuthStyle),


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
