### PR TITLE
[BUGFIX] Add refresh token to the variable fetch

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -29,9 +29,10 @@ import { DiscardChangesConfirmationDialog, ErrorAlert, ErrorBoundary, FormAction
 import { Control, Controller, FormProvider, SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { getSubmitText, getTitleAction } from '../../../utils';
-import { VARIABLE_TYPES } from '../variable-model';
 import { PluginEditor } from '../../PluginEditor';
 import { useValidationSchemas } from '../../../context';
+import { VARIABLE_TYPES } from '../variable-model';
+import { useTimeRange } from '../../../runtime';
 import { VariableListPreview, VariablePreview } from './VariablePreview';
 
 function FallbackPreview(): ReactElement {
@@ -108,7 +109,9 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
    * having to re-fetch the values when the user is still editing the spec.
    */
   const [previewSpec, setPreviewSpec] = useState<ListVariableDefinition>(form.getValues() as ListVariableDefinition);
+  const { refresh } = useTimeRange();
   const refreshPreview = (): void => {
+    refresh();
     setPreviewSpec(form.getValues() as ListVariableDefinition);
   };
 
@@ -150,10 +153,13 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
 
         <Stack>
           {/** Hack?: Cool technique to refresh the preview to simulate onBlur event */}
+          {/* 
+              TODO: What is cool about this? This makes an extra request to the server
+              This is already a bug. Should be removed after investigation
+          */}
           <ClickAwayListener onClickAway={() => refreshPreview()}>
             <Box />
           </ClickAwayListener>
-          {/** **/}
           <ErrorBoundary FallbackComponent={ErrorAlert}>
             <Controller
               control={control}

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useMemo, useState } from 'react';
 import { Alert, Box, Card, Chip, CircularProgress, IconButton, Stack, Typography } from '@mui/material';
 import { InfoTooltip, useSnackbar } from '@perses-dev/components';
 import Refresh from 'mdi-material-ui/Refresh';
@@ -90,16 +90,21 @@ interface VariableListPreviewProps {
 }
 
 export function VariableListPreview(props: VariableListPreviewProps): ReactElement {
-  const { definition, onRefresh } = props;
+  const { onRefresh, definition } = props;
   const { data, isFetching, error } = useListVariablePluginValues(definition);
   const errorMessage = (error as Error)?.message;
 
-  return (
-    <VariablePreview
-      values={data?.map((val) => val.value) || []}
-      onRefresh={onRefresh}
-      isLoading={isFetching}
-      error={errorMessage}
-    />
+  const variablePreview = useMemo(
+    () => (
+      <VariablePreview
+        values={data?.map((val) => val.value) || []}
+        onRefresh={onRefresh}
+        isLoading={isFetching}
+        error={errorMessage}
+      />
+    ),
+    [errorMessage, isFetching, onRefresh, data]
   );
+
+  return variablePreview;
 }

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
@@ -73,6 +73,13 @@ export function useSuggestedStepMs(width?: number): number {
 export function TimeRangeProvider(props: TimeRangeProviderProps): ReactElement {
   const { timeRange, refreshInterval, children, setTimeRange, setRefreshInterval } = props;
 
+  /**
+   * TODO: The hook needs refactor. There is a bug here with refreshKey. If the refreshInterval is not set,
+   * refreshKey string includes an undefined xx:yy:zz:undefined:0
+   * I think exposing refresh functionality also is very risky. A careless usage of refresh may cause
+   * infinite rendering loop.
+   */
+
   const [localTimeRange, setLocalTimeRange] = useState<TimeRangeValue>(timeRange);
   const [localRefreshInterval, setLocalRefreshInterval] = useState<DurationString | undefined>(refreshInterval);
 


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3188

## Description 🖊️ 

The refresh token is not included in the query  key , so the result is cached, and with every refresh action the cached result is returned. To solve this problem, the refresh token should be added to the query key. 


## Test 🧪 

1. Go to the Edit/Add Variables
2. Find preview labels
3. Set the type to the list
4. Set the type on Prometheus Name Variables
5. Press the refresh button
6. Check the network traffic from the developer tool
7. With every single button press, a request (technically 2, because of an existing bug) should be made.

> http://localhost:3000/proxy/projects/quick_query_view/datasources/newdatasource/api/v1/labels

## Warning - Existing Bug ⚠️ 🐞 

There has been already a bug which makes an extra request call to fetch the labels. 
Commented in the code to be addressed later. 

```typescript
 {/** Hack?: Cool technique to refresh the preview to simulate onBlur event */}
          {/* 
              TODO: What is cool about this? This makes an extra request to the server
              This is already a bug. Should be removed after investigation
          */}
          <ClickAwayListener onClickAway={() => refreshPreview()}>
            <Box />
          </ClickAwayListener>
```



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
