### PR TITLE
[FEATURE] CSV export for TimeSeries Chart

### DIFF
--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -50,7 +50,7 @@ export function PanelHeader({
   const title = useReplaceVariablesInString(rawTitle) as string;
   const description = useReplaceVariablesInString(rawDescription);
 
-const timeSeriesDataForExport = useMemo(() => {
+  const timeSeriesDataForExport = useMemo(() => {
     for (const query of queryResults) {
       if (query.data && 'series' in query.data) {
         return query.data as TimeSeriesData;

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -13,9 +13,9 @@
 
 import { CardHeader, CardHeaderProps, Stack, Typography } from '@mui/material';
 import { combineSx } from '@perses-dev/components';
-import { Link } from '@perses-dev/core';
+import { Link, TimeSeriesData } from '@perses-dev/core';
 import { QueryData, useReplaceVariablesInString } from '@perses-dev/plugin-system';
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, useMemo } from 'react';
 import { HEADER_ACTIONS_CONTAINER_NAME } from '../../constants';
 import { PanelActions, PanelActionsProps } from './PanelActions';
 
@@ -50,6 +50,15 @@ export function PanelHeader({
   const title = useReplaceVariablesInString(rawTitle) as string;
   const description = useReplaceVariablesInString(rawDescription);
 
+const timeSeriesDataForExport = useMemo(() => {
+    for (const query of queryResults) {
+      if (query.data && 'series' in query.data) {
+        return query.data as TimeSeriesData;
+      }
+    }
+    return undefined;
+  }, [queryResults]);
+
   return (
     <CardHeader
       id={id}
@@ -79,7 +88,7 @@ export function PanelHeader({
             description={description}
             descriptionTooltipId={descriptionTooltipId}
             links={links}
-            queryResults={queryResults}
+            queryResults={timeSeriesDataForExport}
             readHandlers={readHandlers}
             editHandlers={editHandlers}
             extra={extra}


### PR DESCRIPTION
Signed-off-by: Erica Hinkle <ehinkle@redhat.com>

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
## Explanation: 
Created a button within the hamburger option on each Perses graph panel. This feature takes the graph data from the specified panel and exports it to your computer as a CSV file named "'YourPanelName'_graphData.csv". The first line of the CSV has important information and then the rest of the file is all of the data based on times. Each line has "TimeSeries Information, data1, data2(if applicable)" and all data is comma separated. I only made substantial changes to the "PanelActions.tsx" and "PanelHeader.tsx".

#### Red Hat JIRA: 
https://issues.redhat.com/browse/OU-839

<!-- Context useful to a reviewer -->

#### The illuminated three stacked lines is where my "Export as CSV" option lives:
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/67fd4040-4e86-474d-a5c4-ab18c1810b6c" />

#### What now pops up once you press the three lines "hamburger menu". It is a button that you can press:
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/f6c6332e-b97e-4358-9fc6-cff8f64941a3" />

#### Once you press the export button, it triggers a download on your device with all of the CSV data in the graph that you specified. The name will be "'YourPanelName'_graphData.csv":
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/e4ec9322-5582-446f-8ac1-6d7cc964b3fb" />

#### Then if you click and open the download, it opens a file where the first line holds context information and then all the lines under it have the times and data corresponding to those times:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/bc9b3540-ef44-4a7b-9137-02619ac3503d" />


<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
