### PR TITLE
[IGNORE] Add a trace log in `schema.Load()`

### DIFF
--- a/internal/api/plugin/schema/schema.go
+++ b/internal/api/plugin/schema/schema.go
@@ -61,6 +61,7 @@ func Load(pluginPath string, moduleSpec plugin.ModuleSpec) ([]LoadSchema, error)
 			}
 		}
 		currentDir, _ := filepath.Split(currentPath)
+		logrus.Tracef("Loading model package from %s", currentDir)
 		name, instance, schemaErr := LoadModelSchema(currentDir)
 		if schemaErr != nil {
 			return schemaErr

--- a/internal/cli/cmd/plugin/lint/lint.go
+++ b/internal/cli/cmd/plugin/lint/lint.go
@@ -67,7 +67,7 @@ func (o *option) Execute() error {
 	}
 	if plugin.IsSchemaRequired(npmPackageData.Perses) {
 		if _, err := os.Stat(filepath.Join(o.pluginPath, plugin.CuelangModuleFolder)); os.IsNotExist(err) {
-			return errors.New("cue modules not found")
+			return errors.New("cue module not found")
 		}
 		// There is a possibility the schema path set in package.json differ from the one set in the configuration.
 		// In this case, we will use the one set in the configuration.


### PR DESCRIPTION
# Description

Can help troubleshoot issues when updating schemas of a multi-plugin packages, e.g:
```bash
$ ../perses/bin/percli plugin lint --plugin.path prometheus --log.level trace
time="2025-06-04T21:08:36+02:00" level=trace msg="Loading model package from prometheus\\schemas\\datasource\\"
time="2025-06-04T21:08:36+02:00" level=trace msg="Loading model package from prometheus\\schemas\\prometheus-label-names\\"
Error: imported and not used: "github.com/perses/plugins/prometheus/schemas/datasource:model" as promDs (and 1 more errors)
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
