### PR TITLE
[FEATURE] CLI: list the plugins

### DIFF
--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -59,7 +59,7 @@ func (o *option) Complete(args []string) error {
 
 	// Complete the output only if it has been set by the user
 	// NB: In the case of the `get` command, the default output format is/should be a table, not json
-	// or yaml, hence why we need to skip OutputOption.Complete() if the output flag is not set.
+	// or YAML, hence why we need to skip OutputOption.Complete() if the output flag is not set.
 	if len(o.Output) > 0 {
 		if outputErr := o.OutputOption.Complete(); outputErr != nil {
 			return outputErr

--- a/internal/cli/cmd/plugin/list/list.go
+++ b/internal/cli/cmd/plugin/list/list.go
@@ -1,0 +1,123 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"fmt"
+	"io"
+
+	persesCMD "github.com/perses/perses/internal/cli/cmd"
+	"github.com/perses/perses/internal/cli/config"
+	"github.com/perses/perses/internal/cli/opt"
+	"github.com/perses/perses/internal/cli/output"
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+	pluginModel "github.com/perses/perses/pkg/model/api/v1/plugin"
+	"github.com/spf13/cobra"
+)
+
+var columnHeader = []string{
+	"NAME",
+	"VERSION",
+	"TYPE",
+	"LOADED",
+	"FROM DEV",
+}
+
+type option struct {
+	persesCMD.Option
+	opt.OutputOption
+	writer    io.Writer
+	errWriter io.Writer
+	client    v1.PluginInterface
+}
+
+func (o *option) Complete(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("no args are supported by the command 'list'")
+	}
+	// Complete the output only if it has been set by the user
+	// NB: In the case of the `get` command, the default output format is/should be a table, not json
+	// or YAML, hence why we need to skip OutputOption.Complete() if the output flag is not set.
+	if len(o.Output) > 0 {
+		if outputErr := o.OutputOption.Complete(); outputErr != nil {
+			return outputErr
+		}
+	}
+
+	apiClient, err := config.Global.GetAPIClient()
+	if err != nil {
+		return err
+	}
+
+	o.client = apiClient.V1().Plugin()
+	return nil
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	plugins, err := o.client.List()
+	if err != nil {
+		return err
+	}
+	if len(o.Output) > 0 {
+		return output.Handle(o.writer, o.Output, plugins)
+	}
+	var matrix [][]string
+	for _, plugin := range plugins {
+		kind := plugin.Kind
+		if len(plugin.Spec.Plugins) == 1 {
+			// In case there is only one plugin, we can use its kind directly.
+			// Otherwise, we marked it as a plugin module. That means the plugin module contains a list of plugins.
+			kind = string(plugin.Spec.Plugins[0].Kind)
+		}
+		status := plugin.Status
+		if status == nil {
+			// If the status is nil, we set it to an empty status.
+			status = &pluginModel.ModuleStatus{}
+		}
+		matrix = append(matrix, []string{
+			plugin.Metadata.Name,
+			plugin.Metadata.Version,
+			kind,
+			fmt.Sprintf("%t", status.IsLoaded),
+			fmt.Sprintf("%t", status.InDev),
+		})
+	}
+	output.HandlerTable(o.writer, columnHeader, matrix)
+	return nil
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func (o *option) SetErrWriter(errWriter io.Writer) {
+	o.errWriter = errWriter
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all the plugins installed in the remote server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return persesCMD.Run(o, cmd, args)
+		},
+	}
+	opt.AddOutputFlags(cmd, &o.OutputOption)
+	return cmd
+}

--- a/internal/cli/cmd/plugin/list/list_test.go
+++ b/internal/cli/cmd/plugin/list/list_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"testing"
+
+	cmdTest "github.com/perses/perses/internal/cli/test"
+	fakeapi "github.com/perses/perses/pkg/client/fake/api"
+)
+
+func TestPluginListCMD(t *testing.T) {
+	testSuite := []cmdTest.Suite{
+		{
+			Title:           "use args",
+			Args:            []string{"whatever"},
+			IsErrorExpected: true,
+			ExpectedMessage: "no args are supported by the command 'list'",
+		},
+		{
+			Title:           "list plugins",
+			Args:            []string{},
+			APIClient:       fakeapi.New(),
+			IsErrorExpected: false,
+			ExpectedMessage: `   NAME   | VERSION | TYPE  | LOADED | FROM DEV  
+----------+---------+-------+--------+-----------
+  plugin1 | v0.1.0  | Panel | true   | false     
+`,
+		},
+	}
+	cmdTest.ExecuteSuiteTest(t, NewCMD, testSuite)
+}

