### PR TITLE
[BUGFIX] Handle Piechart tooltip overlap with legend

### DIFF
--- a/ui/.prettierrc.json
+++ b/ui/.prettierrc.json
@@ -1,5 +1,5 @@
 {
   "printWidth": 120,
   "singleQuote": true,
-  "trailingComma": "es5"  
+  "trailingComma": "es5"
 }

--- a/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
+++ b/ui/components/src/ContentWithLegend/ContentWithLegend.tsx
@@ -65,7 +65,6 @@ export function ContentWithLegend({
         sx={{
           marginRight: `${margin.right}px`,
           marginBottom: `${margin.bottom}px`,
-          overflow: 'hidden',
         }}
       >
         {typeof children === 'function' ? children({ width: content.width, height: content.height }) : children}

--- a/ui/components/src/Legend/Legend.tsx
+++ b/ui/components/src/Legend/Legend.tsx
@@ -149,6 +149,7 @@ export function Legend({
           position: 'absolute',
           top: 0,
           right: 0,
+          backgroundColor: (theme) => `${theme.palette.background.default}`,
         }}
       >
         {legendContent}
@@ -166,6 +167,7 @@ export function Legend({
       sx={{
         position: 'absolute',
         bottom: 0,
+        backgroundColor: (theme) => `${theme.palette.background.default}`,
       }}
     >
       {legendContent}


### PR DESCRIPTION
Closes #2772 

# Description
For details of the bug please take a look at the related issue
https://github.com/perses/perses/issues/2772#issue-2919900618

## The Bug
<img width="565" height="366" alt="image" src="https://github.com/user-attachments/assets/2e31e7cc-cf5b-4b71-8c49-41d5d214f0e8" />


# About this change

This fix 

1. Removes Overflow hidden behavior of the chart container, **if there is enough room for both legend and the container** (This is the improvement)
2. If there is an overlap, the legend covers the chart. **This has been the default behavior**
3. If there is no enough room for both, the legend is removed. **This also has been the default behavior** 


## Normal Browser size

<img width="2107" height="962" alt="image" src="https://github.com/user-attachments/assets/5c0450e9-969f-4922-8673-6bc13a7c9420" />

## Smallest possible

<img width="1150" height="808" alt="image" src="https://github.com/user-attachments/assets/f564a20f-d5d8-41ef-91c9-acd1b3294db7" />


## Smallest - Legend Scroll

<img width="1255" height="556" alt="image" src="https://github.com/user-attachments/assets/9f49842d-786e-45d6-8329-58c4eaccd011" />


## Overlap

> :warning: If overlap happens the legend covers the chart. (This has been the default behavior). Under these circumstances, for sure the tool tip also will be covered!

<img width="968" height="815" alt="image" src="https://github.com/user-attachments/assets/602eefeb-d9a5-4d64-8956-e54c7bcaa676" />




# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
