### PR TITLE
[ignore] simplify bug report formular

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,11 +20,6 @@ body:
   - type: textarea
     attributes:
       label: What did you expect to see?
-  - type: textarea
-    attributes:
-      label: What did you see instead? Under which circumstances?
-    validations:
-      required: true
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
I have removed the section `What did you see instead? Under which circumstances?` because most of the time, the explanation about what should be seen is already explained before. 