### PR TITLE
[BUGFIX] After selecting a project in import dashboard import button stays disabled until clicked outside

### DIFF
--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -128,16 +128,12 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
           <Stack width="100%" gap={1}>
             <Autocomplete
               disablePortal
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  required
-                  label="Project name"
-                  onBlur={(event) => {
-                    setProjectName(event.target.value);
-                  }}
-                />
-              )}
+              onChange={(event, value) => {
+                if (value) {
+                  setProjectName(value);
+                }
+              }}
+              renderInput={(params) => <TextField {...params} required label="Project name" />}
               options={data.map((project) => {
                 return project.metadata.name;
               })}


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

I was importing a grafana dashboard from json. When I select a project after migrating the import button was disabled I was wondering why checked everything again and changed project still no 
Then clicked outside of the select box and suddenly it's enabled

Closes the following [issue](https://github.com/perses/perses/issues/3082)

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
