### PR TITLE
[BREAKINGCHANGE] DatasourceProvider: decouple datasource provider and dashboard datasource

### DIFF
--- a/ui/app/jest.setup.ts
+++ b/ui/app/jest.setup.ts
@@ -11,9 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import shared from '../jest.shared';
-
-export default {
-  ...shared,
-  setupFilesAfterEnv: ['./jest.setup.ts'],
-};
+/// <reference types="jest" />
+jest.mock('echarts', () => ({
+  use: jest.fn(),
+  init: jest.fn(() => ({
+    setOption: jest.fn(),
+    dispose: jest.fn(),
+    resize: jest.fn(),
+  })),
+}));

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@rspack/cli": "^1.2.2",
     "@rspack/core": "^1.2.2",
-    "@rspack/plugin-react-refresh": "^1.0.1"
+    "@rspack/plugin-react-refresh": "^1.0.1",
+    "@types/jest": "^30.0.0"
   }
 }

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -23,6 +23,7 @@ import {
   remotePluginLoader,
 } from '@perses-dev/plugin-system';
 import { ReactElement, useMemo, useState } from 'react';
+import { CircularProgress, Stack } from '@mui/material';
 import { DeleteResourceDialog } from '../dialogs';
 import { DrawerProps } from '../form-drawers';
 import { useAllDatasourceResources } from '../../model/datasource-api';
