### PR TITLE
[FEATURE] enhance variable replacement with custom formats

### DIFF
--- a/ui/plugin-system/src/utils/variables.test.ts
+++ b/ui/plugin-system/src/utils/variables.test.ts
@@ -97,3 +97,164 @@ describe('replaceVariables()', () => {
     });
   });
 });
+
+describe('replaceVariables() with custom formats', () => {
+  const tests = [
+    // csv
+    {
+      text: 'hello ${var1:csv} ${var2:csv}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello perses,prometheus world',
+    },
+    // distributed
+    {
+      text: 'hello ${var1:distributed} ${var2:distributed}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello perses,var1=prometheus world',
+    },
+    {
+      text: 'hello ${var1:distributed} ${var2:distributed}',
+      state: {
+        var1: { value: ['perses', 'prometheus', 'timeseries'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello perses,var1=prometheus,var1=timeseries world',
+    },
+    // doublequote
+    {
+      text: 'hello ${var1:doublequote} ${var2:doublequote}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello "perses","prometheus" "world"',
+    },
+    // glob
+    {
+      text: 'hello ${var1:glob} ${var2:glob}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello {perses,prometheus} {world}',
+    },
+    // json
+    {
+      text: 'hello ${var1:json} ${var2:json}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello ["perses","prometheus"] ["world"]',
+    },
+    // lucene
+    {
+      text: 'hello ${var1:lucene} ${var2:lucene}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello ("perses" OR "prometheus") ("world")',
+    },
+    // percentencode
+    {
+      text: 'hello ${var1:percentencode} ${var2:percentencode}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello perses%2Cprometheus world',
+    },
+    // pipe
+    {
+      text: 'hello ${var1:pipe} ${var2:pipe}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello perses|prometheus world',
+    },
+    // raw
+    {
+      text: 'hello ${var1:raw} ${var2:raw}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello perses,prometheus world',
+    },
+    // regex
+    {
+      text: 'hello ${var1:regex} ${var2:regex}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello (perses|prometheus) (world)',
+    },
+    {
+      text: 'hello ${var1:regex} ${var2:regex}',
+      state: {
+        var1: { value: ['perses.', 'prometheus$'], loading: false },
+        var2: { value: 'world.', loading: false },
+      },
+      expected: 'hello (perses\\.|prometheus\\$) (world\\.)',
+    },
+    // singlequote
+    {
+      text: 'hello ${var1:singlequote} ${var2:singlequote}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: "hello 'perses','prometheus' 'world'",
+    },
+    // sqlstring
+    {
+      text: 'hello ${var1:sqlstring} ${var2:sqlstring}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: "hello 'perses','prometheus' 'world'",
+    },
+    {
+      text: 'hello ${var1:sqlstring} ${var2:sqlstring}',
+      state: {
+        var1: { value: ["perses'", 'prometheus'], loading: false },
+        var2: { value: "world'", loading: false },
+      },
+      expected: "hello 'perses''','prometheus' 'world'''",
+    },
+    // text
+    {
+      text: 'hello ${var1:text} ${var2:text}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello perses + prometheus world',
+    },
+    // queryparam
+    {
+      text: 'hello ${var1:queryparam} ${var2:queryparam}',
+      state: {
+        var1: { value: ['perses', 'prometheus'], loading: false },
+        var2: { value: 'world', loading: false },
+      },
+      expected: 'hello var1=perses&var1=prometheus var2=world',
+    },
+  ];
+
+  tests.forEach(({ text, state, expected }) => {
+    it(`replaces ${text} ${JSON.stringify(state)}`, () => {
+      expect(replaceVariables(text, state)).toEqual(expected);
+    });
+  });
+});

--- a/ui/plugin-system/src/utils/variables.ts
+++ b/ui/plugin-system/src/utils/variables.ts
@@ -15,7 +15,8 @@ import { VariableValue } from '@perses-dev/core';
 import { VariableStateMap } from '@perses-dev/plugin-system';
 
 export function replaceVariables(text: string, variableState: VariableStateMap): string {
-  const variables = parseVariables(text);
+  const variablesMap = parseVariablesAndFormat(text);
+  const variables = Array.from(variablesMap.keys());
   let finalText = text;
   variables
     // Sorting variables by their length.
@@ -25,23 +26,92 @@ export function replaceVariables(text: string, variableState: VariableStateMap):
     .forEach((v) => {
       const variable = variableState[v];
       if (variable && variable.value !== undefined) {
-        finalText = replaceVariable(finalText, v, variable?.value);
+        finalText = replaceVariable(finalText, v, variable?.value, variablesMap.get(v));
       }
     });
 
   return finalText;
 }
 
-export function replaceVariable(text: string, varName: string, variableValue: VariableValue): string {
+export enum InterpolationFormat {
+  CSV = 'csv',
+  DISTRIBUTED = 'distributed',
+  DOUBLEQUOTE = 'doublequote',
+  GLOB = 'glob',
+  JSON = 'json',
+  LUCENE = 'lucene',
+  PERCENTENCODE = 'percentencode',
+  PIPE = 'pipe',
+  PROMETHEUS = 'prometheus',
+  RAW = 'raw',
+  REGEX = 'regex',
+  SINGLEQUOTE = 'singlequote',
+  SQLSTRING = 'sqlstring',
+  TEXT = 'text',
+  QUERYPARAM = 'queryparam',
+}
+
+function stringToFormat(val: string | undefined): InterpolationFormat | undefined {
+  if (!val) return undefined;
+
+  const lowerVal = val.toLowerCase();
+  return Object.values(InterpolationFormat).find((format) => format === lowerVal) || undefined;
+}
+
+export function interpolate(values: string[], name: string, format: InterpolationFormat): string {
+  switch (format) {
+    case InterpolationFormat.CSV:
+    case InterpolationFormat.RAW:
+      return values.join(',');
+    case InterpolationFormat.DISTRIBUTED: {
+      const [first, ...rest] = values;
+      return `${[first, ...rest.map((v) => `${name}=${v}`)].join(',')}`;
+    }
+    case InterpolationFormat.DOUBLEQUOTE:
+      return values.map((v) => `"${v}"`).join(',');
+    case InterpolationFormat.GLOB:
+      return `{${values.join(',')}}`;
+    case InterpolationFormat.JSON:
+      return JSON.stringify(values);
+    case InterpolationFormat.LUCENE:
+      return `(${values.map((v) => `"${v}"`).join(' OR ')})`;
+    case InterpolationFormat.PERCENTENCODE:
+      return encodeURIComponent(values.join(','));
+    case InterpolationFormat.PIPE:
+      return values.join('|');
+    case InterpolationFormat.REGEX: {
+      const escapedRegex = values.map((v) => v.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'));
+      return `(${escapedRegex.join('|')})`;
+    }
+    case InterpolationFormat.SINGLEQUOTE:
+      return values.map((v) => `'${v}'`).join(',');
+    case InterpolationFormat.SQLSTRING:
+      return values.map((v) => `'${v.replace(/'/g, "''")}'`).join(',');
+    case InterpolationFormat.TEXT:
+      return values.join(' + ');
+    case InterpolationFormat.QUERYPARAM:
+      return values.map((v) => `${name}=${encodeURIComponent(v)}`).join('&');
+    case InterpolationFormat.PROMETHEUS:
+    default:
+      return `(${values.join('|')})`;
+  }
+}
+
+export function replaceVariable(
+  text: string,
+  varName: string,
+  variableValue: VariableValue,
+  varFormat?: InterpolationFormat
+): string {
   const variableSyntax = '$' + varName;
-  const alternativeVariableSyntax = '${' + varName + '}';
+  const alternativeVariableSyntax = '${' + varName + (varFormat ? ':' + varFormat : '') + '}';
 
   let replaceString = '';
   if (Array.isArray(variableValue)) {
-    replaceString = `(${variableValue.join('|')})`; // regex style
+    replaceString = interpolate(variableValue, varName, varFormat || InterpolationFormat.PROMETHEUS);
   }
   if (typeof variableValue === 'string') {
-    replaceString = variableValue;
+    replaceString = interpolate([variableValue], varName, varFormat || InterpolationFormat.RAW);
   }
 
   text = text.replaceAll(variableSyntax, replaceString);
@@ -52,20 +122,18 @@ export function replaceVariable(text: string, varName: string, variableValue: Va
 // It supports two formats for referencing variables:
 // 1. $variableName - This is a simpler format, and the regular expression captures the variable name (\w+ matches one or more word characters).
 // 2. ${variableName} - This is a more complex format and the regular expression captures the variable name (\w+ matches one or more word characters) in the curly braces.
-// 3. [COMING SOON] ${variableName:value} - This is a more complex format that allows specifying a format function as well.
-// TODO: Fix this lint error
-// eslint-disable-next-line no-useless-escape
-const VARIABLE_REGEX = /\$(\w+)|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/gm;
+// 3. ${variableName:format} - This is a more complex format that allows specifying a format interpolation.
+
+const VARIABLE_REGEX = /\$(\w+)|\${(\w+)(?:\.([^:^}]+))?(?::([^}]+))?}/gm;
 
 /**
  * Returns a list of variables
  */
-export const parseVariables = (text: string): string[] => {
-  const regex = VARIABLE_REGEX;
+export function parseVariables(text: string): string[] {
   const matches = new Set<string>();
   let match;
 
-  while ((match = regex.exec(text)) !== null) {
+  while ((match = VARIABLE_REGEX.exec(text)) !== null) {
     if (match) {
       if (match[1]) {
         // \$(\w+)\
@@ -78,4 +146,29 @@ export const parseVariables = (text: string): string[] => {
   }
   // return unique matches
   return Array.from(matches.values());
-};
+}
+
+/**
+ * Returns a map of variable names and its format. If no format is specified, it will be undefined.
+ */
+export function parseVariablesAndFormat(text: string): Map<string, InterpolationFormat | undefined> {
+  const matches = new Map<string, InterpolationFormat | undefined>();
+  let match;
+
+  while ((match = VARIABLE_REGEX.exec(text)) !== null) {
+    if (match) {
+      let format = undefined;
+      if (match[4]) {
+        format = match[4];
+      }
+      if (match[1]) {
+        // \$(\w+)\
+        matches.set(match[1], stringToFormat(format));
+      } else if (match[2]) {
+        // \${(\w+)}\
+        matches.set(match[2], stringToFormat(format));
+      }
+    }
+  }
+  return matches;
+}


### PR DESCRIPTION
# Description

This PR adds support for custom formats for variable replacements using the `${varName:format}` syntax. For example a query defined as:

```
hello ${var1:json}'
```

with `var1` being an array with `perses` and `prometheus` will be processed as:

```
hello ["perses","prometheus"]
```

more formats and examples are included in the tests.

A new `parseVariablesAndFormat` function was created as the `parseVariables` is being used by plugins to get only variable names, so it was left unchanged.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).