### PR TITLE
[FEATURE] dashboard: add optional confirmation dialog on unsaved leave

### DIFF
--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -104,12 +104,13 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
                   }}
                   onSave={onSave}
                   onDiscard={onDiscard}
-                  initialVariableIsSticky={true}
+                  isInitialVariableSticky={true}
                   isReadonly={isReadonly}
                   isVariableEnabled={isLocalVariableEnabled}
                   isDatasourceEnabled={isLocalDatasourceEnabled}
                   isEditing={isEditing}
                   isCreating={isCreating}
+                  isLeavingConfirmDialogEnabled={true}
                 />
               </UsageMetricsProvider>
             </ErrorBoundary>

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -14,7 +14,7 @@
 import { Typography, Stack, Button, Box, useTheme, useMediaQuery, Alert } from '@mui/material';
 import { ErrorBoundary, ErrorAlert } from '@perses-dev/components';
 import { TimeRangeControls } from '@perses-dev/plugin-system';
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { OnSaveDashboard, useEditMode } from '../../context';
 import { AddPanelButton } from '../AddPanelButton';
 import { AddGroupButton } from '../AddGroupButton';
@@ -28,7 +28,7 @@ import { DashboardStickyToolbar } from '../DashboardStickyToolbar';
 
 export interface DashboardToolbarProps {
   dashboardName: string;
-  dashboardTitleComponent?: JSX.Element;
+  dashboardTitleComponent?: ReactNode;
   initialVariableIsSticky?: boolean;
   isReadonly: boolean;
   isVariableEnabled: boolean;

--- a/ui/dashboards/src/components/LeaveDialog/LeaveDialog.tsx
+++ b/ui/dashboards/src/components/LeaveDialog/LeaveDialog.tsx
@@ -1,0 +1,42 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DashboardResource, EphemeralDashboardResource } from '@perses-dev/core';
+import { ReactNode, useEffect } from 'react';
+
+export function LeaveDialog({
+  original,
+  current,
+}: {
+  original: DashboardResource | EphemeralDashboardResource | undefined;
+  current: DashboardResource | EphemeralDashboardResource;
+}): ReactNode {
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent): string | null => {
+      if (JSON.stringify(original) === JSON.stringify(current)) {
+        return null;
+      }
+      event.preventDefault();
+      event.returnValue = ''; // Required for Chrome
+      return ''; // Required for other browsers
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return (): void => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [original, current]);
+
+  return <div></div>;
+}

--- a/ui/dashboards/src/components/LeaveDialog/LeaveDialog.tsx
+++ b/ui/dashboards/src/components/LeaveDialog/LeaveDialog.tsx
@@ -38,5 +38,5 @@ export function LeaveDialog({
     };
   }, [original, current]);
 
-  return <div></div>;
+  return <></>;
 }

--- a/ui/dashboards/src/components/LeaveDialog/index.ts
+++ b/ui/dashboards/src/components/LeaveDialog/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './LeaveDialog';

--- a/ui/dashboards/src/components/index.ts
+++ b/ui/dashboards/src/components/index.ts
@@ -25,6 +25,7 @@ export * from './EditJsonButton';
 export * from './EditJsonDialog';
 export * from './EmptyDashboard';
 export * from './GridLayout';
+export * from './LeaveDialog';
 export * from './Panel';
 export * from './PanelDrawer';
 export * from './PanelGroupDialog';

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ReactElement, useState } from 'react';
+import { ReactElement, ReactNode, useState } from 'react';
 import { Box } from '@mui/material';
 import { ChartsProvider, ErrorAlert, ErrorBoundary, useChartsTheme } from '@perses-dev/components';
 import { DashboardResource, EphemeralDashboardResource } from '@perses-dev/core';
