### PR TITLE
[IGNORE] apply modernize with efaceany category

### DIFF
--- a/go-sdk/common/format.go
+++ b/go-sdk/common/format.go
@@ -86,7 +86,7 @@ func (f *Format) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (f *Format) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (f *Format) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Format
 	type plain Format
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/go-sdk/common/transform.go
+++ b/go-sdk/common/transform.go
@@ -51,21 +51,21 @@ type MergeSeriesSpec struct {
 
 type Transform struct {
 	Kind TransformKind `json:"kind" yaml:"kind"`
-	Spec interface{}   `json:"spec" yaml:"spec"`
+	Spec any           `json:"spec" yaml:"spec"`
 }
 
 func (t *Transform) UnmarshalJSON(data []byte) error {
-	jsonUnmarshalFunc := func(variable interface{}) error {
+	jsonUnmarshalFunc := func(variable any) error {
 		return json.Unmarshal(data, variable)
 	}
 	return t.unmarshal(jsonUnmarshalFunc, json.Marshal, json.Unmarshal)
 }
 
-func (t *Transform) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (t *Transform) UnmarshalYAML(unmarshal func(any) error) error {
 	return t.unmarshal(unmarshal, yaml.Marshal, yaml.Unmarshal)
 }
 
-func (t *Transform) unmarshal(unmarshal func(interface{}) error, staticMarshal func(interface{}) ([]byte, error), staticUnmarshal func([]byte, interface{}) error) error {
+func (t *Transform) unmarshal(unmarshal func(any) error, staticMarshal func(any) ([]byte, error), staticUnmarshal func([]byte, any) error) error {
 	var tmp Transform
 	type plain Transform
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -75,7 +75,7 @@ func (t *Transform) unmarshal(unmarshal func(interface{}) error, staticMarshal f
 	if err != nil {
 		return err
 	}
-	var spec interface{}
+	var spec any
 	switch tmp.Kind {
 	case JoinByColumValueKind:
 		spec = &JoinByColumnValueSpec{}

--- a/internal/api/crypto/jwt.go
+++ b/internal/api/crypto/jwt.go
@@ -145,7 +145,7 @@ func (j *jwtImpl) DeleteRefreshTokenCookie() *http.Cookie {
 }
 
 func (j *jwtImpl) ValidateRefreshToken(token string) (*jwt.RegisteredClaims, error) {
-	parsedToken, err := jwt.ParseWithClaims(token, &jwt.RegisteredClaims{}, func(_ *jwt.Token) (interface{}, error) {
+	parsedToken, err := jwt.ParseWithClaims(token, &jwt.RegisteredClaims{}, func(_ *jwt.Token) (any, error) {
 		return j.refreshKey, nil
 	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS512.Name}))
 	if err != nil {

--- a/internal/api/database/database.go
+++ b/internal/api/database/database.go
@@ -56,7 +56,7 @@ func (d *dao) Upsert(entity modelAPI.Entity) error {
 func (d *dao) Get(kind modelV1.Kind, metadata modelAPI.Metadata, entity modelAPI.Entity) error {
 	return d.client.Get(kind, metadata, entity)
 }
-func (d *dao) Query(query databaseModel.Query, slice interface{}) error {
+func (d *dao) Query(query databaseModel.Query, slice any) error {
 	return d.client.Query(query, slice)
 }
 func (d *dao) RawQuery(query databaseModel.Query) ([]json.RawMessage, error) {

--- a/internal/api/database/file/file.go
+++ b/internal/api/database/file/file.go
@@ -144,7 +144,7 @@ func (d *DAO) RawQuery(query databaseModel.Query) ([]json.RawMessage, error) {
 		// If it's YAML, we need to convert to JSON first
 		if d.Extension == config.YAMLExtension {
 			// Parse the YAML content
-			var yamlData interface{}
+			var yamlData any
 			if err := yaml.Unmarshal(data, &yamlData); err != nil {
 				return nil, fmt.Errorf("failed to parse YAML from %s: %w", file, err)
 			}
@@ -163,7 +163,7 @@ func (d *DAO) RawQuery(query databaseModel.Query) ([]json.RawMessage, error) {
 	return result, nil
 }
 
-func (d *DAO) Query(query databaseModel.Query, slice interface{}) error {
+func (d *DAO) Query(query databaseModel.Query, slice any) error {
 	typeParameter := reflect.TypeOf(slice)
 	result := reflect.ValueOf(slice)
 	// to avoid any miss usage when using this method, slice should be a pointer to a slice.
@@ -301,14 +301,14 @@ func (d *DAO) buildPath(key string) string {
 	return filepath.Join(d.Folder, fmt.Sprintf("%s.%s", key, d.Extension))
 }
 
-func (d *DAO) unmarshal(data []byte, entity interface{}) error {
+func (d *DAO) unmarshal(data []byte, entity any) error {
 	if d.Extension == config.JSONExtension {
 		return json.Unmarshal(data, entity)
 	}
 	return yaml.Unmarshal(data, entity)
 }
 
-func (d *DAO) marshal(entity interface{}) ([]byte, error) {
+func (d *DAO) marshal(entity any) ([]byte, error) {
 	if d.Extension == config.JSONExtension {
 		return json.Marshal(entity)
 	}

--- a/internal/api/database/model/dao.go
+++ b/internal/api/database/model/dao.go
@@ -38,7 +38,7 @@ type DAO interface {
 	Get(kind modelV1.Kind, metadata modelAPI.Metadata, entity modelAPI.Entity) error
 	// Query will find a list of resource that is matching the query passed in parameter. The list found will be set in slice.
 	// slice is an interface for casting simplification. But slice must be a pointer to a slice of modelAPI.Metadata
-	Query(query Query, slice interface{}) error
+	Query(query Query, slice any) error
 	RawQuery(query Query) ([]json.RawMessage, error)
 	RawMetadataQuery(query Query, kind modelV1.Kind) ([]json.RawMessage, error)
 	Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error

--- a/internal/api/database/sql/query.go
+++ b/internal/api/database/sql/query.go
@@ -39,7 +39,7 @@ import (
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
-func generateProjectResourceInsertQuery(tableName string, id string, rowJSONDoc []byte, metadata *modelV1.ProjectMetadata) (string, []interface{}) {
+func generateProjectResourceInsertQuery(tableName string, id string, rowJSONDoc []byte, metadata *modelV1.ProjectMetadata) (string, []any) {
 	return sqlbuilder.NewInsertBuilder().
 		InsertInto(tableName).
 		Cols(colID, colName, colProject, colDoc).
@@ -47,7 +47,7 @@ func generateProjectResourceInsertQuery(tableName string, id string, rowJSONDoc 
 		Build()
 }
 
-func generateResourceInsertQuery(tableName string, id string, rowJSONDoc []byte, metadata *modelV1.Metadata) (string, []interface{}) {
+func generateResourceInsertQuery(tableName string, id string, rowJSONDoc []byte, metadata *modelV1.Metadata) (string, []any) {
 	return sqlbuilder.NewInsertBuilder().
 		InsertInto(tableName).
 		Cols(colID, colName, colDoc).
@@ -55,7 +55,7 @@ func generateResourceInsertQuery(tableName string, id string, rowJSONDoc []byte,
 		Build()
 }
 
-func (d *DAO) generateInsertQuery(entity modelAPI.Entity) (string, []interface{}, error) {
+func (d *DAO) generateInsertQuery(entity modelAPI.Entity) (string, []any, error) {
 	id, tableName, idErr := d.getIDAndTableName(modelV1.Kind(entity.GetKind()), entity.GetMetadata())
 	if idErr != nil {
 		return "", nil, idErr
@@ -65,7 +65,7 @@ func (d *DAO) generateInsertQuery(entity modelAPI.Entity) (string, []interface{}
 		return "", nil, unmarshalErr
 	}
 	var sql string
-	var args []interface{}
+	var args []any
 	switch m := entity.GetMetadata().(type) {
 	case *modelV1.ProjectMetadata:
 		sql, args = generateProjectResourceInsertQuery(tableName, id, rowJSONDoc, m)
@@ -75,7 +75,7 @@ func (d *DAO) generateInsertQuery(entity modelAPI.Entity) (string, []interface{}
 	return sql, args, nil
 }
 
-func (d *DAO) generateUpdateQuery(entity modelAPI.Entity) (string, []interface{}, error) {
+func (d *DAO) generateUpdateQuery(entity modelAPI.Entity) (string, []any, error) {
 	id, tableName, idErr := d.getIDAndTableName(modelV1.Kind(entity.GetKind()), entity.GetMetadata())
 	if idErr != nil {
 		return "", nil, idErr
@@ -91,7 +91,7 @@ func (d *DAO) generateUpdateQuery(entity modelAPI.Entity) (string, []interface{}
 	return sql, args, nil
 }
 
-func (d *DAO) generateSelectQuery(tableName string, project string, name string) (string, []interface{}) {
+func (d *DAO) generateSelectQuery(tableName string, project string, name string) (string, []any) {
 	p := project
 	n := name
 	if !d.CaseSensitive {
@@ -110,9 +110,9 @@ func (d *DAO) generateSelectQuery(tableName string, project string, name string)
 	return queryBuilder.Build()
 }
 
-func (d *DAO) buildQuery(query databaseModel.Query) (string, []interface{}, error) {
+func (d *DAO) buildQuery(query databaseModel.Query) (string, []any, error) {
 	var sqlQuery string
-	var args []interface{}
+	var args []any
 	switch qt := query.(type) {
 	case *dashboard.Query:
 		sqlQuery, args = d.generateSelectQuery(d.generateCompleteTableName(tableDashboard), qt.Project, qt.NamePrefix)
@@ -150,7 +150,7 @@ func (d *DAO) buildQuery(query databaseModel.Query) (string, []interface{}, erro
 	return sqlQuery, args, nil
 }
 
-func (d *DAO) generateDeleteQuery(tableName string, project string, name string) (string, []interface{}) {
+func (d *DAO) generateDeleteQuery(tableName string, project string, name string) (string, []any) {
 	p := project
 	n := name
 	if !d.CaseSensitive {
@@ -169,9 +169,9 @@ func (d *DAO) generateDeleteQuery(tableName string, project string, name string)
 	return queryBuilder.Build()
 }
 
-func (d *DAO) buildDeleteQuery(query databaseModel.Query) (string, []interface{}, error) {
+func (d *DAO) buildDeleteQuery(query databaseModel.Query) (string, []any, error) {
 	var sqlQuery string
-	var args []interface{}
+	var args []any
 	switch qt := query.(type) {
 	case *dashboard.Query:
 		sqlQuery, args = d.generateDeleteQuery(d.generateCompleteTableName(tableDashboard), qt.Project, qt.NamePrefix)

--- a/internal/api/database/sql/query_test.go
+++ b/internal/api/database/sql/query_test.go
@@ -25,28 +25,28 @@ func TestGenerateProjectResourceSelectQuery(t *testing.T) {
 		project  string
 		name     string
 		sqlQuery string
-		sqlArgs  []interface{}
+		sqlArgs  []any
 	}{
 		{
 			title:    "no project with a prefix name",
 			project:  "",
 			name:     "test",
 			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ?",
-			sqlArgs:  []interface{}{"test%"},
+			sqlArgs:  []any{"test%"},
 		},
 		{
 			title:    "with a prefix name",
 			project:  "",
 			name:     "test",
 			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ?",
-			sqlArgs:  []interface{}{"test%"},
+			sqlArgs:  []any{"test%"},
 		},
 		{
 			title:    "a project with a prefix name",
 			project:  "foo",
 			name:     "bar",
 			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ? AND project = ?",
-			sqlArgs:  []interface{}{"bar%", "foo"},
+			sqlArgs:  []any{"bar%", "foo"},
 		},
 		{
 			title:    "empty query",

--- a/internal/api/database/sql/sql.go
+++ b/internal/api/database/sql/sql.go
@@ -229,7 +229,7 @@ func (d *DAO) Upsert(entity modelAPI.Entity) error {
 		return err
 	}
 	var sqlQuery string
-	var args []interface{}
+	var args []any
 	var queryGeneratorErr error
 	if !isExist {
 		sqlQuery, args, queryGeneratorErr = d.generateInsertQuery(entity)
@@ -290,7 +290,7 @@ func (d *DAO) RawMetadataQuery(_ databaseModel.Query, _ modelV1.Kind) ([]json.Ra
 	return nil, fmt.Errorf("raw metadata query not implemented")
 }
 
-func (d *DAO) Query(query databaseModel.Query, slice interface{}) error {
+func (d *DAO) Query(query databaseModel.Query, slice any) error {
 	typeParameter := reflect.TypeOf(slice)
 	result := reflect.ValueOf(slice)
 	// to avoid any miss usage when using this method, slice should be a pointer to a slice.

--- a/internal/api/discovery/cuetils/cuetils.go
+++ b/internal/api/discovery/cuetils/cuetils.go
@@ -77,11 +77,11 @@ func BuildPluginAndInjectProxy(decodedSchema []*Node, proxy http.Config) (common
 	return plugin, err
 }
 
-func buildPluginSpecWithProxy(spec *Node, proxy http.Config) (map[string]interface{}, error) {
-	result := make(map[string]interface{})
+func buildPluginSpecWithProxy(spec *Node, proxy http.Config) (map[string]any, error) {
+	result := make(map[string]any)
 	type queueElement struct {
 		node *Node
-		val  map[string]interface{}
+		val  map[string]any
 	}
 	queue := []queueElement{{node: spec, val: result}}
 	// It is our current element on each iteration.
@@ -101,7 +101,7 @@ func buildPluginSpecWithProxy(spec *Node, proxy http.Config) (map[string]interfa
 			//
 			// So that means we need to create the struct attached to the field 'proxy' and inject the actual proxy in it.
 			// First thing, let's create the maps representing the struct associated to 'proxy'
-			newResult := make(map[string]interface{})
+			newResult := make(map[string]any)
 			// We grab the node corresponding to the 'kind' field
 			kindNode := el.node.Nodes[kindIndex]
 			// We set the map to the field 'proxy'
@@ -124,7 +124,7 @@ func buildPluginSpecWithProxy(spec *Node, proxy http.Config) (map[string]interfa
 
 		// In case kind doesn't exist, then we just need to complete the current map or to fill the queue with additional nodes
 		if el.node.Type == StructNodeType {
-			newResult := make(map[string]interface{})
+			newResult := make(map[string]any)
 			el.val[el.node.FieldName] = newResult
 			for _, node := range el.node.Nodes {
 				queue = append(queue, queueElement{node: node, val: newResult})

--- a/internal/api/discovery/cuetils/node.go
+++ b/internal/api/discovery/cuetils/node.go
@@ -59,7 +59,7 @@ func (n *Node) sort() {
 	}
 }
 
-func (n *Node) setPrimitiveValue(result map[string]interface{}) error {
+func (n *Node) setPrimitiveValue(result map[string]any) error {
 	switch n.Type {
 	case StringNodeType:
 		// We consider that any empty string is a nil value.

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -87,7 +87,7 @@ func newOAuthConfig(provider config.OAuthProvider, override *config.OAuthOverrid
 
 type oauthUserInfo struct {
 	externalUserInfoProfile
-	RawProperties map[string]interface{}
+	RawProperties map[string]any
 	loginKeys     []string
 	authURL       url.URL
 }

--- a/internal/api/impl/proxy/proxy.go
+++ b/internal/api/impl/proxy/proxy.go
@@ -646,10 +646,10 @@ func writeCSVResponse(c echo.Context, rows *sql.Rows) error {
 	}
 
 	// Create a slice of interface{} to hold the column values
-	values := make([]interface{}, len(cols))
+	values := make([]any, len(cols))
 
 	// Create a slice of sql.RawBytes to hold the raw bytes of the column values
-	scanArgs := make([]interface{}, len(cols))
+	scanArgs := make([]any, len(cols))
 	for i := range values {
 		scanArgs[i] = &values[i]
 	}

--- a/internal/api/toolbox/list.go
+++ b/internal/api/toolbox/list.go
@@ -153,7 +153,7 @@ func (t *toolbox[T, K, V]) listProjectWhenPermissionIsActivated(parameters apiIn
 		}
 		return result, nil
 	}
-	return []interface{}{}, nil
+	return []any{}, nil
 }
 
 func (t *toolbox[T, K, V]) metadataOrFullList(parameters apiInterface.Parameters, query V) (any, error) {

--- a/internal/api/validate/custom_rule.go
+++ b/internal/api/validate/custom_rule.go
@@ -21,12 +21,12 @@ import (
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
-func convertDashboardToJSONRaw(dash *modelV1.Dashboard) (map[string]interface{}, error) {
+func convertDashboardToJSONRaw(dash *modelV1.Dashboard) (map[string]any, error) {
 	data, err := json.Marshal(dash)
 	if err != nil {
 		return nil, fmt.Errorf("error while marshalling the dashboard: %w", err)
 	}
-	var jsonRaw map[string]interface{}
+	var jsonRaw map[string]any
 	return jsonRaw, json.Unmarshal(data, &jsonRaw)
 }
 

--- a/internal/cli/cmd/plugin/generate/generate.go
+++ b/internal/cli/cmd/plugin/generate/generate.go
@@ -242,7 +242,7 @@ func (o *generateOptions) Execute() error {
 		}
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ModuleName":              GetKebabCase(o.pluginModuleName),
 		"ModulePascalName":        GetPascalCase(o.pluginModuleName),
 		"ModuleOrg":               GetKebabCase(o.pluginModuleOrg),

--- a/internal/cli/cmd/plugin/start/stream.go
+++ b/internal/cli/cmd/plugin/start/stream.go
@@ -26,7 +26,7 @@ type prefixedStream struct {
 	prefix string
 	buff   *bytes.Buffer
 	writer io.Writer
-	color  func(a ...interface{}) string
+	color  func(a ...any) string
 }
 
 func newPrefixedStream(prefix string, writer io.Writer, c *color.Color) *prefixedStream {

--- a/internal/cli/cmd/plugin/testschemas/test-schemas.go
+++ b/internal/cli/cmd/plugin/testschemas/test-schemas.go
@@ -375,7 +375,7 @@ func (o *option) runMigrationTestsForPath(testDir string, buildInstance *build.I
 		}
 
 		// Convert back to map for comparison
-		resultValue := map[string]interface{}{
+		resultValue := map[string]any{
 			"kind": resultPlugin.Kind,
 			"spec": resultPlugin.Spec,
 		}
@@ -386,7 +386,7 @@ func (o *option) runMigrationTestsForPath(testDir string, buildInstance *build.I
 		}
 
 		// Normalizing the bytes of expectedData is needed for comparison
-		var expectedNormalized map[string]interface{}
+		var expectedNormalized map[string]any
 		if err := json.Unmarshal(expectedData, &expectedNormalized); err != nil {
 			result.Error = fmt.Sprintf("Failed to parse expected migration output: %v", err)
 			results = append(results, result)

--- a/internal/cli/file/file.go
+++ b/internal/cli/file/file.go
@@ -39,7 +39,7 @@ func Exists(filePath string) (bool, error) {
 	return true, nil
 }
 
-func Unmarshal(file string, obj interface{}) error {
+func Unmarshal(file string, obj any) error {
 	data, isJSON, err := readAndDetect(file)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func Copy(src, dst string) error {
 type unmarshaller struct {
 	isJSON  bool
 	file    string
-	objects []map[string]interface{}
+	objects []map[string]any
 }
 
 func (u *unmarshaller) unmarshal() ([]modelAPI.Entity, error) {
@@ -177,8 +177,8 @@ func (u *unmarshaller) read() error {
 	}
 	u.isJSON = isJSON
 
-	var objects []map[string]interface{}
-	var object map[string]interface{}
+	var objects []map[string]any
+	var object map[string]any
 
 	if u.isJSON {
 		if jsonErr := json.Unmarshal(data, &objects); jsonErr != nil {

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -44,7 +44,7 @@ func ValidateAndSet(o *string) error {
 	return nil
 }
 
-func Handle(writer io.Writer, output string, obj interface{}) error {
+func Handle(writer io.Writer, output string, obj any) error {
 	var data []byte
 	var err error
 	if output == JSONOutput {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // simple wrapper to json.Marshal for testing, to ensure the test gets aborted in case of error
-func JSONMarshalStrict(obj interface{}) []byte {
+func JSONMarshalStrict(obj any) []byte {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		panic(err)
@@ -34,19 +34,19 @@ func JSONMarshalStrict(obj interface{}) []byte {
 }
 
 // simple wrapper to json.Unmarshal for testing, to ensure the test gets aborted in case of error
-func JSONUnmarshal(src []byte, dst interface{}) {
+func JSONUnmarshal(src []byte, dst any) {
 	if err := json.Unmarshal(src, dst); err != nil {
 		panic(err)
 	}
 }
 
-func JSONUnmarshalFromFile(filepath string, dst interface{}) {
+func JSONUnmarshalFromFile(filepath string, dst any) {
 	data := ReadFile(filepath)
 	JSONUnmarshal(data, dst)
 }
 
 // simple wrapper to yaml.Unmarshal for testing, to ensure the test gets aborted in case of error
-func YAMLMarshalStrict(obj interface{}) []byte {
+func YAMLMarshalStrict(obj any) []byte {
 	data, err := yaml.Marshal(obj)
 	if err != nil {
 		panic(err)
@@ -54,13 +54,13 @@ func YAMLMarshalStrict(obj interface{}) []byte {
 	return data
 }
 
-func YAMLUnmarshal(src []byte, dst interface{}) {
+func YAMLUnmarshal(src []byte, dst any) {
 	if err := yaml.Unmarshal(src, dst); err != nil {
 		panic(err)
 	}
 }
 
-func YAMLUnmarshalFromFile(filepath string, dst interface{}) {
+func YAMLUnmarshalFromFile(filepath string, dst any) {
 	data := ReadFile(filepath)
 	YAMLUnmarshal(data, dst)
 }

--- a/pkg/client/perseshttp/request.go
+++ b/pkg/client/perseshttp/request.go
@@ -118,7 +118,7 @@ func (r *Request) Query(query QueryInterface) *Request {
 
 // Body defines the body in the HTTP request.
 // The body shall be json compatible
-func (r *Request) Body(obj interface{}) *Request {
+func (r *Request) Body(obj any) *Request {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		r.err = err
@@ -330,7 +330,7 @@ func (r *Response) Error() error {
 }
 
 // Object stores the result into respObj.
-func (r *Response) Object(respObj interface{}) error {
+func (r *Response) Object(respObj any) error {
 	err := r.Error()
 
 	if err != nil {

--- a/pkg/model/api/config/dashboard.go
+++ b/pkg/model/api/config/dashboard.go
@@ -57,7 +57,7 @@ func (c *CustomLintRule) Verify() error {
 	return nil
 }
 
-func (c *CustomLintRule) Evaluate(data map[string]interface{}) error {
+func (c *CustomLintRule) Evaluate(data map[string]any) error {
 	if c.jsonEval == nil {
 		if err := c.evaluateAndLoadJSONExpression(); err != nil {
 			return err
@@ -74,7 +74,7 @@ func (c *CustomLintRule) Evaluate(data map[string]interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error while evaluating the jsonpath expression for the rule %q: %w", c.Name, err)
 	}
-	out, _, err := c.celProgram.Eval(map[string]interface{}{"value": value})
+	out, _, err := c.celProgram.Eval(map[string]any{"value": value})
 	if err != nil {
 		return fmt.Errorf("error while evaluating the CEL program for the rule %q: %w", c.Name, err)
 	}

--- a/pkg/model/api/config/datasourcediscovery.go
+++ b/pkg/model/api/config/datasourcediscovery.go
@@ -28,7 +28,7 @@ type HTTPDiscovery struct {
 	config.RestConfigClient `json:",inline" yaml:",inline"`
 }
 
-func (d HTTPDiscovery) MarshalYAML() (interface{}, error) {
+func (d HTTPDiscovery) MarshalYAML() (any, error) {
 	cfg := config.NewPublicRestConfigClient(&d.RestConfigClient)
 	return cfg, nil
 }

--- a/pkg/model/api/config/security.go
+++ b/pkg/model/api/config/security.go
@@ -95,12 +95,12 @@ func (s *SameSite) UnmarshalText(text []byte) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface.
-func (s SameSite) MarshalYAML() (interface{}, error) {
+func (s SameSite) MarshalYAML() (any, error) {
 	return s.String(), nil
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *SameSite) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *SameSite) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err

--- a/pkg/model/api/entity.go
+++ b/pkg/model/api/entity.go
@@ -21,5 +21,5 @@ type Metadata interface {
 type Entity interface {
 	GetKind() string
 	GetMetadata() Metadata
-	GetSpec() interface{}
+	GetSpec() any
 }

--- a/pkg/model/api/v1/common/duration.go
+++ b/pkg/model/api/v1/common/duration.go
@@ -184,12 +184,12 @@ func (d *Duration) UnmarshalText(text []byte) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface.
-func (d Duration) MarshalYAML() (interface{}, error) {
+func (d Duration) MarshalYAML() (any, error) {
 	return d.String(), nil
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err

--- a/pkg/model/api/v1/common/jsonref.go
+++ b/pkg/model/api/v1/common/jsonref.go
@@ -35,7 +35,7 @@ type JSONRef struct {
 	// Path is a list of string that will be used to find from the root of the struct the object pointed.
 	Path []string `json:"-" yaml:"-"`
 	// Object will contain the pointer to the actual object referenced by Ref
-	Object interface{} `json:"-" yaml:"-"`
+	Object any `json:"-" yaml:"-"`
 }
 
 func (j *JSONRef) UnmarshalJSON(data []byte) error {
@@ -51,7 +51,7 @@ func (j *JSONRef) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (j *JSONRef) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (j *JSONRef) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp JSONRef
 	type plain JSONRef
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/common/plugin.go
+++ b/pkg/model/api/v1/common/plugin.go
@@ -22,7 +22,7 @@ type Plugin struct {
 	Kind string `json:"kind" yaml:"kind"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
-	Spec interface{} `json:"spec" yaml:"spec"`
+	Spec any `json:"spec" yaml:"spec"`
 }
 
 func (p Plugin) JSONMarshal() ([]byte, error) {
@@ -42,7 +42,7 @@ func (p *Plugin) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *Plugin) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *Plugin) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Plugin
 	type plain Plugin
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/common/regexp.go
+++ b/pkg/model/api/v1/common/regexp.go
@@ -51,7 +51,7 @@ func (re *Regexp) UnmarshalJSON(data []byte) error {
 	return re.validate(s)
 }
 
-func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (re *Regexp) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -66,7 +66,7 @@ func (re Regexp) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 
-func (re Regexp) MarshalYAML() (interface{}, error) {
+func (re Regexp) MarshalYAML() (any, error) {
 	if len(re.original) > 0 {
 		return re.original, nil
 	}

--- a/pkg/model/api/v1/common/url.go
+++ b/pkg/model/api/v1/common/url.go
@@ -59,7 +59,7 @@ func (u *URL) IsNilOrEmpty() bool {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for URLs.
-func (u *URL) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (u *URL) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -74,7 +74,7 @@ func (u *URL) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for URLs.
-func (u URL) MarshalYAML() (interface{}, error) {
+func (u URL) MarshalYAML() (any, error) {
 	if u.URL != nil {
 		return u.String(), nil
 	}

--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -49,7 +49,7 @@ func (p *PanelDisplay) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *PanelDisplay) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *PanelDisplay) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp PanelDisplay
 	type plain PanelDisplay
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -116,7 +116,7 @@ func (d *DashboardSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (d *DashboardSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *DashboardSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp DashboardSpec
 	type plain DashboardSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -161,7 +161,7 @@ func (d *Dashboard) GetKind() string {
 	return string(d.Kind)
 }
 
-func (d *Dashboard) GetSpec() interface{} {
+func (d *Dashboard) GetSpec() any {
 	return d.Spec
 }
 
@@ -178,7 +178,7 @@ func (d *Dashboard) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (d *Dashboard) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *Dashboard) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Dashboard
 	type plain Dashboard
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/dashboard/layout.go
+++ b/pkg/model/api/v1/dashboard/layout.go
@@ -44,7 +44,7 @@ func (k *LayoutKind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (k *LayoutKind) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (k *LayoutKind) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp LayoutKind
 	type plain LayoutKind
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -90,12 +90,11 @@ type GridLayoutSpec struct {
 	RepeatVariable string             `json:"repeatVariable,omitempty" yaml:"repeatVariable,omitempty"`
 }
 
-type LayoutSpec interface {
-}
+type LayoutSpec any
 
 type tmpDashboardLayout struct {
-	Kind LayoutKind             `json:"kind" yaml:"kind"`
-	Spec map[string]interface{} `json:"spec" yaml:"spec"`
+	Kind LayoutKind     `json:"kind" yaml:"kind"`
+	Spec map[string]any `json:"spec" yaml:"spec"`
 }
 
 type Layout struct {
@@ -106,17 +105,17 @@ type Layout struct {
 }
 
 func (d *Layout) UnmarshalJSON(data []byte) error {
-	jsonUnmarshalFunc := func(panel interface{}) error {
+	jsonUnmarshalFunc := func(panel any) error {
 		return json.Unmarshal(data, panel)
 	}
 	return d.unmarshal(jsonUnmarshalFunc, json.Marshal, json.Unmarshal)
 }
 
-func (d *Layout) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *Layout) UnmarshalYAML(unmarshal func(any) error) error {
 	return d.unmarshal(unmarshal, yaml.Marshal, yaml.Unmarshal)
 }
 
-func (d *Layout) unmarshal(unmarshal func(interface{}) error, staticMarshal func(interface{}) ([]byte, error), staticUnmarshal func([]byte, interface{}) error) error {
+func (d *Layout) unmarshal(unmarshal func(any) error, staticMarshal func(any) ([]byte, error), staticUnmarshal func([]byte, any) error) error {
 	var tmpLayout tmpDashboardLayout
 	if err := unmarshal(&tmpLayout); err != nil {
 		return err
@@ -131,7 +130,7 @@ func (d *Layout) unmarshal(unmarshal func(interface{}) error, staticMarshal func
 	if err != nil {
 		return err
 	}
-	var spec interface{}
+	var spec any
 	switch tmpLayout.Kind {
 	case KindGridLayout:
 		spec = &GridLayoutSpec{}

--- a/pkg/model/api/v1/dashboard/variable.go
+++ b/pkg/model/api/v1/dashboard/variable.go
@@ -53,7 +53,7 @@ func (v *TextVariableSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (v *TextVariableSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *TextVariableSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp TextVariableSpec
 	type plain TextVariableSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -101,7 +101,7 @@ func (v *ListVariableSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (v *ListVariableSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *ListVariableSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp ListVariableSpec
 	type plain ListVariableSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -131,21 +131,21 @@ type Variable struct {
 
 type tmpVariable struct {
 	Kind variable.Kind `json:"kind" yaml:"kind"`
-	Spec interface{}   `json:"spec" yaml:"spec"`
+	Spec any           `json:"spec" yaml:"spec"`
 }
 
 func (v *Variable) UnmarshalJSON(data []byte) error {
-	jsonUnmarshalFunc := func(variable interface{}) error {
+	jsonUnmarshalFunc := func(variable any) error {
 		return json.Unmarshal(data, variable)
 	}
 	return v.unmarshal(jsonUnmarshalFunc, json.Marshal, json.Unmarshal)
 }
 
-func (v *Variable) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *Variable) UnmarshalYAML(unmarshal func(any) error) error {
 	return v.unmarshal(unmarshal, yaml.Marshal, yaml.Unmarshal)
 }
 
-func (v *Variable) unmarshal(unmarshal func(interface{}) error, staticMarshal func(interface{}) ([]byte, error), staticUnmarshal func([]byte, interface{}) error) error {
+func (v *Variable) unmarshal(unmarshal func(any) error, staticMarshal func(any) ([]byte, error), staticUnmarshal func([]byte, any) error) error {
 	var tmp tmpVariable
 	if err := unmarshal(&tmp); err != nil {
 		return err

--- a/pkg/model/api/v1/dashboard/variable_test.go
+++ b/pkg/model/api/v1/dashboard/variable_test.go
@@ -80,7 +80,7 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelNamesVariable",
-							Spec: map[string]interface{}{},
+							Spec: map[string]any{},
 						},
 					},
 					Name: "MyList",
@@ -118,8 +118,8 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelNamesVariable",
-							Spec: map[string]interface{}{
-								"matchers": []interface{}{"up"},
+							Spec: map[string]any{
+								"matchers": []any{"up"},
 							},
 						},
 					},
@@ -160,9 +160,9 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -204,9 +204,9 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 						DefaultValue: &variable.DefaultValue{SingleValue: "default"},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -250,9 +250,9 @@ func TestUnmarshalJSONVariable(t *testing.T) {
 						DefaultValue:  &variable.DefaultValue{SliceValues: []string{"default1", "default2"}},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -347,8 +347,8 @@ spec:
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelNamesVariable",
-							Spec: map[string]interface{}{
-								"matchers": []interface{}{"up"},
+							Spec: map[string]any{
+								"matchers": []any{"up"},
 							},
 						},
 					},
@@ -382,9 +382,9 @@ spec:
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -419,9 +419,9 @@ spec:
 						DefaultValue: &variable.DefaultValue{SingleValue: "default"},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -460,9 +460,9 @@ spec:
 						DefaultValue:  &variable.DefaultValue{SliceValues: []string{"default1", "default2"}},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -578,7 +578,7 @@ func TestMarshalListVariable(t *testing.T) {
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelNamesVariable",
-							Spec: map[string]interface{}{},
+							Spec: map[string]any{},
 						},
 					},
 					Name: "MyList",
@@ -613,8 +613,8 @@ func TestMarshalListVariable(t *testing.T) {
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelNamesVariable",
-							Spec: map[string]interface{}{
-								"matchers": []interface{}{"up"},
+							Spec: map[string]any{
+								"matchers": []any{"up"},
 							},
 						},
 					},
@@ -654,9 +654,9 @@ func TestMarshalListVariable(t *testing.T) {
 						},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -698,9 +698,9 @@ func TestMarshalListVariable(t *testing.T) {
 						DefaultValue: &variable.DefaultValue{SingleValue: "default"},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},
@@ -744,9 +744,9 @@ func TestMarshalListVariable(t *testing.T) {
 						DefaultValue:  &variable.DefaultValue{SliceValues: []string{"default1", "default2"}},
 						Plugin: common.Plugin{
 							Kind: "PrometheusLabelValuesVariable",
-							Spec: map[string]interface{}{
+							Spec: map[string]any{
 								"labelName": "instance",
-								"matchers":  []interface{}{"up"},
+								"matchers":  []any{"up"},
 							},
 						},
 					},

--- a/pkg/model/api/v1/dashboard_test.go
+++ b/pkg/model/api/v1/dashboard_test.go
@@ -163,7 +163,7 @@ func TestMarshalDashboard(t *testing.T) {
 								ListSpec: variable.ListSpec{
 									Plugin: common.Plugin{
 										Kind: "PrometheusLabelNamesVariable",
-										Spec: map[string]interface{}{
+										Spec: map[string]any{
 											"matchers": []string{
 												"up",
 											},
@@ -179,7 +179,7 @@ func TestMarshalDashboard(t *testing.T) {
 								ListSpec: variable.ListSpec{
 									Plugin: common.Plugin{
 										Kind: "PrometheusLabelValuesVariable",
-										Spec: map[string]interface{}{
+										Spec: map[string]any{
 											"labelName": "$labelName",
 											"matchers": []string{
 												"up",
@@ -418,8 +418,8 @@ func TestUnmarshallDashboard(t *testing.T) {
 			},
 			Plugin: common.Plugin{
 				Kind: "TimeSeriesChart",
-				Spec: map[string]interface{}{
-					"lines": []interface{}{
+				Spec: map[string]any{
+					"lines": []any{
 						"up",
 					},
 					"showLegend": false,
@@ -445,8 +445,8 @@ func TestUnmarshallDashboard(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusLabelNamesVariable",
-								Spec: map[string]interface{}{
-									"matchers": []interface{}{
+								Spec: map[string]any{
+									"matchers": []any{
 										"up",
 									},
 								},
@@ -461,9 +461,9 @@ func TestUnmarshallDashboard(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusLabelValuesVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"labelName": "$labelName",
-									"matchers": []interface{}{
+									"matchers": []any{
 										"up",
 									},
 								},

--- a/pkg/model/api/v1/datasource.go
+++ b/pkg/model/api/v1/datasource.go
@@ -68,7 +68,7 @@ func (d *GlobalDatasource) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (d *GlobalDatasource) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *GlobalDatasource) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp GlobalDatasource
 	type plain GlobalDatasource
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -103,7 +103,7 @@ func (d *GlobalDatasource) GetDatasourceSpec() DatasourceSpec {
 	return d.Spec
 }
 
-func (d *GlobalDatasource) GetSpec() interface{} {
+func (d *GlobalDatasource) GetSpec() any {
 	return d.Spec
 }
 
@@ -129,7 +129,7 @@ func (d *Datasource) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (d *Datasource) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *Datasource) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Datasource
 	type plain Datasource
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -164,6 +164,6 @@ func (d *Datasource) GetDatasourceSpec() DatasourceSpec {
 	return d.Spec
 }
 
-func (d *Datasource) GetSpec() interface{} {
+func (d *Datasource) GetSpec() any {
 	return d.Spec
 }

--- a/pkg/model/api/v1/datasource/http/http.go
+++ b/pkg/model/api/v1/datasource/http/http.go
@@ -39,7 +39,7 @@ func (h *AllowedEndpoint) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (h *AllowedEndpoint) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (h *AllowedEndpoint) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp AllowedEndpoint
 	type plain AllowedEndpoint
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -96,7 +96,7 @@ func (h *Config) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (h *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (h *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Config
 	type plain Config
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/datasource/proxy.go
+++ b/pkg/model/api/v1/datasource/proxy.go
@@ -30,7 +30,7 @@ const (
 
 // ValidateAndExtract finds a proxy in the pluginSpec
 // It then unmarshals the corresponding 'spec' field into the config interace{}.
-func ValidateAndExtract(pluginSpec interface{}) (interface{}, string, error) {
+func ValidateAndExtract(pluginSpec any) (any, string, error) {
 	finder := &configFinder{}
 	finder.find(reflect.ValueOf(pluginSpec))
 
@@ -42,7 +42,7 @@ type configFinder struct {
 	found     bool
 	foundKind string
 
-	config interface{}
+	config any
 }
 
 func (c *configFinder) find(v reflect.Value) {

--- a/pkg/model/api/v1/datasource/proxy_test.go
+++ b/pkg/model/api/v1/datasource/proxy_test.go
@@ -47,7 +47,7 @@ func TestValidateAndExtract(t *testing.T) {
 
 	validSpec := testSpec{URL: "https://test.com"}
 	validSQLSpec := testSQLSpec{Driver: "postgres", Host: "test.com", Database: "test", Postgres: &sql.PostgresConfig{SSLMode: "disable"}}
-	validSpecMap := map[string]interface{}{"url": "https://test.com"}
+	validSpecMap := map[string]any{"url": "https://test.com"}
 
 	testURL, err := url.Parse("https://test.com")
 	assert.NoError(t, err)
@@ -61,9 +61,9 @@ func TestValidateAndExtract(t *testing.T) {
 	testCases := []struct {
 		name           string
 		expectedKind   string
-		pluginSpec     interface{}
-		config         interface{}
-		expectedConfig interface{}
+		pluginSpec     any
+		config         any
+		expectedConfig any
 		expectError    bool
 		expectedError  string
 	}{
@@ -80,7 +80,7 @@ func TestValidateAndExtract(t *testing.T) {
 		},
 		{
 			name:         "simple map",
-			pluginSpec:   map[string]interface{}{"kind": "SQLProxy", "spec": validSQLSpec},
+			pluginSpec:   map[string]any{"kind": "SQLProxy", "spec": validSQLSpec},
 			expectedKind: "sqlproxy",
 			expectedConfig: &sql.Config{
 				Driver:   "postgres",
@@ -99,7 +99,7 @@ func TestValidateAndExtract(t *testing.T) {
 		},
 		{
 			name:           "nested map",
-			pluginSpec:     map[string]interface{}{"proxy": map[string]interface{}{"kind": "HTTPProxy", "spec": validSpecMap}},
+			pluginSpec:     map[string]any{"proxy": map[string]any{"kind": "HTTPProxy", "spec": validSpecMap}},
 			expectedKind:   "httpproxy",
 			expectedConfig: validHTTPConfig,
 		},

--- a/pkg/model/api/v1/datasource/sql/sql.go
+++ b/pkg/model/api/v1/datasource/sql/sql.go
@@ -74,7 +74,7 @@ func (p *PostgresConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *PostgresConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *PostgresConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp PostgresConfig
 	type plain PostgresConfig
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -131,7 +131,7 @@ func (s *Config) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (s *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Config
 	type plain Config
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/datasource_test.go
+++ b/pkg/model/api/v1/datasource_test.go
@@ -38,7 +38,7 @@ func TestUnmarshalJSONDatasource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var pluginSpecAsMapInterface map[string]interface{}
+	var pluginSpecAsMapInterface map[string]any
 	if err := json.Unmarshal(data, &pluginSpecAsMapInterface); err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestUnmarshalYAMLLayout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var pluginSpecAsMapInterface map[string]interface{}
+	var pluginSpecAsMapInterface map[string]any
 	if err := yaml.Unmarshal(data, &pluginSpecAsMapInterface); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/model/api/v1/ephemeraldashboard.go
+++ b/pkg/model/api/v1/ephemeraldashboard.go
@@ -36,7 +36,7 @@ func (edsb *EphemeralDashboardSpecBase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (edsb *EphemeralDashboardSpecBase) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (edsb *EphemeralDashboardSpecBase) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp EphemeralDashboardSpecBase
 	type plain EphemeralDashboardSpecBase
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -73,7 +73,7 @@ func (eds *EphemeralDashboardSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (eds *EphemeralDashboardSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (eds *EphemeralDashboardSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	// Call UnmarshalYAML methods of the embedded structs
 	var ephemeralDashboardSpecBaseTmp EphemeralDashboardSpecBase
 	if err := ephemeralDashboardSpecBaseTmp.UnmarshalYAML(unmarshal); err != nil {
@@ -106,7 +106,7 @@ func (e *EphemeralDashboard) GetKind() string {
 	return string(e.Kind)
 }
 
-func (e *EphemeralDashboard) GetSpec() interface{} {
+func (e *EphemeralDashboard) GetSpec() any {
 	return e.Spec
 }
 
@@ -123,7 +123,7 @@ func (e *EphemeralDashboard) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (e *EphemeralDashboard) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *EphemeralDashboard) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp EphemeralDashboard
 	type plain EphemeralDashboard
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/ephemeraldashboard_test.go
+++ b/pkg/model/api/v1/ephemeraldashboard_test.go
@@ -167,7 +167,7 @@ func TestMarshalEphemeralDashboard(t *testing.T) {
 									ListSpec: variable.ListSpec{
 										Plugin: common.Plugin{
 											Kind: "PrometheusLabelNamesVariable",
-											Spec: map[string]interface{}{
+											Spec: map[string]any{
 												"matchers": []string{
 													"up",
 												},
@@ -183,7 +183,7 @@ func TestMarshalEphemeralDashboard(t *testing.T) {
 									ListSpec: variable.ListSpec{
 										Plugin: common.Plugin{
 											Kind: "PrometheusLabelValuesVariable",
-											Spec: map[string]interface{}{
+											Spec: map[string]any{
 												"labelName": "$labelName",
 												"matchers": []string{
 													"up",
@@ -425,8 +425,8 @@ func TestUnmarshallEphemeralDashboard(t *testing.T) {
 			},
 			Plugin: common.Plugin{
 				Kind: "TimeSeriesChart",
-				Spec: map[string]interface{}{
-					"lines": []interface{}{
+				Spec: map[string]any{
+					"lines": []any{
 						"up",
 					},
 					"showLegend": false,
@@ -456,8 +456,8 @@ func TestUnmarshallEphemeralDashboard(t *testing.T) {
 							ListSpec: variable.ListSpec{
 								Plugin: common.Plugin{
 									Kind: "PrometheusLabelNamesVariable",
-									Spec: map[string]interface{}{
-										"matchers": []interface{}{
+									Spec: map[string]any{
+										"matchers": []any{
 											"up",
 										},
 									},
@@ -472,9 +472,9 @@ func TestUnmarshallEphemeralDashboard(t *testing.T) {
 							ListSpec: variable.ListSpec{
 								Plugin: common.Plugin{
 									Kind: "PrometheusLabelValuesVariable",
-									Spec: map[string]interface{}{
+									Spec: map[string]any{
 										"labelName": "$labelName",
-										"matchers": []interface{}{
+										"matchers": []any{
 											"up",
 										},
 									},

--- a/pkg/model/api/v1/folder.go
+++ b/pkg/model/api/v1/folder.go
@@ -43,7 +43,7 @@ func (f *FolderSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (f *FolderSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (f *FolderSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp FolderSpec
 	type plain FolderSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -83,7 +83,7 @@ func (f *Folder) GetKind() string {
 	return string(f.Kind)
 }
 
-func (f *Folder) GetSpec() interface{} {
+func (f *Folder) GetSpec() any {
 	return f.Spec
 }
 
@@ -100,7 +100,7 @@ func (f *Folder) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (f *Folder) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (f *Folder) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Folder
 	type plain Folder
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/kind.go
+++ b/pkg/model/api/v1/kind.go
@@ -72,7 +72,7 @@ func (k *Kind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (k *Kind) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (k *Kind) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Kind
 	type plain Kind
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/metadata.go
+++ b/pkg/model/api/v1/metadata.go
@@ -91,7 +91,7 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (m *Metadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (m *Metadata) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Metadata
 	type plain Metadata
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -125,7 +125,7 @@ func (p *ProjectMetadataWrapper) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *ProjectMetadataWrapper) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *ProjectMetadataWrapper) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp ProjectMetadataWrapper
 	type plain ProjectMetadataWrapper
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -161,7 +161,7 @@ func (pm *ProjectMetadata) UnmarshalJSON(data []byte) error {
 }
 
 // This method is needed in the case of YAML otherwise the validation part is not triggered when unmarshalling
-func (pm *ProjectMetadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pm *ProjectMetadata) UnmarshalYAML(unmarshal func(any) error) error {
 	// Call UnmarshalYAML methods of the embedded structs
 	var metadataTmp Metadata
 	if err := metadataTmp.UnmarshalYAML(unmarshal); err != nil {

--- a/pkg/model/api/v1/partial.go
+++ b/pkg/model/api/v1/partial.go
@@ -29,7 +29,7 @@ func (p *PartialEntity) GetKind() string {
 	return string(p.Kind)
 }
 
-func (p *PartialEntity) GetSpec() interface{} {
+func (p *PartialEntity) GetSpec() any {
 	return p.Spec
 }
 
@@ -47,6 +47,6 @@ func (p *PartialProjectEntity) GetKind() string {
 	return string(p.Kind)
 }
 
-func (p *PartialProjectEntity) GetSpec() interface{} {
+func (p *PartialProjectEntity) GetSpec() any {
 	return p.Spec
 }

--- a/pkg/model/api/v1/plugin.go
+++ b/pkg/model/api/v1/plugin.go
@@ -57,7 +57,7 @@ func (p *PluginInDevelopment) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *PluginInDevelopment) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *PluginInDevelopment) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp PluginInDevelopment
 	type plain PluginInDevelopment
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/plugin/plugin.go
+++ b/pkg/model/api/v1/plugin/plugin.go
@@ -61,7 +61,7 @@ func (p *Plugin) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *Plugin) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *Plugin) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Plugin
 	type plain Plugin
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -108,7 +108,7 @@ func (m *ModuleSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (m *ModuleSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (m *ModuleSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp ModuleSpec
 	type plain ModuleSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/project.go
+++ b/pkg/model/api/v1/project.go
@@ -39,7 +39,7 @@ func (p *Project) GetKind() string {
 	return string(p.Kind)
 }
 
-func (p *Project) GetSpec() interface{} {
+func (p *Project) GetSpec() any {
 	return p.Spec
 }
 
@@ -56,7 +56,7 @@ func (p *Project) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *Project) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *Project) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Project
 	type plain Project
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/public_secret.go
+++ b/pkg/model/api/v1/public_secret.go
@@ -62,7 +62,7 @@ func (g *PublicGlobalSecret) GetKind() string {
 	return string(g.Kind)
 }
 
-func (g *PublicGlobalSecret) GetSpec() interface{} {
+func (g *PublicGlobalSecret) GetSpec() any {
 	return g.Spec
 }
 
@@ -91,6 +91,6 @@ func (s *PublicSecret) GetKind() string {
 	return string(s.Kind)
 }
 
-func (s *PublicSecret) GetSpec() interface{} {
+func (s *PublicSecret) GetSpec() any {
 	return s.Spec
 }

--- a/pkg/model/api/v1/public_user.go
+++ b/pkg/model/api/v1/public_user.go
@@ -54,7 +54,7 @@ func (u *PublicUser) GetKind() string {
 	return string(u.Kind)
 }
 
-func (u *PublicUser) GetSpec() interface{} {
+func (u *PublicUser) GetSpec() any {
 	return u.Spec
 }
 

--- a/pkg/model/api/v1/role.go
+++ b/pkg/model/api/v1/role.go
@@ -51,7 +51,7 @@ func (g *GlobalRole) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (g *GlobalRole) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (g *GlobalRole) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp GlobalRole
 	type plain GlobalRole
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -86,7 +86,7 @@ func (g *GlobalRole) GetRoleSpec() RoleSpec {
 	return g.Spec
 }
 
-func (g *GlobalRole) GetSpec() interface{} {
+func (g *GlobalRole) GetSpec() any {
 	return g.Spec
 }
 
@@ -111,7 +111,7 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *Role) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Role
 	type plain Role
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -151,6 +151,6 @@ func (r *Role) GetKind() string {
 	return string(r.Kind)
 }
 
-func (r *Role) GetSpec() interface{} {
+func (r *Role) GetSpec() any {
 	return r.Spec
 }

--- a/pkg/model/api/v1/role/action.go
+++ b/pkg/model/api/v1/role/action.go
@@ -42,7 +42,7 @@ func (k *Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (k *Action) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (k *Action) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Action
 	type plain Action
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/role/permission.go
+++ b/pkg/model/api/v1/role/permission.go
@@ -39,7 +39,7 @@ func (p *Permission) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *Permission) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *Permission) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Permission
 	type plain Permission
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/role/scope.go
+++ b/pkg/model/api/v1/role/scope.go
@@ -53,7 +53,7 @@ func (k *Scope) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (k *Scope) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (k *Scope) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Scope
 	type plain Scope
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/rolebinding.go
+++ b/pkg/model/api/v1/rolebinding.go
@@ -43,7 +43,7 @@ func (s *Subject) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (s *Subject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Subject) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Subject
 	type plain Subject
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -95,7 +95,7 @@ func (r *RoleBindingSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *RoleBindingSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *RoleBindingSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp RoleBindingSpec
 	type plain RoleBindingSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -138,7 +138,7 @@ func (g *GlobalRoleBinding) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (g *GlobalRoleBinding) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (g *GlobalRoleBinding) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp GlobalRoleBinding
 	type plain GlobalRoleBinding
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -173,7 +173,7 @@ func (g *GlobalRoleBinding) GetRoleBindingSpec() RoleBindingSpec {
 	return g.Spec
 }
 
-func (g *GlobalRoleBinding) GetSpec() interface{} {
+func (g *GlobalRoleBinding) GetSpec() any {
 	return g.Spec
 }
 
@@ -198,7 +198,7 @@ func (r *RoleBinding) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *RoleBinding) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *RoleBinding) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp RoleBinding
 	type plain RoleBinding
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -229,6 +229,6 @@ func (r *RoleBinding) GetKind() string {
 	return string(r.Kind)
 }
 
-func (r *RoleBinding) GetSpec() interface{} {
+func (r *RoleBinding) GetSpec() any {
 	return r.Spec
 }

--- a/pkg/model/api/v1/secret.go
+++ b/pkg/model/api/v1/secret.go
@@ -44,7 +44,7 @@ func (s *SecretSpec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (s *SecretSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *SecretSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp SecretSpec
 	type plain SecretSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -78,7 +78,7 @@ func (g *GlobalSecret) GetKind() string {
 	return string(g.Kind)
 }
 
-func (g *GlobalSecret) GetSpec() interface{} {
+func (g *GlobalSecret) GetSpec() any {
 	return g.Spec
 }
 
@@ -96,6 +96,6 @@ func (s *Secret) GetKind() string {
 	return string(s.Kind)
 }
 
-func (s *Secret) GetSpec() interface{} {
+func (s *Secret) GetSpec() any {
 	return s.Spec
 }

--- a/pkg/model/api/v1/secret/authorization.go
+++ b/pkg/model/api/v1/secret/authorization.go
@@ -66,7 +66,7 @@ func (a *Authorization) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (a *Authorization) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (a *Authorization) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Authorization
 	type plain Authorization
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/secret/basic_auth.go
+++ b/pkg/model/api/v1/secret/basic_auth.go
@@ -58,7 +58,7 @@ func (b *BasicAuth) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (b *BasicAuth) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (b *BasicAuth) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp BasicAuth
 	type plain BasicAuth
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/secret/oauth.go
+++ b/pkg/model/api/v1/secret/oauth.go
@@ -77,7 +77,7 @@ func (o *OAuth) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (o *OAuth) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (o *OAuth) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp OAuth
 	type plain OAuth
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/secret/secret.go
+++ b/pkg/model/api/v1/secret/secret.go
@@ -21,7 +21,7 @@ const secretToken = "<secret>"
 type Hidden string
 
 // MarshalYAML implements the yaml.Marshaler interface for Hidden.
-func (h Hidden) MarshalYAML() (interface{}, error) {
+func (h Hidden) MarshalYAML() (any, error) {
 	if h != "" {
 		return secretToken, nil
 	}
@@ -29,7 +29,7 @@ func (h Hidden) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Hidden.
-func (h *Hidden) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (h *Hidden) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain Hidden
 	return unmarshal((*plain)(h))
 }

--- a/pkg/model/api/v1/user.go
+++ b/pkg/model/api/v1/user.go
@@ -55,7 +55,7 @@ func (u *User) GetKind() string {
 	return string(u.Kind)
 }
 
-func (u *User) GetSpec() interface{} {
+func (u *User) GetSpec() any {
 	return u.Spec
 }
 

--- a/pkg/model/api/v1/utils/variable_build_order_test.go
+++ b/pkg/model/api/v1/utils/variable_build_order_test.go
@@ -61,7 +61,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "vector(1)",
 								},
 							},
@@ -81,7 +81,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "vector($__to)",
 								},
 							},
@@ -101,7 +101,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "sum by($doe) (rate($foo{label='$bar'}))",
 								},
 							},
@@ -115,7 +115,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "test",
 								},
 							},
@@ -140,7 +140,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						Spec: &variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "vector($foo)",
 								},
 							},
@@ -163,7 +163,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						Spec: &variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "sum by($undefinedVar) (rate($foo{label='$undefinedVar'}))",
 								},
 							},
@@ -195,7 +195,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						Spec: &variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "vector($undefinedVar)",
 								},
 							},
@@ -221,9 +221,9 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusLabelValuesVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"labelName": "$foo",
-									"matchers": []interface{}{
+									"matchers": []any{
 										"$foo{$bar='test'}",
 									},
 								},
@@ -238,7 +238,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "test",
 								},
 							},
@@ -252,7 +252,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "vector($foo)",
 								},
 							},
@@ -288,7 +288,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
 								},
 							},
@@ -302,7 +302,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "test",
 								},
 							},
@@ -316,7 +316,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "vector($foo)",
 								},
 							},
@@ -388,7 +388,7 @@ func TestBuildVariableDependencies(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr":      "group by(prometheus) (label_replace(kube_statefulset_labels{$filter_platform,stack=~\"$PaaS\",$filter_kube_sts,stack=~\"$PaaS\",namespace=~\"$extlabels_prometheus_namespace\"},\"prometheus\",\"$1\",\"label_app_kubernetes_io_instance\",\"([^-]+)-?.*\"))",
 									"labelName": "prometheus",
 								},
@@ -434,7 +434,7 @@ func TestBuildVariableDependenciesError(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
 								},
 							},
@@ -595,7 +595,7 @@ func TestBuildOrder(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "sum by($doe, $bar) (rate($foo{label='$bar'}))",
 								},
 							},
@@ -609,7 +609,7 @@ func TestBuildOrder(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "test",
 								},
 							},
@@ -623,7 +623,7 @@ func TestBuildOrder(t *testing.T) {
 						ListSpec: variable.ListSpec{
 							Plugin: common.Plugin{
 								Kind: "PrometheusPromQLVariable",
-								Spec: map[string]interface{}{
+								Spec: map[string]any{
 									"expr": "vector($foo)",
 								},
 							},

--- a/pkg/model/api/v1/variable.go
+++ b/pkg/model/api/v1/variable.go
@@ -31,21 +31,21 @@ type VariableInterface interface {
 type VariableSpec struct {
 	// Kind is the type of the variable. Depending on the value of Kind, it will change the content of Spec.
 	Kind variable.Kind `json:"kind" yaml:"kind"`
-	Spec interface{}   `json:"spec" yaml:"spec"`
+	Spec any           `json:"spec" yaml:"spec"`
 }
 
 func (v *VariableSpec) UnmarshalJSON(data []byte) error {
-	jsonUnmarshalFunc := func(variable interface{}) error {
+	jsonUnmarshalFunc := func(variable any) error {
 		return json.Unmarshal(data, variable)
 	}
 	return v.unmarshal(jsonUnmarshalFunc, json.Marshal, json.Unmarshal)
 }
 
-func (v *VariableSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *VariableSpec) UnmarshalYAML(unmarshal func(any) error) error {
 	return v.unmarshal(unmarshal, yaml.Marshal, yaml.Unmarshal)
 }
 
-func (v *VariableSpec) unmarshal(unmarshal func(interface{}) error, staticMarshal func(interface{}) ([]byte, error), staticUnmarshal func([]byte, interface{}) error) error {
+func (v *VariableSpec) unmarshal(unmarshal func(any) error, staticMarshal func(any) ([]byte, error), staticUnmarshal func([]byte, any) error) error {
 	var tmp VariableSpec
 	type plain VariableSpec
 	if err := unmarshal((*plain)(&tmp)); err != nil {
@@ -55,7 +55,7 @@ func (v *VariableSpec) unmarshal(unmarshal func(interface{}) error, staticMarsha
 	if err != nil {
 		return err
 	}
-	var spec interface{}
+	var spec any
 	switch tmp.Kind {
 	case variable.KindList:
 		spec = &variable.ListSpec{}
@@ -91,7 +91,7 @@ func (v *GlobalVariable) GetVarSpec() VariableSpec {
 	return v.Spec
 }
 
-func (v *GlobalVariable) GetSpec() interface{} {
+func (v *GlobalVariable) GetSpec() any {
 	return v.Spec
 }
 
@@ -115,7 +115,7 @@ func (v *Variable) GetVarSpec() VariableSpec {
 	return v.Spec
 }
 
-func (v *Variable) GetSpec() interface{} {
+func (v *Variable) GetSpec() any {
 	return v.Spec
 }
 

--- a/pkg/model/api/v1/variable/list.go
+++ b/pkg/model/api/v1/variable/list.go
@@ -38,7 +38,7 @@ func (v *DefaultValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (v *DefaultValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *DefaultValue) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	var slice []string
 	if unmarshalStringErr := unmarshal(&s); unmarshalStringErr != nil {
@@ -58,7 +58,7 @@ func (v *DefaultValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.SliceValues)
 }
 
-func (v *DefaultValue) MarshalYAML() (interface{}, error) {
+func (v *DefaultValue) MarshalYAML() (any, error) {
 	if len(v.SingleValue) > 0 {
 		return v.SingleValue, nil
 	}
@@ -100,7 +100,7 @@ func (s *Sort) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (s *Sort) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Sort) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Sort
 	type plain Sort
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/variable/variable.go
+++ b/pkg/model/api/v1/variable/variable.go
@@ -43,7 +43,7 @@ func (k *Kind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (k *Kind) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (k *Kind) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp Kind
 	type plain Kind
 	if err := unmarshal((*plain)(&tmp)); err != nil {

--- a/pkg/model/api/v1/view.go
+++ b/pkg/model/api/v1/view.go
@@ -43,7 +43,7 @@ func (v *View) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (v *View) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *View) UnmarshalYAML(unmarshal func(any) error) error {
 	var tmp View
 	type plain View
 


### PR DESCRIPTION
# Description
Rename all usages of `interface{}` to `any`

```
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category=efaceany -fix -test ./...
```

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
