### PR TITLE
[ignore] avoid checking datatracker url in doc as it returns a 403

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -8,6 +8,9 @@ validators:
   # somehow stackoverflow is returning also a status code 403
   - regex: 'stackoverflow\.com'
     type: 'ignore'
+  # datatracker is now returning a 403 error, while when you visit the page it works.
+  - regex: 'datatracker\.ietf\.org'
+    type: 'ignore'
   # context timeout
   - regex: 'mui\.com'
     type: 'ignore'


### PR DESCRIPTION
datatracker is the website referencing all RFC and it now returns a 403 when GitHub is checking the URL. Perphaps GitHub has been blacklisted