### PR TITLE
[ENHANCEMENT] create RouterProvider to remove hard dependency on react-router in plugins

### DIFF
--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -18,6 +18,7 @@ import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard } from '@per
 import {
   PluginRegistry,
   UsageMetricsProvider,
+  ReactRouterProvider,
   ValidationProvider,
   remotePluginLoader,
 } from '@perses-dev/plugin-system';
@@ -82,39 +83,41 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
       }}
     >
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <PluginRegistry
-          pluginLoader={remotePluginLoader()}
-          defaultPluginKinds={{
-            Panel: 'TimeSeriesChart',
-            TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
-          }}
-        >
-          <ValidationProvider>
-            <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <UsageMetricsProvider project={project.metadata.name} dashboard={dashboardResource.metadata.name}>
-                <ViewDashboard
-                  dashboardResource={dashboardResource}
-                  datasourceApi={datasourceApi}
-                  externalVariableDefinitions={externalVariableDefinitions}
-                  dashboardTitleComponent={
-                    <ProjectBreadcrumbs dashboardName={getResourceDisplayName(dashboardResource)} project={project} />
-                  }
-                  emptyDashboardProps={{
-                    additionalText: 'In order to save this dashboard, you need to add at least one panel!',
-                  }}
-                  onSave={onSave}
-                  onDiscard={onDiscard}
-                  initialVariableIsSticky={true}
-                  isReadonly={isReadonly}
-                  isVariableEnabled={isLocalVariableEnabled}
-                  isDatasourceEnabled={isLocalDatasourceEnabled}
-                  isEditing={isEditing}
-                  isCreating={isCreating}
-                />
-              </UsageMetricsProvider>
-            </ErrorBoundary>
-          </ValidationProvider>
-        </PluginRegistry>
+        <ReactRouterProvider>
+          <PluginRegistry
+            pluginLoader={remotePluginLoader()}
+            defaultPluginKinds={{
+              Panel: 'TimeSeriesChart',
+              TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+            }}
+          >
+            <ValidationProvider>
+              <ErrorBoundary FallbackComponent={ErrorAlert}>
+                <UsageMetricsProvider project={project.metadata.name} dashboard={dashboardResource.metadata.name}>
+                  <ViewDashboard
+                    dashboardResource={dashboardResource}
+                    datasourceApi={datasourceApi}
+                    externalVariableDefinitions={externalVariableDefinitions}
+                    dashboardTitleComponent={
+                      <ProjectBreadcrumbs dashboardName={getResourceDisplayName(dashboardResource)} project={project} />
+                    }
+                    emptyDashboardProps={{
+                      additionalText: 'In order to save this dashboard, you need to add at least one panel!',
+                    }}
+                    onSave={onSave}
+                    onDiscard={onDiscard}
+                    initialVariableIsSticky={true}
+                    isReadonly={isReadonly}
+                    isVariableEnabled={isLocalVariableEnabled}
+                    isDatasourceEnabled={isLocalDatasourceEnabled}
+                    isEditing={isEditing}
+                    isCreating={isCreating}
+                  />
+                </UsageMetricsProvider>
+              </ErrorBoundary>
+            </ValidationProvider>
+          </PluginRegistry>
+        </ReactRouterProvider>
       </ErrorBoundary>
     </Box>
   );

--- a/ui/app/src/views/projects/explore/ProjectExploreView.tsx
+++ b/ui/app/src/views/projects/explore/ProjectExploreView.tsx
@@ -15,7 +15,13 @@ import { CircularProgress, Stack } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 import { ViewExplore } from '@perses-dev/explore';
-import { PluginRegistry, ProjectStoreProvider, useProjectStore, remotePluginLoader } from '@perses-dev/plugin-system';
+import {
+  PluginRegistry,
+  ProjectStoreProvider,
+  ReactRouterProvider,
+  useProjectStore,
+  remotePluginLoader,
+} from '@perses-dev/plugin-system';
 import React, { ReactElement, useMemo } from 'react';
 import { useGlobalVariableList } from '../../../model/global-variable-client';
 import { useVariableList } from '../../../model/variable-client';
