### PR TITLE
[ENHANCEMENT] Add Execute Query Button to query editors

### DIFF
--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -11,7 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from '@mui/material';
+import { Box, Button } from '@mui/material';
+import Reload from 'mdi-material-ui/Reload';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { ReactElement } from 'react';
 import { PluginKindSelect } from '../PluginKindSelect';
@@ -32,19 +33,31 @@ export function PluginEditor(props: PluginEditorProps): ReactElement {
   const { pendingSelection, isLoading, error, onSelectionChange, onSpecChange } = usePluginEditor(props);
   return (
     <Box {...others}>
-      <PluginKindSelect
-        fullWidth={false}
-        sx={{ mb: 2, minWidth: 120 }}
-        margin="dense"
-        label={pluginKindLabel}
-        pluginTypes={pluginTypes}
-        disabled={isLoading}
-        value={pendingSelection ? pendingSelection : value.selection}
-        InputProps={{ readOnly: isReadonly }}
-        error={!!error}
-        helperText={error?.message}
-        onChange={onSelectionChange}
-      />
+      <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+        <PluginKindSelect
+          fullWidth={false}
+          sx={{ mb: 2, minWidth: 120 }}
+          margin="dense"
+          label={pluginKindLabel}
+          pluginTypes={pluginTypes}
+          disabled={isLoading}
+          value={pendingSelection ? pendingSelection : value.selection}
+          InputProps={{ readOnly: isReadonly }}
+          error={!!error}
+          helperText={error?.message}
+          onChange={onSelectionChange}
+        />
+
+        <Button
+          variant="contained"
+          sx={{ marginTop: 1.5, marginBottom: 1.5, paddingTop: 0.5, marginLeft: 'auto' }}
+          startIcon={<Reload />}
+          onClick={() => onSpecChange(value.spec)}
+        >
+          Run Query
+        </Button>
+      </Box>
+
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginSpecEditor
           pluginSelection={value.selection}


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Solves #2840

Currently when you edit a query it runs whenever there is a re-render done (generally when you click off of the editor box). This leads to a weird experience if you're not used to that, where your query seemingly runs at random. Here we add a new button to Query Editors that gives users the ability to manually run their query, making this flow more explicit.

# Screenshots

![image](https://github.com/user-attachments/assets/deffd3b7-473c-4543-9389-c9e0729bd679)
![image](https://github.com/user-attachments/assets/70f80f2a-d5d7-4bd4-8786-2f461debf08b)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
