### PR TITLE
[IGNORE] components: add missing dep immer

### DIFF
--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -39,6 +39,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",
+    "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "mathjs": "^10.6.4",
     "mdi-material-ui": "^7.9.2",
@@ -46,8 +47,7 @@
     "react-colorful": "^5.6.1",
     "react-error-boundary": "^3.1.4",
     "react-hook-form": "^7.51.3",
-    "react-virtuoso": "^4.12.2",
-    "zod": "^3.21.4"
+    "react-virtuoso": "^4.12.2"
   },
   "peerDependencies": {
     "@mui/material": "^6.1.10",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -127,6 +127,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
+        "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "mathjs": "^10.6.4",
         "mdi-material-ui": "^7.9.2",
@@ -134,8 +135,7 @@
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
         "react-hook-form": "^7.51.3",
-        "react-virtuoso": "^4.12.2",
-        "zod": "^3.21.4"
+        "react-virtuoso": "^4.12.2"
       },
       "peerDependencies": {
         "@mui/material": "^6.1.10",


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Adding immer as deps and remove zod (not used in this repo)

Hopefully, should remove these warnings:
```
[HistogramChart] warn    Compile Warning: 
[HistogramChart] File: /.../Projects/plugins/node_modules/@perses-dev/components/dist/Legend/Legend.js:1:1
[HistogramChart]   ⚠ No required version specified and unable to automatically determine one. Unable to find required version for "immer" in description file/s
[HistogramChart]   │ /.../Projects/plugins/node_modules/@perses-dev/components/package.json
[HistogramChart]   │ /.../Projects/plugins/package.json
[HistogramChart]   │ It need to be in dependencies, devDependencies or peerDependencies. file: shared module immer
[HistogramChart] 
[HistogramChart]  @ ../node_modules/@perses-dev/components/dist/Legend/index.js
[HistogramChart]  @ ../node_modules/@perses-dev/components/dist/index.js
[HistogramChart]  @ consume shared module (default) @perses-dev/components@^0.51.0-rc.0 (strict) (fallback: /.../Projects/plugins/node_modules/@perses-dev/components/dist/index.js)
[HistogramChart]  @ ./src/components/HistogramChartOptionsEditorSettings.tsx
[HistogramChart]  @ ./src/components/index.ts
[HistogramChart]  @ ./src/HistogramChart.ts
[HistogramChart]  @ container entry
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  fllowing `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
