### PR TITLE
[BUGFIX] Use word form of integers for panel names when migrating Graf…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.2-0.20240726212847-3a740cf7976f
 	github.com/brunoga/deep v1.2.5
 	github.com/charmbracelet/huh v0.7.0
+	github.com/divan/num2words v1.0.1
 	github.com/efficientgo/core v1.0.0-rc.3
 	github.com/fatih/color v1.18.0
 	github.com/gavv/httpexpect/v2 v2.17.0

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/divan/num2words v1.0.1 h1:0vt7HY3CVqqkq+vbB2J8eJNwGgaTCeHYjr7tYGxw2rc=
+github.com/divan/num2words v1.0.1/go.mod h1:duNwU06A80oPNPA5fX2puj/uQBpLWMBrE/gS8kX/0BU=
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 h1:2tV76y6Q9BB+NEBasnqvs7e49aEBFI8ejC89PSnWH+4=
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=

--- a/internal/api/plugin/migrate/migrate.go
+++ b/internal/api/plugin/migrate/migrate.go
@@ -26,13 +26,14 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
+	"github.com/sirupsen/logrus"
+
 	apiinterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/plugin/schema"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/perses/perses/pkg/model/api/v1/dashboard"
 	"github.com/perses/perses/pkg/model/api/v1/plugin"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -233,8 +234,8 @@ func (m *mig) migrateGrid(grafanaDashboard *SimplifiedDashboard) []dashboard.Lay
 				X:      panel.GridPosition.X,
 				Y:      panel.GridPosition.Y,
 				Content: &common.JSONRef{
-					Ref:  fmt.Sprintf("#/spec/panels/%d", i),
-					Path: []string{"spec", "panels", fmt.Sprintf("%d", i)},
+					Ref:  fmt.Sprintf("#/spec/panels/%s", normalizePanelName(i)),
+					Path: []string{"spec", "panels", normalizePanelName(i)},
 				},
 			})
 		} else {
@@ -257,8 +258,8 @@ func (m *mig) migrateGrid(grafanaDashboard *SimplifiedDashboard) []dashboard.Lay
 					X:      innerPanel.GridPosition.X,
 					Y:      innerPanel.GridPosition.Y,
 					Content: &common.JSONRef{
-						Ref:  fmt.Sprintf("#/spec/panels/%d_%d", i, j),
-						Path: []string{"spec", "panels", fmt.Sprintf("%d_%d", i, j)},
+						Ref:  fmt.Sprintf("#/spec/panels/%s", normalizePanelName(i, j)),
+						Path: []string{"spec", "panels", normalizePanelName(i, j)},
 					},
 				})
 			}

--- a/internal/api/plugin/migrate/testdata/barchart_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/barchart_perses_dashboard.json
@@ -12,7 +12,7 @@
       "name": "Barchart panel dash"
     },
     "panels": {
-      "0": {
+      "zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -56,7 +56,7 @@
               "width": 6,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0"
+                "$ref": "#/spec/panels/zero"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/grafana_user_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/grafana_user_perses_dashboard.json
@@ -12,7 +12,7 @@
       "name": "Node dashboard"
     },
     "panels": {
-      "0": {
+      "zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -61,7 +61,7 @@
           ]
         }
       },
-      "1": {
+      "one": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -110,7 +110,7 @@
           ]
         }
       },
-      "2": {
+      "two": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -159,7 +159,7 @@
           ]
         }
       },
-      "3": {
+      "three": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -208,7 +208,7 @@
           ]
         }
       },
-      "4": {
+      "four": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -257,7 +257,7 @@
           ]
         }
       },
-      "5": {
+      "five": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -306,7 +306,7 @@
           ]
         }
       },
-      "6": {
+      "six": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -355,7 +355,7 @@
           ]
         }
       },
-      "7": {
+      "seven": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -404,7 +404,7 @@
           ]
         }
       },
-      "8": {
+      "eight": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -453,7 +453,7 @@
           ]
         }
       },
-      "9": {
+      "nine": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -502,7 +502,7 @@
           ]
         }
       },
-      "10": {
+      "ten": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -551,7 +551,7 @@
           ]
         }
       },
-      "11": {
+      "eleven": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -600,7 +600,7 @@
           ]
         }
       },
-      "12": {
+      "twelve": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -649,7 +649,7 @@
           ]
         }
       },
-      "13": {
+      "thirteen": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -698,7 +698,7 @@
           ]
         }
       },
-      "14": {
+      "fourteen": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -747,7 +747,7 @@
           ]
         }
       },
-      "15": {
+      "fifteen": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -796,7 +796,7 @@
           ]
         }
       },
