### PR TITLE
[ignore] Add make targets for development Dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,3 +131,40 @@ The API backend is now available on port 8080 :). You can log in with user: `adm
 ### Web App
 
 See the [ui/README.md](./ui/README.md) file for details around the build process and the structure of the web UI.
+
+### Development Container Image
+
+A Dockerfile can be found at the root of the repo which can build a container
+for development purposes which includes both the API and UI.
+
+```
+make container-dev
+```
+
+The resulting image can be used as follows.
+
+```
+# the version here depends on your local git state
+=> => naming to localhost:5000/persesdev:v0.51.0-rc.0-48-g18d1e15d
+
+$ docker run -p 8080:8080 localhost:5000/persesdev:v0.51.0-rc.0-48-g18d1e15d
+```
+
+The image can be pushed to the registry with a make target.
+
+```
+make push-container-dev
+```
+
+If you would like to push this image to a remote container registry using the
+tag `myregistry.io/myname/myrepo:v0.0.51` then you can use the make targets as
+follows. Keep in mind that this is a development image which does not match the
+one built by the `goreleaser` build process.
+
+```
+export IMAGE_REGISTRY_DEV=myregistry.io/myname
+export IMAGE_REPO_DEV=myname
+export IMAGE_VERSION_DEV=v0.0.51
+make container-dev
+make push-container-dev
+```

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ COVER_PROFILE         := coverage.txt
 PKG_LDFLAGS           := github.com/prometheus/common/version
 LDFLAGS               := -s -w -X ${PKG_LDFLAGS}.Version=${VERSION} -X ${PKG_LDFLAGS}.Revision=${COMMIT} -X ${PKG_LDFLAGS}.BuildDate=${DATE} -X ${PKG_LDFLAGS}.Branch=${BRANCH}
 GORELEASER_PARALLEL   ?= 0
+IMAGE_REGISTRY_DEV    ?= localhost:5000
+IMAGE_REPO_DEV        ?= persesdev
+IMAGE_VERSION_DEV     ?= $(shell git describe --tags)
 
 export LDFLAGS
 export DATE
@@ -213,3 +216,11 @@ update-helm-readme:
 install-default-plugins:
 	@echo ">> install default plugins"
 	$(GO) run ./scripts/plugin/install_plugin.go
+
+.PHONY: container-dev
+container-dev: generate
+	docker build -f Dockerfile.dev . -t ${IMAGE_REGISTRY_DEV}/${IMAGE_REPO_DEV}:${IMAGE_VERSION_DEV}
+
+.PHONY: push-container-dev
+push-container-dev:
+	docker push ${IMAGE_REGISTRY_DEV}/${IMAGE_REPO_DEV}:${IMAGE_VERSION_DEV}


### PR DESCRIPTION
Add a container-dev and push-container-dev make target.

Document them in CONTRIBUTING.md.

A Dockerfile can be found at the root of the repo which can build a container for development purposes which includes both the API and UI.

```
make container-dev
```

If you have a remote Docker repository named myregistry.io/myname/myrepo and an intended temporary tag version of v0.0.151, then you can build and push the image as follows using the Makefile.

```
REGISTRY_DEV=myregistry.io/myname REPO_DEV=myname VERSION_DEV=v0.0.151 make container-dev
make push-container-dev
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