@@ -27,34 +27,38 @@ import {
   EmptyDashboardProps,
   EditJsonDialog,
   SaveChangesConfirmationDialog,
+  LeaveDialog,
 } from '../../components';
 import { OnSaveDashboard, useDashboard, useDiscardChangesConfirmationDialog, useEditMode } from '../../context';
 
 export interface DashboardAppProps {
-  emptyDashboardProps?: Partial<EmptyDashboardProps>;
   dashboardResource: DashboardResource | EphemeralDashboardResource;
-  dashboardTitleComponent?: JSX.Element;
-  onSave?: OnSaveDashboard;
-  onDiscard?: (entity: DashboardResource) => void;
-  initialVariableIsSticky?: boolean;
+  emptyDashboardProps?: Partial<EmptyDashboardProps>;
   isReadonly: boolean;
   isVariableEnabled: boolean;
   isDatasourceEnabled: boolean;
   isCreating?: boolean;
+  isInitialVariableSticky?: boolean;
+  // If true, browser confirmation dialog will be shown when navigating away with unsaved changes (closing tab, ...).
+  isLeavingConfirmDialogEnabled?: boolean;
+  dashboardTitleComponent?: ReactNode;
+  onSave?: OnSaveDashboard;
+  onDiscard?: (entity: DashboardResource) => void;
 }
 
 export const DashboardApp = (props: DashboardAppProps): ReactElement => {
   const {
     dashboardResource,
-    dashboardTitleComponent,
     emptyDashboardProps,
-    onSave,
-    onDiscard,
-    initialVariableIsSticky,
     isReadonly,
     isVariableEnabled,
     isDatasourceEnabled,
     isCreating,
+    isInitialVariableSticky,
+    isLeavingConfirmDialogEnabled,
+    dashboardTitleComponent,
+    onSave,
+    onDiscard,
   } = props;
 
   const chartsTheme = useChartsTheme();
@@ -116,7 +120,7 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
       <DashboardToolbar
         dashboardName={dashboardResource.metadata.name}
         dashboardTitleComponent={dashboardTitleComponent}
-        initialVariableIsSticky={initialVariableIsSticky}
+        initialVariableIsSticky={isInitialVariableSticky}
         onSave={onSave}
         isReadonly={isReadonly}
         isVariableEnabled={isVariableEnabled}
@@ -142,6 +146,9 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
         <DashboardDiscardChangesConfirmationDialog />
         <EditJsonDialog isReadonly={!isEditMode} disableMetadataEdition={!isCreating} />
         <SaveChangesConfirmationDialog />
+        {isLeavingConfirmDialogEnabled && isEditMode && (
+          <LeaveDialog original={originalDashboard} current={dashboard} />
+        )}
       </Box>
     </Box>
   );

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -45,16 +45,17 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
     dashboardResource,
     datasourceApi,
     externalVariableDefinitions,
-    dashboardTitleComponent,
     emptyDashboardProps,
-    onSave,
-    onDiscard,
-    initialVariableIsSticky,
     isReadonly,
     isVariableEnabled,
     isDatasourceEnabled,
     isEditing,
     isCreating,
+    isInitialVariableSticky,
+    isLeavingConfirmDialogEnabled,
+    dashboardTitleComponent,
+    onSave,
+    onDiscard,
     sx,
     ...others
   } = props;
@@ -133,15 +134,16 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
               <ErrorBoundary FallbackComponent={ErrorAlert}>
                 <DashboardApp
                   dashboardResource={dashboardResource}
-                  dashboardTitleComponent={dashboardTitleComponent}
                   emptyDashboardProps={emptyDashboardProps}
-                  onSave={onSave}
-                  onDiscard={onDiscard}
-                  initialVariableIsSticky={initialVariableIsSticky}
                   isReadonly={isReadonly}
                   isVariableEnabled={isVariableEnabled}
                   isDatasourceEnabled={isDatasourceEnabled}
                   isCreating={isCreating}
+                  isInitialVariableSticky={isInitialVariableSticky}
+                  isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
+                  dashboardTitleComponent={dashboardTitleComponent}
+                  onSave={onSave}
+                  onDiscard={onDiscard}
                 />
               </ErrorBoundary>
             </Box>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Add an optional confirmation dialog when the user try to close/refresh/change manually the url with unsaved change on a dashboard.

**KNOW ISSUE:**
If you navigate with react-router links (`<Link>`), it will not trigger this popup. For this, we need to add another custom popup with `Prompt` or `useBlocker`. However, it need a complete refactor of the router: we need to change declarative mode data mode (https://reactrouter.com/start/modes).

I will do it in a separate PR, hopefully it will not be to hard 🙏


# Screenshots

<!-- If there are UI changes -->
Chrome:

<img width="1277" height="622" alt="image" src="https://github.com/user-attachments/assets/2d8e34cf-a234-4893-9210-21aaf1b05657" />

Firefox:

<img width="1279" height="824" alt="image" src="https://github.com/user-attachments/assets/0c19a4ed-d348-4adc-98c0-54ecbf5fc6b1" />



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
