### PR TITLE
[ENHANCEMENT] pass rest of options from queryOptions

### DIFF
--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -132,6 +132,7 @@ export function useTimeSeriesQueries(
       const plugin = pluginLoaderResponse[idx]?.data;
       const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
       return {
+        ...queryOptions,
         enabled: (queryOptions?.enabled ?? true) && queryEnabled,
         queryKey: queryKey,
         queryFn: async (): Promise<TimeSeriesData> => {


### PR DESCRIPTION
# Description

`<DataQueriesProvider />` accepts a `queryOptions` prop that is intended to match the options used in `@tanstack/react-query` query hooks. 

Although it appears that all options can be passed in, only a limited subset is actually forwarded to the query configuration. This can create a false impression that all fetching options are customizable. This PR updates the implementation to pass all options using the spread operator. The spread is applied as the first argument to avoid accidentally overriding custom logic such as `enabled` or `queryFn`.



# Screenshots

N/A

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A
