### PR TITLE
[BUGFIX] Add watch_query_changes to fix run query button issue

### DIFF
--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.test.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.test.tsx
@@ -1,0 +1,78 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { screen, cleanup } from '@testing-library/react';
+import { QueryDefinition, QueryPluginType } from '@perses-dev/core';
+import { renderWithContext } from '../../test';
+import { QueryEditorContainer } from './QueryEditorContainer';
+
+describe('QueryEditorContainer', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ success: true }),
+      })
+    ) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  const querySpec = { query: 'any-fake-query', limit: 20, datasource: undefined };
+  const renderingProps: Record<string, { queryTypes: string[]; value: object }> = {
+    TimeSeriesQuery: {
+      queryTypes: ['TimeSeriesQuery'],
+      value: {
+        kind: 'TimeSeriesQuery',
+        spec: {
+          plugin: {
+            kind: 'PrometheusTimeSeriesQuery',
+            spec: querySpec,
+          },
+        },
+      },
+    },
+    TraceQuery: {
+      queryTypes: ['TraceQuery'],
+      value: {
+        kind: 'TraceQuery',
+        spec: {
+          plugin: {
+            kind: 'TempoTraceQuery',
+            spec: querySpec,
+          },
+        },
+      },
+    },
+  };
+
+  Object.keys(renderingProps).forEach((key) => {
+    it(`should render ${key} with run query button`, () => {
+      renderWithContext(
+        <QueryEditorContainer
+          queryTypes={renderingProps[key]?.queryTypes as QueryPluginType[]}
+          index={1}
+          query={renderingProps[key]?.value as QueryDefinition}
+          isCollapsed={false}
+          onDelete={jest.fn()}
+          onChange={jest.fn()}
+          onCollapseExpand={jest.fn()}
+        />
+      );
+      const runQuerybutton = screen.getByTestId('run_query_button');
+      expect(runQuerybutton).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.test.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.test.tsx
@@ -15,7 +15,7 @@ import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
 import { ReactElement, useState } from 'react';
 import { renderWithContext } from '../../test';
-import { DefaultPluginKinds } from '../../model';
+import { DefaultPluginKinds, PluginType } from '../../model';
 import { PluginEditor } from './PluginEditor';
 import { PluginEditorProps } from './plugin-editor-api';
 
@@ -141,6 +141,29 @@ describe('PluginEditor', () => {
       // Wait for specified panel kind to load.
       const pluginKind = screen.getByLabelText('Variable Type');
       await waitFor(() => expect(pluginKind).toHaveTextContent('Ernie Variable 2'));
+    });
+  });
+
+  describe('Run Query Button', () => {
+    describe('When withRunQueryButton is true', () => {
+      ['TimeSeriesQuery', 'TraceQuery', 'ProfileQuery'].forEach((type) => {
+        it(`should render the run query button for ${type}`, () => {
+          const onChangeHandler = jest.fn();
+          renderWithContext(
+            <PluginEditor
+              pluginTypes={[type] as unknown as PluginEditorProps['pluginTypes']}
+              pluginKindLabel="Variable Type"
+              withRunQueryButton
+              value={{ selection: { type: type as PluginType, kind: '' }, spec: {} }}
+              onChange={onChangeHandler}
+            />
+          );
+          const queryButton = screen.getByTestId('run_query_button');
+          expect(queryButton).toBeInTheDocument();
+          userEvent.click(queryButton);
+          expect(onChangeHandler).toHaveBeenCalledTimes(1);
+        });
+      });
     });
   });
 });

--- a/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.tsx
+++ b/ui/plugin-system/src/components/PluginSpecEditor/PluginSpecEditor.tsx
@@ -14,6 +14,7 @@
 import { ErrorAlert } from '@perses-dev/components';
 import { UnknownSpec } from '@perses-dev/core';
 import { ReactElement } from 'react';
+import { CircularProgress, Stack } from '@mui/material';
 import { OptionsEditorProps } from '../../model';
 import { usePlugin } from '../../runtime';
 import { PluginEditorSelection } from '../PluginEditor';
@@ -34,24 +35,22 @@ export function PluginSpecEditor(props: PluginSpecEditorProps): ReactElement | n
     return <ErrorAlert error={error} />;
   }
 
-  // TODO: Proper loading indicator
   if (isLoading) {
-    return null;
+    return (
+      <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Stack>
+    );
   }
 
-  if (plugin === undefined) {
+  if (!plugin) {
     throw new Error(`Missing implementation for ${pluginType} plugin with kind '${pluginKind}'`);
   }
 
   if (pluginType === 'Panel') {
     throw new Error('This editor should not be used for panel type. Please use Panel Spec Editor instead.');
   }
-
   const { OptionsEditorComponent } = plugin;
 
-  if (OptionsEditorComponent !== undefined) {
-    return <OptionsEditorComponent {...others} />;
-  }
-
-  return null;
+  return OptionsEditorComponent ? <OptionsEditorComponent {...others} /> : null;
 }

--- a/ui/plugin-system/src/model/plugin-base.ts
+++ b/ui/plugin-system/src/model/plugin-base.ts
@@ -38,6 +38,10 @@ export interface OptionsEditorProps<Spec> {
   value: Spec;
   onChange: (next: Spec) => void;
   isReadonly?: boolean;
+  queryHandlerSettings?: {
+    runWithOnBlur: boolean;
+    watchQueryChanges: (query: string) => void;
+  };
 }
 
 /**


### PR DESCRIPTION
Relates to #3187 

## IMPORTANT NOTES ⚠️ 
>  This PR and https://github.com/perses/plugins/pull/242 should be merged together to be effective, So you need to review them together.

> 🔍  Read the PR before you review anything.

> ⚠️ I would like to have @jgbernalp  and @Nexucis  approval as well. Do not merge unless they have tested and approved this fix

> ⚠️  This change will affect Explorer, Edit Panel View, (**Prometheus and Tempo**)

> 🧪  Please test before merge

> 💀   This change will not cover similar onBlur issues of Legend and Min Step. They will have their own dedicated issues

## The Bug 🐛 

`Run Query Button` as its name suggests is responsible for running an **_updated_** query. At the moment, this button does not function properly, and the query-execution is triggered by onBlur event. 

## The Change 🔧 

This change is tracking the changes of the query using a watch function. When, the button is pressed, the spec is updated, and subsequently the query is executed. I would like to mention that the button and query editor are disconnected, and the query editor is a plugin which is deduced on run-time. 

## Test 🧪 

1. In any Edit Panel > Change the query, trigger the onBlur > The Query Should NOT run
2. In any Edit Panel > Change the query, press the button > The Query Should run
3. Please repeat the same steps in Explorer View for both Prometheus and Tempo / Update Plugins-System manually first
4. If the query has not changed, pressing button will not do anything
5. @Nexucis Running query on enter is not possible, because multi-line query is possible. Enter should simply break the line 



![the_button](https://github.com/user-attachments/assets/5e33be0d-63cf-434e-821f-4afe76251175)



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
