### PR TITLE
[ENHANCEMENT] PluginsList: sort plugins

### DIFF
--- a/ui/app/src/views/config/PluginsList.tsx
+++ b/ui/app/src/views/config/PluginsList.tsx
@@ -13,7 +13,7 @@
 
 import { Box, Card, CardContent, Typography, Divider, Button } from '@mui/material';
 import Grid from '@mui/material/Grid2';
-import { ReactElement, useState } from 'react';
+import { ReactElement, useMemo, useState } from 'react';
 import { PluginModuleResource } from '@perses-dev/plugin-system';
 import { useSnackbar } from '@perses-dev/components';
 import { usePlugins } from '../../model/plugin-client';
@@ -25,6 +25,10 @@ export function PluginsList(): ReactElement {
   const { exceptionSnackbar } = useSnackbar();
 
   const { data: pluginModules, isLoading, error } = usePlugins();
+
+  const sortedPluginModules = useMemo(() => {
+    return (pluginModules ?? []).toSorted((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+  }, [pluginModules]);
 
   if (isLoading || pluginModules === undefined) {
     return <PersesLoader />;
@@ -45,7 +49,7 @@ export function PluginsList(): ReactElement {
   return (
     <Box sx={{ p: 2 }}>
       <Grid container spacing={3}>
-        {pluginModules.map((pluginModule) => (
+        {sortedPluginModules.map((pluginModule) => (
           <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }} key={pluginModule.metadata.name}>
             <Card elevation={2} sx={{ height: '100%' }}>
               <CardContent>


### PR DESCRIPTION
# Description

The order of plugins returned by `usePlugins()` is not deterministic (i.e. changes with every restart of the Perses backend), so let's sort them alphabetically in the UI.

# Screenshots

<img width="3838" height="1338" alt="image" src="https://github.com/user-attachments/assets/e4ff78b8-2512-44a1-a54a-9bc005c3236d" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
