### PR TITLE
[ENHANCEMENT] Invalid content type when it is not JSON

### DIFF
--- a/internal/api/interface/error.go
+++ b/internal/api/interface/error.go
@@ -32,12 +32,13 @@ func (e *PersesError) Error() string {
 }
 
 var (
-	InternalError     = &PersesError{message: "internal server error"}
-	NotFoundError     = &PersesError{message: "document not found"}
-	ConflictError     = &PersesError{message: "document already exists"}
-	BadRequestError   = &PersesError{message: "bad request"}
-	UnauthorizedError = &PersesError{message: "unauthorized"}
-	ForbiddenError    = &PersesError{message: "forbidden access"}
+	InternalError        = &PersesError{message: "internal server error"}
+	NotFoundError        = &PersesError{message: "document not found"}
+	ConflictError        = &PersesError{message: "document already exists"}
+	BadRequestError      = &PersesError{message: "bad request"}
+	UnauthorizedError    = &PersesError{message: "unauthorized"}
+	ForbiddenError       = &PersesError{message: "forbidden access"}
+	UnsupportedMediaType = &PersesError{message: "unsupported media type"}
 )
 
 // HandleError is translating the given error to the echo.HTTPError
@@ -70,6 +71,9 @@ func HandleError(err error) error {
 	}
 	if errors.Is(err, ForbiddenError) {
 		return echo.NewHTTPError(http.StatusForbidden, err.Error())
+	}
+	if errors.Is(err, UnsupportedMediaType) {
+		return echo.NewHTTPError(http.StatusUnsupportedMediaType, err.Error())
 	}
 
 	var HTTPError *echo.HTTPError

--- a/internal/api/toolbox/toolbox.go
+++ b/internal/api/toolbox/toolbox.go
@@ -43,6 +43,14 @@ func ExtractParameters(ctx echo.Context, caseSensitive bool) apiInterface.Parame
 	}
 }
 
+func isJSONContentType(ctx echo.Context) bool {
+	contentType := ctx.Request().Header.Get(echo.HeaderContentType)
+	if len(contentType) == 0 {
+		return false
+	}
+	return strings.Contains(contentType, echo.MIMEApplicationJSON)
+}
+
 // Toolbox is an interface that defines the different methods that can be used in the different endpoint of the API.
 // This is a way to align the code of the different endpoint.
 type Toolbox[T api.Entity, K databaseModel.Query] interface {
@@ -206,6 +214,9 @@ func (t *toolbox[T, K, V]) List(ctx echo.Context, query V) error {
 }
 
 func (t *toolbox[T, K, V]) bind(ctx echo.Context, entity api.Entity) error {
+	if !isJSONContentType(ctx) {
+		return apiInterface.UnsupportedMediaType
+	}
 	if err := ctx.Bind(entity); err != nil {
 		return apiInterface.HandleBadRequestError(err.Error())
 	}


### PR DESCRIPTION
fix https://github.com/perses/perses/issues/2919

Instead of throwing a 400 error, it returns a 415 error which seems more accurate based on the meaning of the error code.

Let me know if we need to differentiate when the header `Content-Type` is missing or wrong.