### PR TITLE
[FEATURE] Enable role, rolebinding and user only when native authz is used

### DIFF
--- a/cmd/perses/main.go
+++ b/cmd/perses/main.go
@@ -57,12 +57,12 @@ func main() {
 	promRegistry := prometheus.NewRegistry()
 	registerMetrics(promRegistry)
 
-	runner, persistentManager, err := core.New(conf, *pprof, promRegistry, banner)
+	runner, dependencyManager, err := core.New(conf, *pprof, promRegistry, banner)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 	defer func() {
-		if daoCloseErr := persistentManager.GetPersesDAO().Close(); daoCloseErr != nil {
+		if daoCloseErr := dependencyManager.Persistence().GetPersesDAO().Close(); daoCloseErr != nil {
 			logrus.WithError(daoCloseErr).Error("unable to close the connection to the database")
 		}
 	}()

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -65,19 +65,26 @@ func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager d
 		ephemeraldashboard.NewEndpoint(serviceManager.GetEphemeralDashboard(), serviceManager.GetAuthorization(), readonly, caseSensitive, cfg.EphemeralDashboard.Enable),
 		folder.NewEndpoint(serviceManager.GetFolder(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		globaldatasource.NewEndpoint(cfg.Datasource, serviceManager.GetGlobalDatasource(), serviceManager.GetAuthorization(), readonly, caseSensitive),
-		globalrole.NewEndpoint(serviceManager.GetGlobalRole(), serviceManager.GetAuthorization(), readonly, caseSensitive),
-		globalrolebinding.NewEndpoint(serviceManager.GetGlobalRoleBinding(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		globalsecret.NewEndpoint(serviceManager.GetGlobalSecret(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		globalvariable.NewEndpoint(cfg.Variable, serviceManager.GetGlobalVariable(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		health.NewEndpoint(serviceManager.GetHealth()),
 		plugin.NewEndpoint(serviceManager.GetPlugin(), cfg.Plugin.EnableDev),
 		project.NewEndpoint(serviceManager.GetProject(), serviceManager.GetAuthorization(), readonly, caseSensitive),
-		role.NewEndpoint(serviceManager.GetRole(), serviceManager.GetAuthorization(), readonly, caseSensitive),
-		rolebinding.NewEndpoint(serviceManager.GetRoleBinding(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		secret.NewEndpoint(serviceManager.GetSecret(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetAuthorization(), cfg.Security.Authentication.DisableSignUp, readonly, caseSensitive),
 		variable.NewEndpoint(cfg.Variable, serviceManager.GetVariable(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		view.NewEndpoint(serviceManager.GetView(), serviceManager.GetAuthorization(), serviceManager.GetDashboard()),
+	}
+
+	if cfg.Security.Authorization.Provider.Native.Enable {
+		// When the authorization is provided by a third-party service, roles are not managed by the Perses API.
+		// Therefore, we provide endpoints to manage them only if the native authorization is enabled.
+		apiV1Endpoints = append(apiV1Endpoints,
+			globalrole.NewEndpoint(serviceManager.GetGlobalRole(), serviceManager.GetAuthorization(), readonly, caseSensitive),
+			globalrolebinding.NewEndpoint(serviceManager.GetGlobalRoleBinding(), serviceManager.GetAuthorization(), readonly, caseSensitive),
+			role.NewEndpoint(serviceManager.GetRole(), serviceManager.GetAuthorization(), readonly, caseSensitive),
+			rolebinding.NewEndpoint(serviceManager.GetRoleBinding(), serviceManager.GetAuthorization(), readonly, caseSensitive),
+		)
 	}
 
 	authEndpoint, err := authendpoint.New(

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -56,8 +56,10 @@ type api struct {
 	apiPrefix              string
 }
 
-func NewPersesAPI(serviceManager dependency.ServiceManager, persistenceManager dependency.PersistenceManager, cfg config.Config) echoUtils.Register {
+func NewPersesAPI(dependencyManager dependency.Manager, cfg config.Config) echoUtils.Register {
 	readonly := cfg.Security.Readonly
+	persistenceManager := dependencyManager.Persistence()
+	serviceManager := dependencyManager.Service()
 	caseSensitive := persistenceManager.GetPersesDAO().IsCaseSensitive()
 	apiV1Endpoints := []route.Endpoint{
 		dashboard.NewEndpoint(serviceManager.GetDashboard(), serviceManager.GetAuthorization(), readonly, caseSensitive),

--- a/internal/api/dependency/dependency.go
+++ b/internal/api/dependency/dependency.go
@@ -1,0 +1,49 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependency
+
+import "github.com/perses/perses/pkg/model/api/config"
+
+type Manager interface {
+	Persistence() PersistenceManager
+	Service() ServiceManager
+}
+
+func NewManager(conf config.Config) (Manager, error) {
+	persistenceManager, err := newPersistenceManager(conf.Database)
+	if err != nil {
+		return nil, err
+	}
+	serviceManager, err := newServiceManager(persistenceManager, conf)
+	if err != nil {
+		return nil, err
+	}
+	return &manager{
+		persistenceManager: persistenceManager,
+		serviceManager:     serviceManager,
+	}, nil
+}
+
+type manager struct {
+	persistenceManager PersistenceManager
+	serviceManager     ServiceManager
+}
+
+func (m *manager) Persistence() PersistenceManager {
+	return m.persistenceManager
+}
+
+func (m *manager) Service() ServiceManager {
+	return m.serviceManager
+}

--- a/internal/api/dependency/persistence_manager.go
+++ b/internal/api/dependency/persistence_manager.go
@@ -92,7 +92,7 @@ type persistence struct {
 	variable           variable.DAO
 }
 
-func NewPersistenceManager(conf config.Database) (PersistenceManager, error) {
+func newPersistenceManager(conf config.Database) (PersistenceManager, error) {
 	persesDAO, err := database.New(conf)
 	if err != nil {
 		return nil, err

--- a/internal/api/dependency/service_manager.go
+++ b/internal/api/dependency/service_manager.go
@@ -111,7 +111,7 @@ type service struct {
 	view               view.Service
 }
 
-func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManager, error) {
+func newServiceManager(dao PersistenceManager, conf config.Config) (ServiceManager, error) {
 	cryptoService, jwtService, err := crypto.New(conf.Security)
 	if err != nil {
 		return nil, err

--- a/internal/api/dependency/service_manager.go
+++ b/internal/api/dependency/service_manager.go
@@ -134,7 +134,7 @@ func NewServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 	globalSecret := globalSecretImpl.NewService(dao.GetGlobalSecret(), cryptoService)
 	globalVariableService := globalVariableImpl.NewService(dao.GetGlobalVariable(), schemaService)
 	healthService := healthImpl.NewService(dao.GetHealth())
-	projectService := projectImpl.NewService(dao.GetProject(), dao.GetFolder(), dao.GetDatasource(), dao.GetDashboard(), dao.GetRole(), dao.GetRoleBinding(), dao.GetSecret(), dao.GetVariable(), authzService)
+	projectService := projectImpl.NewService(dao.GetProject(), dao.GetFolder(), dao.GetDatasource(), dao.GetDashboard(), dao.GetRole(), dao.GetRoleBinding(), dao.GetSecret(), dao.GetVariable(), authzService, conf.Security.Authorization.Provider.Native.Enable)
 	roleService := roleImpl.NewService(dao.GetRole(), authzService, schemaService)
 	roleBindingService := roleBindingImpl.NewService(dao.GetRoleBinding(), dao.GetRole(), dao.GetUser(), authzService, schemaService)
 	secretService := secretImpl.NewService(dao.GetSecret(), cryptoService)

--- a/internal/api/e2e/api/globalrolebinding_test.go
+++ b/internal/api/e2e/api/globalrolebinding_test.go
@@ -30,46 +30,26 @@ import (
 
 func TestMainScenarioGlobalRoleBinding(t *testing.T) {
 	e2eframework.WithServerAuthConfig(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager, token string) []api.Entity {
-		// First we need to provide the necessary permissions to Alice so she can create a GlobalRoleBinding
-		// We create a GlobalRole and a GlobalRoleBinding for Alice
-		globalRole := e2eframework.NewGlobalRole("admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), globalRole)
-		globalRoleBinding := e2eframework.NewGlobalRoleBinding("admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), globalRoleBinding)
-		// Refresh the permissions to ensure Alice has the latest permissions
-		err := manager.Service().GetAuthorization().RefreshPermissions()
-		if err != nil {
-			t.Fatalf("failed to refresh permissions: %v", err)
-		}
-
 		entity := e2eframework.NewGlobalRoleBinding("foo")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathGlobalRoleBinding)).
 			WithHeader(e2eframework.CreateAuthorizationHeader(token)).
 			WithJSON(entity).
 			Expect().
 			Status(http.StatusOK)
-		return []api.Entity{entity, globalRole, globalRoleBinding}
+		return []api.Entity{entity}
 	})
 }
 
 func TestUpdateScenarioGlobalRoleBindingRole(t *testing.T) {
 	e2eframework.WithServerAuthConfig(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager, token string) []api.Entity {
-		globalRole := e2eframework.NewGlobalRole("admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), globalRole)
-		entity := e2eframework.NewGlobalRoleBinding("admin")
+		entity := e2eframework.NewGlobalRoleBinding("foo")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), entity)
-		// Refresh the permissions to ensure Alice has the latest permissions
-		err := manager.Service().GetAuthorization().RefreshPermissions()
-		if err != nil {
-			t.Fatalf("failed to refresh permissions: %v", err)
-		}
-
 		entity.Spec.Role = "newRoleName"
 		expect.PUT(fmt.Sprintf("%s/%s/%s", utils.APIV1Prefix, utils.PathGlobalRoleBinding, entity.Metadata.Name)).
 			WithHeader(e2eframework.CreateAuthorizationHeader(token)).
 			WithJSON(entity).
 			Expect().
 			Status(http.StatusBadRequest)
-		return []api.Entity{entity, globalRole}
+		return []api.Entity{entity}
 	})
 }

--- a/internal/api/e2e/api/globalrolebinding_test.go
+++ b/internal/api/e2e/api/globalrolebinding_test.go
@@ -29,34 +29,47 @@ import (
 )
 
 func TestMainScenarioGlobalRoleBinding(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice", "password")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
+	e2eframework.WithServerAuthConfig(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager, token string) []api.Entity {
+		// First we need to provide the necessary permissions to Alice so she can create a GlobalRoleBinding
+		// We create a GlobalRole and a GlobalRoleBinding for Alice
 		globalRole := e2eframework.NewGlobalRole("admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, globalRole)
-		entity := e2eframework.NewGlobalRoleBinding("admin")
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), globalRole)
+		globalRoleBinding := e2eframework.NewGlobalRoleBinding("admin")
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), globalRoleBinding)
+		// Refresh the permissions to ensure Alice has the latest permissions
+		err := manager.Service().GetAuthorization().RefreshPermissions()
+		if err != nil {
+			t.Fatalf("failed to refresh permissions: %v", err)
+		}
+
+		entity := e2eframework.NewGlobalRoleBinding("foo")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathGlobalRoleBinding)).
+			WithHeader(e2eframework.CreateAuthorizationHeader(token)).
 			WithJSON(entity).
 			Expect().
 			Status(http.StatusOK)
-		return []api.Entity{entity, globalRole, user}
+		return []api.Entity{entity, globalRole, globalRoleBinding}
 	})
 }
 
 func TestUpdateScenarioGlobalRoleBindingRole(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice", "password")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
+	e2eframework.WithServerAuthConfig(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager, token string) []api.Entity {
 		globalRole := e2eframework.NewGlobalRole("admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, globalRole)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), globalRole)
 		entity := e2eframework.NewGlobalRoleBinding("admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), entity)
+		// Refresh the permissions to ensure Alice has the latest permissions
+		err := manager.Service().GetAuthorization().RefreshPermissions()
+		if err != nil {
+			t.Fatalf("failed to refresh permissions: %v", err)
+		}
 
 		entity.Spec.Role = "newRoleName"
 		expect.PUT(fmt.Sprintf("%s/%s/%s", utils.APIV1Prefix, utils.PathGlobalRoleBinding, entity.Metadata.Name)).
+			WithHeader(e2eframework.CreateAuthorizationHeader(token)).
 			WithJSON(entity).
 			Expect().
 			Status(http.StatusBadRequest)
-		return []api.Entity{entity, globalRole, user}
+		return []api.Entity{entity, globalRole}
 	})
 }

--- a/internal/api/e2e/api/rolebinding_test.go
+++ b/internal/api/e2e/api/rolebinding_test.go
@@ -34,21 +34,13 @@ func TestMainScenarioRoleBinding(t *testing.T) {
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
 		role := e2eframework.NewRole(project.Metadata.Name, "admin")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), role)
-		roleBiding := e2eframework.NewRoleBinding(project.Metadata.Name, "admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), roleBiding)
-		// Refresh the permissions to ensure Alice has the latest permissions
-		err := manager.Service().GetAuthorization().RefreshPermissions()
-		if err != nil {
-			t.Fatalf("failed to refresh permissions: %v", err)
-		}
-
-		entity := e2eframework.NewRoleBinding(project.Metadata.Name, "foo")
+		entity := e2eframework.NewRoleBinding(project.Metadata.Name, "admin")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathRoleBinding)).
 			WithHeader(e2eframework.CreateAuthorizationHeader(token)).
 			WithJSON(entity).
 			Expect().
 			Status(http.StatusOK)
-		return []api.Entity{entity, role, roleBiding, project}
+		return []api.Entity{entity, project}
 	})
 }
 
@@ -62,12 +54,6 @@ func TestUpdateScenarioRoleBindingRole(t *testing.T) {
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), role)
 		entity := e2eframework.NewRoleBinding(project.Metadata.Name, "admin")
 		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), entity)
-		// Refresh the permissions to ensure Alice has the latest permissions
-		err := manager.Service().GetAuthorization().RefreshPermissions()
-		if err != nil {
-			t.Fatalf("failed to refresh permissions: %v", err)
-		}
-
 		entity.Spec.Role = "newRoleName"
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.PathProject, entity.Metadata.Project, utils.APIV1Prefix, utils.PathRoleBinding, entity.Metadata.Name)).
 			WithHeader(e2eframework.CreateAuthorizationHeader(token)).

--- a/internal/api/e2e/api/rolebinding_test.go
+++ b/internal/api/e2e/api/rolebinding_test.go
@@ -29,38 +29,51 @@ import (
 )
 
 func TestMainScenarioRoleBinding(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice", "password")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
+	e2eframework.WithServerAuthConfig(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager, token string) []api.Entity {
 		project := e2eframework.NewProject("mysuperproject")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
 		role := e2eframework.NewRole(project.Metadata.Name, "admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, role)
-		entity := e2eframework.NewRoleBinding(project.Metadata.Name, "admin")
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), role)
+		roleBiding := e2eframework.NewRoleBinding(project.Metadata.Name, "admin")
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), roleBiding)
+		// Refresh the permissions to ensure Alice has the latest permissions
+		err := manager.Service().GetAuthorization().RefreshPermissions()
+		if err != nil {
+			t.Fatalf("failed to refresh permissions: %v", err)
+		}
+
+		entity := e2eframework.NewRoleBinding(project.Metadata.Name, "foo")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathRoleBinding)).
+			WithHeader(e2eframework.CreateAuthorizationHeader(token)).
 			WithJSON(entity).
 			Expect().
 			Status(http.StatusOK)
-		return []api.Entity{entity, role, project, user}
+		return []api.Entity{entity, role, roleBiding, project}
 	})
 }
 
 func TestUpdateScenarioRoleBindingRole(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
-		user := e2eframework.NewUser("alice", "password")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, user)
+	e2eframework.WithServerAuthConfig(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager, token string) []api.Entity {
+		// First we need to provide the necessary permissions to Alice so she can create a GlobalRoleBinding
+		// We create a GlobalRole and a GlobalRoleBinding for Alice
 		project := e2eframework.NewProject("mysuperproject")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
 		role := e2eframework.NewRole(project.Metadata.Name, "admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, role)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), role)
 		entity := e2eframework.NewRoleBinding(project.Metadata.Name, "admin")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), entity)
