### PR TITLE
[BREAKING] core: switch the trace data model to OpenTelemetry (OTLP)

### DIFF
--- a/ui/core/src/model/index.ts
+++ b/ui/core/src/model/index.ts
@@ -23,6 +23,7 @@ export * from './kind';
 export * from './layout';
 export * from './legend';
 export * from './notice';
+export * from './otlp';
 export * from './panels';
 export * from './project';
 export * from './query';

--- a/ui/core/src/model/otlp/common/v1/common.ts
+++ b/ui/core/src/model/otlp/common/v1/common.ts
@@ -1,0 +1,29 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/opentelemetry/proto/common/v1/common.proto
+
+export interface KeyValue {
+  key: string;
+  value: AnyValue;
+}
+
+export type AnyValue =
+  | { stringValue: string }
+  | { intValue: string }
+  | { boolValue: boolean }
+  | { arrayValue: { values: AnyValue[] } };
+
+export interface InstrumentationScope {
+  name?: string;
+}

--- a/ui/core/src/model/otlp/index.ts
+++ b/ui/core/src/model/otlp/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * as otlpcommonv1 from './common/v1/common';
+export * as otlpresourcev1 from './resource/v1/resource';
+export * as otlptracev1 from './trace/v1/trace';

--- a/ui/core/src/model/otlp/resource/v1/resource.ts
+++ b/ui/core/src/model/otlp/resource/v1/resource.ts
@@ -1,0 +1,20 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { KeyValue } from '../../common/v1/common';
+
+// https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/opentelemetry/proto/resource/v1/resource.proto
+
+export interface Resource {
+  attributes?: KeyValue[];
+}

--- a/ui/core/src/model/otlp/trace/v1/trace.ts
+++ b/ui/core/src/model/otlp/trace/v1/trace.ts
@@ -1,0 +1,60 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { InstrumentationScope, KeyValue } from '../../common/v1/common';
+import { Resource } from '../../resource/v1/resource';
+
+// https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/opentelemetry/proto/trace/v1/trace.proto
+// https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/examples/trace.json
+
+export interface TracesData {
+  resourceSpans: ResourceSpan[];
+}
+
+export interface ResourceSpan {
+  resource?: Resource;
+  scopeSpans: ScopeSpans[];
+}
+
+export interface ScopeSpans {
+  scope?: InstrumentationScope;
+  spans: Span[];
+}
+
+export interface Span {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind?: string;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes?: KeyValue[];
+  events?: Event[];
+  status?: Status;
+}
+
+export interface Event {
+  timeUnixNano: string;
+  name: string;
+  attributes?: KeyValue[];
+}
+
+export interface Status {
+  code?: typeof StatusCodeUnset | typeof StatusCodeOk | typeof StatusCodeError;
+  message?: string;
+}
+
+export const StatusCodeUnset = 'STATUS_CODE_UNSET';
+export const StatusCodeOk = 'STATUS_CODE_OK';
+export const StatusCodeError = 'STATUS_CODE_ERROR';

--- a/ui/core/src/model/trace-data.ts
+++ b/ui/core/src/model/trace-data.ts
@@ -11,69 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * Common types
- */
-export interface TraceAttribute {
-  key: string;
-  value: TraceAttributeValue;
-}
-
-export type TraceAttributeValue =
-  | { stringValue: string }
-  | { intValue: string }
-  | { boolValue: boolean }
-  | { arrayValue: { values: TraceAttributeValue[] } };
-
-/**
- * An entire trace
- */
-export interface Trace {
-  rootSpan: Span;
-}
-
-export interface TraceResource {
-  serviceName: string;
-  attributes: TraceAttribute[];
-}
-
-export interface TraceScope {
-  name: string;
-}
-
-export interface Span {
-  resource: TraceResource;
-  scope: TraceScope;
-  parentSpan?: Span;
-  /** child spans, sorted by startTime */
-  childSpans: Span[];
-
-  traceId: string;
-  spanId: string;
-  parentSpanId?: string;
-  name: string;
-  kind: string;
-  startTimeUnixMs: number;
-  endTimeUnixMs: number;
-  attributes: TraceAttribute[];
-  events: SpanEvent[];
-  status?: SpanStatus;
-}
-
-export interface SpanEvent {
-  timeUnixMs: number;
-  name: string;
-  attributes: TraceAttribute[];
-}
-
-export interface SpanStatus {
-  code?: typeof SpanStatusUnset | typeof SpanStatusOk | typeof SpanStatusError;
-  message?: string;
-}
-
-export const SpanStatusUnset = 'STATUS_CODE_UNSET';
-export const SpanStatusOk = 'STATUS_CODE_OK';
-export const SpanStatusError = 'STATUS_CODE_ERROR';
+import { TracesData } from './otlp/trace/v1/trace';
 
 /**
  * Partial trace information returned by search endpoint
@@ -101,7 +39,7 @@ export interface ServiceStats {
  * If the query contains a TraceQL query, the 'searchResult' attribute will contain the search results.
  */
 export interface TraceData {
-  trace?: Trace;
+  trace?: TracesData;
   searchResult?: TraceSearchResult[];
 
   metadata?: TraceMetaData;

--- a/ui/plugin-system/src/runtime/trace-queries.tsx
+++ b/ui/plugin-system/src/runtime/trace-queries.tsx
@@ -56,11 +56,6 @@ export function useTraceQueries(definitions: TraceQueryDefinition[]): Array<UseQ
           const data = await plugin.getTraceData(definition.spec.plugin.spec, context);
           return data;
         },
-
-        // The data returned by getTraceData() contains circular dependencies (a span has a reference to the parent span, and the parent span has an array of child spans)
-        // Therefore structuralSharing must be turned off, otherwise the query is stuck in the 'fetching' state on re-fetch.
-        // Ref: https://github.com/TanStack/query/issues/6954#issuecomment-1962321426
-        structuralSharing: false,
       };
     }),
   });


### PR DESCRIPTION
# Description

Previously, the Tempo plugin received traces in OTLP format, transformed it into a custom Perses data model (a span tree), and passed it to the TracingGanttChart plugin.

Retrospectively, I think this wasn't ideal, and the data model transformation should be moved from the data source (Tempo) to the panel plugin (e.g. TracingGanttChart), because:

* using a standard input format like OTLP is better for adoption by other panel plugins
* some plugins might not need a span tree, i.e. computing the span tree is a waste of compute resources
* some edge cases (partial traces) are better handled at the panel plugin (e.g. TracingGanttChart)

This is the change for the core data model, I already prepared the change for the Tempo and TracingGanttChart plugins in a separate PR.

It is a breaking change for plugins which use the trace data model, not for end users, if the respective plugins are updated at the same time.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
