### PR TITLE
[DOC] Update link to dev dockerfile in the doc

### DIFF
--- a/docs/installation/in-a-container.md
+++ b/docs/installation/in-a-container.md
@@ -72,7 +72,7 @@ For fun, you can optionally flip the switch in the top right corner to enable da
 
 # Building your own container image
 
-If you want to build your own container image, you can use [`Dockerfile.dev`](../../Dockerfile.dev).
+If you want to build your own container image, you can use [`Dockerfile.dev`](https://github.com/perses/perses/blob/main/Dockerfile.dev).
 This container will include the Perses binary, percli, Perses UI and it will download the core [plugins](https://github.com/perses/plugins) at build time.
 
 To build your own container image, and run it you can use the following commands:


### PR DESCRIPTION
I am doing that as the Dockerfile is outside of the `docs` folder and the website does not have access to any other file than the one in the `docs` folder.

So when the website is building the navigation, it doesn't find the file `Dockerfile`