### PR TITLE
[BUGFIX] fix issue when configuring datasource with direct access

### DIFF
--- a/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
+++ b/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
@@ -34,7 +34,7 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
   const strProxy = 'Proxy';
 
   // Initialize Proxy mode by default, if neither direct nor proxy mode is selected.
-  if (!value.directUrl && !value.proxy) {
+  if (value.directUrl === undefined && value.proxy === undefined) {
     Object.assign(value, initialSpecProxy);
   }
 
@@ -60,36 +60,6 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
   };
 
   const tabs = [
-    {
-      label: strDirect,
-      content: (
-        <Controller
-          name="URL"
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              fullWidth
-              label="URL"
-              value={value.directUrl || ''}
-              error={!!fieldState.error}
-              helperText={fieldState.error?.message}
-              InputProps={{
-                readOnly: isReadonly,
-              }}
-              InputLabelProps={{ shrink: isReadonly ? true : undefined }}
-              onChange={(e) => {
-                field.onChange(e);
-                onChange(
-                  produce(value, (draft) => {
-                    draft.directUrl = e.target.value;
-                  })
-                );
-              }}
-            />
-          )}
-        />
-      ),
-    },
     {
       label: strProxy,
       content: (
@@ -423,6 +393,36 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
             )}
           />
         </>
+      ),
+    },
+    {
+      label: strDirect,
+      content: (
+        <Controller
+          name="URL"
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              fullWidth
+              label="URL"
+              value={value.directUrl || ''}
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              InputProps={{
+                readOnly: isReadonly,
+              }}
+              InputLabelProps={{ shrink: isReadonly ? true : undefined }}
+              onChange={(e) => {
+                field.onChange(e);
+                onChange(
+                  produce(value, (draft) => {
+                    draft.directUrl = e.target.value;
+                  })
+                );
+              }}
+            />
+          )}
+        />
       ),
     },
   ];


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Fixes https://github.com/perses/perses/issues/3015.

I also took the opportunity to make the Proxy tab the 1rst one since it was made the default one.

# Screenshots

![image](https://github.com/user-attachments/assets/69e4d874-c2ed-407f-a095-e8f60cd4a1db)

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
