### PR TITLE
[ENHANCEMENT] CLI: improve the "no args are supported" feedback for several commands

### DIFF
--- a/internal/cli/cmd/dac/setup/setup.go
+++ b/internal/cli/cmd/dac/setup/setup.go
@@ -121,7 +121,7 @@ type option struct {
 
 func (o *option) Complete(args []string) error {
 	if len(args) > 0 {
-		return fmt.Errorf("no args are supported by the command 'setup'")
+		return fmt.Errorf("no args are supported by the command 'dac setup'")
 	}
 
 	version, err := computeProperVersion(o.version)

--- a/internal/cli/cmd/plugin/build/build.go
+++ b/internal/cli/cmd/plugin/build/build.go
@@ -49,7 +49,7 @@ type option struct {
 
 func (o *option) Complete(args []string) error {
 	if len(args) > 0 {
-		return fmt.Errorf("no args are supported by the command 'build'")
+		return fmt.Errorf("no args are supported by the command 'plugin build'")
 	}
 	cfg, err := config.Resolve(o.pluginPath, o.cfgPath)
 	if err != nil {

--- a/internal/cli/cmd/plugin/lint/lint.go
+++ b/internal/cli/cmd/plugin/lint/lint.go
@@ -41,7 +41,7 @@ type option struct {
 
 func (o *option) Complete(args []string) error {
 	if len(args) > 0 {
-		return fmt.Errorf("no args are supported by the command 'update'")
+		return fmt.Errorf("no args are supported by the command 'plugin lint'")
 	}
 	cfg, err := config.Resolve(o.pluginPath, o.cfgPath)
 	if err != nil {

--- a/internal/cli/cmd/plugin/list/list.go
+++ b/internal/cli/cmd/plugin/list/list.go
@@ -44,7 +44,7 @@ type option struct {
 
 func (o *option) Complete(args []string) error {
 	if len(args) > 0 {
-		return fmt.Errorf("no args are supported by the command 'list'")
+		return fmt.Errorf("no args are supported by the command 'plugin list'")
 	}
 	// Complete the output only if it has been set by the user
 	// NB: In the case of the `get` command, the default output format is/should be a table, not json

--- a/internal/cli/cmd/plugin/list/list_test.go
+++ b/internal/cli/cmd/plugin/list/list_test.go
@@ -26,7 +26,7 @@ func TestPluginListCMD(t *testing.T) {
 			Title:           "use args",
 			Args:            []string{"whatever"},
 			IsErrorExpected: true,
-			ExpectedMessage: "no args are supported by the command 'list'",
+			ExpectedMessage: "no args are supported by the command 'plugin list'",
 		},
 		{
 			Title:           "list plugins",


### PR DESCRIPTION
# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).