### PR TITLE
[BUGFIX] Dashboard import: fix wrong form reset + UX improvements

### DIFF
--- a/ui/app/src/views/import/PersesFlow.tsx
+++ b/ui/app/src/views/import/PersesFlow.tsx
@@ -66,7 +66,6 @@ function PersesFlow({ dashboard }: PersesFlowProps): ReactElement {
                   label="Project name"
                 />
               )}
-            
             />
             <Button
               variant="contained"

--- a/ui/app/src/views/import/PersesFlow.tsx
+++ b/ui/app/src/views/import/PersesFlow.tsx
@@ -55,19 +55,18 @@ function PersesFlow({ dashboard }: PersesFlowProps): ReactElement {
           <Stack width="100%" gap={1}>
             <Autocomplete
               disablePortal
+              options={data.map((project) => project.metadata.name)}
+              onInputChange={(event, value) => {
+                setProjectName(value);
+              }}
               renderInput={(params) => (
                 <TextField
                   {...params}
                   required
                   label="Project name"
-                  onBlur={(event) => {
-                    setProjectName(event.target.value);
-                  }}
                 />
               )}
-              options={data.map((project) => {
-                return project.metadata.name;
-              })}
+            
             />
             <Button
               variant="contained"

--- a/ui/app/src/views/import/PersesFlow.tsx
+++ b/ui/app/src/views/import/PersesFlow.tsx
@@ -59,13 +59,7 @@ function PersesFlow({ dashboard }: PersesFlowProps): ReactElement {
               onInputChange={(event, value) => {
                 setProjectName(value);
               }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  required
-                  label="Project name"
-                />
-              )}
+              renderInput={(params) => <TextField {...params} required label="Project name" />}
             />
             <Button
               variant="contained"

--- a/ui/components/src/JSONEditor.tsx
+++ b/ui/components/src/JSONEditor.tsx
@@ -31,10 +31,6 @@ export function JSONEditor<T>(props: JSONEditorProps<T>): ReactElement {
   const [value, setValue] = useState(() => JSON.stringify(props.value, null, 2));
   const [lastProcessedValue, setLastProcessedValue] = useState<string>(value);
 
-  useEffect(() => {
-    setValue(JSON.stringify(props.value, null, 2));
-  }, [props.value]);
-
   return (
     <CodeMirror
       {...props}
@@ -44,6 +40,10 @@ export function JSONEditor<T>(props: JSONEditorProps<T>): ReactElement {
       value={value}
       onChange={(newValue) => {
         setValue(newValue);
+        // Trigger the provided onChange callback in real-time
+        if (props.onChange) {
+          props.onChange(newValue);
+        }
       }}
       onBlur={() => {
         // Don't trigger the provided onChange if the last processed value is equal to the current value.

--- a/ui/components/src/JSONEditor.tsx
+++ b/ui/components/src/JSONEditor.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ReactElement, useEffect, useState } from 'react';
+import { ReactElement, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { linter, lintGutter } from '@codemirror/lint';


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

UX when importing dashboards via JSON can be laggy, I'm proposing couple changes

**Actual result**
![perses_import_bug](https://github.com/user-attachments/assets/802ecd53-5d45-4636-a912-a9391fdbe56b)

# Screenshots

<!-- If there are UI changes -->
**Expected result**
![perses_import_fix](https://github.com/user-attachments/assets/13940f86-3318-44d9-b755-63bebe2ce6a8)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
