### PR TITLE
[BUGFIX] Grafana migration: fix invisible group generated for orphan panels

### DIFF
--- a/internal/api/plugin/migrate/migrate.go
+++ b/internal/api/plugin/migrate/migrate.go
@@ -260,9 +260,6 @@ func (m *completeMigration) migrateGrid(grafanaDashboard *SimplifiedDashboard) [
 	orphansGridSpec := &dashboard.GridLayoutSpec{
 		Display: &dashboard.GridLayoutDisplay{
 			Title: "Panel Group 1", // placeholder value since we don't want an empty string.
-			Collapse: &dashboard.GridLayoutCollapse{
-				Open: true, // because orphan panels are always visible in Grafana
-			},
 		},
 	}
 	orphansGrid := dashboard.Layout{

--- a/internal/api/plugin/migrate/testdata/dashboards/panel_with_links_perses_dashboard.json
+++ b/internal/api/plugin/migrate/testdata/dashboards/panel_with_links_perses_dashboard.json
@@ -90,10 +90,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Panel Group 1",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {


### PR DESCRIPTION
# Description

Migrating a Grafana dashboard with "orphan" panels (aka not belonging to a row) leads to such result on Perses:

<img width="1915" height="495" alt="image" src="https://github.com/user-attachments/assets/93568a3d-9d91-444a-bc6e-40e5ffc7e7aa" />

Which looks fine at first glance, but if you go to the edit view for the first panels, this is what you see 

<img width="347" height="192" alt="image (14)" src="https://github.com/user-attachments/assets/298bbc0a-2b82-44e9-8f0d-2343824d8f6f" />

There's a deeper fix/change to consider here (see https://github.com/perses/perses/issues/3272), this PR aims just to fix the current migration result by adding a placeholder title to the grid getting generated for orphan panels, so that it properly shows on the UI.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
