### PR TITLE
[FEATURE]: Add Quick Query Viewer

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -27,6 +27,7 @@ export interface PanelProps extends CardProps<'section'> {
   editHandlers?: PanelHeaderProps['editHandlers'];
   panelOptions?: PanelOptions;
   panelGroupItemId?: PanelGroupItemId;
+  viewQueriesHandler?: PanelHeaderProps['viewQueriesHandler'];
 }
 
 export type PanelOptions = {
@@ -71,6 +72,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
     sx,
     panelOptions,
     panelGroupItemId,
+    viewQueriesHandler,
     ...others
   } = props;
 
@@ -223,6 +225,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
           queryResults={queryResults}
           readHandlers={readHandlers}
           editHandlers={editHandlers}
+          viewQueriesHandler={viewQueriesHandler}
           links={definition.spec.links}
           pluginActions={pluginActions}
           sx={{ paddingX: `${chartsTheme.container.padding.default}px` }}

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -15,6 +15,7 @@ import { Stack, Box, Popover, CircularProgress, styled, PopoverPosition } from '
 import { isValidElement, PropsWithChildren, ReactNode, useMemo, useState } from 'react';
 import { InfoTooltip } from '@perses-dev/components';
 import { QueryData } from '@perses-dev/plugin-system';
+import DatabaseSearch from 'mdi-material-ui/DatabaseSearch';
 import ArrowCollapseIcon from 'mdi-material-ui/ArrowCollapse';
 import ArrowExpandIcon from 'mdi-material-ui/ArrowExpand';
 import PencilIcon from 'mdi-material-ui/PencilOutline';
@@ -50,6 +51,9 @@ export interface PanelActionsProps {
     isPanelViewed?: boolean;
     onViewPanelClick: () => void;
   };
+  viewQueriesHandler?: {
+    onClick: () => void;
+  };
   queryResults: QueryData[];
   pluginActions?: ReactNode[];
 }
@@ -64,6 +68,7 @@ const ConditionalBox = styled(Box)({
 export const PanelActions: React.FC<PanelActionsProps> = ({
   editHandlers,
   readHandlers,
+  viewQueriesHandler,
   extra,
   title,
   description,
@@ -136,6 +141,21 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
     }
     return undefined;
   }, [readHandlers, title]);
+
+  const viewQueryAction = useMemo(() => {
+    if (!viewQueriesHandler?.onClick) return null;
+    return (
+      <InfoTooltip description={TOOLTIP_TEXT.queryView}>
+        <HeaderIconButton
+          aria-label={ARIA_LABEL_TEXT.openQueryView(title)}
+          size="small"
+          onClick={viewQueriesHandler.onClick}
+        >
+          <DatabaseSearch fontSize="inherit" />
+        </HeaderIconButton>
+      </InfoTooltip>
+    );
+  }, [viewQueriesHandler, title]);
 
   const editActions = useMemo((): ReactNode | undefined => {
     if (editHandlers !== undefined) {
@@ -216,7 +236,8 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         {divider}
         <OnHover>
           <OverflowMenu title={title}>
-            {descriptionAction} {linksAction} {queryStateIndicator} {extraActions} {readActions} {pluginActions}
+            {descriptionAction} {linksAction} {queryStateIndicator} {extraActions} {viewQueryAction}
+            {readActions} {pluginActions}
             {editActions}
           </OverflowMenu>
           {moveAction}
@@ -236,9 +257,10 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         </OnHover>
         {divider} {queryStateIndicator}
         <OnHover>
-          {extraActions} {readActions}
+          {extraActions}
+          {readActions}
           <OverflowMenu title={title}>
-            {editActions} {pluginActions}
+            {editActions} {viewQueryAction} {pluginActions}
           </OverflowMenu>
           {moveAction}
         </OnHover>
@@ -257,7 +279,9 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         </OnHover>
         {divider} {queryStateIndicator}
         <OnHover>
-          {extraActions} {readActions} {editActions}
+          {extraActions}
+          {viewQueryAction}
+          {readActions} {editActions}
           {/* Show plugin actions inside a menu if it gets crowded */}
           {pluginActions.length <= 1 ? pluginActions : <OverflowMenu title={title}>{pluginActions}</OverflowMenu>}
           {moveAction}

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -28,6 +28,7 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
   links?: Link[];
   extra?: ReactNode;
   queryResults: QueryData[];
+  viewQueriesHandler?: PanelActionsProps['viewQueriesHandler'];
   readHandlers?: PanelActionsProps['readHandlers'];
   editHandlers?: PanelActionsProps['editHandlers'];
   pluginActions?: ReactNode[]; // Add pluginActions prop
@@ -44,6 +45,7 @@ export function PanelHeader({
   sx,
   extra,
   pluginActions,
+  viewQueriesHandler,
   ...rest
 }: PanelHeaderProps): ReactElement {
   const titleElementId = `${id}-title`;
@@ -83,6 +85,7 @@ export function PanelHeader({
             links={links}
             readHandlers={readHandlers}
             editHandlers={editHandlers}
+            viewQueriesHandler={viewQueriesHandler}
             extra={extra}
             queryResults={queryResults}
             pluginActions={pluginActions}

--- a/ui/dashboards/src/constants/user-interface-text.ts
+++ b/ui/dashboards/src/constants/user-interface-text.ts
@@ -34,6 +34,7 @@ export const TOOLTIP_TEXT = {
   // Variable editor buttons
   refreshVariableValues: 'Refresh values',
   copyVariableValues: 'Copy values to clipboard',
+  queryView: 'Open query view',
 };
 
 export const ARIA_LABEL_TEXT = {
@@ -50,4 +51,5 @@ export const ARIA_LABEL_TEXT = {
   deletePanel: (panelName: string): string => `delete panel ${panelName}`,
   showPanelActions: (panelName: string): string => `show panel actions for ${panelName}`,
   movePanel: (panelName: string): string => `move panel ${panelName}`,
+  openQueryView: (panelName: string): string => `open query view for panel ${panelName}`,
 };


### PR DESCRIPTION
Closes #3071 

## Description 🖊️ 

This is the Quick Query Viewer **kick-off** . 
> ⚠️ More interesting ideas can be added later on top. Let's have a scaffold first ...

## Test 🧪 

1. Open a project
2. Then go to a dashboard
3. All panel headers should have an extra functionality (Query Viewer)
4. Click on the icon button
5. Do you see the queries? (It should show all quires)
6. You can also open Tree View

## Screenshots 🖼️ 


![queryviewer](https://github.com/user-attachments/assets/59203567-3b8a-4f35-9189-fd4a61bb38c2)


<img width="937" height="413" alt="image" src="https://github.com/user-attachments/assets/7183dbac-3e05-4b8b-9a38-77f435f7d403" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
