### PR TITLE
[ENHANCEMENT] Add readonly prop to the data source select

### DIFF
--- a/ui/plugin-system/src/components/DatasourceSelect.tsx
+++ b/ui/plugin-system/src/components/DatasourceSelect.tsx
@@ -64,7 +64,7 @@ export interface DatasourceSelectProps extends Omit<OutlinedSelectProps & BaseSe
  * the input deal with a `DatasourceSelector`.
  */
 export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
-  const { datasourcePluginKind, value, project, onChange, ...others } = props;
+  const { datasourcePluginKind, value, project, readOnly, onChange, ...others } = props;
   const { data, isLoading } = useListDatasourceSelectItems(datasourcePluginKind, project);
   const variables = useVariableValues();
 
@@ -137,6 +137,7 @@ export function DatasourceSelect(props: DatasourceSelectProps): ReactElement {
 
   return (
     <Autocomplete<DataSourceOption>
+      readOnly={readOnly}
       options={options}
       renderInput={(params) => <TextField {...params} label={others.label} placeholder="" />}
       groupBy={(option) => option.groupLabel || 'No group'}


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3218
# Description 🖊️ 

This PR uses the unused read-only property of the data source select. This prop should be used for the Query Query Viewer

## Screenshots

<img width="1689" height="786" alt="image" src="https://github.com/user-attachments/assets/e8eb36f9-c7f3-4f2d-a672-1c571206d1c0" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
