### PR TITLE
[ENHANCEMENT] CLI/PLUGIN: improve output of the cmd test-schemas

### DIFF
--- a/internal/cli/cmd/plugin/testschemas/test-schemas_test.go
+++ b/internal/cli/cmd/plugin/testschemas/test-schemas_test.go
@@ -28,13 +28,13 @@ func TestPluginTestSchemasCMD(t *testing.T) {
 			Title:                "Schema tests for a panel plugin, all succeeding",
 			Args:                 []string{"--plugin.path", filepath.Join(projectPath, "internal", "cli", "cmd", "plugin", "testschemas", "testdata", "my-panel-plugin")},
 			IsErrorExpected:      false,
-			ExpectedRegexMessage: "Test Results: 6 passed, 0 failed\nAll schema tests passed",
+			ExpectedRegexMessage: `SUCCESS: All of the 6 schema test\(s\) passed`,
 		},
 		{
 			Title:           "Schema tests for datasource plugin (multi-plugins), 2 failing",
 			Args:            []string{"--plugin.path", filepath.Join(projectPath, "internal", "cli", "cmd", "plugin", "testschemas", "testdata", "my-datasource-plugin")},
 			IsErrorExpected: true,
-			ExpectedMessage: "2 test(s) failed",
+			ExpectedMessage: "ERROR: 2 out of the 6 test(s) failed",
 		},
 		{
 			Title:           "Schema tests for plugin without schemas",

--- a/internal/cli/test/test.go
+++ b/internal/cli/test/test.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -66,6 +67,7 @@ func ExecuteSuiteTest(t *testing.T, newCMD func() *cobra.Command, suites []Suite
 				if len(test.ExpectedRegexMessage) > 0 {
 					matched, _ := regexp.MatchString(test.ExpectedRegexMessage, buffer.String())
 					assert.True(t, matched, "Expected output to match regex: %s", test.ExpectedRegexMessage)
+					fmt.Println("output message: ", buffer.String())
 				} else {
 					assert.Equal(t, test.ExpectedMessage, buffer.String())
 				}


### PR DESCRIPTION
I am adding green or red color on each test result depending if the test failed or is a success.
The message summarising the tests result is also improved.

Edit: I have also added a color for the type of the test and for the path.


Before:
<img width="803" height="423" alt="image" src="https://github.com/user-attachments/assets/aca0088b-314a-4dea-9d77-123a322c73fa" />


After:
<img width="1834" height="614" alt="image" src="https://github.com/user-attachments/assets/23e0b4c9-0670-4c73-9d8b-aa7146cf355a" />

