### PR TITLE
[FEATURE]: Add tool tip in case of panel header ellipsis

### DIFF
--- a/ui/dashboards/src/components/Panel/Panel.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.tsx
@@ -238,6 +238,7 @@ export const Panel = memo(function Panel(props: PanelProps) {
           pluginActions={pluginActions}
           showIcons={showIcons}
           sx={{ paddingX: `${chartsTheme.container.padding.default}px` }}
+          dimension={contentDimensions}
         />
       )}
       <CardContent

--- a/ui/dashboards/src/components/Panel/PanelHeader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelHeader.tsx
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CardHeader, CardHeaderProps, Stack, Typography } from '@mui/material';
+import { CardHeader, CardHeaderProps, Stack, Typography, Tooltip } from '@mui/material';
 import { combineSx } from '@perses-dev/components';
 import { Link } from '@perses-dev/core';
 import { QueryData, useReplaceVariablesInString } from '@perses-dev/plugin-system';
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
 import { HEADER_ACTIONS_CONTAINER_NAME } from '../../constants';
 import { PanelActions, PanelActionsProps } from './PanelActions';
 import { PanelOptions } from './Panel';
@@ -34,6 +34,7 @@ export interface PanelHeaderProps extends Omit<CardHeaderProps, OmittedProps> {
   editHandlers?: PanelActionsProps['editHandlers'];
   pluginActions?: ReactNode[]; // Add pluginActions prop
   showIcons: PanelOptions['showIcons'];
+  dimension?: { width: number };
 }
 
 export function PanelHeader({
@@ -49,6 +50,7 @@ export function PanelHeader({
   pluginActions,
   showIcons,
   viewQueriesHandler,
+  dimension,
   ...rest
 }: PanelHeaderProps): ReactElement {
   const titleElementId = `${id}-title`;
@@ -56,6 +58,15 @@ export function PanelHeader({
 
   const title = useReplaceVariablesInString(rawTitle) as string;
   const description = useReplaceVariablesInString(rawDescription);
+
+  const textRef = useRef<HTMLDivElement>(null);
+  const [isEllipsisActive, setIsEllipsisActive] = useState(false);
+
+  useEffect(() => {
+    if (textRef.current && dimension?.width) {
+      setIsEllipsisActive(textRef.current.scrollWidth > textRef.current.clientWidth);
+    }
+  }, [title, dimension?.width]);
 
   return (
     <CardHeader
@@ -66,21 +77,24 @@ export function PanelHeader({
       disableTypography
       title={
         <Stack direction="row" alignItems="center" height="var(--panel-header-height, 30px)">
-          <Typography
-            id={titleElementId}
-            variant="subtitle1"
-            sx={{
-              // `minHeight` guarantees that the header has the correct height
-              // when there is no title (i.e. in the preview)
-              lineHeight: '24px',
-              minHeight: '26px',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {title}
-          </Typography>
+          <Tooltip title={title} disableHoverListener={!isEllipsisActive}>
+            <Typography
+              id={titleElementId}
+              variant="subtitle1"
+              ref={textRef}
+              sx={{
+                // `minHeight` guarantees that the header has the correct height
+                // when there is no title (i.e. in the preview)
+                lineHeight: '24px',
+                minHeight: '26px',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {title}
+            </Typography>
+          </Tooltip>
           <PanelActions
             title={title}
             description={description}


### PR DESCRIPTION
Closes #3254 

## Adding the tooltip accordingly

This change adds/removes the panel header title according to the text ellipsis


![tooltip](https://github.com/user-attachments/assets/0182b615-eef9-43d4-aac2-6d75132ed0af)


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