@@ -73,22 +74,28 @@ export function VariableDrawer<T extends Variable>({
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry pluginLoader={remotePluginLoader()}>
           <ValidationProvider>
-            <DatasourceStoreProvider datasources={allDatasources} projectName={projectName}>
-              <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>
-                <VariableProviderWithQueryParams initialVariableDefinitions={[]}>
-                  <VariableEditorForm
-                    initialVariableDefinition={variableDef}
-                    action={action}
-                    isDraft={false}
-                    isReadonly={isReadonly}
-                    onActionChange={onActionChange}
-                    onSave={handleSave}
-                    onClose={onClose}
-                    onDelete={onDelete ? (): void => setDeleteVariableDialogStateOpened(true) : undefined}
-                  />
-                </VariableProviderWithQueryParams>
-              </TimeRangeProviderWithQueryParams>
-            </DatasourceStoreProvider>
+            {allDatasources.isLoading ? (
+              <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
+                <CircularProgress />
+              </Stack>
+            ) : (
+              <DatasourceStoreProvider datasources={allDatasources.datasources} projectName={projectName}>
+                <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>
+                  <VariableProviderWithQueryParams initialVariableDefinitions={[]}>
+                    <VariableEditorForm
+                      initialVariableDefinition={variableDef}
+                      action={action}
+                      isDraft={false}
+                      isReadonly={isReadonly}
+                      onActionChange={onActionChange}
+                      onSave={handleSave}
+                      onClose={onClose}
+                      onDelete={onDelete ? (): void => setDeleteVariableDialogStateOpened(true) : undefined}
+                    />
+                  </VariableProviderWithQueryParams>
+                </TimeRangeProviderWithQueryParams>
+              </DatasourceStoreProvider>
+            )}
           </ValidationProvider>
         </PluginRegistry>
         {onDelete && (

--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -12,19 +12,34 @@
 // limitations under the License.
 
 import { useMemo } from 'react';
-import { GenericDatasourceResource, GenericMetadata } from '@perses-dev/core';
+import {
+  DashboardResource,
+  DatasourceResource,
+  EphemeralDashboardResource,
+  GenericDatasourceResource,
+  GenericMetadata,
+  GlobalDatasourceResource,
+} from '@perses-dev/core';
 import { useDatasourceList } from './datasource-client';
 import { useGlobalDatasourceList } from './global-datasource-client';
 import { getBasePathName } from './route';
+import { useDashboard } from './dashboard-client';
+import { useEphemeralDashboard } from './ephemeral-dashboard-client';
 
 interface DataSourceFilter {
   project?: string;
+  dashboard?: string;
 }
 
 interface ProxyBuilderParam {
   project?: string;
   dashboard?: string;
   name: string;
+}
+
+export interface AllDatasources {
+  datasources: GenericDatasourceResource[];
+  isLoading: boolean;
 }
 
 export const buildProxyUrl = ({ project, dashboard, name }: ProxyBuilderParam): string => {
@@ -44,8 +59,8 @@ export const buildProxyUrl = ({ project, dashboard, name }: ProxyBuilderParam): 
  * to filter the projects datasources
  * @param filter Filters the project datasources
  */
-export const useAllDatasourceResources = (filter?: DataSourceFilter): GenericDatasourceResource[] => {
-  const { project } = filter || {};
+export const useAllDatasourceResources = (filter?: DataSourceFilter): AllDatasources => {
+  const { project, dashboard } = filter || {};
 
   const { data: datasources, isLoading: isDatasourceLoading, error: datasourceError } = useDatasourceList({ project });
   const {
@@ -54,27 +69,96 @@ export const useAllDatasourceResources = (filter?: DataSourceFilter): GenericDat
     error: globalDatasourceError,
   } = useGlobalDatasourceList();
 
-  if (globalDatasourceError || datasourceError) {
-    throw new Error('Could not fetch all datasources');
-  }
+  const {
+    data: dashboardResource,
+    isLoading: isDashboardRecourseLoading,
+    error: dashboardResourceError,
+  } = useDashboard(project || '', dashboard || '');
 
-  const allDatasources = useMemo(() => {
-    if (isDatasourceLoading || isGlobalDatasourceLoading) return [];
-    return [
-      ...globalDatasources.map<GenericDatasourceResource>((gds) => ({
+  const {
+    data: ephemeralResource,
+    isLoading: isEphemeralLoading,
+    error: ephemeralError,
+  } = useEphemeralDashboard(project || '', dashboard || '');
+
+  /*
+    It is likely that for a combination of input filters either of 401, 403, and 404 is thrown. Remember this hook is TRYING to get all datasources.
+    Therefore, these exception are expected, and should not stop the process. 
+  */
+  const anyError = [datasourceError, globalDatasourceError, dashboardResourceError, ephemeralError]
+    .filter((err) => err)
+    .map((err) => err?.status)
+    .filter((status) => status && ![401, 403, 404].includes(status))
+    .some((status) => status && status >= 400);
+  if (anyError) throw new Error('Critical error occurred while fetching datasource resources');
+
+  const allDatasources = useMemo((): AllDatasources => {
+    if (isGlobalDatasourceLoading || isDashboardRecourseLoading || isEphemeralLoading || isDatasourceLoading) {
+      return { isLoading: true, datasources: [] };
+    }
+
+    const processGlobalDatasources = (globalDatasources: GlobalDatasourceResource[]): GenericDatasourceResource[] => {
+      return (globalDatasources || []).map<GenericDatasourceResource>((gds) => ({
         ...(gds as GenericDatasourceResource),
         spec: { ...gds.spec, proxyUrl: buildProxyUrl({ name: gds.metadata.name }) },
-      })),
-      ...datasources.map<GenericDatasourceResource>((ds) => ({
+      }));
+    };
+
+    const processProjectDatasources = (datasources: DatasourceResource[]): GenericDatasourceResource[] => {
+      return (datasources || []).map<GenericDatasourceResource>((ds) => ({
         ...ds,
         spec: { ...ds.spec, proxyUrl: buildProxyUrl({ name: ds.metadata.name, project: ds.metadata.project }) },
         metadata: {
           ...ds.metadata,
           project: ds.metadata.project,
         } as unknown as GenericMetadata,
-      })),
-    ];
-  }, [datasources, globalDatasources, isDatasourceLoading, isGlobalDatasourceLoading]);
+      }));
+    };
 
-  return allDatasources as GenericDatasourceResource[];
+    const processDashboardDatasources = (
+      dashboardResource?: DashboardResource,
+      ephemeralResource?: EphemeralDashboardResource
+    ): GenericDatasourceResource[] => {
+      const allDashboardDatasources = [
+        ...Object.entries(dashboardResource?.spec?.datasources || []).map<GenericDatasourceResource>(
+          ([name, spec]) =>
+            ({
+              kind: 'Dashboard',
+              metadata: { name },
+              spec,
+            }) as GenericDatasourceResource
+        ),
+        ...Object.entries(ephemeralResource?.spec?.datasources || []).map<GenericDatasourceResource>(
+          ([name, spec]) =>
+            ({
+              kind: 'Dashboard',
+              metadata: { name },
+              spec,
+            }) as GenericDatasourceResource
+        ),
+      ];
+
+      return allDashboardDatasources;
+    };
+
+    return {
+      isLoading: false,
+      datasources: [
+        ...processGlobalDatasources(globalDatasources || []),
+        ...processProjectDatasources(datasources || []),
+        ...processDashboardDatasources(dashboardResource, ephemeralResource),
+      ],
+    };
+  }, [
+    datasources,
+    isDatasourceLoading,
+    globalDatasources,
+    isGlobalDatasourceLoading,
+    dashboardResource,
+    isDashboardRecourseLoading,
+    ephemeralResource,
+    isEphemeralLoading,
+  ]);
+
+  return allDatasources;
 };

--- a/ui/app/src/views/explore/ProjectExploreView.tsx
+++ b/ui/app/src/views/explore/ProjectExploreView.tsx
@@ -42,7 +42,7 @@ function HelperExploreView(props: ProjectExploreViewProps): ReactElement {
   // Collect the Project variables and setup external variables from it
   const { data: globalVars, isLoading: isLoadingGlobalVars } = useGlobalVariableList();
   const { data: projectVars, isLoading: isLoadingProjectVars } = useVariableList(projectName);
-  const allDatasources = useAllDatasourceResources();
+  const { datasources: allDatasources, isLoading: isAllDatasourcesLoading } = useAllDatasourceResources();
   const externalVariableDefinitions: ExternalVariableDefinition[] | undefined = useMemo(
     () => [
       buildProjectVariableDefinition(projectName || '', projectVars ?? []),
@@ -51,7 +51,7 @@ function HelperExploreView(props: ProjectExploreViewProps): ReactElement {
     [projectName, projectVars, globalVars]
   );
 
-  if (isLoadingProjectVars || isLoadingGlobalVars) {
+  if (isLoadingProjectVars || isLoadingGlobalVars || isAllDatasourcesLoading) {
     return (
       <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
         <CircularProgress />

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -80,7 +80,10 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
 
   const isLocalDatasourceEnabled = useIsLocalDatasourceEnabled();
   const isLocalVariableEnabled = useIsLocalVariableEnabled();
-  const allDatasources = useAllDatasourceResources({ project: dashboardResourceWithProxy.metadata.project });
+  const { datasources: allDatasources, isLoading: isAllDatasourcesLoading } = useAllDatasourceResources({
+    project: dashboardResourceWithProxy.metadata.project,
+    dashboard: dashboardResourceWithProxy.metadata.name,
+  });
   // Collect the Project variables and setup external variables from it
   const { data: project, isLoading: isLoadingProject } = useProject(dashboardResourceWithProxy.metadata.project);
   const { data: globalVars, isLoading: isLoadingGlobalVars } = useGlobalVariableList();
@@ -95,7 +98,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
     [dashboardResourceWithProxy, projectVars, globalVars]
   );
 
-  if (isLoadingProject || isLoadingProjectVars || isLoadingGlobalVars) {
+  if (isLoadingProject || isLoadingProjectVars || isLoadingGlobalVars || isAllDatasourcesLoading) {
     return (
       <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
         <CircularProgress />

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -35,6 +35,7 @@
     "@types/react-grid-layout": "^1.3.2",
     "date-fns": "^4.1.0",
     "immer": "^10.1.1",
+    "lodash": "^4.17.21",
     "mdi-material-ui": "^7.9.2",
     "react-grid-layout": "^1.3.4",
     "react-hook-form": "^7.46.1",

--- a/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
+++ b/ui/dashboards/src/components/EditJsonDialog/EditJsonDialog.tsx
@@ -49,7 +49,13 @@ const EditJsonDialogForm = (props: EditJsonDialogProps): ReactElement => {
     setDashboard(draftDashboard);
     setTimeRange({ pastDuration: draftDashboard.spec.duration });
     setRefreshInterval(draftDashboard.spec.refreshInterval ?? '0s');
-    setLocalDatasources(draftDashboard.spec.datasources ?? {});
+    setLocalDatasources(
+      Object.entries(draftDashboard?.spec?.datasources || []).map(([name, spec]) => ({
+        kind: 'Dashboard',
+        metadata: { name },
+        spec,
+      }))
+    );
     closeEditJsonDialog();
   };
 

--- a/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
+++ b/ui/dashboards/src/context/DatasourceStoreProvider.test.tsx
@@ -24,8 +24,6 @@ import { DatasourceStoreProvider } from '@perses-dev/dashboards';
 import { PropsWithChildren, ReactElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
-  DashboardResource,
-  DashboardSpec,
   Datasource,
   DatasourceSpec,
   GlobalDatasourceResource,
@@ -496,17 +494,19 @@ describe('DatasourceStoreProvider::useListDatasourceSelectItems', () => {
     const mockDatasources: GenericDatasourceResource[] = [
       ...(data.input.datasources.global as GenericDatasourceResource[]),
       ...(data.input.datasources.project as GenericDatasourceResource[]),
+      ...Object.entries(data.input.datasources.local || []).map<GenericDatasourceResource>(([name, spec]) => ({
+        kind: 'Dashboard',
+        metadata: { name },
+        spec: spec as DatasourceSpec,
+      })),
     ];
     const queryClient = new QueryClient();
-    const dashboard = {
-      spec: { datasources: data.input.datasources.local } as Partial<DashboardSpec>,
-    } as DashboardResource;
+
     const wrapper = ({ children }: PropsWithChildren): ReactElement => {
       return (
         <PluginRegistry {...mockPluginRegistry(MOCK_DS_PLUGIN)}>
           <QueryClientProvider client={queryClient}>
             <DatasourceStoreProvider
-              dashboardResource={dashboard}
               projectName={PROJECT}
               datasources={mockDatasources}
               savedDatasources={

--- a/ui/dashboards/src/test/datasource-provider.tsx
+++ b/ui/dashboards/src/test/datasource-provider.tsx
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import { GlobalDatasourceResource } from '@perses-dev/core';
-import { DatasourceStoreProviderProps } from '../context';
-import { getTestDashboard } from './dashboard-provider';
+// import { DatasourceStoreProviderProps } from '../context';
+// import { getTestDashboard } from './dashboard-provider';
 
 export const prometheusDemoUrl = 'https://prometheus.demo.prometheus.io';
 export const prometheusDemo: GlobalDatasourceResource = {
@@ -36,6 +36,6 @@ export const prometheusDemo: GlobalDatasourceResource = {
 // This default currently defines the bare minimum to get a story working in
 // the `Dashboard` storybook with the Prometheus demo api. We'll likely want
 // to expand it to do more in the future.
-export const defaultDatasourceProps: Pick<DatasourceStoreProviderProps, 'dashboardResource'> = {
-  dashboardResource: getTestDashboard(),
-};
+// export const defaultDatasourceProps: Pick<DatasourceStoreProviderProps, 'dashboardResource'> = {
+//   dashboardResource: getTestDashboard(),
+// };

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -101,7 +101,7 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
   }, [dashboardResource.metadata.name, dashboardResource.metadata.project, data]);
 
   return (
-    <DatasourceStoreProvider dashboardResource={dashboardResource} datasources={datasources}>
+    <DatasourceStoreProvider datasources={datasources}>
       <DashboardProviderWithQueryParams
         initialState={{
           dashboardResource,

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -16,16 +16,13 @@ import userEvent from '@testing-library/user-event';
 import { TimeRangeProvider } from '@perses-dev/plugin-system';
 import { GenericDatasourceResource } from '@perses-dev/core';
 import { DashboardProvider, DatasourceStoreProvider, VariableProvider } from '../../../context';
-import { defaultDatasourceProps, getTestDashboard, prometheusDemo, renderWithContext } from '../../../test';
+import { getTestDashboard, prometheusDemo, renderWithContext } from '../../../test';
 import { DashboardApp } from '../DashboardApp';
 
 describe('Panel Groups', () => {
   const renderDashboard = (): void => {
     renderWithContext(
-      <DatasourceStoreProvider
-        datasources={[prometheusDemo] as GenericDatasourceResource[]}
-        {...defaultDatasourceProps}
-      >
+      <DatasourceStoreProvider datasources={[prometheusDemo] as GenericDatasourceResource[]}>
         <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
           <VariableProvider>
             <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>

--- a/ui/e2e/src/fixtures/dashboardTest.ts
+++ b/ui/e2e/src/fixtures/dashboardTest.ts
@@ -94,6 +94,8 @@ const IGNORE_CONSOLE_ERRORS = [
   // See https://github.com/emotion-js/emotion/issues/1105
   'potentially unsafe when doing server-side rendering',
   'MUI X: useResizeContainer - The parent DOM element of the Data Grid has an empty height.',
+  /* TODO: This exception is expected from ephemeral dashboard. We need to find a clean way to avoid such a request when running Playwright dashboard tests  */
+  'Failed to load resource: the server responded with a status of 404 (Not Found)',
 ];
 function shouldIgnoreConsoleError(message: ConsoleMessage): boolean {
   const msgText = message.text();
@@ -156,6 +158,7 @@ export const test = testBase.extend<DashboardTestOptions & DashboardTestFixtures
     const persesApp = new AppHomePage(page);
 
     const consoleErrors: string[] = [];
+
     page.on('console', (msg) => {
       if (msg.type() === 'error' && !shouldIgnoreConsoleError(msg)) {
         // Watch for console errors because they are often a sign that something

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -98,8 +98,240 @@
       "devDependencies": {
         "@rspack/cli": "^1.2.2",
         "@rspack/core": "^1.2.2",
-        "@rspack/plugin-react-refresh": "^1.0.1"
+        "@rspack/plugin-react-refresh": "^1.0.1",
+        "@types/jest": "^30.0.0"
       }
+    },
+    "app/node_modules/@jest/expect-utils": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.4.tgz",
+      "integrity": "sha512-EgXecHDNfANeqOkcak0DxsoVI4qkDUsR7n/Lr2vtmTBjwLPBnnPOF71S11Q8IObWzxm2QgQoY6f9hzrRD3gHRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/@jest/schemas": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
+      "integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/@jest/types": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
+      "integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/@sinclair/typebox": {
+      "version": "0.34.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
+      "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "app/node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "app/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "app/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "app/node_modules/expect": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.4.tgz",
+      "integrity": "sha512-dDLGjnP2cKbEppxVICxI/Uf4YemmGMPNy0QytCbfafbpYk9AFQsxb8Uyrxii0RPK7FWgLGlSem+07WirwS3cFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.0.4",
+        "@jest/get-type": "30.0.1",
+        "jest-matcher-utils": "30.0.4",
+        "jest-message-util": "30.0.2",
+        "jest-mock": "30.0.2",
+        "jest-util": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/jest-diff": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.4.tgz",
+      "integrity": "sha512-TSjceIf6797jyd+R64NXqicttROD+Qf98fex7CowmlSn7f8+En0da1Dglwr1AXxDtVizoxXYZBlUQwNhoOXkNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/jest-matcher-utils": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.4.tgz",
+      "integrity": "sha512-ubCewJ54YzeAZ2JeHHGVoU+eDIpQFsfPQs0xURPWoNiO42LGJ+QGgfSf+hFIRplkZDkhH5MOvuxHKXRTUU3dUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.0.4",
+        "pretty-format": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/jest-message-util": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.2.tgz",
+      "integrity": "sha512-vXywcxmr0SsKXF/bAD7t7nMamRvPuJkras00gqYeB1V0WllxZrbZ0paRr3XqpFU2sYYjD0qAaG2fRyn/CGZ0aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/jest-mock": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.2.tgz",
+      "integrity": "sha512-PnZOHmqup/9cT/y+pXIVbbi8ID6U1XHRmbvR7MvUy4SLqhCbwpkmXhLbsWbGewHrV5x/1bF7YDjs+x24/QSvFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.1",
+        "@types/node": "*",
+        "jest-util": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/jest-util": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.2.tgz",
+      "integrity": "sha512-8IyqfKS4MqprBuUpZNlFB5l+WFehc8bfCe1HSZFHzft2mOuND8Cvi9r1musli+u6F3TqanCZ/Ik4H4pXUolZIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "app/node_modules/pretty-format": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
+      "integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.1",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "app/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "components": {
       "name": "@perses-dev/components",
@@ -163,6 +395,7 @@
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^4.1.0",
         "immer": "^10.1.1",
+        "lodash": "^4.17.21",
         "mdi-material-ui": "^7.9.2",
         "react-grid-layout": "^1.3.4",
         "react-hook-form": "^7.46.1",
@@ -300,14 +533,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -471,9 +704,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2150,6 +2383,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2211,6 +2454,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2225,6 +2478,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {

--- a/ui/plugin-system/src/runtime/datasources.ts
+++ b/ui/plugin-system/src/runtime/datasources.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DatasourceSelector, DatasourceSpec } from '@perses-dev/core';
+import { DatasourceSelector, DatasourceSpec, GenericDatasourceResource } from '@perses-dev/core';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { createContext, useContext } from 'react';
 
@@ -30,24 +30,30 @@ export interface DatasourceStore {
   listDatasourceSelectItems(datasourcePluginName: string): Promise<DatasourceSelectItemGroup[]>;
 
   /**
-   * Gets the list of datasources defined in the dashboard
-   */
-  getLocalDatasources(): Record<string, DatasourceSpec>;
-
-  /**
-   * Sets the list of datasources defined in the dashboard
-   */
-  setLocalDatasources(datasources: Record<string, DatasourceSpec>): void;
-
-  /**
    * Gets the list of datasources that are available in the dashboard (i.e. dashboards that have been created on the server side that we can use).
    */
   getSavedDatasources(): Record<string, DatasourceSpec>;
 
   /**
+   * Tries to find and retrieve a cloned array of datasources available in the provider
+   */
+  queryDatasources(selector: DatasourceSelector): GenericDatasourceResource[];
+
+  /**
    * Sets the list of datasources that are saved in the dashboard
    */
   setSavedDatasources(datasources: Record<string, DatasourceSpec>): void;
+
+  /**
+   * Sets a local temporary of datasources that are injected into the store.
+   * This is used to have some temporary datasources that are not saved in the dashboard yet.
+   */
+  setLocalDatasources(newLocalDatasources: GenericDatasourceResource[]): void;
+
+  /**
+   * Retrieves the cloned set of local datasources
+   */
+  getLocalDatasources(): GenericDatasourceResource[];
 }
 
 export interface DatasourceSelectItemGroup {


### PR DESCRIPTION
# Description

Relates to #3059 
This PR removes the the `dashboardResource` prop from the data source provider. The `dashboardResource` prop used to be a way to override the persisted datasources which would be served from the provider.  This idea used to be useful, because it gave the developers the opportunity to temporarily override the current datasources and test and use them in the dashboards. 

However, from the provider point of view, a datasource should always be a datasource regardless of its origin. That is why we came up with the idea of the Generic Data Source (@Gladorme) This idea keep the provider super flexible and this means the components which are wrapped by this provider can be used in other applications. Therefore, the notion of dashboardResource should be removed. 

To achieve this goal, the PR removes the mentioned prop, but it provides a functionality by which a temporary set of data sources can be served along the persisted datasouces. 


# Test

> :warning:
>Please Test Carefully!

Please check the following components or views and make sure the data source provider is working fine

- [ ] Explorer View - You should be able to run your query over a specific valid datasource
- [ ] Variable Drawers - You should be able to see all valid datasource and select them
- [ ] Dashboard View - Open a valid dashboard connected to a valid ds and check if your panels are working as expected
- [ ] Dashboard => Data source Edit mode - You should be able to edit local ds, if they are valid, they would override others
- [ ] Dashboard => Data source Edit mode => Apply Local Data source
- [ ] Dashboard => Data source Edit mode => Apply Local Data source => Then remove it
- [ ] Dashboard => Data source Edit mode => Apply Local Data source => Save (Should reload if the save is successful)
- [ ]  Dashboard => Data source Edit mode => Apply Local Data source => Save and fully refresh

# Screenshots

<img width="1054" height="673" alt="image" src="https://github.com/user-attachments/assets/fe1ab009-6729-467a-81d1-c3f22d3181e1" />

<img width="1263" height="946" alt="image" src="https://github.com/user-attachments/assets/2014b26d-3b78-4722-8891-2c0d57b0be3e" />

<img width="1980" height="758" alt="image" src="https://github.com/user-attachments/assets/46141df6-d7da-45fe-9c28-e6c91a20ad7a" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
