### PR TITLE
[IGNORE] add panelOptions.showIcons setting

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -37,6 +37,11 @@ export type PanelOptions = {
    */
   hideHeader?: boolean;
   /**
+   * Whether to show panel icons always, or only when hovering over the panel.
+   * Default: if the dashboard is in editing mode or the panel is in fullscreen mode: 'always', otherwise 'hover'
+   */
+  showIcons?: 'always' | 'hover';
+  /**
    * Content to render in right of the panel header. (top right of the panel)
    * It will only be rendered when the panel is in edit mode.
    */
@@ -195,6 +200,9 @@ export const Panel = memo(function Panel(props: PanelProps) {
     onMouseLeave?.(e);
   };
 
+  // default value for showIcons: if the dashboard is in editing mode or the panel is in fullscreen mode: 'always', otherwise 'hover'
+  const showIcons = panelOptions?.showIcons ?? (editHandlers || readHandlers?.isPanelViewed ? 'always' : 'hover');
+
   return (
     <Card
       component="section"
@@ -228,6 +236,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
           viewQueriesHandler={viewQueriesHandler}
           links={definition.spec.links}
           pluginActions={pluginActions}
+          showIcons={showIcons}
           sx={{ paddingX: `${chartsTheme.container.padding.default}px` }}
         />
       )}

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../constants';
 import { HeaderIconButton } from './HeaderIconButton';
 import { PanelLinks } from './PanelLinks';
+import { PanelOptions } from './Panel';
 
 export interface PanelActionsProps {
   title: string;
@@ -56,6 +57,7 @@ export interface PanelActionsProps {
   };
   queryResults: QueryData[];
   pluginActions?: ReactNode[];
+  showIcons: PanelOptions['showIcons'];
 }
 
 const ConditionalBox = styled(Box)({
@@ -76,6 +78,7 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
   links,
   queryResults,
   pluginActions = [],
+  showIcons,
 }) => {
   const descriptionAction = useMemo((): ReactNode | undefined => {
     if (description && description.trim().length > 0) {
@@ -217,13 +220,9 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
 
   const divider = <Box sx={{ flexGrow: 1 }}></Box>;
 
-  // if the panel is in non-editing, non-fullscreen mode, show certain icons only on hover
+  // By default, the panel header shows certain icons only on hover if the panel is in non-editing, non-fullscreen mode
   const OnHover = ({ children }: PropsWithChildren): ReactNode =>
-    editHandlers === undefined && !readHandlers?.isPanelViewed ? (
-      <Box sx={{ display: 'var(--panel-hover, none)' }}>{children}</Box>
-    ) : (
-      <>{children}</>
-    );
+    showIcons === 'hover' ? <Box sx={{ display: 'var(--panel-hover, none)' }}>{children}</Box> : <>{children}</>;
 
   return (
     <>

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -18,6 +18,7 @@ import { QueryData, useReplaceVariablesInString } from '@perses-dev/plugin-syste
 import { ReactElement, ReactNode } from 'react';
 import { HEADER_ACTIONS_CONTAINER_NAME } from '../../constants';
 import { PanelActions, PanelActionsProps } from './PanelActions';
+import { PanelOptions } from './Panel';
 
 type OmittedProps = 'children' | 'action' | 'title' | 'disableTypography';
 
@@ -32,6 +33,7 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
   readHandlers?: PanelActionsProps['readHandlers'];
   editHandlers?: PanelActionsProps['editHandlers'];
   pluginActions?: ReactNode[]; // Add pluginActions prop
+  showIcons: PanelOptions['showIcons'];
 }
 
 export function PanelHeader({
@@ -45,6 +47,7 @@ export function PanelHeader({
   sx,
   extra,
   pluginActions,
+  showIcons,
   viewQueriesHandler,
   ...rest
 }: PanelHeaderProps): ReactElement {
@@ -89,6 +92,7 @@ export function PanelHeader({
             extra={extra}
             queryResults={queryResults}
             pluginActions={pluginActions}
+            showIcons={showIcons}
           />
         </Stack>
       }


### PR DESCRIPTION
# Description

Currently, we show most of the panel icons only on hover, unless the dashboard is in editing mode, or the panel is in fullscreen mode.

In the Tempo explore view, the panel is in fullscreen mode, but doesn't have `readHandlers.isPanelViewed` set (because it's always fullscreen, there is no option to change the panel size), therefore the icons (among others, the download icon) is only shown on hover, which is bad UX.

This PR adds an explicit `showIcons` setting which can be either `hover` or `always`, and by default uses the current behavior (`always` if the dashboard is in editing mode or panel is in fullscreen mode, `hover` otherwise).

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