-      "16": {
+      "sixteen": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -845,7 +845,7 @@
           ]
         }
       },
-      "17": {
+      "seventeen": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -889,7 +889,7 @@
           ]
         }
       },
-      "18": {
+      "eighteen": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -938,7 +938,7 @@
           ]
         }
       },
-      "19": {
+      "nineteen": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -982,7 +982,7 @@
           ]
         }
       },
-      "20": {
+      "twenty": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1026,7 +1026,7 @@
           ]
         }
       },
-      "21": {
+      "twenty_one": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1087,7 +1087,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0"
+                "$ref": "#/spec/panels/zero"
               }
             },
             {
@@ -1096,7 +1096,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1"
+                "$ref": "#/spec/panels/one"
               }
             },
             {
@@ -1105,7 +1105,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2"
+                "$ref": "#/spec/panels/two"
               }
             },
             {
@@ -1114,7 +1114,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3"
+                "$ref": "#/spec/panels/three"
               }
             },
             {
@@ -1123,7 +1123,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4"
+                "$ref": "#/spec/panels/four"
               }
             },
             {
@@ -1132,7 +1132,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5"
+                "$ref": "#/spec/panels/five"
               }
             },
             {
@@ -1141,7 +1141,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6"
+                "$ref": "#/spec/panels/six"
               }
             },
             {
@@ -1150,7 +1150,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7"
+                "$ref": "#/spec/panels/seven"
               }
             },
             {
@@ -1159,7 +1159,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8"
+                "$ref": "#/spec/panels/eight"
               }
             },
             {
@@ -1168,7 +1168,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9"
+                "$ref": "#/spec/panels/nine"
               }
             },
             {
@@ -1177,7 +1177,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/10"
+                "$ref": "#/spec/panels/ten"
               }
             },
             {
@@ -1186,7 +1186,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11"
+                "$ref": "#/spec/panels/eleven"
               }
             },
             {
@@ -1195,7 +1195,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/12"
+                "$ref": "#/spec/panels/twelve"
               }
             },
             {
@@ -1204,7 +1204,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/13"
+                "$ref": "#/spec/panels/thirteen"
               }
             },
             {
@@ -1213,7 +1213,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/14"
+                "$ref": "#/spec/panels/fourteen"
               }
             },
             {
@@ -1222,7 +1222,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/15"
+                "$ref": "#/spec/panels/fifteen"
               }
             },
             {
@@ -1231,7 +1231,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/16"
+                "$ref": "#/spec/panels/sixteen"
               }
             },
             {
@@ -1240,7 +1240,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/17"
+                "$ref": "#/spec/panels/seventeen"
               }
             },
             {
@@ -1249,7 +1249,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/18"
+                "$ref": "#/spec/panels/eighteen"
               }
             },
             {
@@ -1258,7 +1258,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/19"
+                "$ref": "#/spec/panels/nineteen"
               }
             },
             {
@@ -1267,7 +1267,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/20"
+                "$ref": "#/spec/panels/twenty"
               }
             },
             {
@@ -1276,7 +1276,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/21"
+                "$ref": "#/spec/panels/twenty_one"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/library_panel_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/library_panel_perses_dashboard.json
@@ -12,7 +12,7 @@
       "name": "Perses testing / Dashboard with library panel"
     },
     "panels": {
-      "0_0": {
+      "zero_zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -44,7 +44,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/zero_zero"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/old_grafana_panels_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/old_grafana_panels_perses_dashboard.json
@@ -33,7 +33,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "zero_zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -47,7 +47,7 @@
           }
         }
       },
-      "0_1": {
+      "zero_one": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -61,7 +61,7 @@
           }
         }
       },
-      "1_0": {
+      "one_zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -93,7 +93,7 @@
           ]
         }
       },
-      "1_1": {
+      "one_one": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -156,7 +156,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/zero_zero"
               }
             },
             {
@@ -165,7 +165,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/zero_one"
               }
             }
           ]
@@ -187,7 +187,7 @@
               "width": 12,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/one_zero"
               }
             },
             {
@@ -196,7 +196,7 @@
               "width": 12,
               "height": 11,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/one_one"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/old_grafana_query_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/old_grafana_query_perses_dashboard.json
@@ -53,7 +53,7 @@
       }
     ],
     "panels": {
-      "0": {
+      "zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -90,7 +90,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0"
+                "$ref": "#/spec/panels/zero"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/piechart_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/piechart_perses_dashboard.json
@@ -12,7 +12,7 @@
       "name": "Piechart sample"
     },
     "panels": {
-      "0": {
+      "zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -69,7 +69,7 @@
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/0"
+                "$ref": "#/spec/panels/zero"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/simple_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/simple_perses_dashboard.json
@@ -290,7 +290,7 @@
       }
     ],
     "panels": {
-      "0": {
+      "zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -340,7 +340,7 @@
           ]
         }
       },
