### PR TITLE
[BUGFIX] Remove ClickAwaya to avoid unnecessaey endpoint call

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -11,19 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { DispatchWithoutAction, ReactElement, useState } from 'react';
-import {
-  Box,
-  Typography,
-  Switch,
-  TextField,
-  Grid,
-  FormControlLabel,
-  MenuItem,
-  Stack,
-  ClickAwayListener,
-  Divider,
-} from '@mui/material';
+import { DispatchWithoutAction, ReactElement, useState } from 'react';
+import { Box, Typography, Switch, TextField, Grid, FormControlLabel, MenuItem, Stack, Divider } from '@mui/material';
 import { VariableDefinition, ListVariableDefinition, Action } from '@perses-dev/core';
 import { DiscardChangesConfirmationDialog, ErrorAlert, ErrorBoundary, FormActions } from '@perses-dev/components';
 import { Control, Controller, FormProvider, SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
@@ -152,14 +141,6 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
         )}
 
         <Stack>
-          {/** Hack?: Cool technique to refresh the preview to simulate onBlur event */}
-          {/* 
-              TODO: What is cool about this? This makes an extra request to the server
-              This is already a bug. Should be removed after investigation
-          */}
-          <ClickAwayListener onClickAway={() => refreshPreview()}>
-            <Box />
-          </ClickAwayListener>
           <ErrorBoundary FallbackComponent={ErrorAlert}>
             <Controller
               control={control}


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3234


## Description (IMPORTANT)

There is a block of code in ` VariableEditorForm\VariableEditorForm.tsx`  which is used to call `refreshPreview` when the user clicks anywhere on the Edit Variable Form. Technically when they click outside the <Box /> which not dimension. 
To understand what I am talking about you can take a quick look at 

https://mui.com/material-ui/react-click-away-listener/

I think this was a trick to refresh the Edit Form after changes, imitating the onBlur behavior. 

1. Change a control value
2. Click anywhere on the Form 
3. The  `refreshPreview` should be called

## Why should we remove this block ❓ 

Since we are moving away from onBlur behavior, and all interactions should happen through onClick event, this old piece of code causes a bug. For instance, if I click on a button to get the fresh results, the target function would be called twice.

1. Once with onclick 
2. And also with react-click-away-listener

##  Test  🧪 

1. In Variable Add/Edit form click on the refresh button
2. Only one request should be made 

<img width="1940" height="1010" alt="image" src="https://github.com/user-attachments/assets/8df72ed7-9747-4386-976d-c0051dc93910" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
