### PR TITLE
[ENHANCEMENT] CLI/PLUGIN: schema files are watched and reloaded when modified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/huh v0.7.0
 	github.com/efficientgo/core v1.0.0-rc.3
 	github.com/fatih/color v1.18.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gavv/httpexpect/v2 v2.17.0
 	github.com/go-jose/go-jose/v4 v4.1.2
 	github.com/go-sql-driver/mysql v1.9.3
@@ -97,7 +98,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fatih/structs v1.1.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect

--- a/internal/api/impl/v1/plugin/endpoint.go
+++ b/internal/api/impl/v1/plugin/endpoint.go
@@ -44,7 +44,7 @@ func (e *endpoint) CollectRoutes(g *route.Group) {
 	if e.enableDev {
 		group.POST("", e.PushDevPlugin, true)
 		group.DELETE(fmt.Sprintf("/:%s", utils.ParamName), e.DeleteDevPlugin, true)
-		group.POST(fmt.Sprintf("/:%s/refresh", utils.ParamName), e.PushDevPlugin, true)
+		group.POST(fmt.Sprintf("/:%s/refresh", utils.ParamName), e.RefreshDevPlugin, true)
 	}
 }
 

--- a/internal/api/impl/v1/plugin/endpoint.go
+++ b/internal/api/impl/v1/plugin/endpoint.go
@@ -44,6 +44,7 @@ func (e *endpoint) CollectRoutes(g *route.Group) {
 	if e.enableDev {
 		group.POST("", e.PushDevPlugin, true)
 		group.DELETE(fmt.Sprintf("/:%s", utils.ParamName), e.DeleteDevPlugin, true)
+		group.POST(fmt.Sprintf("/:%s/refresh", utils.ParamName), e.PushDevPlugin, true)
 	}
 }
 
@@ -62,6 +63,18 @@ func (e *endpoint) PushDevPlugin(ctx echo.Context) error {
 		return apiinterface.HandleBadRequestError(err.Error())
 	}
 	return e.svc.LoadDevPlugin(list)
