### PR TITLE
[IGNORE] RBAC interface is using the perses context

### DIFF
--- a/internal/api/impl/v1/view/endpoint_test.go
+++ b/internal/api/impl/v1/view/endpoint_test.go
@@ -43,11 +43,11 @@ type testRBAC struct {
 	allow bool
 }
 
-func (t *testRBAC) GetPermissions(_ string) map[string][]*role.Permission {
+func (t *testRBAC) GetPermissions(_ apiInterface.PersesContext) map[string][]*role.Permission {
 	return map[string][]*role.Permission{}
 }
 
-func (t *testRBAC) HasPermission(_ string, _ role.Action, _ string, _ role.Scope) bool {
+func (t *testRBAC) HasPermission(_ apiInterface.PersesContext, _ role.Action, _ string, _ role.Scope) bool {
 	return t.allow
 }
 
@@ -59,7 +59,7 @@ func (t *testRBAC) Refresh() error {
 	panic("unimplemented")
 }
 
-func (t *testRBAC) GetUserProjects(_ string, _ role.Action, _ role.Scope) []string {
+func (t *testRBAC) GetUserProjects(_ apiInterface.PersesContext, _ role.Action, _ role.Scope) []string {
 	panic("unimplemented")
 }
 

--- a/internal/api/interface/service.go
+++ b/internal/api/interface/service.go
@@ -23,20 +23,17 @@ import (
 )
 
 var (
-	EmptyCtx = &context{
-		username: "",
-	}
+	EmptyCtx = &context{}
 )
 
 func NewPersesContext(ctx echo.Context) PersesContext {
 	claims := crypto.ExtractJWTClaims(ctx)
 	if claims == nil {
 		// Claim can be empty in anonymous endpoints
-		return &context{}
+		return EmptyCtx
 	}
-	username, _ := claims.GetSubject()
 	return &context{
-		username: username,
+		username: claims.Subject,
 	}
 }
 
@@ -48,7 +45,7 @@ type context struct {
 	username string
 }
 
-func (c context) GetUsername() string {
+func (c *context) GetUsername() string {
 	return c.username
 }
 

--- a/internal/api/rbac/cache.go
+++ b/internal/api/rbac/cache.go
@@ -86,6 +86,10 @@ func (r *cacheImpl) GetUserProjects(ctx apiInterface.PersesContext, requestActio
 }
 
 func (r *cacheImpl) HasPermission(ctx apiInterface.PersesContext, requestAction v1Role.Action, requestProject string, requestScope v1Role.Scope) bool {
+	if ctx == apiInterface.EmptyCtx {
+		// If the context is empty, we assume the endpoint is an anonymous endpoint.
+		return true
+	}
 	// Checking default permissions
 	if ok := permissionListHasPermission(r.guestPermissions, requestAction, requestScope); ok {
 		return true

--- a/internal/api/rbac/disabled.go
+++ b/internal/api/rbac/disabled.go
@@ -14,6 +14,7 @@
 package rbac
 
 import (
+	apiInterface "github.com/perses/perses/internal/api/interface"
 	v1Role "github.com/perses/perses/pkg/model/api/v1/role"
 )
 
@@ -23,15 +24,15 @@ func (r *disabledImpl) IsEnabled() bool {
 	return false
 }
 
-func (r *disabledImpl) GetUserProjects(_ string, _ v1Role.Action, _ v1Role.Scope) []string {
+func (r *disabledImpl) GetUserProjects(_ apiInterface.PersesContext, _ v1Role.Action, _ v1Role.Scope) []string {
 	return []string{}
 }
 
-func (r *disabledImpl) HasPermission(_ string, _ v1Role.Action, _ string, _ v1Role.Scope) bool {
+func (r *disabledImpl) HasPermission(_ apiInterface.PersesContext, _ v1Role.Action, _ string, _ v1Role.Scope) bool {
 	return true
 }
 
-func (r *disabledImpl) GetPermissions(_ string) map[string][]*v1Role.Permission {
+func (r *disabledImpl) GetPermissions(_ apiInterface.PersesContext) map[string][]*v1Role.Permission {
 	return nil
 }
 

--- a/internal/api/rbac/rbac.go
+++ b/internal/api/rbac/rbac.go
@@ -14,6 +14,7 @@
 package rbac
 
 import (
+	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/interface/v1/globalrole"
 	"github.com/perses/perses/internal/api/interface/v1/globalrolebinding"
 	"github.com/perses/perses/internal/api/interface/v1/role"
@@ -26,9 +27,9 @@ import (
 type RBAC interface {
 	IsEnabled() bool
 	// GetUserProjects return the list of the project the user has access to in the context of the role and the scope requested.
-	GetUserProjects(user string, requestAction v1Role.Action, requestScope v1Role.Scope) []string
-	HasPermission(user string, requestAction v1Role.Action, requestProject string, requestScope v1Role.Scope) bool
-	GetPermissions(user string) map[string][]*v1Role.Permission
+	GetUserProjects(ctx apiInterface.PersesContext, requestAction v1Role.Action, requestScope v1Role.Scope) []string
+	HasPermission(ctx apiInterface.PersesContext, requestAction v1Role.Action, requestProject string, requestScope v1Role.Scope) bool
+	GetPermissions(ctx apiInterface.PersesContext) map[string][]*v1Role.Permission
 	Refresh() error
 }
 

--- a/internal/api/toolbox/list.go
+++ b/internal/api/toolbox/list.go
@@ -62,9 +62,9 @@ func (t *toolbox[T, K, V]) listWhenPermissionIsActivated(ctx echo.Context, param
 	}
 	persesContext := apiInterface.NewPersesContext(ctx)
 	// Get the list of the project the user has access to, depending on the current scope.
-	projects := t.rbac.GetUserProjects(persesContext.GetUsername(), role.ReadAction, *scope)
+	projects := t.rbac.GetUserProjects(persesContext, role.ReadAction, *scope)
 
-	// If there is no project associated to the user, then we should just return an empty list.
+	// If there is no project associated with the user, then we should just return an empty list.
 	if len(projects) == 0 {
 		return []api.Entity{}, nil
 	}


### PR DESCRIPTION
This PR is changing the rbac interface in order to use the Perses context instead of the login of the user.

This is a first PR to make the authorization layer more generic and later to be able to improve and accept the PR #2940.

Other PRs will follow changing step by step the authorization layer

/cc @PeterYurkovich