### PR TITLE
[ENHANCEMENT]: Replace CFB usage by AEAD for encryption and decryption

### DIFF
--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,7 +1,7 @@
 security:
   readonly: false
   encryption_key: "=tW$56zytgB&3jN2E%7-+qrGZE?v6LCc"
-  enable_auth: true
+  enable_auth: false
   authorization:
     guest_permissions:
       - actions:

--- a/internal/api/crypto/crypto.go
+++ b/internal/api/crypto/crypto.go
@@ -32,6 +32,8 @@ import (
 type Crypto interface {
 	Encrypt(spec *modelV1.SecretSpec) error
 	Decrypt(spec *modelV1.SecretSpec) error
+	EncryptCFB(stringToEncrypt string) (string, error)
+	IsCFBEncrypted() bool
 }
 
 func New(security config.Security) (Crypto, JWT, error) {
@@ -45,8 +47,9 @@ func New(security config.Security) (Crypto, JWT, error) {
 		return nil, nil, err
 	}
 	return &crypto{
-			key:   key,
-			block: aesBlock,
+			key:            key,
+			block:          aesBlock,
+			isCfbEncrypted: false,
 		},
 		&jwtImpl{
 			accessKey:       key,
@@ -58,8 +61,9 @@ func New(security config.Security) (Crypto, JWT, error) {
 }
 
 type crypto struct {
-	key   []byte
-	block cipher.Block
+	key            []byte
+	block          cipher.Block
+	isCfbEncrypted bool
 }
 
 func (c *crypto) Encrypt(spec *modelV1.SecretSpec) error {
@@ -172,6 +176,66 @@ func (c *crypto) encrypt(stringToEncrypt string) (string, error) {
 }
 
 func (c *crypto) decrypt(stringToDecrypt string) (string, error) {
+	// Try AES decryption first
+	aeadDecryptedPassword, err := c.decryptAEAD(stringToDecrypt)
+	if err != nil {
+		// Try CFB decryption if AES failed
+		cfbDecryptedPassword, cfbErr := c.decryptCFB(stringToDecrypt)
+		if cfbErr != nil {
+			return "", fmt.Errorf("failed to decrypt - AES error: %w\nCFB error: %v", err, cfbErr)
+		}
+		c.isCfbEncrypted = true
+		return cfbDecryptedPassword, nil
+	}
+	return aeadDecryptedPassword, nil
+}
+
+func (c *crypto) IsCFBEncrypted() bool {
+	return c.isCfbEncrypted
+}
+
+func (c *crypto) EncryptCFB(stringToEncrypt string) (string, error) {
+	if len(stringToEncrypt) == 0 {
+		return "", nil
+	}
+	plainText := []byte(stringToEncrypt)
+	cipherText := make([]byte, aes.BlockSize+len(plainText))
+	iv := cipherText[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return "", err
+	}
+
+	// TODO use AEAD instead of CFB as recommended by Go
+	stream := cipher.NewCFBEncrypter(c.block, iv) //nolint: staticcheck
+	stream.XORKeyStream(cipherText[aes.BlockSize:], plainText)
+
+	return base64.URLEncoding.EncodeToString(cipherText), nil
+}
+
+func (c *crypto) decryptCFB(stringToDecrypt string) (string, error) {
+	if len(stringToDecrypt) == 0 {
+		return "", nil
+	}
+	cipherText, err := base64.URLEncoding.DecodeString(stringToDecrypt)
+	if err != nil {
+		return "", err
+	}
+	if len(cipherText) < aes.BlockSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	iv := cipherText[:aes.BlockSize]
+	cipherText = cipherText[aes.BlockSize:]
+
+	// TODO use AEAD instead of CFB as recommended by Go
+	stream := cipher.NewCFBDecrypter(c.block, iv) //nolint: staticcheck
+
+	// XORKeyStream can work in-place if the two arguments are the same.
+	stream.XORKeyStream(cipherText, cipherText)
+
+	return string(cipherText), nil
+}
+
+func (c *crypto) decryptAEAD(stringToDecrypt string) (string, error) {
 	if len(stringToDecrypt) == 0 {
 		return "", nil
 	}

--- a/internal/api/crypto/crypto_test.go
+++ b/internal/api/crypto/crypto_test.go
@@ -20,11 +20,8 @@ func TestEncryptDecryptUsingCFB(t *testing.T) {
 	}
 	assert.NoError(t, err)
 	assert.NotEmpty(t, spec.BasicAuth.Password)
-	cfbEncryptedPassword, err := crypto.EncryptCFB(spec.BasicAuth.Password)
+	cfbEncryptedPassword := "Bm11iHDx3AL966MEKBjQrL_AN8pzFqnRtluw"
 	spec.BasicAuth.Password = cfbEncryptedPassword
-	assert.NoError(t, err)
-	assert.NotEmpty(t, cfbEncryptedPassword)
-	assert.NotEqual(t, cfbEncryptedPassword, "password123")
 
 	err = crypto.Decrypt(spec)
 	assert.NoError(t, err)

--- a/internal/api/crypto/crypto_test.go
+++ b/internal/api/crypto/crypto_test.go
@@ -1,3 +1,16 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package crypto
 
 import (
@@ -20,7 +33,8 @@ func TestEncryptDecryptUsingCFB(t *testing.T) {
 	}
 	assert.NoError(t, err)
 	assert.NotEmpty(t, spec.BasicAuth.Password)
-	cfbEncryptedPassword := "Bm11iHDx3AL966MEKBjQrL_AN8pzFqnRtluw"
+	// this is just an encrypted string of password123 which I printed out on runtime. ONLY for testing purpose
+	cfbEncryptedPassword := "Bm11iHDx3AL966MEKBjQrL_AN8pzFqnRtluw" //nolint: gosec
 	spec.BasicAuth.Password = cfbEncryptedPassword
 
 	err = crypto.Decrypt(spec)

--- a/internal/api/crypto/crypto_test.go
+++ b/internal/api/crypto/crypto_test.go
@@ -1,0 +1,55 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/perses/perses/pkg/model/api/config"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	modelV1Secret "github.com/perses/perses/pkg/model/api/v1/secret"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncryptDecryptUsingCFB(t *testing.T) {
+	crypto, _, err := New(config.Security{
+		EncryptionKey: "3d74572435367a797467372d2b7172475a453f76364c4363",
+	})
+	spec := &modelV1.SecretSpec{
+		BasicAuth: &modelV1Secret.BasicAuth{
+			Password: "password123",
+		},
+	}
+	assert.NoError(t, err)
+	assert.NotEmpty(t, spec.BasicAuth.Password)
+	cfbEncryptedPassword, err := crypto.EncryptCFB(spec.BasicAuth.Password)
+	spec.BasicAuth.Password = cfbEncryptedPassword
+	assert.NoError(t, err)
+	assert.NotEmpty(t, cfbEncryptedPassword)
+	assert.NotEqual(t, cfbEncryptedPassword, "password123")
+
+	err = crypto.Decrypt(spec)
+	assert.NoError(t, err)
+	assert.Equal(t, crypto.IsCFBEncrypted(), true)
+	assert.Equal(t, spec.BasicAuth.Password, "password123")
+}
+
+func TestEncryptDecryptUsingAES(t *testing.T) {
+	crypto, _, err := New(config.Security{
+		EncryptionKey: "3d74572435367a797467372d2b7172475a453f76364c4363",
+	})
+	spec := &modelV1.SecretSpec{
+		BasicAuth: &modelV1Secret.BasicAuth{
+			Password: "password123",
+		},
+	}
+	assert.NoError(t, err)
+	assert.NotEmpty(t, spec.BasicAuth.Password)
+	err = crypto.Encrypt(spec)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, spec.BasicAuth.Password)
+	assert.NotEqual(t, spec.BasicAuth.Password, "password123")
+
+	err = crypto.Decrypt(spec)
+	assert.NoError(t, err)
+	assert.Equal(t, crypto.IsCFBEncrypted(), false)
+	assert.Equal(t, spec.BasicAuth.Password, "password123")
+}


### PR DESCRIPTION
# Description

Fixes: #2901 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
