### PR TITLE
[ENHANCEMENT] Check default plugin path instead of checking environment

### DIFF
--- a/pkg/model/api/config/plugin.go
+++ b/pkg/model/api/config/plugin.go
@@ -27,32 +27,9 @@ var (
 	DefaultArchivePluginPathInContainer = "/etc/perses/plugins-archive"
 )
 
-func isRunningInContainer() bool {
-	// This file exists when podman is used
-	if _, err := os.Stat("/run/.containerenv"); err == nil {
-		return true
-	}
-	// This file exists when docker is used
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-	return false
-}
-
-// isRunningInKubernetes checks if the application is running in a kubernetes cluster.
-// In this context, the function isRunningInContainer will always return false as the files `/run/.containerenv` and `/.dockerenv`
-// are not created in a kubernetes cluster.
-func isRunningInKubernetes() bool {
-	if _, err := os.Stat("/var/run/secrets/kubernetes.io"); err == nil {
-		return true
-	}
-	// In case the value automountServiceAccountToken is equal to false, then the directory `/var/run/secrets/kubernetes.io` will not be created.
-	// So another way to verify if the application is running in a kubernetes cluster is to check if the environment variable `KUBERNETES_SERVICE_HOST` is set.
-	// This variable is set only if the pod is running on a node as stamped in the documentation: https://kubernetes.io/docs/tutorials/services/connect-applications-service/#environment-variables.
-	if _, present := os.LookupEnv("KUBERNETES_SERVICE_HOST"); present {
-		return true
-	}
-	return false
+func isFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 type Plugin struct {
@@ -66,17 +43,20 @@ type Plugin struct {
 }
 
 func (p *Plugin) Verify() error {
-	runningInContainer := isRunningInContainer()
-	runningInKubernetes := isRunningInKubernetes()
+	// Initially, to determine the default paths, we were trying to check if the binary was running in a container.
+	// However, it was not reliable enough, there were cases where the binary was running in a container, but our checks failed.
+	// So now we just check if the default paths exist, and if they do, we use them as defaults.
+	// The fact Perses is running in a container is not useful information for the plugin configuration.
+	// The fact the path where the plugin is stored exists is more relevant.
 	if len(p.Path) == 0 {
-		if runningInContainer || runningInKubernetes {
+		if isFileExists(DefaultPluginPathInContainer) {
 			p.Path = DefaultPluginPathInContainer
 		} else {
 			p.Path = DefaultPluginPath
 		}
 	}
 	if len(p.ArchivePath) == 0 {
-		if runningInContainer || runningInKubernetes {
+		if isFileExists(DefaultArchivePluginPathInContainer) {
 			p.ArchivePath = DefaultArchivePluginPathInContainer
 		} else {
 			p.ArchivePath = DefaultArchivePluginPath


### PR DESCRIPTION
Initially, to determine the default paths, we were trying to check if the binary was running in a container.
However, it was not reliable enough, there were cases where the binary was running in a container, but our checks failed.
So now we just check if the default paths exist, and if they do, we use them as defaults.

The fact Perses is running in a container is not useful information for the plugin configuration.
The fact the path where the plugin is stored exists is more relevant.

fix #3067 