### PR TITLE
[ENHANCEMENT] data source settings editor: use proxy mode by default

### DIFF
--- a/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
+++ b/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
@@ -33,6 +33,11 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
   const strDirect = 'Direct access';
   const strProxy = 'Proxy';
 
+  // Initialize Proxy mode by default, if neither direct nor proxy mode is selected.
+  if (!value.directUrl && !value.proxy) {
+    Object.assign(value, initialSpecProxy);
+  }
+
   // utilitary function used for headers when renaming a property
   // -> TODO it would be cleaner to manipulate headers as an intermediary list instead, to avoid doing this.
   const buildNewHeaders = (
@@ -427,8 +432,7 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
   const directModeId = tabs.findIndex((tab) => tab.label === strDirect);
   const proxyModeId = tabs.findIndex((tab) => tab.label === strProxy);
 
-  // In "update datasource" case, set defaultTab to the mode that this datasource is currently relying on.
-  // Otherwise (create datasource), set defaultTab to Direct access.
+  // Set defaultTab to the mode that this datasource is currently relying on.
   const defaultTab = value.proxy ? proxyModeId : directModeId;
 
   // For better user experience, save previous states in mind for both mode.


### PR DESCRIPTION
# Description

data source settings editor: use proxy mode by default
Resolves: https://github.com/perses/perses/issues/2914

# Screenshots

no notable changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
