### PR TITLE
[DOC] Fix docs for plugin configuration

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -768,13 +768,15 @@ dashboard: <string>
 ```yaml
 # The path to the folder containing the plugins
 # The default value depends if Perses is running in a container or not.
-folder: <path> | default = ("plugins" | "/etc/perses/plugins") # Optional
+path: <path> | default = ("plugins" | "/etc/perses/plugins") # Optional
 
 # The path to the folder containing the plugins archive. 
 # When Perses is starting, it will extract the content of the archive in the folder specified in the `folder` attribute.
 archive_path: <path> | default = ("plugins-archive" | "/etc/perses/plugins-archive") # Optional
 
-dev_environment: <PluginDevEnvironment config> # Optional
+# Allow use of plugins in dev mode.
+enable_dev: <bool> | default = false # Optional
+
 ```
 
 #### PluginDevEnvironment config


### PR DESCRIPTION
Finishes changes introduced in f8b3caac (#2831).

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

I've came across some cods inconsistencies when trying to run some plugin in dev mode. The changes in docs should match the changes in the code. In parallel, I'm sending a PR to plugins repo as well.



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
