### PR TITLE
[BUGFIX] fix the redundant consumption of the response object when th…

### DIFF
--- a/ui/core/src/utils/fetch.ts
+++ b/ui/core/src/utils/fetch.ts
@@ -19,7 +19,7 @@ export async function fetch(...args: Parameters<typeof global.fetch>): Promise<R
   if (response.ok === false) {
     const contentType = response.headers.get('content-type');
     if (contentType?.includes('application/json')) {
-      const json = await response.json();
+      const json = await response.clone().json();
       if (json.error) {
         throw new UserFriendlyError(json.error, response.status);
       }
@@ -28,7 +28,7 @@ export async function fetch(...args: Parameters<typeof global.fetch>): Promise<R
       }
     }
 
-    const text = await response.text();
+    const text = await response.clone().text();
     if (text) {
       throw new UserFriendlyError(text, response.status);
     }


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

closes #3006 

A subtle bug has been found in the `fetch` util of the project. The response body **might** be consumed two times by `json` and `text` functions. This will throw the following exception

> Failed to execute text on Response body stream already read

The reason behind this exception is that the fetch API response body can be consumed only once. If developers try to consume the response multiple times, the mentioned exception will be thrown. The simple trick to solve the issue is to clone the object before consuming it. 

## Why this happens randomly? 

It really depends on your network calls. The execute path only enters the culprit conditional branch , if a network response status is not 200, meaning you only would see it if you had some network failures. 

## To Test The fix

### First approach
Intercept your network and try return none 200 (OK) responses.

### Second approach
You can also change the condition to `!==false`, so you fall in the trap by any 200. Then you see (In chrome) the mentioned issue is not printed. 

@AntoineThebaud @Gladorme 





# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
