### PR TITLE
[IGNORE] fix swc configuration to use the root directory for transpiled files

### DIFF
--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -17,8 +17,8 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",
-    "build:cjs": "swc ./src -d dist/cjs --config-file ../.cjs.swcrc",
-    "build:esm": "swc ./src -d dist --config-file ../.swcrc",
+    "build:cjs": "swc ./src -d dist/cjs --strip-leading-paths --config-file ../.cjs.swcrc",
+    "build:esm": "swc ./src -d dist --strip-leading-paths --config-file ../.swcrc",
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",
-    "build:cjs": "swc ./src -d dist/cjs --config-file ../.cjs.swcrc",
-    "build:esm": "swc ./src -d dist --config-file ../.swcrc",
+    "build:cjs": "swc ./src -d dist/cjs --strip-leading-paths --config-file ../.cjs.swcrc",
+    "build:esm": "swc ./src -d dist --strip-leading-paths --config-file ../.swcrc",
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",

--- a/ui/dashboards/package.json
+++ b/ui/dashboards/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",
-    "build:cjs": "swc ./src -d dist/cjs --config-file ../.cjs.swcrc",
-    "build:esm": "swc ./src -d dist --config-file ../.swcrc",
+    "build:cjs": "swc ./src -d dist/cjs --strip-leading-paths --config-file ../.cjs.swcrc",
+    "build:esm": "swc ./src -d dist --strip-leading-paths --config-file ../.swcrc",
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",

--- a/ui/explore/package.json
+++ b/ui/explore/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",
-    "build:cjs": "swc ./src -d dist/cjs --config-file ../.cjs.swcrc",
-    "build:esm": "swc ./src -d dist --config-file ../.swcrc",
+    "build:cjs": "swc ./src -d dist/cjs --strip-leading-paths --config-file ../.cjs.swcrc",
+    "build:esm": "swc ./src -d dist --strip-leading-paths --config-file ../.swcrc",
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",

--- a/ui/plugin-system/package.json
+++ b/ui/plugin-system/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "concurrently \"npm:build:*\"",
-    "build:cjs": "swc ./src -d dist/cjs --config-file ../.cjs.swcrc",
-    "build:esm": "swc ./src -d dist --config-file ../.swcrc",
+    "build:cjs": "swc ./src -d dist/cjs --strip-leading-paths --config-file ../.cjs.swcrc",
+    "build:esm": "swc ./src -d dist --strip-leading-paths --config-file ../.swcrc",
     "build:types": "tsc --project tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "start": "concurrently -P \"npm:build:* -- {*}\" -- --watch",


### PR DESCRIPTION
# Description

Fix swc configuration to use the root `./dist` folder as target for transpiled files. This will fix https://github.com/perses/plugins/pull/235

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