+		// Refresh the permissions to ensure Alice has the latest permissions
+		err := manager.Service().GetAuthorization().RefreshPermissions()
+		if err != nil {
+			t.Fatalf("failed to refresh permissions: %v", err)
+		}
 
 		entity.Spec.Role = "newRoleName"
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.PathProject, entity.Metadata.Project, utils.APIV1Prefix, utils.PathRoleBinding, entity.Metadata.Name)).
+			WithHeader(e2eframework.CreateAuthorizationHeader(token)).
 			WithJSON(entity).
 			Expect().
 			Status(http.StatusBadRequest)
-		return []api.Entity{entity, role, project, user}
+		return []api.Entity{entity, role, project}
 	})
 }

--- a/internal/api/e2e/client/test_utils.go
+++ b/internal/api/e2e/client/test_utils.go
@@ -28,11 +28,11 @@ import (
 )
 
 func withClient(t *testing.T, testFunc func(v1.ClientInterface, dependency.PersistenceManager) []api.Entity) {
-	server, _, persistenceManager := e2eframework.CreateServer(t, e2eframework.DefaultConfig())
+	server, _, dependencyManager := e2eframework.CreateServer(t, e2eframework.DefaultConfig())
 	defer server.Close()
 	persesClient := createClient(t, server)
-	entities := testFunc(persesClient, persistenceManager)
-	e2eframework.ClearAllKeys(t, persistenceManager.GetPersesDAO(), entities...)
+	entities := testFunc(persesClient, dependencyManager.Persistence())
+	e2eframework.ClearAllKeys(t, dependencyManager.Persistence().GetPersesDAO(), entities...)
 
 }
 

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -348,8 +348,8 @@ func newRoleSpec() v1.RoleSpec {
 	return v1.RoleSpec{
 		Permissions: []role.Permission{
 			{
-				Actions: []role.Action{role.CreateAction, role.UpdateAction},
-				Scopes:  []role.Scope{role.VariableScope, role.DatasourceScope, role.RoleScope, role.RoleBindingScope},
+				Actions: []role.Action{role.CreateAction},
+				Scopes:  []role.Scope{role.VariableScope, role.DatasourceScope},
 			},
 		},
 	}
@@ -359,8 +359,8 @@ func newGlobalRoleSpec() v1.RoleSpec {
 	return v1.RoleSpec{
 		Permissions: []role.Permission{
 			{
-				Actions: []role.Action{role.CreateAction, role.UpdateAction},
-				Scopes:  []role.Scope{role.VariableScope, role.DatasourceScope, role.ProjectScope, role.GlobalRoleScope, role.GlobalRoleBindingScope},
+				Actions: []role.Action{role.WildcardAction},
+				Scopes:  []role.Scope{role.WildcardScope},
 			},
 		},
 	}

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -348,8 +348,19 @@ func newRoleSpec() v1.RoleSpec {
 	return v1.RoleSpec{
 		Permissions: []role.Permission{
 			{
-				Actions: []role.Action{role.CreateAction},
-				Scopes:  []role.Scope{role.VariableScope, role.DatasourceScope},
+				Actions: []role.Action{role.CreateAction, role.UpdateAction},
+				Scopes:  []role.Scope{role.VariableScope, role.DatasourceScope, role.RoleScope, role.RoleBindingScope},
+			},
+		},
+	}
+}
+
+func newGlobalRoleSpec() v1.RoleSpec {
+	return v1.RoleSpec{
+		Permissions: []role.Permission{
+			{
+				Actions: []role.Action{role.CreateAction, role.UpdateAction},
+				Scopes:  []role.Scope{role.VariableScope, role.DatasourceScope, role.ProjectScope, role.GlobalRoleScope, role.GlobalRoleBindingScope},
 			},
 		},
 	}
@@ -359,7 +370,7 @@ func NewGlobalRole(name string) *v1.GlobalRole {
 	entity := &v1.GlobalRole{
 		Kind:     v1.KindGlobalRole,
 		Metadata: newMetadata(name),
-		Spec:     newRoleSpec(),
+		Spec:     newGlobalRoleSpec(),
 	}
 	entity.Metadata.CreateNow()
 	return entity

--- a/internal/api/impl/v1/project/service.go
+++ b/internal/api/impl/v1/project/service.go
@@ -37,28 +37,39 @@ import (
 
 type service struct {
 	project.Service
-	dao            project.DAO
-	folderDAO      folder.DAO
-	datasourceDAO  datasource.DAO
-	dashboardDAO   dashboard.DAO
-	roleDAO        role.DAO
-	roleBindingDAO rolebinding.DAO
-	secretDAO      secret.DAO
-	variableDAO    variable.DAO
-	authz          authorization.Authorization
+	dao                   project.DAO
+	folderDAO             folder.DAO
+	datasourceDAO         datasource.DAO
+	dashboardDAO          dashboard.DAO
+	roleDAO               role.DAO
+	roleBindingDAO        rolebinding.DAO
+	secretDAO             secret.DAO
+	variableDAO           variable.DAO
+	authz                 authorization.Authorization
+	isAuthorizationNative bool
 }
 
-func NewService(dao project.DAO, folderDAO folder.DAO, datasourceDAO datasource.DAO, dashboardDAO dashboard.DAO, roleDAO role.DAO, roleBindingDAO rolebinding.DAO, secretDAO secret.DAO, variableDAO variable.DAO, authz authorization.Authorization) project.Service {
+func NewService(dao project.DAO,
+	folderDAO folder.DAO,
+	datasourceDAO datasource.DAO,
+	dashboardDAO dashboard.DAO,
+	roleDAO role.DAO,
+	roleBindingDAO rolebinding.DAO,
+	secretDAO secret.DAO,
+	variableDAO variable.DAO,
+	authz authorization.Authorization,
+	isAuthorizationNative bool) project.Service {
 	return &service{
-		dao:            dao,
-		folderDAO:      folderDAO,
-		datasourceDAO:  datasourceDAO,
-		dashboardDAO:   dashboardDAO,
-		roleDAO:        roleDAO,
-		roleBindingDAO: roleBindingDAO,
-		secretDAO:      secretDAO,
-		variableDAO:    variableDAO,
-		authz:          authz,
+		dao:                   dao,
+		folderDAO:             folderDAO,
+		datasourceDAO:         datasourceDAO,
+		dashboardDAO:          dashboardDAO,
+		roleDAO:               roleDAO,
+		roleBindingDAO:        roleBindingDAO,
+		secretDAO:             secretDAO,
+		variableDAO:           variableDAO,
+		authz:                 authz,
+		isAuthorizationNative: isAuthorizationNative,
 	}
 }
 
@@ -78,7 +89,7 @@ func (s *service) create(ctx echo.Context, entity *v1.Project) (*v1.Project, err
 	}
 
 	// If authorization is enabled, permissions to the creator need to be given
-	if s.authz.IsEnabled() {
+	if s.authz.IsEnabled() && s.isAuthorizationNative {
 		if err := s.createProjectRoleAndRoleBinding(ctx, entity.Metadata.Name); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Role, RoleBinding and user are here to make the native authorisation working. As such when a third-party authorisation service is used, we don't need to expose these resources

Edit: As a side effect, I had to rework the e2e tests. Indeed, by deactivating the possibility to create role/roleBinding when the native authorisation is not activated, then current tests were not passing anymore as we are creating the tests without any authentication.

This is not the case anymore, every standard tests scenarios are using a server with auth activated. A default user is created "alice" with default role and roleBiding to give her full right on any object provided by the API.