### PR TITLE
[BUGFIX] Shared Tooltip In Edit Panel Overflowing

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -106,7 +106,8 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
   },
   ref
 ) {
-  const { chartsTheme, enablePinning, lastTooltipPinnedCoords, setLastTooltipPinnedCoords } = useChartsContext();
+  const { chartsTheme, enablePinning, enableSyncGrouping, lastTooltipPinnedCoords, setLastTooltipPinnedCoords } =
+    useChartsContext();
   const isPinningEnabled = tooltipConfig.enablePinning && enablePinning;
   const chartRef = useRef<EChartsInstance>();
   const [showTooltip, setShowTooltip] = useState<boolean>(true);
@@ -444,7 +445,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
         theme={chartsTheme.echartsTheme}
         onEvents={handleEvents}
         _instance={chartRef}
-        syncGroup={syncGroup}
+        syncGroup={enableSyncGrouping ? syncGroup : undefined}
       />
     </Box>
   );

--- a/ui/components/src/context/ChartsProvider.tsx
+++ b/ui/components/src/context/ChartsProvider.tsx
@@ -18,18 +18,20 @@ import { CursorCoordinates } from '../TimeSeriesTooltip';
 export interface ChartsProviderProps {
   chartsTheme: PersesChartsTheme;
   enablePinning?: boolean;
+  enableSyncGrouping?: boolean;
   children?: React.ReactNode;
 }
 
 export interface SharedChartsState {
   chartsTheme: PersesChartsTheme;
   enablePinning: boolean;
+  enableSyncGrouping: boolean;
   lastTooltipPinnedCoords: CursorCoordinates | null;
   setLastTooltipPinnedCoords: (lastTooltipPinnedCoords: CursorCoordinates | null) => void;
 }
 
 export function ChartsProvider(props: ChartsProviderProps): ReactElement {
-  const { children, chartsTheme, enablePinning = false } = props;
+  const { children, chartsTheme, enablePinning = false, enableSyncGrouping = true } = props;
 
   const [lastTooltipPinnedCoords, setLastTooltipPinnedCoords] = useState<CursorCoordinates | null>(null);
 
@@ -38,9 +40,10 @@ export function ChartsProvider(props: ChartsProviderProps): ReactElement {
       chartsTheme,
       enablePinning,
       lastTooltipPinnedCoords,
+      enableSyncGrouping,
       setLastTooltipPinnedCoords,
     };
-  }, [chartsTheme, enablePinning, lastTooltipPinnedCoords, setLastTooltipPinnedCoords]);
+  }, [chartsTheme, enablePinning, enableSyncGrouping, lastTooltipPinnedCoords, setLastTooltipPinnedCoords]);
 
   return <ChartsThemeContext.Provider value={ctx}>{children}</ChartsThemeContext.Provider>;
 }

--- a/ui/components/src/test-utils/theme.ts
+++ b/ui/components/src/test-utils/theme.ts
@@ -41,6 +41,7 @@ export const testChartsTheme: PersesChartsTheme = generateChartsTheme(createMuiT
 export const mockChartsContext: SharedChartsState = {
   chartsTheme: testChartsTheme,
   enablePinning: false,
+  enableSyncGrouping: true,
   lastTooltipPinnedCoords: null,
   setLastTooltipPinnedCoords: () => null,
 };

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -133,7 +133,7 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
             }}
           />
         </ErrorBoundary>
-        <ChartsProvider chartsTheme={chartsTheme} enablePinning={false}>
+        <ChartsProvider chartsTheme={chartsTheme} enablePinning={false} enableSyncGrouping={false}>
           <PanelDrawer />
         </ChartsProvider>
         <PanelGroupDialog />


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
solves https://github.com/perses/perses/issues/2813

`syncGroup` property used to be available regardless if we are within the edit panel or not.
Similar solution to the `enablePinning`:
- Added another property to `ChartsProvider` called `enableSyncGrouping`.
- `TimeChart` consumes this property and accordingly syncs the group or not.

<!-- Context useful to a reviewer -->

# Screenshots

**BEFORE**
![before](https://github.com/user-attachments/assets/8b989885-c438-4e59-9988-ebb9bb4742fa)

**AFTER**
![after](https://github.com/user-attachments/assets/567531d3-9087-46ef-8e71-db8fee577ff3)


<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