-      "1": {
+      "one": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -388,7 +388,7 @@
           ]
         }
       },
-      "2": {
+      "two": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -445,7 +445,7 @@
           ]
         }
       },
-      "3": {
+      "three": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -503,7 +503,7 @@
           ]
         }
       },
-      "4_0": {
+      "four_zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -540,7 +540,7 @@
           ]
         }
       },
-      "4_1": {
+      "four_one": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -554,7 +554,7 @@
           }
         }
       },
-      "4_2": {
+      "four_two": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -580,7 +580,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0"
+                "$ref": "#/spec/panels/zero"
               }
             },
             {
@@ -589,7 +589,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1"
+                "$ref": "#/spec/panels/one"
               }
             },
             {
@@ -598,7 +598,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2"
+                "$ref": "#/spec/panels/two"
               }
             },
             {
@@ -607,7 +607,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3"
+                "$ref": "#/spec/panels/three"
               }
             }
           ]
@@ -629,7 +629,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/four_zero"
               }
             },
             {
@@ -638,7 +638,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/four_one"
               }
             },
             {
@@ -647,7 +647,7 @@
               "width": 6,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/four_two"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/stat_calc_undefined_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/stat_calc_undefined_perses_dashboard.json
@@ -12,7 +12,7 @@
       "name": "Stat panel with undefined reduceOptions"
     },
     "panels": {
-      "0": {
+      "zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -110,7 +110,7 @@
               "width": 6,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0"
+                "$ref": "#/spec/panels/zero"
               }
             }
           ]

--- a/internal/api/plugin/migrate/testdata/statushistory_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/statushistory_perses_dashboard.json
@@ -12,7 +12,7 @@
             "name": "status history"
         },
         "panels": {
-            "0": {
+            "one": {
                 "kind": "Panel",
                 "spec": {
                     "display": {
@@ -106,7 +106,7 @@
                             "width": 12,
                             "height": 8,
                             "content": {
-                                "$ref": "#/spec/panels/0"
+                                "$ref": "#/spec/panels/one"
                             }
                         }
                     ]

--- a/internal/api/plugin/migrate/testdata/tables_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/tables_perses_dashboard.json
@@ -25,7 +25,7 @@
       }
     ],
     "panels": {
-      "0": {
+      "zero": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -98,7 +98,7 @@
           ]
         }
       },
-      "1": {
+      "one": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -139,7 +139,7 @@
           ]
         }
       },
-      "2": {
+      "two": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -188,7 +188,7 @@
           ]
         }
       },
-      "3": {
+      "three": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -237,7 +237,7 @@
           ]
         }
       },
-      "4": {
+      "four": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -280,7 +280,7 @@
           ]
         }
       },
-      "5": {
+      "five": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -321,7 +321,7 @@
           ]
         }
       },
-      "6": {
+      "six": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -362,7 +362,7 @@
           ]
         }
       },
-      "7": {
+      "seven": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -411,7 +411,7 @@
           ]
         }
       },
-      "8": {
+      "eight": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -476,7 +476,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0"
+                "$ref": "#/spec/panels/zero"
               }
             },
             {
@@ -485,7 +485,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1"
+                "$ref": "#/spec/panels/one"
               }
             },
             {
@@ -494,7 +494,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2"
+                "$ref": "#/spec/panels/two"
               }
             },
             {
@@ -503,7 +503,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3"
+                "$ref": "#/spec/panels/three"
               }
             },
             {
@@ -512,7 +512,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4"
+                "$ref": "#/spec/panels/four"
               }
             },
             {
@@ -521,7 +521,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5"
+                "$ref": "#/spec/panels/five"
               }
             },
             {
@@ -530,7 +530,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6"
+                "$ref": "#/spec/panels/six"
               }
             },
             {
@@ -539,7 +539,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7"
+                "$ref": "#/spec/panels/seven"
               }
             },
             {
@@ -548,7 +548,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8"
+                "$ref": "#/spec/panels/eight"
               }
             }
           ]


### PR DESCRIPTION
# Description

When Migrating a Grafana dashboard to Perses, we currently create the panel names using the index of the panel in the lists. This causes issues in naming when exporting via CR, because it doesn't keep the quotes around the panel name. This PR changes the integers to their word form so they are considered strings.

Closes #3062

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).