+}
+
+func (e *endpoint) RefreshDevPlugin(ctx echo.Context) error {
+	name := utils.GetNameParameter(ctx)
+	if len(name) == 0 {
+		return apiinterface.HandleBadRequestError("plugin name is required")
+	}
+	if err := e.svc.RefreshDevPlugin(name); err != nil {
+		logrus.WithError(err).Errorf("unable to refresh plugin %s", name)
+		return err
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (e *endpoint) DeleteDevPlugin(ctx echo.Context) error {

--- a/internal/api/plugin/dev.go
+++ b/internal/api/plugin/dev.go
@@ -72,7 +72,7 @@ func (p *pluginFile) LoadDevPlugin(plugins []v1.PluginInDevelopment) error {
 }
 
 func (p *pluginFile) RefreshDevPlugin(name string) error {
-	p.mutex.RUnlock()
+	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 	plg, ok := p.devLoaded[name]
 	if !ok {

--- a/internal/api/plugin/dev.go
+++ b/internal/api/plugin/dev.go
@@ -54,15 +54,15 @@ func (p *pluginFile) LoadDevPlugin(plugins []v1.PluginInDevelopment) error {
 			},
 			Module: pluginModule,
 		}
-		if IsSchemaRequired(pluginModule.Spec) && !plg.DisableSchema {
-			if pluginSchemaLoadErr := p.sch.LoadDevPlugin(plg.AbsolutePath, pluginModule); pluginSchemaLoadErr != nil {
-				return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to load plugin schema: %s", pluginSchemaLoadErr))
-			}
-			if pluginMigrateLoadErr := p.mig.LoadDevPlugin(plg.AbsolutePath, pluginModule); pluginMigrateLoadErr != nil {
-				return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to load plugin migration: %s", pluginMigrateLoadErr))
-			}
-		} else {
+		if !IsSchemaRequired(pluginModule.Spec) || plg.DisableSchema {
 			logrus.Debugf("schema is disabled or not required for plugin %q", pluginModule.Metadata.Name)
+			return nil
+		}
+		if pluginSchemaLoadErr := p.sch.LoadDevPlugin(plg.AbsolutePath, pluginModule); pluginSchemaLoadErr != nil {
+			return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to load plugin schema: %s", pluginSchemaLoadErr))
+		}
+		if pluginMigrateLoadErr := p.mig.LoadDevPlugin(plg.AbsolutePath, pluginModule); pluginMigrateLoadErr != nil {
+			return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to load plugin migration: %s", pluginMigrateLoadErr))
 		}
 		p.mutex.Lock()
 		p.devLoaded[manifest.Name] = pluginLoaded
@@ -71,12 +71,34 @@ func (p *pluginFile) LoadDevPlugin(plugins []v1.PluginInDevelopment) error {
 	return p.storeLoadedList()
 }
 
-func (p *pluginFile) UnLoadDevPlugin(name string) error {
+func (p *pluginFile) RefreshDevPlugin(name string) error {
+	p.mutex.RUnlock()
+	defer p.mutex.RUnlock()
 	plg, ok := p.devLoaded[name]
 	if !ok {
 		return apiinterface.HandleNotFoundError(fmt.Sprintf("plugin %q not found in development mode", name))
 	}
+	if !IsSchemaRequired(plg.Module.Spec) || plg.DevEnvironment.DisableSchema {
+		logrus.Debugf("schema is disabled or not required for plugin %q", name)
+		return nil
+	}
+	if err := p.sch.LoadDevPlugin(plg.DevEnvironment.AbsolutePath, plg.Module); err != nil {
+		return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to refresh plugin schema: %s", err))
+	}
+	if err := p.mig.LoadDevPlugin(plg.DevEnvironment.AbsolutePath, plg.Module); err != nil {
+		return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to refresh plugin migration schema: %s", err))
+	}
+	logrus.Infof("plugin %q has been refreshed in development mode", name)
+	return nil
+}
+
+func (p *pluginFile) UnLoadDevPlugin(name string) error {
 	p.mutex.Lock()
+	plg, ok := p.devLoaded[name]
+	if !ok {
+		p.mutex.Unlock()
+		return apiinterface.HandleNotFoundError(fmt.Sprintf("plugin %q not found in development mode", name))
+	}
 	p.sch.UnloadDevPlugin(plg.Module)
 	p.mig.UnLoadDevPlugin(plg.Module)
 	delete(p.devLoaded, name)

--- a/internal/api/plugin/migrate/migrate.go
+++ b/internal/api/plugin/migrate/migrate.go
@@ -476,8 +476,8 @@ func (m *mig) remove(kind plugin.Kind, name string) {
 			delete(m.panels, name)
 		case plugin.KindVariable:
 			delete(m.variables, name)
-		case plugin.KindDatasource:
-			// No migration script for datasource, so nothing to remove
+		case plugin.KindDatasource, plugin.KindExplore:
+		// No migration script for datasource or explorer, so nothing to remove
 		default:
 			logrus.Warnf("unable to remove migration script for %q: kind %q not supported", name, kind)
 		}

--- a/internal/api/plugin/plugin.go
+++ b/internal/api/plugin/plugin.go
@@ -43,6 +43,7 @@ type Loaded struct {
 type Plugin interface {
 	Load() error
 	LoadDevPlugin(plugins []v1.PluginInDevelopment) error
+	RefreshDevPlugin(name string) error
 	UnLoadDevPlugin(name string) error
 	List() ([]byte, error)
 	UnzipArchives() error

--- a/pkg/client/api/v1/plugin.go
+++ b/pkg/client/api/v1/plugin.go
@@ -14,6 +14,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/perses/perses/pkg/client/perseshttp"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
@@ -22,6 +24,7 @@ const pluginResource = "plugins"
 
 type PluginInterface interface {
 	PushDevPlugin([]*v1.PluginInDevelopment) error
+	RefreshDevPlugin(name string) error
 	UnLoadDevPlugin(name string) error
 	List() ([]v1.PluginModule, error)
 }
@@ -41,6 +44,13 @@ func (c *plugin) PushDevPlugin(plugins []*v1.PluginInDevelopment) error {
 	return c.client.Post().
 		Resource(pluginResource).
 		Body(plugins).
+		Do().
+		Error()
+}
+
+func (c *plugin) RefreshDevPlugin(name string) error {
+	return c.client.Post().
+		Resource(fmt.Sprintf("%s/%s/refresh", pluginResource, name)).
 		Do().
 		Error()
 }


### PR DESCRIPTION
The CLI is watching any Cuelang files contained in the `schema` folder. 
Anytime a change occurred on any files watched, the CLI is calling the API to reload the schema and the migration file.

This should complete the plugin development and help to load or reload a plugin in development without having to re-start the Perses server.