### PR TITLE
[FEATURE] Explore: allow users to collapse tabs menu

### DIFF
--- a/ui/explore/src/components/ExploreManager/ExploreManager.tsx
+++ b/ui/explore/src/components/ExploreManager/ExploreManager.tsx
@@ -11,9 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Card, Stack, Tab, Tabs, useMediaQuery } from '@mui/material';
+import { Box, Button, Card, Stack, Tab, Tabs, useMediaQuery } from '@mui/material';
 import { PluginLoaderComponent, useListPluginMetadata } from '@perses-dev/plugin-system';
 import { ReactElement, ReactNode, useEffect, useMemo } from 'react';
+import ChevronRight from 'mdi-material-ui/ChevronRight';
+import ChevronLeft from 'mdi-material-ui/ChevronLeft';
+import { useLocalStorage } from '@perses-dev/app/src/utils/browser-storage';
 import { ExploreToolbar } from '../ExploreToolbar';
 import { useExplorerManagerContext } from './ExplorerManagerProvider';
 
@@ -27,7 +30,8 @@ export function ExploreManager(props: ExploreManagerProps): ReactElement {
 
   const plugins = useListPluginMetadata(['Explore']);
 
-  const smallScreen = useMediaQuery('(max-width: 768px)');
+  const isSmallScreen = useMediaQuery('(max-width: 768px)');
+  const [isCollapsed, setIsCollapsed] = useLocalStorage<boolean>('explore-tabs-collapsed', false);
 
   const explorerPluginsMap = useMemo(
     () =>
@@ -49,32 +53,60 @@ export function ExploreManager(props: ExploreManagerProps): ReactElement {
   }
 
   return (
-    <Stack sx={{ width: '100%' }} px={2} pb={2} pt={1.5} gap={3}>
+    <Stack sx={{ width: '100%' }} px={2} pb={2} pt={1.5} gap={1}>
       <ExploreToolbar exploreTitleComponent={exploreTitleComponent} />
 
-      <Stack direction={smallScreen ? 'column' : 'row'} gap={2} sx={{ width: '100%' }}>
-        <Tabs
-          orientation={smallScreen ? 'horizontal' : 'vertical'}
-          value={explorer}
-          onChange={(_, state) => setExplorer(state)}
-          variant={smallScreen ? 'fullWidth' : 'scrollable'}
+      <Stack direction={isSmallScreen ? 'column' : 'row'} gap={2} sx={{ width: '100%' }}>
+        <Stack
           sx={{
-            borderRight: smallScreen ? 0 : 1,
-            borderBottom: smallScreen ? 1 : 0,
+            borderRight: isSmallScreen ? 0 : 1,
+            borderBottom: isSmallScreen ? 1 : 0,
             borderColor: 'divider',
-            minWidth: '100px',
+            minWidth: isCollapsed ? 15 : 100,
           }}
         >
-          {plugins.data
-            ?.sort((a, b) => a.spec.display.name.localeCompare(b.spec.display.name))
-            .map((plugin) => (
-              <Tab
-                key={`${plugin.module.name}-${plugin.spec.name}`}
-                value={`${plugin.module.name}-${plugin.spec.name}`}
-                label={plugin.spec.display.name}
-              />
-            ))}
-        </Tabs>
+          <Box sx={{ position: 'relative', height: 30, display: isSmallScreen ? 'none' : undefined }} test-id="qdqwd">
+            <Button
+              title={isCollapsed ? 'Expand explorer tabs' : 'Collapse explorer tabs'}
+              aria-label={isCollapsed ? 'Expand explorer tabs' : 'Collapse explorer tabs'}
+              variant="text"
+              sx={{
+                position: 'absolute',
+                right: -15,
+                zIndex: 1,
+                padding: 0.5,
+                minWidth: 'auto',
+                backgroundColor: (theme) => theme.palette.background.default,
+              }}
+              onClick={() => setIsCollapsed(!isCollapsed)}
+            >
+              {isCollapsed ? <ChevronRight /> : <ChevronLeft />}
+            </Button>
+          </Box>
+
+          <Tabs
+            orientation={isSmallScreen ? 'horizontal' : 'vertical'}
+            value={explorer}
+            onChange={(_, state) => setExplorer(state)}
+            variant={isSmallScreen ? 'fullWidth' : 'scrollable'}
+            sx={{
+              display: isCollapsed ? 'none' : 'flex',
+            }}
+          >
+            {plugins.data
+              ?.sort((a, b) => a.spec.display.name.localeCompare(b.spec.display.name))
+              .map((plugin) => (
+                <Tab
+                  key={`${plugin.module.name}-${plugin.spec.name}`}
+                  value={`${plugin.module.name}-${plugin.spec.name}`}
+                  label={plugin.spec.display.name}
+                  sx={{
+                    padding: 0.5,
+                  }}
+                />
+              ))}
+          </Tabs>
+        </Stack>
         <Card sx={{ padding: '10px', width: '100%' }}>
           {currentPlugin && (
             <PluginLoaderComponent


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
After looking at @iNecas [super demo](https://www.youtube.com/watch?v=-ieiplT1k5g). I found explorer tabs were using too much space to my liking on small screens. 
I remove some whitespace + adding a toggle to collapse or expand tabs (state stored in localStorage). On mobile screen button is hidden.

# Screenshots

<!-- If there are UI changes -->
BEFORE:
![image](https://github.com/user-attachments/assets/d0e72dc6-9b4a-40dc-a59b-341d4f1dc89c)


AFTER:
![image](https://github.com/user-attachments/assets/ced0cfea-2939-463b-94a3-278e9e95d32e)
![image](https://github.com/user-attachments/assets/5add4afd-cbd3-4b1d-b0df-801ec838df30)
![image](https://github.com/user-attachments/assets/927790e9-76d8-404a-bba9-39fccfc8a1f6)


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
