### PR TITLE
[BUGFIX] Force a refresh time range when the Run Query Button is clicked everytime

### DIFF
--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -13,7 +13,7 @@
 
 import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Button, Grid, MenuItem, Stack, TextField, Typography } from '@mui/material';
-import { Action, PanelDefinition, PanelEditorValues } from '@perses-dev/core';
+import { Action, DEFAULT_DASHBOARD_DURATION, PanelDefinition, PanelEditorValues } from '@perses-dev/core';
 import { DiscardChangesConfirmationDialog, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import {
   PluginKindSelect,
@@ -23,10 +23,13 @@ import {
   getSubmitText,
   useValidationSchemas,
   PluginEditorRef,
+  TimeRangeProvider,
+  useTimeRangeParams,
+  useInitialTimeRange,
 } from '@perses-dev/plugin-system';
 import { Controller, FormProvider, SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useListPanelGroups } from '../../context';
+import { useDashboard, useListPanelGroups } from '../../context';
 import { PanelPreview } from './PanelPreview';
 import { usePanelEditor } from './usePanelEditor';
 
@@ -52,6 +55,10 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
     mode: 'onBlur',
     defaultValues: initialValues,
   });
+
+  const { dashboard } = useDashboard();
+  const dashboardDuration = dashboard?.kind === 'Dashboard' ? dashboard.spec.duration : DEFAULT_DASHBOARD_DURATION;
+  const initialTimeRange = useInitialTimeRange(dashboardDuration);
 
   // Use common plugin editor logic even though we've split the inputs up in this form
   const pluginEditor = usePluginEditor({
@@ -112,6 +119,7 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
   const watchedName = useWatch({ control: form.control, name: 'panelDefinition.spec.display.name' });
   const watchedDescription = useWatch({ control: form.control, name: 'panelDefinition.spec.display.description' });
   const watchedPluginKind = useWatch({ control: form.control, name: 'panelDefinition.spec.plugin.kind' });
+  const { timeRange } = useTimeRangeParams(initialTimeRange);
 
   const handleSubmit = useCallback(() => {
     pluginEditorRef.current?.flushChanges?.();
@@ -119,155 +127,157 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
   }, [form, processForm]);
 
   return (
-    <FormProvider {...form}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          padding: (theme) => theme.spacing(1, 2),
-          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-        }}
-      >
-        <Typography variant="h2">{titleAction} Panel</Typography>
-        <Stack direction="row" spacing={1} marginLeft="auto">
-          <Button variant="contained" disabled={!form.formState.isValid} onClick={handleSubmit}>
-            {submitText}
-          </Button>
-          <Button color="secondary" variant="outlined" onClick={handleCancel}>
-            Cancel
-          </Button>
-        </Stack>
-      </Box>
-      <Box id={panelEditorFormId} sx={{ flex: 1, overflowY: 'scroll', padding: (theme) => theme.spacing(2) }}>
-        <Grid container spacing={2}>
-          <Grid item xs={8}>
-            <Controller
-              control={form.control}
-              name="panelDefinition.spec.display.name"
-              render={({ field, fieldState }) => (
-                <TextField
-                  {...field}
-                  required
-                  fullWidth
-                  label="Name"
-                  error={!!fieldState.error}
-                  helperText={fieldState.error?.message}
-                  value={watchedName ?? ''}
-                  onChange={(event) => {
-                    field.onChange(event);
-                    setName(event.target.value);
-                  }}
-                />
-              )}
-            />
-          </Grid>
-          <Grid item xs={4}>
-            <Controller
-              control={form.control}
-              name="groupId"
-              render={({ field, fieldState }) => (
-                <TextField
-                  select
-                  {...field}
-                  required
-                  fullWidth
-                  label="Group"
-                  error={!!fieldState.error}
-                  helperText={fieldState.error?.message}
-                  onChange={(event) => {
-                    field.onChange(event);
-                  }}
-                >
-                  {panelGroups.map((panelGroup, index) => (
-                    <MenuItem key={panelGroup.id} value={panelGroup.id}>
-                      {panelGroup.title ?? `Group ${index + 1}`}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              )}
-            />
-          </Grid>
-          <Grid item xs={8}>
-            <Controller
-              control={form.control}
-              name="panelDefinition.spec.display.description"
-              render={({ field, fieldState }) => (
-                <TextField
-                  {...field}
-                  fullWidth
-                  label="Description"
-                  error={!!fieldState.error}
-                  helperText={fieldState.error?.message}
-                  value={watchedDescription ?? ''}
-                  onChange={(event) => {
-                    field.onChange(event);
-                    setDescription(event.target.value);
-                  }}
-                />
-              )}
-            />
-          </Grid>
-          <Grid item xs={4}>
-            <Controller
-              control={form.control}
-              name="panelDefinition.spec.plugin.kind"
-              render={({ field, fieldState }) => (
-                <PluginKindSelect
-                  {...field}
-                  pluginTypes={['Panel']}
-                  required
-                  fullWidth
-                  label="Type"
-                  disabled={pluginEditor.isLoading}
-                  error={!!pluginEditor.error || !!fieldState.error}
-                  helperText={pluginEditor.error?.message ?? fieldState.error?.message}
-                  value={{ type: 'Panel', kind: watchedPluginKind }}
-                  onChange={(event) => {
-                    field.onChange(event.kind);
-                    pluginEditor.onSelectionChange(event);
-                  }}
-                />
-              )}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="h4" marginBottom={1}>
-              Preview
-            </Typography>
-            <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <PanelPreview panelDefinition={panelDefinition} />
-            </ErrorBoundary>
-          </Grid>
-          <Grid item xs={12}>
-            <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <PanelSpecEditor
-                ref={pluginEditorRef}
+    <TimeRangeProvider timeRange={timeRange}>
+      <FormProvider {...form}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: (theme) => theme.spacing(1, 2),
+            borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+          }}
+        >
+          <Typography variant="h2">{titleAction} Panel</Typography>
+          <Stack direction="row" spacing={1} marginLeft="auto">
+            <Button variant="contained" disabled={!form.formState.isValid} onClick={handleSubmit}>
+              {submitText}
+            </Button>
+            <Button color="secondary" variant="outlined" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </Stack>
+        </Box>
+        <Box id={panelEditorFormId} sx={{ flex: 1, overflowY: 'scroll', padding: (theme) => theme.spacing(2) }}>
+          <Grid container spacing={2}>
+            <Grid item xs={8}>
+              <Controller
                 control={form.control}
-                panelDefinition={panelDefinition}
-                onJSONChange={handlePanelDefinitionChange}
-                onQueriesChange={(queries) => {
-                  setQueries(queries);
-                }}
-                onPluginSpecChange={(spec) => {
-                  pluginEditor.onSpecChange(spec);
-                }}
+                name="panelDefinition.spec.display.name"
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    required
+                    fullWidth
+                    label="Name"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    value={watchedName ?? ''}
+                    onChange={(event) => {
+                      field.onChange(event);
+                      setName(event.target.value);
+                    }}
+                  />
+                )}
               />
