### PR TITLE
[FEATURE] Add currency value formatting (perses#2225)

### DIFF
--- a/cue/common/format.cue
+++ b/cue/common/format.cue
@@ -13,7 +13,7 @@
 
 package common
 
-#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat | #currencyFormat
 
 #timeFormat: {
 	unit?:          "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
@@ -41,4 +41,9 @@ package common
 	unit?:          "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
 	decimalPlaces?: number
 	shortValues?:   bool
+}
+
+#currencyFormat: {
+	unit?:          "aud" | "cad" | "chf" | "cny" | "eur" | "gbp" | "hkd" | "inr" | "jpy" | "krw" | "nok" | "nzd" | "sek" | "sgd" | "usd"
+	decimalPlaces?: number
 }

--- a/docs/plugins/common.md
+++ b/docs/plugins/common.md
@@ -15,7 +15,7 @@ Calculation is defined as:
 The format spec is defined as:
 
 ```yaml
-<anyOf = Time format | Percent format | Decimal format | Bytes format | Throughput format>
+<anyOf = Time format | Percent format | Decimal format | Bytes format | Throughput format | Currency Format>
 ```
 
 ### Time format
@@ -56,6 +56,13 @@ decimalPlaces: <int> # Optional
 shortValues: <boolean> | default = false # Optional
 ```
 
+### Currency format
+
+```yaml
+unit: < enum = "aud" | "cad" | "chf" | "cny" | "eur" | "gbp" | "hkd" | "inr" | "jpy" | "krw" | "nok" | "nzd" | "usd" | "sek" | "sgd" >
+decimalPlaces: <int> # Optional
+```
+
 ## Legend specification
 
 ```yaml
