### PR TITLE
[ENHANCEMENT] CLI/PLUGIN: improve the condition to run npm ci

### DIFF
--- a/internal/cli/cmd/plugin/build/build.go
+++ b/internal/cli/cmd/plugin/build/build.go
@@ -185,7 +185,7 @@ func NewCMD() *cobra.Command {
 		Use:   "build",
 		Short: "Build the plugin.",
 		Long: `The command will build the plugin by following these steps:
-- Run npm ci to install the frontend dependencies
+- Run npm ci to install the frontend dependencies. If the node_modules folder already exists, it will skip this step. As a best effort, it will also check if the node_modules folder exists in the root folder of the plugin (if it is a npm workspace / monorepo) and skip the step if it exists.
 - Run npm run build to build the frontend
 - Vendor all cue dependencies if the plugin requires a schema
 - Create the archive with the following files:


### PR DESCRIPTION
I am improving the command `percli plugin build` by adding more condition to run the command `npm ci`. It will check if it founds a folder `node_modules` in the parent directory.
It's a best effort verification as a better check would be to know if we are in a npm workspace / monorepo. But I think it will solve 90% of the issue when people are using our plugin mono repo for their development.