-            </ErrorBoundary>
+            </Grid>
+            <Grid item xs={4}>
+              <Controller
+                control={form.control}
+                name="groupId"
+                render={({ field, fieldState }) => (
+                  <TextField
+                    select
+                    {...field}
+                    required
+                    fullWidth
+                    label="Group"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    onChange={(event) => {
+                      field.onChange(event);
+                    }}
+                  >
+                    {panelGroups.map((panelGroup, index) => (
+                      <MenuItem key={panelGroup.id} value={panelGroup.id}>
+                        {panelGroup.title ?? `Group ${index + 1}`}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
+            </Grid>
+            <Grid item xs={8}>
+              <Controller
+                control={form.control}
+                name="panelDefinition.spec.display.description"
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    fullWidth
+                    label="Description"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    value={watchedDescription ?? ''}
+                    onChange={(event) => {
+                      field.onChange(event);
+                      setDescription(event.target.value);
+                    }}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item xs={4}>
+              <Controller
+                control={form.control}
+                name="panelDefinition.spec.plugin.kind"
+                render={({ field, fieldState }) => (
+                  <PluginKindSelect
+                    {...field}
+                    pluginTypes={['Panel']}
+                    required
+                    fullWidth
+                    label="Type"
+                    disabled={pluginEditor.isLoading}
+                    error={!!pluginEditor.error || !!fieldState.error}
+                    helperText={pluginEditor.error?.message ?? fieldState.error?.message}
+                    value={{ type: 'Panel', kind: watchedPluginKind }}
+                    onChange={(event) => {
+                      field.onChange(event.kind);
+                      pluginEditor.onSelectionChange(event);
+                    }}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <Typography variant="h4" marginBottom={1}>
+                Preview
+              </Typography>
+              <ErrorBoundary FallbackComponent={ErrorAlert}>
+                <PanelPreview panelDefinition={panelDefinition} />
+              </ErrorBoundary>
+            </Grid>
+            <Grid item xs={12}>
+              <ErrorBoundary FallbackComponent={ErrorAlert}>
+                <PanelSpecEditor
+                  ref={pluginEditorRef}
+                  control={form.control}
+                  panelDefinition={panelDefinition}
+                  onJSONChange={handlePanelDefinitionChange}
+                  onQueriesChange={(queries) => {
+                    setQueries(queries);
+                  }}
+                  onPluginSpecChange={(spec) => {
+                    pluginEditor.onSpecChange(spec);
+                  }}
+                />
+              </ErrorBoundary>
+            </Grid>
           </Grid>
-        </Grid>
-      </Box>
-      <DiscardChangesConfirmationDialog
-        description="You have unapplied changes in this panel. Are you sure you want to discard these changes? Changes cannot be recovered."
-        isOpen={isDiscardDialogOpened}
-        onCancel={() => {
-          setDiscardDialogOpened(false);
-        }}
-        onDiscardChanges={() => {
-          setDiscardDialogOpened(false);
-          onClose();
-        }}
-      />
-    </FormProvider>
+        </Box>
+        <DiscardChangesConfirmationDialog
+          description="You have unapplied changes in this panel. Are you sure you want to discard these changes? Changes cannot be recovered."
+          isOpen={isDiscardDialogOpened}
+          onCancel={() => {
+            setDiscardDialogOpened(false);
+          }}
+          onDiscardChanges={() => {
+            setDiscardDialogOpened(false);
+            onClose();
+          }}
+        />
+      </FormProvider>
+    </TimeRangeProvider>
   );
 }
 

--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
@@ -19,6 +19,7 @@ import ChevronDown from 'mdi-material-ui/ChevronDown';
 import ChevronRight from 'mdi-material-ui/ChevronRight';
 import { forwardRef, ReactElement } from 'react';
 import { PluginEditor, PluginEditorProps, PluginEditorRef } from '../PluginEditor';
+import { useTimeRange } from '../../runtime';
 
 /**
  * Properties for {@link QueryEditorContainer}
@@ -96,7 +97,7 @@ interface QueryEditorProps extends Omit<BoxProps, OmittedMuiProps> {
 
 const QueryEditor = forwardRef<PluginEditorRef, QueryEditorProps>((props, ref): ReactElement => {
   const { value, onChange, queryTypes, ...others } = props;
-
+  const { refresh } = useTimeRange();
   const handlePluginChange: PluginEditorProps['onChange'] = (next) => {
     onChange(
       produce(value, (draft) => {
@@ -110,6 +111,7 @@ const QueryEditor = forwardRef<PluginEditorRef, QueryEditorProps>((props, ref): 
   return (
     <Box {...others}>
       <PluginEditor
+        postExecuteRunQuery={refresh}
         ref={ref}
         withRunQueryButton
         pluginTypes={queryTypes}

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -30,8 +30,16 @@ import { PluginEditorProps, PluginEditorRef, usePluginEditor } from './plugin-ed
  */
 
 export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((props, ref): ReactElement => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { value, withRunQueryButton = true, pluginTypes, pluginKindLabel, onChange: _, isReadonly, ...others } = props;
+  const {
+    value,
+    withRunQueryButton = true,
+    pluginTypes,
+    pluginKindLabel,
+    onChange: _,
+    isReadonly,
+    postExecuteRunQuery: refresh,
+    ...others
+  } = props;
   const { pendingSelection, isLoading, error, onSelectionChange, onSpecChange } = usePluginEditor(props);
 
   /* 
@@ -46,7 +54,8 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
 
   const runQueryHandler = useCallback((): void => {
     onSpecChange({ ...value.spec, ...watchedOtherSpecs, query: watchedQuery });
-  }, [value.spec, onSpecChange, watchedQuery, watchedOtherSpecs]);
+    refresh?.();
+  }, [value.spec, onSpecChange, watchedQuery, watchedOtherSpecs, refresh]);
 
   const queryHandlerSettings = useMemo(() => {
     return withRunQueryButton

--- a/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
+++ b/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
@@ -41,6 +41,7 @@ export interface PluginEditorProps extends Omit<BoxProps, OmittedMuiProps> {
   isReadonly?: boolean;
   withRunQueryButton?: boolean;
   onChange: (next: PluginEditorValue) => void;
+  postExecuteRunQuery?: () => void;
 }
 
 export interface PluginEditorRef {

--- a/ui/plugin-system/src/test/utils.tsx
+++ b/ui/plugin-system/src/test/utils.tsx
@@ -13,8 +13,10 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
+import { DEFAULT_DASHBOARD_DURATION } from '@perses-dev/core';
 import { PluginRegistry } from '../components';
 import { DefaultPluginKinds } from '../model';
+import { TimeRangeProvider } from '../runtime';
 import { testPluginLoader } from './test-plugins';
 
 export type ContextOptions = {
@@ -27,20 +29,23 @@ export function getTestContextWrapper(contextOptions?: ContextOptions) {
     defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } },
   });
 
+  const timeRange = { start: new Date(Date.now() - Number(DEFAULT_DASHBOARD_DURATION)), end: new Date() };
   return function Wrapper({ children }: { children: ReactNode }): ReactNode {
     return (
-      <QueryClientProvider client={queryClient}>
-        <PluginRegistry
-          pluginLoader={testPluginLoader}
-          defaultPluginKinds={
-            contextOptions?.defaultPluginKinds ?? {
-              TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+      <TimeRangeProvider timeRange={timeRange}>
+        <QueryClientProvider client={queryClient}>
+          <PluginRegistry
+            pluginLoader={testPluginLoader}
+            defaultPluginKinds={
+              contextOptions?.defaultPluginKinds ?? {
+                TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+              }
             }
-          }
-        >
-          {children}
-        </PluginRegistry>
-      </QueryClientProvider>
+          >
+            {children}
+          </PluginRegistry>
+        </QueryClientProvider>
+      </TimeRangeProvider>
     );
   };
 }


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3242
Closes https://github.com/perses/perses/discussions/3201

## Description

Discussed in details https://github.com/perses/perses/issues/3242 with @andreasgerstmayr 

## The Fix 🔧 

This PR wraps the PanelEditorForm with a new Time Range. Whenever the Run Query Button is pressed a fresh time range is generated, forcing  the query to be executed. So, whether the spec has changed or not, the query is executed, and no cached result will be returned. 

## Test 🧪 

The following picture is self-explanatory 

<img width="2451" height="1205" alt="image" src="https://github.com/user-attachments/assets/7aa7bdc2-69eb-45ed-a2a7-9b3c1f6eae84" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
