### PR TITLE
[BREAKINGCHANGE] Watch the changes of the unknown specs in all Editor Plugins

### DIFF
--- a/ui/plugin-system/src/model/plugin-base.ts
+++ b/ui/plugin-system/src/model/plugin-base.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { QueryDefinition } from '@perses-dev/core';
+import { QueryDefinition, UnknownSpec } from '@perses-dev/core';
 import React from 'react';
 
 /**
@@ -41,6 +41,7 @@ export interface OptionsEditorProps<Spec> {
   queryHandlerSettings?: {
     runWithOnBlur: boolean;
     watchQueryChanges: (query: string) => void;
+    setWatchOtherSpecs: (otherSpecs: UnknownSpec) => void;
   };
 }
 


### PR DESCRIPTION
Relates to #3195 

> ⚠️ Should be merged with https://github.com/perses/plugins/pull/268 to be effective 

## Description 🖊️ 

Prometheus Time Series Query Editor gives you two options called `Legend` and `Min_Steps`. If you change the values of the mentioned fields and trigger the onBlur event the, query will be executed immediately. This is **NOT** an ideal behavior, and we prefer to have the query executed when the `Run Query Button` is pressed. 



<img width="1633" height="1106" alt="image" src="https://github.com/user-attachments/assets/091baf98-8abe-46e5-8c2b-b3d1b3284db8" />


## What does this PR do ❔ 

This change adds a generic watch mechanism to the PluginEditor. This helps us to track the changes of the `UnknownSpec`. When the `Run Query Button` is pressed, the stale specs are replaced with tracked changes, and then, the query is executed. 

## No New Unit and E2E Test 🧪 💻 

This is already tested by 
https://github.com/perses/perses/commit/f95c59636da1bf9142d1340dc3381b77af5ad64b

**I see some room for e2e tests, but for that we need to have the Preses/Plugins changes merged first**


## How to test manually ❔ 🧪 

1. Run Client and Server
2. **IMPORTANT Update the node_module/@perses-dev manually with built plugin-system**
3. Make sure you have done step 2
4. Attach to your plugin using `Plugin Start` command
5. From both explorer and Edit Panel =>
6. Change **legend and min_step**
7. Query should NOT execute with onBlur
8. Query should execute with the `Run Query Button`


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
