### PR TITLE
[BUGFIX] Move namespace to correct location for Dashboard CR export

### DIFF
--- a/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
+++ b/ui/dashboards/src/components/DownloadButton/DownloadButton.tsx
@@ -54,8 +54,8 @@ export function DownloadButton(): ReactElement {
                   'app.kubernetes.io/part-of': 'perses-operator',
                 },
                 name,
+                namespace: dashboard.metadata.project,
               },
-              namespace: dashboard.metadata.project,
               spec: dashboard.spec,
             });
           } else {


### PR DESCRIPTION
# Description

The namespace was not in the correct location for the perses-operator Dashboard CR while using the download feature.

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).