@@ -62,15 +68,17 @@ function HelperExploreView(props: ProjectExploreViewProps): ReactElement {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
-      <PluginRegistry pluginLoader={remotePluginLoader()}>
-        <ErrorBoundary FallbackComponent={ErrorAlert}>
-          <ViewExplore
-            datasourceApi={datasourceApi}
-            externalVariableDefinitions={externalVariableDefinitions}
-            exploreTitleComponent={exploreTitleComponent}
-          />
-        </ErrorBoundary>
-      </PluginRegistry>
+      <ReactRouterProvider>
+        <PluginRegistry pluginLoader={remotePluginLoader()}>
+          <ErrorBoundary FallbackComponent={ErrorAlert}>
+            <ViewExplore
+              datasourceApi={datasourceApi}
+              externalVariableDefinitions={externalVariableDefinitions}
+              exploreTitleComponent={exploreTitleComponent}
+            />
+          </ErrorBoundary>
+        </PluginRegistry>
+      </ReactRouterProvider>
     </ErrorBoundary>
   );
 }

--- a/ui/plugin-system/src/runtime/RouterProvider.tsx
+++ b/ui/plugin-system/src/runtime/RouterProvider.tsx
@@ -1,0 +1,65 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { createContext, useContext, ReactNode, ReactElement } from 'react';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
+
+interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  to: string;
+}
+
+export interface RouterContextType {
+  RouterComponent: (props: LinkProps & React.RefAttributes<HTMLAnchorElement>) => ReactNode;
+  navigate: (to: string) => void;
+}
+
+export const RouterContext = createContext<RouterContextType | undefined>(undefined);
+
+export function useRouterContext(): RouterContextType {
+  const ctx = useContext(RouterContext);
+  if (ctx === undefined) {
+    throw new Error('No RouterContext found. Did you forget a <RouterProvider>?');
+  }
+  return ctx;
+}
+
+interface RouterProviderProps {
+  RouterComponent: RouterContextType['RouterComponent'];
+  navigate: RouterContextType['navigate'];
+  children?: React.ReactNode;
+}
+
+/**
+ * Some panel plugins (TraceTable, ScatterPlot, TracingGanttChart) support linking to other pages,
+ * e.g. clicking on a trace in the TraceTable should navigate to the TracingGanttChart.
+ *
+ * We can't use react-router in the panel, because panels might be embedded into React applications
+ * which use a different routing library, or a different major version of react-router.
+ *
+ * This provider abstracts the basic routing functionality, to remove the dependency on the exact version of react-router.
+ */
+export function RouterProvider(props: RouterProviderProps): ReactElement {
+  const { RouterComponent, navigate, children } = props;
+  return <RouterContext.Provider value={{ RouterComponent, navigate }}>{children}</RouterContext.Provider>;
+}
+
+interface ReactRouterProviderProps {
+  children?: React.ReactNode;
+}
+
+/** An implementation of RouterProvider for using the react-router library, shipped with Perses */
+export function ReactRouterProvider(props: ReactRouterProviderProps): ReactElement {
+  const { children } = props;
+  const navigate = useNavigate();
+  return <RouterContext.Provider value={{ RouterComponent: RouterLink, navigate }}>{children}</RouterContext.Provider>;
+}

--- a/ui/plugin-system/src/runtime/index.ts
+++ b/ui/plugin-system/src/runtime/index.ts
@@ -21,4 +21,5 @@ export * from './trace-queries';
 export * from './profile-queries';
 export * from './DataQueriesProvider';
 export * from './QueryCountProvider';
+export * from './RouterProvider';
 export * from './UsageMetricsProvider';


### PR DESCRIPTION
# Description

Some panel plugins (TraceTable, ScatterPlot, TracingGanttChart) support linking to other pages, e.g. clicking on a trace in the TraceTable should navigate to the TracingGanttChart.

We can't use react-router in the panel, because panels might be embedded into React applications which use a different routing library, or a different major version of react-router.

This new provider abstracts the basic routing functionality, to remove the dependency on the exact version of react-router.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
