### PR TITLE
[IGNORE] make <RouterProvider> optional

### DIFF
--- a/ui/plugin-system/src/runtime/RouterProvider.tsx
+++ b/ui/plugin-system/src/runtime/RouterProvider.tsx
@@ -19,8 +19,8 @@ interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 export interface RouterContextType {
-  RouterComponent: (props: LinkProps & React.RefAttributes<HTMLAnchorElement>) => ReactNode;
-  navigate: (to: string) => void;
+  RouterComponent?: (props: LinkProps & React.RefAttributes<HTMLAnchorElement>) => ReactNode;
+  navigate?: (to: string) => void;
 }
 
 export const RouterContext = createContext<RouterContextType | undefined>(undefined);
@@ -28,7 +28,8 @@ export const RouterContext = createContext<RouterContextType | undefined>(undefi
 export function useRouterContext(): RouterContextType {
   const ctx = useContext(RouterContext);
   if (ctx === undefined) {
-    throw new Error('No RouterContext found. Did you forget a <RouterProvider>?');
+    console.warn('No RouterContext found. Did you forget a <RouterProvider>?');
+    return {};
   }
   return ctx;
 }


### PR DESCRIPTION
# Description

Log a warning instead of throwing an exception if `<RouterProvider>` (see https://github.com/perses/perses/pull/3140 for more details) is not present.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
