### PR TITLE
BUGFIX: Remove unnecessary network call on variable refresh

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -152,14 +152,6 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
         )}
 
         <Stack>
-          {/** Hack?: Cool technique to refresh the preview to simulate onBlur event */}
-          {/* 
-              TODO: What is cool about this? This makes an extra request to the server
-              This is already a bug. Should be removed after investigation
-          */}
-          <ClickAwayListener onClickAway={() => refreshPreview()}>
-            <Box />
-          </ClickAwayListener>
           <ErrorBoundary FallbackComponent={ErrorAlert}>
             <Controller
               control={control}


### PR DESCRIPTION
This PR removes the `ClickAwayListener` component that was causing a second, unnecessary network request when refreshing variable values in the editor.

Closes #3234

Hi @shahrokni, I've submitted the fix for review. Please let me know if any changes are needed. Thanks!