### PR TITLE
[BUGFIX] set default panel header height to avoid layout shift

### DIFF
--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -216,9 +216,9 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         {divider}
         <OnHover>
           <OverflowMenu title={title}>
-            {descriptionAction} {linksAction} {queryStateIndicator} {extraActions} {readActions} {editActions}
+            {descriptionAction} {linksAction} {queryStateIndicator} {extraActions} {readActions} {pluginActions}
+            {editActions}
           </OverflowMenu>
-          {pluginActions}
           {moveAction}
         </OnHover>
       </ConditionalBox>
@@ -236,8 +236,10 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         </OnHover>
         {divider} {queryStateIndicator}
         <OnHover>
-          {extraActions} {readActions} {pluginActions}
-          <OverflowMenu title={title}>{editActions}</OverflowMenu>
+          {extraActions} {readActions}
+          <OverflowMenu title={title}>
+            {editActions} {pluginActions}
+          </OverflowMenu>
           {moveAction}
         </OnHover>
       </ConditionalBox>
@@ -255,7 +257,10 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         </OnHover>
         {divider} {queryStateIndicator}
         <OnHover>
-          {extraActions} {readActions} {pluginActions} {editActions} {moveAction}
+          {extraActions} {readActions} {editActions}
+          {/* Show plugin actions inside a menu if it gets crowded */}
+          {pluginActions.length <= 1 ? pluginActions : <OverflowMenu title={title}>{pluginActions}</OverflowMenu>}
+          {moveAction}
         </OnHover>
       </ConditionalBox>
     </>

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -60,7 +60,7 @@ export function PanelHeader({
       aria-describedby={descriptionTooltipId}
       disableTypography
       title={
-        <Stack direction="row">
+        <Stack direction="row" alignItems="center" height="var(--panel-header-height, 30px)">
           <Typography
             id={titleElementId}
             variant="subtitle1"


### PR DESCRIPTION
# Description

- Add default height to panel header, so actions don't generate layout shift.
- Moved the plugin actions into the overflow menu for small resolutions or when there are many plugin actions

# Videos

Before:

https://github.com/user-attachments/assets/03b1d78a-d0b9-477e-a951-a50345d1955a

After

https://github.com/user-attachments/assets/65f177c8-a698-4344-bb99-687b601014bb


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