--- a/internal/cli/cmd/plugin/plugin.go
+++ b/internal/cli/cmd/plugin/plugin.go
@@ -16,6 +16,7 @@ package plugin
 import (
 	"github.com/perses/perses/internal/cli/cmd/plugin/build"
 	"github.com/perses/perses/internal/cli/cmd/plugin/lint"
+	"github.com/perses/perses/internal/cli/cmd/plugin/list"
 	"github.com/perses/perses/internal/cli/cmd/plugin/start"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ func NewCMD() *cobra.Command {
 	}
 	cmd.AddCommand(build.NewCMD())
 	cmd.AddCommand(lint.NewCMD())
+	cmd.AddCommand(list.NewCMD())
 	cmd.AddCommand(start.NewCMD())
 
 	return cmd

--- a/pkg/client/fake/api/v1/client.go
+++ b/pkg/client/fake/api/v1/client.go
@@ -53,6 +53,10 @@ func (c *client) Health() v1.HealthInterface {
 	return &health{}
 }
 
+func (c *client) Plugin() v1.PluginInterface {
+	return &plugin{}
+}
+
 func (c *client) Project() v1.ProjectInterface {
 	return &project{}
 }

--- a/pkg/client/fake/api/v1/plugin.go
+++ b/pkg/client/fake/api/v1/plugin.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakev1
+
+import (
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	pluginModel "github.com/perses/perses/pkg/model/api/v1/plugin"
+)
+
+type plugin struct {
+	v1.PluginInterface
+}
+
+func (c *plugin) List() ([]modelV1.PluginModule, error) {
+	return []modelV1.PluginModule{
+		{
+			Kind: "PluginModule",
+			Metadata: pluginModel.ModuleMetadata{
+				Name:    "plugin1",
+				Version: "v0.1.0",
+			},
+			Spec: pluginModel.ModuleSpec{
+				Plugins: []pluginModel.Plugin{
+					{
+						Kind: pluginModel.KindPanel,
+					},
+				},
+			},
+			Status: &pluginModel.ModuleStatus{
+				IsLoaded: true,
+				InDev:    false,
+			},
+		},
+	}, nil
+}

--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -87,7 +87,7 @@ func (f *frontend) servePluginFiles(c echo.Context) error {
 		return apiinterface.NotFoundError
 	}
 	loaded, isLoaded := f.pluginService.GetLoadedPlugin(pluginName)
-	if !isLoaded {
+	if !isLoaded || !loaded.Module.Status.IsLoaded {
 		logrus.Errorf("unable to find the plugin %s", pluginName)
 		return apiinterface.NotFoundError
 	}


### PR DESCRIPTION
```bash
➜  perses git:(main) ✗ ./bin/percli plugin list
         NAME        | VERSION |     TYPE     | LOADED | FROM DEV
---------------------+---------+--------------+--------+-----------
  TracingGanttChart  | 0.5.0   | Panel        | true   | false
  BarChart           | 0.5.0   | Panel        | true   | false
  GaugeChart         | 0.5.0   | Panel        | true   | false
  Markdown           | 0.6.0   | Panel        | true   | false
  PieChart           | 0.5.0   | Panel        | true   | false
  Prometheus         | 0.6.0   | PluginModule | true   | false
  ScatterChart       | 0.5.0   | Panel        | true   | false
  StatChart          | 0.5.0   | Panel        | true   | false
  StaticListVariable | 0.2.0   | Variable     | true   | false
  Table              | 0.5.0   | Panel        | true   | false
  Tempo              | 0.3.0   | PluginModule | true   | false
  TimeSeriesChart    | 0.5.0   | Panel        | true   | false
  TimeSeriesTable    | 0.5.0   | Panel        | true   | false
  TraceTable         | 0.5.0   | Panel        | true   | false
```