### PR TITLE
[FEATURE]: Decouple datasource provider from builing proxy url logic

### DIFF
--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -44,7 +44,7 @@ const GuardedProjectRoute = lazy(() => import('./guard/GuardedProjectRoute'));
 const ProjectView = lazy(() => import('./views/projects/ProjectView'));
 const CreateDashboardView = lazy(() => import('./views/projects/dashboards/CreateDashboardView'));
 const DashboardView = lazy(() => import('./views/projects/dashboards/DashboardView'));
-const ExploreView = lazy(() => import('./views/projects/explore/ExploreView'));
+const ExploreView = lazy(() => import('./views/explore/ExploreView'));
 const CreateEphemeralDashboardView = lazy(() => import('./views/projects/dashboards/CreateEphemeralDashboardView'));
 const EphemeralDashboardView = lazy(() => import('./views/projects/dashboards/EphemeralDashboardView'));
 const ProfileView = lazy(() => import('./views/profile/ProfileView'));

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -25,7 +25,7 @@ import {
 import { ReactElement, useMemo, useState } from 'react';
 import { DeleteResourceDialog } from '../dialogs';
 import { DrawerProps } from '../form-drawers';
-import { buildProxyUrl, useAllDatasourceResources } from '../../model/datasource-api';
+import { useAllDatasourceResources } from '../../model/datasource-api';
 
 interface VariableDrawerProps<T extends Variable> extends DrawerProps<T> {
   variable: T;
@@ -73,11 +73,7 @@ export function VariableDrawer<T extends Variable>({
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry pluginLoader={remotePluginLoader()}>
           <ValidationProvider>
-            <DatasourceStoreProvider
-              buildProxyUrl={buildProxyUrl}
-              datasources={allDatasources}
-              projectName={projectName}
-            >
+            <DatasourceStoreProvider datasources={allDatasources} projectName={projectName}>
               <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>
                 <VariableProviderWithQueryParams initialVariableDefinitions={[]}>
                   <VariableEditorForm

--- a/ui/app/src/model/url-builder.ts
+++ b/ui/app/src/model/url-builder.ts
@@ -42,5 +42,5 @@ export default function buildURL(params: URLParams): string {
   if (params.queryParams !== undefined) {
     url = `${url}?${params.queryParams.toString()}`;
   }
-  return basePath + url;
+  return `${basePath}${url}`;
 }

--- a/ui/app/src/views/explore/ExploreView.tsx
+++ b/ui/app/src/views/explore/ExploreView.tsx
@@ -13,7 +13,7 @@
 
 import Compass from 'mdi-material-ui/Compass';
 import { ReactElement } from 'react';
-import AppBreadcrumbs from '../../../components/breadcrumbs/AppBreadcrumbs';
+import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
 import ProjectExploreView from './ProjectExploreView';
 
 function ExploreView(): ReactElement {

--- a/ui/app/src/views/explore/ProjectExploreView.tsx
+++ b/ui/app/src/views/explore/ProjectExploreView.tsx
@@ -17,10 +17,10 @@ import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 import { ViewExplore } from '@perses-dev/explore';
 import { PluginRegistry, ProjectStoreProvider, useProjectStore, remotePluginLoader } from '@perses-dev/plugin-system';
 import React, { ReactElement, useMemo } from 'react';
-import { useGlobalVariableList } from '../../../model/global-variable-client';
-import { useVariableList } from '../../../model/variable-client';
-import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
-import { buildProxyUrl, useAllDatasourceResources } from '../../../model/datasource-api';
+import { useGlobalVariableList } from '../../model/global-variable-client';
+import { useVariableList } from '../../model/variable-client';
+import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../utils/variables';
+import { useAllDatasourceResources } from '../../model/datasource-api';
 
 export interface ProjectExploreViewProps {
   exploreTitleComponent?: React.ReactNode;
@@ -65,7 +65,6 @@ function HelperExploreView(props: ProjectExploreViewProps): ReactElement {
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <ViewExplore
             datasources={allDatasources}
-            buildProxyUrl={buildProxyUrl}
             externalVariableDefinitions={externalVariableDefinitions}
             exploreTitleComponent={exploreTitleComponent}
           />

--- a/ui/core/src/model/datasource.ts
+++ b/ui/core/src/model/datasource.ts
@@ -19,6 +19,7 @@ export interface DatasourceSpec<PluginSpec = UnknownSpec> {
   display?: Display;
   default: boolean;
   plugin: Definition<PluginSpec>;
+  proxyUrl?: string;
 }
 
 export interface GenericDatasourceResource {

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -26,12 +26,7 @@ import {
   usePluginBuiltinVariableDefinitions,
 } from '@perses-dev/plugin-system';
 import { ReactElement, useMemo } from 'react';
-import {
-  BuildDatasourceProxyUrlFunc,
-  DatasourceStoreProvider,
-  VariableProviderProps,
-  VariableProviderWithQueryParams,
-} from '../../context';
+import { DatasourceStoreProvider, VariableProviderProps, VariableProviderWithQueryParams } from '../../context';
 import { DashboardProviderWithQueryParams } from '../../context/DashboardProvider/DashboardProviderWithQueryParams';
 import { DashboardApp, DashboardAppProps } from './DashboardApp';
 
@@ -40,7 +35,6 @@ export interface ViewDashboardProps extends Omit<BoxProps, 'children'>, Dashboar
   isEditing?: boolean;
   isCreating?: boolean;
   datasources: GenericDatasourceResource[];
-  buildProxyUrl: BuildDatasourceProxyUrlFunc;
 }
 
 /**
@@ -55,7 +49,6 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
     datasources,
     onSave,
     onDiscard,
-    buildProxyUrl,
     initialVariableIsSticky,
     isReadonly,
     isVariableEnabled,
@@ -108,11 +101,7 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
   }, [dashboardResource.metadata.name, dashboardResource.metadata.project, data]);
 
   return (
-    <DatasourceStoreProvider
-      buildProxyUrl={buildProxyUrl}
-      dashboardResource={dashboardResource}
-      datasources={datasources}
-    >
+    <DatasourceStoreProvider dashboardResource={dashboardResource} datasources={datasources}>
       <DashboardProviderWithQueryParams
         initialState={{
           dashboardResource,

--- a/ui/explore/src/views/ViewExplore/ViewExplore.tsx
+++ b/ui/explore/src/views/ViewExplore/ViewExplore.tsx
@@ -19,12 +19,7 @@ import {
 } from '@perses-dev/plugin-system';
 import { DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL, GenericDatasourceResource } from '@perses-dev/core';
 import { ErrorAlert, ErrorBoundary, combineSx } from '@perses-dev/components';
-import {
-  VariableProviderProps,
-  DatasourceStoreProvider,
-  VariableProvider,
-  BuildDatasourceProxyUrlFunc,
-} from '@perses-dev/dashboards';
+import { VariableProviderProps, DatasourceStoreProvider, VariableProvider } from '@perses-dev/dashboards';
 import React, { ReactElement } from 'react';
 import { ViewExploreApp } from './ViewExploreApp';
 
@@ -32,17 +27,16 @@ export interface ViewExploreProps extends Omit<BoxProps, 'children'> {
   externalVariableDefinitions?: VariableProviderProps['externalVariableDefinitions'];
   exploreTitleComponent?: React.ReactNode;
   datasources: GenericDatasourceResource[];
-  buildProxyUrl: BuildDatasourceProxyUrlFunc;
 }
 
 export function ViewExplore(props: ViewExploreProps): ReactElement {
-  const { externalVariableDefinitions, datasources, buildProxyUrl, sx, exploreTitleComponent, ...others } = props;
+  const { externalVariableDefinitions, datasources, sx, exploreTitleComponent, ...others } = props;
 
   const initialTimeRange = useInitialTimeRange(DEFAULT_DASHBOARD_DURATION);
   const initialRefreshInterval = useInitialRefreshInterval(DEFAULT_REFRESH_INTERVAL);
 
   return (
-    <DatasourceStoreProvider datasources={datasources} buildProxyUrl={buildProxyUrl}>
+    <DatasourceStoreProvider datasources={datasources}>
       <TimeRangeProviderWithQueryParams
         initialTimeRange={initialTimeRange}
         initialRefreshInterval={initialRefreshInterval}


### PR DESCRIPTION
# Description

Relates to #3059 
This PR pulls the datasource build proxy URL logic out of the Data Source Provider properties. 
Every single data source should carry a concrete proxy URL. It means, building the proxy URL is the responsibility of the consumer.  

# How To Test? 🧪

- [x] You should be able to run your queries for valid data sources in explore view  
- [x] Your dashboards and their relevant panels should work as expected
- [x] Variable drawer should show relevant datasources




# Screenshots
**_This is a refactor_**

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
