### PR TITLE
[ENHANCEMENT] Enable Datasource Variables

### DIFF
--- a/ui/plugin-system/src/components/DatasourceSelect.tsx
+++ b/ui/plugin-system/src/components/DatasourceSelect.tsx
@@ -48,6 +48,8 @@ type DataSourceOption = {
 } & Omit<DatasourceSelectItem, 'selector'> &
   Omit<DatasourceSelectItem['selector'], 'kind'>;
 
+const emptyDatasourceOption: DataSourceOption = { name: '', value: '' };
+
 export type DatasourceSelectValue<T = DatasourceSelector> = T | VariableName;
 
 export interface DatasourceSelectProps extends Omit<OutlinedSelectProps & BaseSelectProps<string>, OmittedMuiProps> {
@@ -66,7 +68,7 @@ export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
   const { data, isLoading } = useListDatasourceSelectItems(datasourcePluginKind, project);
   const variables = useVariableValues();
 
-  const defaultValue = useMemo(() => {
+  const defaultValue = useMemo<VariableName | DatasourceSelectItemSelector>(() => {
     if (isVariableDatasource(value)) {
       return value;
     }
@@ -112,8 +114,10 @@ export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
     return [...datasourceOptions, ...variableOptions];
   }, [data, variables]);
 
-  // While loading available values, just use an empty string so MUI select doesn't warn about values out of range
-  const optionValue = isLoading ? null : options.find((option) => option.value === selectorToOptionValue(defaultValue));
+  // While loading available values, just use an empty datasource option so MUI select doesn't warn about values out of range
+  const optionValue = isLoading
+    ? emptyDatasourceOption
+    : options.find((option) => option.value === selectorToOptionValue(defaultValue));
 
   // When the user makes a selection, convert the string option value back to a DatasourceSelector
   const handleChange = (selectedOption: DataSourceOption | null): void => {

--- a/ui/plugin-system/src/components/DatasourceSelect.tsx
+++ b/ui/plugin-system/src/components/DatasourceSelect.tsx
@@ -13,29 +13,46 @@
 
 import OpenInNewIcon from 'mdi-material-ui/OpenInNew';
 import {
-  Select,
-  SelectProps,
-  MenuItem,
   Stack,
-  Divider,
   ListItemText,
   Chip,
   IconButton,
   Box,
   OutlinedSelectProps,
   BaseSelectProps,
+  Autocomplete,
+  TextField,
 } from '@mui/material';
-import { DatasourceSelector } from '@perses-dev/core';
+import { DatasourceSelector, VariableName } from '@perses-dev/core';
 import { ReactElement, useMemo } from 'react';
-import { DatasourceSelectItemSelector, useListDatasourceSelectItems } from '../runtime';
+import {
+  DatasourceSelectItem,
+  DatasourceSelectItemGroup,
+  DatasourceSelectItemSelector,
+  useListDatasourceSelectItems,
+  useVariableValues,
+  VariableStateMap,
+} from '../runtime';
+import { parseVariables } from '../utils';
 
+const DATASOURCE_VARIABLE_VALUE_PREFIX = '__DATASOURCE_VARIABLE_VALUE__';
+const VARIABLE_IDENTIFIER = '$';
 // Props on MUI Select that we don't want people to pass because we're either redefining them or providing them in
 // this component
 type OmittedMuiProps = 'children' | 'value' | 'onChange';
 
+type DataSourceOption = {
+  groupEditLink?: string;
+  groupLabel?: string;
+  value: string;
+} & Omit<DatasourceSelectItem, 'selector'> &
+  Omit<DatasourceSelectItem['selector'], 'kind'>;
+
+export type DatasourceSelectValue<T = DatasourceSelector> = T | VariableName;
+
 export interface DatasourceSelectProps extends Omit<OutlinedSelectProps & BaseSelectProps<string>, OmittedMuiProps> {
-  value: DatasourceSelector;
-  onChange: (next: DatasourceSelector) => void;
+  value: DatasourceSelectValue;
+  onChange: (next: DatasourceSelectValue) => void;
   datasourcePluginKind: string;
   project?: string;
 }
@@ -47,8 +64,13 @@ export interface DatasourceSelectProps extends Omit<OutlinedSelectProps & BaseSe
 export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
   const { datasourcePluginKind, value, project, onChange, ...others } = props;
   const { data, isLoading } = useListDatasourceSelectItems(datasourcePluginKind, project);
-  // Rebuild the group of the value if not provided
+  const variables = useVariableValues();
+
   const defaultValue = useMemo(() => {
+    if (isVariableDatasource(value)) {
+      return value;
+    }
+
     const group = (data ?? [])
       .flatMap((itemGroup) => itemGroup.items)
       .find((item) => {
@@ -57,29 +79,50 @@ export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
     return { ...value, group };
   }, [value, data]);
 
-  // Convert the datasource list into menu items with name/group?/value strings that the Select input can work with
-  const menuItems = useMemo(() => {
-    return (data ?? []).map((itemGroup) => ({
-      group: itemGroup.group,
-      editLink: itemGroup.editLink,
-      items: itemGroup.items.map((item) => ({
+  const options = useMemo<DataSourceOption[]>(() => {
+    const datasourceOptions = (data || []).flatMap<DataSourceOption>((itemGroup) =>
+      itemGroup.items.map<DataSourceOption>((item) => ({
+        groupLabel: itemGroup.group,
+        groupEditLink: itemGroup.editLink,
         name: item.name,
         overriding: item.overriding,
         overridden: item.overridden,
         saved: item.saved ?? true,
         group: item.selector.group,
         value: selectorToOptionValue(item.selector),
-      })),
-    }));
-  }, [data]);
+      }))
+    );
+
+    const datasourceOptionsMap = new Map(datasourceOptions.map((option) => [option.name, option]));
+
+    const variableOptions = Object.entries(variables).flatMap<DataSourceOption>(([name, variable]) => {
+      if (Array.isArray(variable.value)) return [];
+
+      const associatedDatasource = datasourceOptionsMap.get(variable.value ?? '');
+      if (!associatedDatasource) return [];
+
+      return {
+        groupLabel: 'Variables',
+        name: `${VARIABLE_IDENTIFIER}${name}`,
+        saved: true,
+        value: `${DATASOURCE_VARIABLE_VALUE_PREFIX}${VARIABLE_IDENTIFIER}${name}`,
+      };
+    });
+
+    return [...datasourceOptions, ...variableOptions];
+  }, [data, variables]);
 
   // While loading available values, just use an empty string so MUI select doesn't warn about values out of range
-  const optionValue = isLoading ? '' : selectorToOptionValue(defaultValue);
+  const optionValue = isLoading ? null : options.find((option) => option.value === selectorToOptionValue(defaultValue));
 
   // When the user makes a selection, convert the string option value back to a DatasourceSelector
-  const handleChange: SelectProps<string>['onChange'] = (e) => {
-    const next = optionValueToSelector(e.target.value);
-    onChange(next);
+  const handleChange = (selectedOption: DataSourceOption | null): void => {
+    if (selectedOption) {
+      const next = optionValueToSelector(selectedOption?.value || '');
+      onChange(next);
+    } else {
+      onChange({ kind: datasourcePluginKind });
+    }
   };
 
   // We use a fake action event when we click on the action of the chip (hijack the "delete" feature).
@@ -88,36 +131,34 @@ export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const fakeActionEvent = (): void => {};
 
-  // TODO:
-  //  - Does this need a loading indicator of some kind?
-  //  - The group's edit link is not clickable once selected.
-  //  - The group's edit link is disabled if datasource is overridden.
-  //    Ref: https://github.com/mui/material-ui/issues/36572
   return (
-    <Select {...others} value={optionValue} onChange={handleChange}>
-      {menuItems.map((menuItemGroup) => [
-        <Divider key={`${menuItemGroup.group}-divider`} />,
-        ...menuItemGroup.items.map((menuItem) => (
-          <MenuItem key={menuItem.value} value={menuItem.value} disabled={menuItem.overridden || !menuItem.saved}>
+    <Autocomplete<DataSourceOption>
+      options={options}
+      renderInput={(params) => <TextField {...params} label={others.label} placeholder="" />}
+      groupBy={(option) => option.groupLabel || 'No group'}
+      getOptionLabel={(option) => {
+        return option.name;
+      }}
+      onChange={(_, v) => handleChange(v)}
+      value={optionValue}
+      renderOption={(props, option) => {
+        return (
+          <li {...props} key={option.value}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
               <ListItemText>
-                <DatasourceName
-                  name={menuItem.name}
-                  overridden={menuItem.overridden}
-                  overriding={menuItem.overriding}
-                />
+                <DatasourceName name={option.name} overridden={option.overridden} overriding={option.overriding} />
               </ListItemText>
-              {!menuItem.saved && <ListItemText>Save the dashboard to enable this datasource</ListItemText>}
+              {!option.saved && <ListItemText>Save the dashboard to enable this datasource</ListItemText>}
               <ListItemText style={{ textAlign: 'right' }}>
-                {menuItemGroup.group && menuItemGroup.group.length > 0 && (
+                {option.groupLabel && option.groupLabel.length > 0 && (
                   <Chip
                     disabled={false}
-                    label={menuItemGroup.group}
+                    label={option.groupLabel}
                     size="small"
-                    onDelete={menuItemGroup.editLink ? fakeActionEvent : undefined}
+                    onDelete={option.groupEditLink ? fakeActionEvent : undefined}
                     deleteIcon={
-                      menuItemGroup.editLink ? (
-                        <IconButton href={menuItemGroup.editLink} target="_blank">
+                      option.groupEditLink ? (
+                        <IconButton href={option.groupEditLink} target="_blank">
                           <OpenInNewIcon fontSize="small" />
                         </IconButton>
                       ) : undefined
@@ -126,10 +167,10 @@ export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
                 )}
               </ListItemText>
             </Stack>
-          </MenuItem>
-        )),
-      ])}
-    </Select>
+          </li>
+        );
+      }}
+    />
   );
 }
 
@@ -156,7 +197,10 @@ const OPTION_VALUE_DELIMITER = '_____';
  * returns a string value like `{kind}_____{group}_____{name}` that can be used as a Select input value.
  * @param selector
  */
-function selectorToOptionValue(selector: DatasourceSelectItemSelector): string {
+function selectorToOptionValue(selector: DatasourceSelectItemSelector | VariableName): string {
+  if (isVariableDatasource(selector)) {
+    return `${DATASOURCE_VARIABLE_VALUE_PREFIX}${selector}`;
+  }
   return [selector.kind, selector.group ?? '', selector.name ?? ''].join(OPTION_VALUE_DELIMITER);
 }
 
@@ -165,7 +209,11 @@ function selectorToOptionValue(selector: DatasourceSelectItemSelector): string {
  * returns a DatasourceSelector to be used by the query data model.
  * @param optionValue
  */
-function optionValueToSelector(optionValue: string): DatasourceSelector {
+function optionValueToSelector(optionValue: string): DatasourceSelectValue {
+  if (optionValue.startsWith(DATASOURCE_VARIABLE_VALUE_PREFIX)) {
+    return optionValue.split(DATASOURCE_VARIABLE_VALUE_PREFIX)[1]!;
+  }
+
   const words = optionValue.split(OPTION_VALUE_DELIMITER);
   const kind = words[0];
   const name = words[2];
@@ -177,3 +225,54 @@ function optionValueToSelector(optionValue: string): DatasourceSelector {
     name: name === '' ? undefined : name,
   };
 }
+
+export function isVariableDatasource(value: DatasourceSelectValue | undefined): value is VariableName {
+  return typeof value === 'string' && value.startsWith(VARIABLE_IDENTIFIER);
+}
+
+export const datasourceSelectValueToSelector = (
+  value: DatasourceSelectValue | undefined,
+  variables: VariableStateMap,
+  datasourceSelectItemGroups: DatasourceSelectItemGroup[] | undefined
+): DatasourceSelector | undefined => {
+  if (!isVariableDatasource(value)) {
+    return value;
+  }
+
+  const [variableName] = parseVariables(value);
+  const variable = variables[variableName ?? ''];
+
+  // If the variable is not defined or if its value is an array, we cannot determine a selector and return undefined
+  if (!variable || Array.isArray(variable.value)) {
+    return undefined;
+  }
+
+  const associatedDatasource = (datasourceSelectItemGroups || [])
+    .flatMap((itemGroup) => itemGroup.items)
+    .find((datasource) => datasource.name === variable.value);
+
+  // If the variable value is not a datasource, we cannot determine a selector and return undefined
+  if (associatedDatasource === undefined) {
+    return undefined;
+  }
+
+  const datasourceSelector: DatasourceSelector = {
+    kind: associatedDatasource.selector.kind,
+    name: associatedDatasource.selector.name,
+  };
+
+  return datasourceSelector;
+};
+
+export const useDatasourceSelectValueToSelector = (
+  value: DatasourceSelectValue,
+  datasourcePluginKind: string
+): DatasourceSelector => {
+  const { data } = useListDatasourceSelectItems(datasourcePluginKind);
+  const variables = useVariableValues();
+  if (!isVariableDatasource(value)) {
+    return value;
+  }
+
+  return datasourceSelectValueToSelector(value, variables, data) ?? { kind: datasourcePluginKind };
+};

--- a/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
+++ b/ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx
@@ -89,7 +89,7 @@ export function PluginRegistry(props: PluginRegistryProps): ReactElement {
   );
 
   const listPluginMetadata = useCallback(
-    async (pluginTypes: string[]) => {
+    async (pluginTypes: PluginType[]) => {
       const pluginIndexes = await getPluginIndexes();
       return pluginTypes.flatMap((type) => pluginIndexes.pluginMetadataByKind.get(type) ?? []);
     },

--- a/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
+++ b/ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts
@@ -19,7 +19,7 @@ export interface PluginIndexes {
   // Plugin resources by plugin type and kind (i.e. look up what module a plugin type and kind is in)
   pluginResourcesByNameAndKind: Map<string, PluginModuleResource>;
   // Plugin metadata by plugin type
-  pluginMetadataByKind: Map<string, PluginMetadataWithModule[]>;
+  pluginMetadataByKind: Map<PluginType, PluginMetadataWithModule[]>;
 }
 
 /**
@@ -35,7 +35,7 @@ export function usePluginIndexes(
 
     // Create the two indexes from the installed plugins
     const pluginResourcesByNameAndKind = new Map<string, PluginModuleResource>();
-    const pluginMetadataByKind = new Map<string, PluginMetadataWithModule[]>();
+    const pluginMetadataByKind = new Map<PluginType, PluginMetadataWithModule[]>();
 
     for (const resource of installedPlugins) {
       for (const pluginMetadata of resource.spec.plugins) {

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -112,7 +112,10 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
     setPreviewSpec(form.getValues() as ListVariableDefinition);
   };
 
-  const kind = useWatch<VariableDefinition, 'spec.plugin.kind'>({ control: control, name: 'spec.plugin.kind' });
+  const plugin = useWatch<VariableDefinition, 'spec.plugin'>({ control, name: 'spec.plugin' });
+  const kind = plugin?.kind;
+  const pluginSpec = plugin?.spec;
+
   const _allowAllValue = useWatch<VariableDefinition, 'spec.allowAllValue'>({
     control: control,
     name: 'spec.allowAllValue',
@@ -155,24 +158,26 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
             <Controller
               control={control}
               name="spec.plugin"
-              render={({ field }) => (
-                <PluginEditor
-                  width="100%"
-                  pluginTypes={['Variable']}
-                  pluginKindLabel="Source"
-                  value={{
-                    selection: {
-                      type: 'Variable',
-                      kind: field.value?.kind ?? 'StaticListVariable',
-                    },
-                    spec: field.value?.spec ?? { values: [] },
-                  }}
-                  isReadonly={action === 'read'}
-                  onChange={(v) => {
-                    field.onChange({ kind: v.selection.kind, spec: v.spec });
-                  }}
-                />
-              )}
+              render={({ field }) => {
+                return (
+                  <PluginEditor
+                    width="100%"
+                    pluginTypes={['Variable']}
+                    pluginKindLabel="Source"
+                    value={{
+                      selection: {
+                        type: 'Variable',
+                        kind: kind ?? 'StaticListVariable',
+                      },
+                      spec: pluginSpec ?? { values: [] },
+                    }}
+                    isReadonly={action === 'read'}
+                    onChange={(v) => {
+                      field.onChange({ kind: v.selection.kind, spec: v.spec });
+                    }}
+                  />
+                );
+              }}
             />
           </ErrorBoundary>
         </Stack>

--- a/ui/plugin-system/src/model/trace-queries.ts
+++ b/ui/plugin-system/src/model/trace-queries.ts
@@ -13,14 +13,25 @@
 
 import { Query, QueryKey } from '@tanstack/react-query';
 import { UnknownSpec, TraceData, AbsoluteTimeRange } from '@perses-dev/core';
-import { DatasourceStore } from '../runtime';
+import { DatasourceStore, VariableStateMap } from '../runtime';
 import { Plugin } from './plugin-base';
+
+/**
+ * An object containing all the dependencies of a TraceQuery.
+ */
+type TraceQueryQueryPluginDependencies = {
+  /**
+   * Returns a list of variables name this trace query depends on.
+   */
+  variables?: string[];
+};
 
 /**
  * A plugin for running trace queries.
  */
 export interface TraceQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
   getTraceData: (spec: Spec, ctx: TraceQueryContext) => Promise<TraceData>;
+  dependsOn?: (spec: Spec, ctx: TraceQueryContext) => TraceQueryQueryPluginDependencies;
 }
 
 /**
@@ -29,6 +40,7 @@ export interface TraceQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
 export interface TraceQueryContext {
   datasourceStore: DatasourceStore;
   absoluteTimeRange?: AbsoluteTimeRange;
+  variableState: VariableStateMap;
 }
 
 export type TraceDataQuery = Query<TraceData, unknown, TraceData, QueryKey>;

--- a/ui/plugin-system/src/runtime/plugin-registry.ts
+++ b/ui/plugin-system/src/runtime/plugin-registry.ts
@@ -18,7 +18,7 @@ import { DefaultPluginKinds, PluginImplementation, PluginMetadataWithModule, Plu
 
 export interface PluginRegistryContextType {
   getPlugin<T extends PluginType>(kind: T, name: string): Promise<PluginImplementation<T>>;
-  listPluginMetadata(pluginTypes: string[]): Promise<PluginMetadataWithModule[]>;
+  listPluginMetadata(pluginTypes: PluginType[]): Promise<PluginMetadataWithModule[]>;
   defaultPluginKinds?: DefaultPluginKinds;
 }
 
@@ -101,7 +101,7 @@ type UseListPluginMetadataOptions = Omit<
  * Gets a list of plugin metadata for the specified plugin type and returns it, along with loading/error state.
  */
 export function useListPluginMetadata(
-  pluginTypes: string[],
+  pluginTypes: PluginType[],
   options?: UseListPluginMetadataOptions
 ): UseQueryResult<PluginMetadataWithModule[]> {
   const { listPluginMetadata } = usePluginRegistry();

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -23,10 +23,11 @@ import {
 } from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec, TimeSeriesData } from '@perses-dev/core';
 import { TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryMode, TimeSeriesQueryPlugin } from '../model';
-import { VariableStateMap, useAllVariableValues } from './variables';
+import { useAllVariableValues } from './variables';
 import { useTimeRange } from './TimeRangeProvider';
 import { useDatasourceStore } from './datasources';
 import { usePlugin, usePluginRegistry, usePlugins } from './plugin-registry';
+import { filterVariableStateMap, getVariableValuesKey } from './utils';
 
 export interface UseTimeSeriesQueryOptions {
   suggestedStepMs?: number;
@@ -34,22 +35,6 @@ export interface UseTimeSeriesQueryOptions {
 }
 
 export const TIME_SERIES_QUERY_KEY = 'TimeSeriesQuery';
-
-/**
- * Returns a serialized string of the current state of variable values.
- */
-function getVariableValuesKey(v: VariableStateMap): string {
-  return Object.values(v)
-    .map((v) => JSON.stringify(v.value))
-    .join(',');
-}
-
-function filterVariableStateMap(v: VariableStateMap, names?: string[]): VariableStateMap {
-  if (!names) {
-    return v;
-  }
-  return Object.fromEntries(Object.entries(v).filter(([name]) => names.includes(name)));
-}
 
 function getQueryOptions({
   plugin,
@@ -155,6 +140,7 @@ export function useTimeSeriesQueries(
             // Keep suggested step changes out of the query key, so we don´t have to run again query when it changes
             suggestedStepMs: options?.suggestedStepMs,
           };
+          console.log('running query');
           const plugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
           const data = await plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx);
           return data;

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -140,7 +140,6 @@ export function useTimeSeriesQueries(
             // Keep suggested step changes out of the query key, so we don´t have to run again query when it changes
             suggestedStepMs: options?.suggestedStepMs,
           };
-          console.log('running query');
           const plugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
           const data = await plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx);
           return data;

--- a/ui/plugin-system/src/runtime/trace-queries.tsx
+++ b/ui/plugin-system/src/runtime/trace-queries.tsx
@@ -13,10 +13,13 @@
 
 import { getUnixTime } from 'date-fns';
 import { QueryDefinition, UnknownSpec, AbsoluteTimeRange, TraceData } from '@perses-dev/core';
-import { useQueries, UseQueryResult } from '@tanstack/react-query';
+import { QueryKey, useQueries, UseQueryResult } from '@tanstack/react-query';
+import { TraceQueryContext, TraceQueryPlugin } from '../model';
 import { useDatasourceStore } from './datasources';
-import { usePluginRegistry } from './plugin-registry';
+import { usePluginRegistry, usePlugins } from './plugin-registry';
 import { useTimeRange } from './TimeRangeProvider';
+import { useAllVariableValues } from './variables';
+import { filterVariableStateMap, getVariableValuesKey } from './utils';
 export type TraceQueryDefinition<PluginSpec = UnknownSpec> = QueryDefinition<'TraceQuery', PluginSpec>;
 export const TRACE_QUERY_KEY = 'TraceQuery';
 
@@ -35,21 +38,22 @@ export function getUnixTimeRange(timeRange: AbsoluteTimeRange): { start: number;
  */
 export function useTraceQueries(definitions: TraceQueryDefinition[]): Array<UseQueryResult<TraceData>> {
   const { getPlugin } = usePluginRegistry();
-  const datasourceStore = useDatasourceStore();
-  const { absoluteTimeRange } = useTimeRange();
+  const context = useTraceQueryContext();
 
-  const context = {
-    datasourceStore,
-    absoluteTimeRange,
-  };
+  const pluginLoaderResponse = usePlugins(
+    'TraceQuery',
+    definitions.map((d) => ({ kind: d.spec.plugin.kind }))
+  );
 
   // useQueries() handles data fetching from query plugins (e.g. traceQL queries, promQL queries)
   // https://tanstack.com/query/v4/docs/react/reference/useQuery
   return useQueries({
-    queries: definitions.map((definition) => {
-      const queryKey = [definition, datasourceStore, absoluteTimeRange] as const; // `queryKey` watches and reruns `queryFn` if keys in the array change
+    queries: definitions.map((definition, idx) => {
+      const plugin = pluginLoaderResponse[idx]?.data;
+      const { queryEnabled, queryKey } = getQueryOptions({ context, definition, plugin });
       const traceQueryKind = definition?.spec?.plugin?.kind;
       return {
+        enabled: queryEnabled,
         queryKey: queryKey,
         queryFn: async (): Promise<TraceData> => {
           const plugin = await getPlugin(TRACE_QUERY_KEY, traceQueryKind);
@@ -59,4 +63,49 @@ export function useTraceQueries(definitions: TraceQueryDefinition[]): Array<UseQ
       };
     }),
   });
+}
+
+function getQueryOptions({
+  plugin,
+  definition,
+  context,
+}: {
+  plugin?: TraceQueryPlugin;
+  definition: TraceQueryDefinition;
+  context: TraceQueryContext;
+}): {
+  queryKey: QueryKey;
+  queryEnabled: boolean;
+} {
+  const { datasourceStore, variableState, absoluteTimeRange } = context;
+
+  const dependencies = plugin?.dependsOn ? plugin.dependsOn(definition.spec.plugin.spec, context) : {};
+  const variableDependencies = dependencies?.variables;
+
+  const filteredVariabledState = filterVariableStateMap(variableState, variableDependencies);
+  const variablesValueKey = getVariableValuesKey(filteredVariabledState);
+  const queryKey = [definition, datasourceStore, absoluteTimeRange, variablesValueKey] as const;
+
+  let waitToLoad = false;
+  if (variableDependencies) {
+    waitToLoad = variableDependencies.some((v) => variableState[v]?.loading);
+  }
+
+  const queryEnabled = plugin !== undefined && !waitToLoad;
+  return {
+    queryKey,
+    queryEnabled,
+  };
+}
+
+function useTraceQueryContext(): TraceQueryContext {
+  const { absoluteTimeRange } = useTimeRange();
+  const variableState = useAllVariableValues();
+  const datasourceStore = useDatasourceStore();
+
+  return {
+    variableState,
+    datasourceStore,
+    absoluteTimeRange,
+  };
 }

--- a/ui/plugin-system/src/runtime/utils.ts
+++ b/ui/plugin-system/src/runtime/utils.ts
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { VariableStateMap } from './variables';
 
 export function filterVariableStateMap(v: VariableStateMap, names?: string[]): VariableStateMap {

--- a/ui/plugin-system/src/runtime/utils.ts
+++ b/ui/plugin-system/src/runtime/utils.ts
@@ -1,0 +1,17 @@
+import { VariableStateMap } from './variables';
+
+export function filterVariableStateMap(v: VariableStateMap, names?: string[]): VariableStateMap {
+  if (!names) {
+    return v;
+  }
+  return Object.fromEntries(Object.entries(v).filter(([name]) => names.includes(name)));
+}
+
+/**
+ * Returns a serialized string of the current state of variable values.
+ */
+export function getVariableValuesKey(v: VariableStateMap): string {
+  return Object.values(v)
+    .map((v) => JSON.stringify(v.value))
+    .join(',');
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
solves https://github.com/perses/perses/issues/1514
connected to https://github.com/perses/plugins/pull/110

- `DatasourceSelect` component now works with variables
- `DatasourceSelect` component returns a `DatasourceSelectValue` of type `DatasourceSelect | VariableName`
- Type fixes for `listPluginMetadata`, accepts `PluginType[]` instead of `string[]`
- TraceData now supports variables, and therefore also has `dependsOn` function

Fixes:
- `VariableEditorForm` wasn't updated properly whenever the spec was changed, watching the plugin instead of only watching the plugin.kind solves it.

Unknowns:
- We do not support for now multiple variables for prometheus and tempo datasources, need a way to manually remove the options for multi-selection whenever working with those specific datasource kinds.


This pull request introduces significant updates to the `DatasourceSelect` component in the `ui/plugin-system` directory, improves variable handling, and refines plugin-related type definitions. The key changes include replacing the MUI `Select` component with `Autocomplete`, introducing support for variable-based datasources, and enhancing type safety across plugin metadata and variable handling.

### DatasourceSelect Component Enhancements:
* Replaced the MUI `Select` component with `Autocomplete` for better user experience and grouping options by labels. (`ui/plugin-system/src/components/DatasourceSelect.tsx`, [[1]](diffhunk://#diff-5969817cf05c0ed12c3a7773071fc4ab21c8a3a1c0c8dfba7abde0ab76624459L91-R161) [[2]](diffhunk://#diff-5969817cf05c0ed12c3a7773071fc4ab21c8a3a1c0c8dfba7abde0ab76624459L129-R173)
* Added support for variable-based datasource selection, including handling variables in the options list and converting variable values to selectors. (`ui/plugin-system/src/components/DatasourceSelect.tsx`, [[1]](diffhunk://#diff-5969817cf05c0ed12c3a7773071fc4ab21c8a3a1c0c8dfba7abde0ab76624459L50-R73) [[2]](diffhunk://#diff-5969817cf05c0ed12c3a7773071fc4ab21c8a3a1c0c8dfba7abde0ab76624459L168-R216)
* Introduced helper functions like `isVariableDatasource` and `datasourceSelectValueToSelector` to manage variable-based datasource logic. (`ui/plugin-system/src/components/DatasourceSelect.tsx`, [ui/plugin-system/src/components/DatasourceSelect.tsxR228-R278](diffhunk://#diff-5969817cf05c0ed12c3a7773071fc4ab21c8a3a1c0c8dfba7abde0ab76624459R228-R278))

### Plugin and Variable Handling Improvements:
* Updated plugin-related types to use `PluginType` instead of generic `string` for better type safety. (`ui/plugin-system/src/components/PluginRegistry/PluginRegistry.tsx`, [[1]](diffhunk://#diff-b1b94ab7853e6ce70d838d530f7ef28a032f7932f45c6c584222110667504849L92-R92); `ui/plugin-system/src/components/PluginRegistry/plugin-indexes.ts`, [[2]](diffhunk://#diff-1e954a46bccd64b758e34098a5647f4dc61398fb18b090e12a349deb9652b862L22-R22) [[3]](diffhunk://#diff-1e954a46bccd64b758e34098a5647f4dc61398fb18b090e12a349deb9652b862L38-R38)
* Enhanced the `TraceQueryPlugin` interface to include a `dependsOn` method for identifying variable dependencies. (`ui/plugin-system/src/model/trace-queries.ts`, [[1]](diffhunk://#diff-658291c374ff7a4ac9421a126b9bbbc41ff78716ffbb820ecf3f6180f8fc610bL16-R34) [[2]](diffhunk://#diff-658291c374ff7a4ac9421a126b9bbbc41ff78716ffbb820ecf3f6180f8fc610bR43)

### Miscellaneous Changes:
* Simplified the `VariableEditorForm` component by restructuring how plugin kinds and specs are managed. (`ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx`, [[1]](diffhunk://#diff-34df26ad2a5549c1936d10ece5017deb5b99fb70b64b03873ef54d5249442077L115-R118) [[2]](diffhunk://#diff-34df26ad2a5549c1936d10ece5017deb5b99fb70b64b03873ef54d5249442077L158-R180)
* Removed redundant utility functions like `filterVariableStateMap` and `getVariableValuesKey` from `time-series-queries.ts` and replaced them with imports from shared utilities. (`ui/plugin-system/src/runtime/time-series-queries.ts`, [[1]](diffhunk://#diff-be60bc9e89e9ecf81601012de961afcb7947fc6c1cfccb99c6cc23a5508f4af5L26-R30) [[2]](diffhunk://#diff-be60bc9e89e9ecf81601012de961afcb7947fc6c1cfccb99c6cc23a5508f4af5L38-L53)

These changes collectively improve the flexibility, maintainability, and user experience of the `DatasourceSelect` component and related systems.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->
![new](https://github.com/user-attachments/assets/9bc86612-c5da-4b12-b530-5cff5691183e)


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
