### PR TITLE
BUGFIX: Add Kubebuilder annotation to common.URL

### DIFF
--- a/cue/model/api/v1/common/url_go_gen.cue
+++ b/cue/model/api/v1/common/url_go_gen.cue
@@ -4,4 +4,7 @@
 
 package common
 
+// +kubebuilder:validation:Schemaless
+// +kubebuilder:validation:Type=string
+// +kubebuilder:validation:Format=uri
 #URL: _

--- a/pkg/model/api/v1/common/url.go
+++ b/pkg/model/api/v1/common/url.go
@@ -47,6 +47,9 @@ func NewURL(u *URL, paths ...string) *URL {
 	return result
 }
 
+// +kubebuilder:validation:Schemaless
+// +kubebuilder:validation:Type=string
+// +kubebuilder:validation:Format=uri
 type URL struct {
 	*url.URL `json:"-" yaml:"-"`
 }


### PR DESCRIPTION
# Description

Adds annotations for kubebuilder to properly validate the common.URL type as a string instead of an object

Closes #2890 

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).