### PR TITLE
[BUGFIX] explore: Fix tabs in random order

### DIFF
--- a/ui/explore/src/components/ExploreManager/ExploreManager.tsx
+++ b/ui/explore/src/components/ExploreManager/ExploreManager.tsx
@@ -65,13 +65,15 @@ export function ExploreManager(props: ExploreManagerProps): ReactElement {
             minWidth: '100px',
           }}
         >
-          {plugins.data?.map((plugin) => (
-            <Tab
-              key={`${plugin.module.name}-${plugin.spec.name}`}
-              value={`${plugin.module.name}-${plugin.spec.name}`}
-              label={plugin.spec.display.name}
-            />
-          ))}
+          {plugins.data
+            ?.sort((a, b) => a.spec.display.name.localeCompare(b.spec.display.name))
+            .map((plugin) => (
+              <Tab
+                key={`${plugin.module.name}-${plugin.spec.name}`}
+                value={`${plugin.module.name}-${plugin.spec.name}`}
+                label={plugin.spec.display.name}
+              />
+            ))}
         </Tabs>
         <Card sx={{ padding: '10px', width: '100%' }}>
           {currentPlugin && (


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Current tab order was random based on plugin loading, now it will keep the same place based on plugin display name

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
