### PR TITLE
[BUGFIX] UI: remove cookies on token refresh fail

### DIFF
--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -164,9 +164,9 @@ function Router(): ReactElement {
  */
 function RequireAuth({ children }: { children: ReactElement }): ReactElement | null {
   const isAuthEnabled = useIsAuthEnabled();
-  const isAuthenticated = useIsAccessTokenExist(isAuthEnabled);
+  const isAccessTokenExist = useIsAccessTokenExist();
   const location = useLocation();
-  if (!isAuthEnabled || isAuthenticated) {
+  if (!isAuthEnabled || isAccessTokenExist) {
     return children;
   }
   let to = SignInRoute;

--- a/ui/app/src/context/Authorization.tsx
+++ b/ui/app/src/context/Authorization.tsx
@@ -33,20 +33,20 @@ const AuthorizationContext = createContext<AuthorizationContext | undefined>(und
 // Provide RBAC helpers for checking current user permissions
 export function AuthorizationProvider(props: { children: ReactNode }): ReactElement {
   const enabled = useIsAuthEnabled();
-  const { data: decodedToken } = useAuthToken();
-  const username = decodedToken?.sub || '';
-  const { data } = useUserPermissions(username);
-  const userPermissions = useMemo(() => {
-    if (!data) {
-      return {} as Record<string, Permission[]>;
-    }
-    return data;
-  }, [data]);
-
   if (enabled) {
     // Will refresh the access token if it has expired when fetching data
     enableRefreshFetch();
   }
+
+  const { data: decodedToken } = useAuthToken();
+  const username = decodedToken?.sub || '';
+  const { data } = useUserPermissions(username);
+  const userPermissions: Record<string, Permission[]> = useMemo(() => {
+    if (!data) {
+      return {};
+    }
+    return data;
+  }, [data]);
 
   return (
     <AuthorizationContext.Provider value={{ enabled, username, userPermissions }}>

--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -30,16 +30,8 @@ export interface NativeAuthBody {
   password: string;
 }
 
-export function useIsAccessTokenExist(isAuthEnabled: boolean): boolean {
+export function useIsAccessTokenExist(): boolean {
   const [cookies] = useCookies();
-  const accessToken = useAuthToken();
-
-  // Warm the access token request cache back
-  // If the refresh token is not expired, the debounce mechanism will get the refreshed accedd token.
-  // Otherwise, debounce will let pass the empty access token and auth guard will redirect to sign in.
-  if (isAuthEnabled && (!accessToken?.data?.exp || accessToken.data.exp > new Date())) {
-    refreshToken();
-  }
 
   // Don't directly say "false" when cookie disappear as it's removed/recreated directly by refresh mechanism.
   const [debouncedValue, setDebouncedValue] = useState(cookies);

--- a/ui/app/src/model/fetch.ts
+++ b/ui/app/src/model/fetch.ts
@@ -14,9 +14,11 @@
 import { StatusError } from '@perses-dev/core';
 import { refreshToken } from './auth-client';
 
+const JWT_COOKIES = ['jwtPayload', 'jwtSignature', 'jwtRefreshToken'];
+
 // Delete a cookie by setting its expiration date to the past
 function deleteCookie(name: string): void {
-  document.cookie = name + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 }
 
 export function enableRefreshFetch(): void {
@@ -34,9 +36,7 @@ export function enableRefreshFetch(): void {
                 if (refreshError.status === 400) {
                   // If refresh token fails, remove jwt cookies
                   // This will force the user to be redirected to the login page
-                  deleteCookie('jwtPayload');
-                  deleteCookie('jwtSignature');
-                  deleteCookie('jwtRefreshToken');
+                  JWT_COOKIES.forEach(deleteCookie);
                 }
                 throw refreshError;
               });


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
With #3031 fix, we are refetching access token when back returns code 401. For this we need to keep expired access token in browser to send it, else we have a 400 error. For this the access token cookie max age is equal to refresh token cookie max age.
However, if by any chance the refresh token cookie is deleted and not the access token cookie, the UI will be stuck in bad state (all fetch failing and not redirecting to login page).

This PR force the delete of the cookie in case of refresh token is failing, forcing the user to be redirected to login page.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