@@ -63,7 +70,6 @@ position: <enum = "bottom" | "right">
 mode: <enum = "list" | "table"> # Optional
 size: <enum = "small" | "medium"> # Optional
 ```
-
 
 ## Legend-with-values specification
 

--- a/go-sdk/common/format.go
+++ b/go-sdk/common/format.go
@@ -18,9 +18,12 @@ import (
 	"fmt"
 )
 
-type TimeUnit string
-type PercentageUnit string
-type ThroughputUnit string
+type (
+	TimeUnit       string
+	PercentageUnit string
+	ThroughputUnit string
+	CurrencyUnit   string
+)
 
 const (
 	MilliSecondsUnit       TimeUnit       = "milliseconds"
@@ -47,12 +50,27 @@ const (
 	RequestsPerSecondsUnit ThroughputUnit = "requests/sec"
 	RowsPerSecondsUnit     ThroughputUnit = "rows/sec"
 	WritesPerSecondsUnit   ThroughputUnit = "writes/sec"
+	AustralianDollarUnit   CurrencyUnit   = "aud"
+	CanadianDollarUnit     CurrencyUnit   = "cad"
+	SwissFrancUnit         CurrencyUnit   = "chf"
+	RenminbiUnit           CurrencyUnit   = "cny"
+	EuroUnit               CurrencyUnit   = "eur"
+	PoundUnit              CurrencyUnit   = "gbp"
+	HongKongDollarUnit     CurrencyUnit   = "hkd"
+	IndianRupeeUniit       CurrencyUnit   = "inr"
+	YenUnit                CurrencyUnit   = "jpy"
+	SouthKoreanWonUnit     CurrencyUnit   = "krw"
+	NorwegianKroneUnit     CurrencyUnit   = "nok"
+	NewZealandDollarUnit   CurrencyUnit   = "nzd"
+	SwedishKronaDollarUnit CurrencyUnit   = "sek"
+	SingaporeDollarUnit    CurrencyUnit   = "sgd"
+	USDollarUnit           CurrencyUnit   = "usd"
 )
 
 type Format struct {
-	Unit          *string `json:"unit,omitempty" yaml:"unit,omitempty"`
+	Unit          *string `json:"unit,omitempty"          yaml:"unit,omitempty"`
 	DecimalPlaces int     `json:"decimalPlaces,omitempty" yaml:"decimalPlaces,omitempty"`
-	ShortValues   bool    `json:"shortValues,omitempty" yaml:"shortValues,omitempty"`
+	ShortValues   bool    `json:"shortValues,omitempty"   yaml:"shortValues,omitempty"`
 }
 
 func (f *Format) UnmarshalJSON(data []byte) error {
@@ -92,7 +110,10 @@ func (f *Format) validate() error {
 		string(BitsPerSecondsUnit), string(BytesPerSecondsUnit), string(CountsPerSecondsUnit), string(EventsPerSecondsUnit),
 		string(MessagesPerSecondsUnit), string(OpsPerSecondsUnit), string(PacketsPerSecondsUnit),
 		string(ReadsPerSecondsUnit), string(RecordsPerSecondsUnit), string(RequestsPerSecondsUnit),
-		string(RowsPerSecondsUnit), string(WritesPerSecondsUnit):
+		string(RowsPerSecondsUnit), string(WritesPerSecondsUnit), string(AustralianDollarUnit), string(CanadianDollarUnit),
+		string(SwissFrancUnit), string(RenminbiUnit), string(EuroUnit), string(PoundUnit),
+		string(HongKongDollarUnit), string(IndianRupeeUniit), string(YenUnit), string(SouthKoreanWonUnit),
+		string(NorwegianKroneUnit), string(NewZealandDollarUnit):
 		return nil
 	default:
 		return fmt.Errorf("unknown format")

--- a/ui/components/src/FormatControls/FormatControls.test.tsx
+++ b/ui/components/src/FormatControls/FormatControls.test.tsx
@@ -184,6 +184,13 @@ describe('FormatControls', () => {
     });
   });
 
+  describe('with a currency unit selected', () => {
+    it('allows the user to modify the decimal places', () => {
+      renderFormatControls({ unit: 'eur' });
+      expect(getDecimalPlacesSelector()).toBeEnabled();
+    });
+  });
+
   it('should not show an option for disabled units', () => {
     const onChange = jest.fn();
     renderFormatControls({ unit: 'decimal' }, onChange);

--- a/ui/components/src/FormatControls/FormatControls.tsx
+++ b/ui/components/src/FormatControls/FormatControls.tsx
@@ -63,7 +63,7 @@ export function FormatControls({ value, onChange, disabled = false }: FormatCont
   const hasShortValues = isUnitWithShortValues(value);
 
   const handleKindChange = (_: unknown, newValue: AutocompleteUnitOption | null): void => {
-    onChange({ unit: newValue?.id || 'decimal' }); // Fallback to 'decimal' if no unit is selected
+    onChange({ unit: newValue?.id || 'decimal' } as FormatOptions); // Fallback to 'decimal' if no unit is selected
   };
 
   const handleDecimalPlacesChange = ({

--- a/ui/core/src/model/units/currency.test.ts
+++ b/ui/core/src/model/units/currency.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { formatValue } from './units';
+import { UnitTestCase } from './types';
+
+const CURRENCY_TESTS: UnitTestCase[] = [
+  {
+    value: 1.23,
+    format: { unit: 'eur' },
+    expected: '€1.23',
+  },
+  {
+    value: 1.23,
+    format: { unit: 'aud' },
+    expected: 'A$1.23',
+  },
+  {
+    value: 1000,
+    format: { unit: 'gbp' },
+    expected: '£1,000',
+  },
+  {
+    value: 100000,
+    format: { unit: 'jpy' },
+    expected: '¥100,000',
+  },
+  {
+    value: -1.23,
+    format: { unit: 'usd' },
+    expected: '-$1.23',
+  },
+];
+
+describe('formatValue', () => {
+  it.each(CURRENCY_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
+    const { value, format: format, expected } = args;
+    expect(formatValue(value, format)).toEqual(expected);
+  });
+});

--- a/ui/core/src/model/units/currency.ts
+++ b/ui/core/src/model/units/currency.ts
@@ -1,0 +1,126 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { toUpper } from 'lodash';
+import { MAX_SIGNIFICANT_DIGITS } from './constants';
+import { UnitConfig, UnitGroupConfig } from './types';
+import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
+
+// See Intl.supportedValuesOf("currency") for valid options, key names will
+// be converted to uppercase to match the expectation of Intl.NumberFormat
+type CurrencyUnits =
+  | 'aud'
+  | 'cad'
+  | 'chf'
+  | 'cny'
+  | 'eur'
+  | 'gbp'
+  | 'hkd'
+  | 'inr'
+  | 'jpy'
+  | 'krw'
+  | 'nok'
+  | 'nzd'
+  | 'sek'
+  | 'sgd'
+  | 'usd';
+export type CurrencyFormatOptions = {
+  unit: CurrencyUnits;
+  decimalPlaces?: number;
+};
+
+const CURRENCY_GROUP = 'Currency';
+export const CURRENCY_GROUP_CONFIG: UnitGroupConfig = {
+  label: 'Currency',
+  decimalPlaces: true,
+};
+export const CURRENCY_UNIT_CONFIG: Readonly<Record<CurrencyUnits, UnitConfig>> = {
+  aud: {
+    group: CURRENCY_GROUP,
+    label: 'Australian Dollar (A$)',
+  },
+  cad: {
+    group: CURRENCY_GROUP,
+    label: 'Canadian Dollar (CA$)',
+  },
+  chf: {
+    group: CURRENCY_GROUP,
+    label: 'Swiss Franc (CHF)',
+  },
+  cny: {
+    group: CURRENCY_GROUP,
+    label: 'Renminbi (CN¥)',
+  },
+  eur: {
+    group: CURRENCY_GROUP,
+    label: 'Euro (€)',
+  },
+  gbp: {
+    group: CURRENCY_GROUP,
+    label: 'Pound (£)',
+  },
+  hkd: {
+    group: CURRENCY_GROUP,
+    label: 'Hong Kong Dollar (HK$)',
+  },
+  inr: {
+    group: CURRENCY_GROUP,
+    label: 'Indian Rupee (₹)',
+  },
+  jpy: {
+    group: CURRENCY_GROUP,
+    label: 'Yen (¥)',
+  },
+  krw: {
+    group: CURRENCY_GROUP,
+    label: 'South Korean Won (₩)',
+  },
+  nok: {
+    group: CURRENCY_GROUP,
+    label: 'Norwegian Krone (NOK)',
+  },
+  nzd: {
+    group: CURRENCY_GROUP,
+    label: 'New Zealand Dollar (NZ$)',
+  },
+  sek: {
+    group: CURRENCY_GROUP,
+    label: 'Swedish Krona (SEK)',
+  },
+  sgd: {
+    group: CURRENCY_GROUP,
+    label: 'Singapore Dollar (S$)',
+  },
+  usd: {
+    group: CURRENCY_GROUP,
+    label: 'US Dollar ($)',
+  },
+};
+
+export function formatCurrency(value: number, { unit, decimalPlaces }: CurrencyFormatOptions): string {
+  const formatterOptions: Intl.NumberFormatOptions = {
+    style: 'currency',
+    currency: toUpper(unit),
+    currencyDisplay: 'symbol',
+  };
+
+  if (hasDecimalPlaces(decimalPlaces)) {
+    formatterOptions.minimumFractionDigits = limitDecimalPlaces(decimalPlaces);
+    formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimalPlaces);
+  } else {
+    formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
+  }
+
+  const formatter = Intl.NumberFormat('en-US', formatterOptions);
+  return formatter.format(value);
+}

--- a/ui/core/src/model/units/types.ts
+++ b/ui/core/src/model/units/types.ts
@@ -18,7 +18,7 @@ import { Duration } from 'date-fns';
 import { AbsoluteTimeRange, DurationString } from '../time';
 import { FormatOptions } from './units';
 
-export type UnitGroup = 'Time' | 'Percent' | 'Decimal' | 'Bytes' | 'Throughput';
+export type UnitGroup = 'Time' | 'Percent' | 'Decimal' | 'Bytes' | 'Throughput' | 'Currency';
 
 /**
  * Configuration for rendering units that are part of a group.

--- a/ui/core/src/model/units/units.ts
+++ b/ui/core/src/model/units/units.ts
@@ -32,6 +32,7 @@ import {
   THROUGHPUT_UNIT_CONFIG,
   ThroughputFormatOptions,
 } from './throughput';
+import { formatCurrency, CURRENCY_GROUP_CONFIG, CURRENCY_UNIT_CONFIG, CurrencyFormatOptions } from './currency';
 
 /**
  * Most of the number formatting is based on Intl.NumberFormat, which is built into JavaScript.
@@ -47,6 +48,7 @@ export const UNIT_GROUP_CONFIG: Readonly<Record<UnitGroup, UnitGroupConfig>> = {
   Decimal: DECIMAL_GROUP_CONFIG,
   Bytes: BYTES_GROUP_CONFIG,
   Throughput: THROUGHPUT_GROUP_CONFIG,
+  Currency: CURRENCY_GROUP_CONFIG,
 };
 export const UNIT_CONFIG = {
   ...TIME_UNIT_CONFIG,
@@ -54,6 +56,7 @@ export const UNIT_CONFIG = {
   ...DECIMAL_UNIT_CONFIG,
   ...BYTES_UNIT_CONFIG,
   ...THROUGHPUT_UNIT_CONFIG,
+  ...CURRENCY_UNIT_CONFIG,
 } as const;
 
 export type FormatOptions =
@@ -61,7 +64,8 @@ export type FormatOptions =
   | PercentFormatOptions
   | DecimalFormatOptions
   | BytesFormatOptions
-  | ThroughputFormatOptions;
+  | ThroughputFormatOptions
+  | CurrencyFormatOptions;
 
 type HasDecimalPlaces<UnitOpt> = UnitOpt extends { decimalPlaces?: number } ? UnitOpt : never;
 type HasShortValues<UnitOpt> = UnitOpt extends { shortValues?: boolean } ? UnitOpt : never;
@@ -89,6 +93,10 @@ export function formatValue(value: number, formatOptions?: FormatOptions): strin
 
   if (isThroughputUnit(formatOptions)) {
     return formatThroughput(value, formatOptions);
+  }
+
+  if (isCurrencyUnit(formatOptions)) {
+    return formatCurrency(value, formatOptions);
   }
 
   const exhaustive: never = formatOptions;
@@ -142,4 +150,8 @@ export function isUnitWithShortValues(formatOptions: FormatOptions): formatOptio
 
 export function isThroughputUnit(formatOptions: FormatOptions): formatOptions is ThroughputFormatOptions {
   return getUnitGroup(formatOptions) === 'Throughput';
+}
+
+export function isCurrencyUnit(formatOptions: FormatOptions): formatOptions is CurrencyFormatOptions {
+  return getUnitGroup(formatOptions) === 'Currency';
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Solves #2225 

The changes in this PR add "Currency" as additional Unit for formatting. Initially the [15 most traded currencies](https://en.wikipedia.org/wiki/Foreign_exchange_market#Most_traded_currencies_by_value) were added. The currency units follow the ISO 4217 currency codes, thus addition or removal of units should be trivial. 

# Screenshots

<img width="1085" height="545" alt="image" src="https://github.com/user-attachments/assets/3cb7157d-60a6-4a72-a06f-2a532373a495" />

<img width="232" height="571" alt="image" src="https://github.com/user-attachments/assets/ee47a4b7-ff1b-4dad-869a-f366a3d07376" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
