### PR TITLE
[FEATURE] Unregister plugin from dev environment

### DIFF
--- a/internal/api/impl/v1/plugin/endpoint.go
+++ b/internal/api/impl/v1/plugin/endpoint.go
@@ -14,12 +14,14 @@
 package plugin
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	apiinterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/plugin"
 	"github.com/perses/perses/internal/api/route"
+	"github.com/perses/perses/internal/api/utils"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -41,6 +43,7 @@ func (e *endpoint) CollectRoutes(g *route.Group) {
 	group.GET("", e.List, true)
 	if e.enableDev {
 		group.POST("", e.PushDevPlugin, true)
+		group.DELETE(fmt.Sprintf("/:%s", utils.ParamName), e.DeleteDevPlugin, true)
 	}
 }
 
@@ -59,4 +62,16 @@ func (e *endpoint) PushDevPlugin(ctx echo.Context) error {
 		return apiinterface.HandleBadRequestError(err.Error())
 	}
 	return e.svc.LoadDevPlugin(list)
+}
+
+func (e *endpoint) DeleteDevPlugin(ctx echo.Context) error {
+	name := utils.GetNameParameter(ctx)
+	if len(name) == 0 {
+		return apiinterface.HandleBadRequestError("plugin name is required")
+	}
+	if err := e.svc.UnLoadDevPlugin(name); err != nil {
+		logrus.WithError(err).Errorf("unable to unload plugin %s", name)
+		return err
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }

--- a/internal/api/plugin/dev.go
+++ b/internal/api/plugin/dev.go
@@ -70,3 +70,16 @@ func (p *pluginFile) LoadDevPlugin(plugins []v1.PluginInDevelopment) error {
 	}
 	return p.storeLoadedList()
 }
+
+func (p *pluginFile) UnLoadDevPlugin(name string) error {
+	plg, ok := p.devLoaded[name]
+	if !ok {
+		return apiinterface.HandleNotFoundError(fmt.Sprintf("plugin %q not found in development mode", name))
+	}
+	p.mutex.Lock()
+	p.sch.UnloadDevPlugin(plg.Module)
+	p.mig.UnLoadDevPlugin(plg.Module)
+	delete(p.devLoaded, name)
+	p.mutex.Unlock()
+	return p.storeLoadedList()
+}

--- a/internal/api/plugin/migrate/panel.go
+++ b/internal/api/plugin/migrate/panel.go
@@ -88,7 +88,7 @@ func (m *completeMigration) migratePanel(grafanaPanel Panel) (*v1.Panel, error) 
 			return result, nil
 		}
 	}
-	panelPlugin, panelMigrationIsEmpty, err := executePanelMigrationScript(migrateScriptInstance, grafanaPanel.RawMessage)
+	panelPlugin, panelMigrationIsEmpty, err := executePanelMigrationScript(migrateScriptInstance.instance, grafanaPanel.RawMessage)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/plugin/plugin.go
+++ b/internal/api/plugin/plugin.go
@@ -43,6 +43,7 @@ type Loaded struct {
 type Plugin interface {
 	Load() error
 	LoadDevPlugin(plugins []v1.PluginInDevelopment) error
+	UnLoadDevPlugin(name string) error
 	List() ([]byte, error)
 	UnzipArchives() error
 	GetLoadedPlugin(name string) (*Loaded, bool)

--- a/internal/cli/cmd/plugin/start/start.go
+++ b/internal/cli/cmd/plugin/start/start.go
@@ -199,6 +199,14 @@ func (o *option) Execute() error {
 	}
 	// Wait for context to be canceled or tasks to be ended and wait for graceful stop
 	taskhelper.JoinAll(ctx, time.Second*30, devServerTasks)
+	// if the context is canceled, we need to unregister the plugin from the remote server
+	for _, plg := range pluginInDev {
+		if err := o.apiClient.V1().Plugin().UnLoadDevPlugin(plg.Name); err != nil {
+			logrus.WithError(err).Errorf("failed to unregister the plugin %q from the remote server", plg.Name)
+		} else {
+			logrus.Infof("plugin %q has been unregistered from the remote server", plg.Name)
+		}
+	}
 	return nil
 }
 

--- a/pkg/client/api/v1/plugin.go
+++ b/pkg/client/api/v1/plugin.go
@@ -22,6 +22,7 @@ const pluginResource = "plugins"
 
 type PluginInterface interface {
 	PushDevPlugin([]*v1.PluginInDevelopment) error
+	UnLoadDevPlugin(name string) error
 	List() ([]v1.PluginModule, error)
 }
 
@@ -40,6 +41,14 @@ func (c *plugin) PushDevPlugin(plugins []*v1.PluginInDevelopment) error {
 	return c.client.Post().
 		Resource(pluginResource).
 		Body(plugins).
+		Do().
+		Error()
+}
+
+func (c *plugin) UnLoadDevPlugin(name string) error {
+	return c.client.Delete().
+		Resource(pluginResource).
+		Name(name).
 		Do().
 		Error()
 }


### PR DESCRIPTION
This PR is providing a way to unregister a plugin from the dev environment.
This will happen when the command `percli plugin start` will be stopped. Before ending, the CLI will unregister every plugin started.

Like that, we don't need to restart the Perses server to get back/load back the plugin from the remove server.

Note: this PR must be merged after #3042 