### PR TITLE
[IGNORE] fix double button nesting error for e2e

### DIFF
--- a/ui/app/src/views/home/ProjectsAndDashboards.tsx
+++ b/ui/app/src/views/home/ProjectsAndDashboards.tsx
@@ -86,7 +86,11 @@ function ProjectAccordion({ row }: ProjectAccordionProps): ReactElement {
               </Link>
             </Stack>
             {hasPermission && (
-              <IconButton onClick={(event: MouseEvent) => openDeleteProjectConfirmDialog(event)} disabled={isReadonly}>
+              <IconButton
+                component="div"
+                onClick={(event: MouseEvent) => openDeleteProjectConfirmDialog(event)}
+                disabled={isReadonly}
+              >
                 <DeleteOutline />
               </IconButton>
             )}


### PR DESCRIPTION
# Description

Render the delete button as div with role=button to avoid nesting error logs that might break e2e tests.

<img width="815" alt="Screenshot 2025-06-03 at 12 18 24" src="https://github.com/user-attachments/assets/0d63495a-b304-4221-a92f-997f4eed786b" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).