### PR TITLE
[BUGFIX] Hide DashboardStickyToolbar when empty

### DIFF
--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -26,20 +26,30 @@ import {
 import PinOutline from 'mdi-material-ui/PinOutline';
 import PinOffOutline from 'mdi-material-ui/PinOffOutline';
 import { TimeRangeControls } from '@perses-dev/plugin-system';
+import { VariableDefinition } from '@perses-dev/core';
 import { VariableList } from '../Variables';
+import { ExternalVariableDefinition, useExternalVariableDefinitions, useVariableDefinitions } from '../../context';
 
 interface DashboardStickyToolbarProps {
   initialVariableIsSticky?: boolean;
   sx?: SxProps<Theme>;
 }
 
-export function DashboardStickyToolbar(props: DashboardStickyToolbarProps): ReactElement {
+export function DashboardStickyToolbar(props: DashboardStickyToolbarProps): ReactElement | null {
   const [isPin, setIsPin] = useState(props.initialVariableIsSticky);
 
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
   const isSticky = scrollTrigger && props.initialVariableIsSticky && isPin;
 
   const isBiggerThanMd = useMediaQuery(useTheme().breakpoints.up('md'));
+
+  const variableDefinitions: VariableDefinition[] = useVariableDefinitions();
+  const externalVariableDefinitions: ExternalVariableDefinition[] = useExternalVariableDefinitions();
+  const variablesLength = variableDefinitions.length + externalVariableDefinitions.length;
+
+  if (!variablesLength) {
+    return null;
+  }
 
   return (
     // marginBottom={-1} counteracts the marginBottom={1} on every variable input.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
We face an issue that when there are no variables in a dashboard the DashboardSticky componant had a padding and a background and it looked funny and wierd

# Screenshots
<img width="1323" height="717" alt="Screenshot 2025-09-04 at 11 36 35" src="https://github.com/user-attachments/assets/679b1d05-5786-40e8-abf9-9aad850052f4" />

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
