### PR TITLE
[BUGFIX] ListVariable Infinite Re-render

### DIFF
--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -51,11 +51,13 @@ export function useListVariablePluginValues(definition: ListVariableDefinition):
   const capturingRegexp =
     definition.spec.capturingRegexp !== undefined ? new RegExp(definition.spec.capturingRegexp, 'g') : undefined;
 
-  let dependsOnVariables: string[] | undefined;
+  let dependsOnVariables: string[] = Object.keys(allVariables); // Default to all variables
   if (variablePlugin?.dependsOn) {
     const dependencies = variablePlugin.dependsOn(spec, variablePluginCtx);
-    dependsOnVariables = dependencies.variables;
+    dependsOnVariables = dependencies.variables ? dependencies.variables : dependsOnVariables;
   }
+  // Exclude self variable to avoid circular dependency
+  dependsOnVariables = dependsOnVariables.filter((v) => v !== definition.spec.name);
 
   const variables = useAllVariableValues(dependsOnVariables);
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
solves https://github.com/perses/perses/issues/2938
# Description
When a list-type variable depends on other variables, it’s possible for it to indirectly or mistakenly depend on itself. If that variable is also configured as multi-select with the "Select All" option enabled, this self-dependency can cause an infinite re-render loop, eventually crashing the application.

The core issue is that the dependsOn method in the variable plugin has no awareness of the variable's own name, so it cannot filter itself out from its list of dependencies. This makes it impossible to prevent self-dependency purely within the plugin logic.


<!-- Context useful to a reviewer -->

# Screenshots
![Bug](https://github.com/user-attachments/assets/f87213bb-8c50-45c5-b248-b1178dfc4f10)

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
