### PR TITLE
[IGNORE] Add examples and e2e tests for embedding Perses panels

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,3 +54,9 @@ jobs:
           path: |
             ui/e2e/playwright-report/
             ui/e2e/test-results/
+      - name: Create tarballs of all packages
+        run: cd ./ui && npm pack -ws
+      - name: Replace Perses dependencies in examples folder with built packages
+        run: for example in ./examples/*/; do (cd "$example"; npm install ../../ui/perses-dev-*.tgz); done
+      - name: Verify all examples build successfully
+        run: cd ./examples && ./test.sh

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+package-lock.json
+out.log

--- a/examples/embedded-react17/package.json
+++ b/examples/embedded-react17/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "embedded-react17",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild dev --open",
+    "preview": "rsbuild preview"
+  },
+  "dependencies": {
+    "@mui/material": "^6",
+    "@perses-dev/components": "latest",
+    "@perses-dev/core": "latest",
+    "@perses-dev/dashboards": "latest",
+    "@perses-dev/plugin-system": "latest",
+    "@perses-dev/prometheus-plugin": "latest",
+    "@perses-dev/timeseries-chart-plugin": "latest",
+    "@tanstack/react-query": "^4",
+    "react": "^17",
+    "react-dom": "^17",
+    "react-router-dom": "^6"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "^1.5.4",
+    "@rsbuild/plugin-react": "^1.4.0",
+    "@types/react": "^17",
+    "@types/react-dom": "^17",
+    "typescript": "^5.9.2"
+  }
+}

--- a/examples/embedded-react17/rsbuild.config.ts
+++ b/examples/embedded-react17/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+});

--- a/examples/embedded-react17/src/App.tsx
+++ b/examples/embedded-react17/src/App.tsx
@@ -1,0 +1,134 @@
+import { ChartsProvider, generateChartsTheme, getTheme, SnackbarProvider } from '@perses-dev/components';
+import {
+  DataQueriesProvider,
+  dynamicImportPluginLoader,
+  PluginRegistry,
+  TimeRangeProvider,
+} from '@perses-dev/plugin-system';
+import { Box, ThemeProvider } from '@mui/material';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DatasourceStoreProvider, Panel, VariableProvider, DatasourceApi } from '@perses-dev/dashboards';
+import { DashboardResource, GlobalDatasourceResource, DatasourceResource } from '@perses-dev/core';
+import * as prometheusPlugin from '@perses-dev/prometheus-plugin';
+import * as timeseriesChartPlugin from '@perses-dev/timeseries-chart-plugin';
+
+const fakeDatasource: GlobalDatasourceResource = {
+  kind: 'GlobalDatasource',
+  metadata: { name: 'hello' },
+  spec: {
+    default: true,
+    plugin: {
+      kind: 'PrometheusDatasource',
+      spec: {
+        // Update to your actual datasource url
+        directUrl: 'https://prometheus.demo.do.prometheus.io',
+      },
+    },
+  },
+};
+
+class DatasourceApiImpl implements DatasourceApi {
+  getDatasource(): Promise<DatasourceResource | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  getGlobalDatasource(): Promise<GlobalDatasourceResource | undefined> {
+    return Promise.resolve(fakeDatasource);
+  }
+
+  listDatasources(): Promise<DatasourceResource[]> {
+    return Promise.resolve([]);
+  }
+
+  listGlobalDatasources(): Promise<GlobalDatasourceResource[]> {
+    return Promise.resolve([fakeDatasource]);
+  }
+
+  buildProxyUrl(): string {
+    return '/prometheus';
+  }
+}
+export const fakeDatasourceApi = new DatasourceApiImpl();
+export const fakeDashboard = {
+  kind: 'Dashboard',
+  metadata: {},
+  spec: {},
+} as DashboardResource;
+
+function App() {
+  const muiTheme = getTheme('light');
+  const chartsTheme = generateChartsTheme(muiTheme, {});
+  const pluginLoader = dynamicImportPluginLoader([
+    {
+      resource: prometheusPlugin.getPluginModule(),
+      importPlugin: () => Promise.resolve(prometheusPlugin),
+    },
+    {
+      resource: timeseriesChartPlugin.getPluginModule(),
+      importPlugin: () => Promise.resolve(timeseriesChartPlugin),
+    },
+  ]);
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: 0,
+      },
+    },
+  });
+  return (
+    <ThemeProvider theme={muiTheme}>
+      <ChartsProvider chartsTheme={chartsTheme}>
+        <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }} variant="default" content="">
+          <PluginRegistry
+            pluginLoader={pluginLoader}
+            defaultPluginKinds={{
+              Panel: 'TimeSeriesChart',
+              TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+            }}
+          >
+            <QueryClientProvider client={queryClient}>
+              <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
+                <VariableProvider>
+                  <DatasourceStoreProvider dashboardResource={fakeDashboard} datasourceApi={fakeDatasourceApi}>
+                    <DataQueriesProvider
+                      definitions={[
+                        {
+                          kind: 'PrometheusTimeSeriesQuery',
+                          spec: { query: `up{job="prometheus"}` },
+                        },
+                      ]}
+                    >
+                      <Box sx={{ width: 500, height: 300 }}>
+                        <Panel
+                          definition={{
+                            kind: 'Panel',
+                            spec: {
+                              display: { name: 'Example Panel' },
+                              plugin: {
+                                kind: 'TimeSeriesChart',
+                                spec: {
+                                  legend: {
+                                    position: 'bottom',
+                                    size: 'medium',
+                                  },
+                                },
+                              },
+                            },
+                          }}
+                        />
+                      </Box>
+                    </DataQueriesProvider>
+                  </DatasourceStoreProvider>
+                </VariableProvider>
+              </TimeRangeProvider>
+            </QueryClientProvider>
+          </PluginRegistry>
+        </SnackbarProvider>
+      </ChartsProvider>
+    </ThemeProvider>
+  );
+}
+
+export default App;

--- a/examples/embedded-react17/src/index.tsx
+++ b/examples/embedded-react17/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {render} from 'react-dom';
+import App from './App';
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+    rootEl
+  );
+}

--- a/examples/embedded-react17/tsconfig.json
+++ b/examples/embedded-react17/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "jsx": "react-jsx",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noUncheckedSideEffectImports": true,
+
+    /* type checking */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/examples/embedded-react18/package.json
+++ b/examples/embedded-react18/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "embedded-react18",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild dev --open",
+    "preview": "rsbuild preview"
+  },
+  "dependencies": {
+    "@mui/material": "^6",
+    "@perses-dev/components": "latest",
+    "@perses-dev/core": "latest",
+    "@perses-dev/dashboards": "latest",
+    "@perses-dev/plugin-system": "latest",
+    "@perses-dev/prometheus-plugin": "latest",
+    "@perses-dev/timeseries-chart-plugin": "latest",
+    "@tanstack/react-query": "^4",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "^1.5.4",
+    "@rsbuild/plugin-react": "^1.4.0",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/examples/embedded-react18/rsbuild.config.ts
+++ b/examples/embedded-react18/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+});

--- a/examples/embedded-react18/src/App.tsx
+++ b/examples/embedded-react18/src/App.tsx
@@ -1,0 +1,134 @@
+import { ChartsProvider, generateChartsTheme, getTheme, SnackbarProvider } from '@perses-dev/components';
+import {
+  DataQueriesProvider,
+  dynamicImportPluginLoader,
+  PluginRegistry,
+  TimeRangeProvider,
+} from '@perses-dev/plugin-system';
+import { Box, ThemeProvider } from '@mui/material';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DatasourceStoreProvider, Panel, VariableProvider, DatasourceApi } from '@perses-dev/dashboards';
+import { DashboardResource, GlobalDatasourceResource, DatasourceResource } from '@perses-dev/core';
+import * as prometheusPlugin from '@perses-dev/prometheus-plugin';
+import * as timeseriesChartPlugin from '@perses-dev/timeseries-chart-plugin';
+
+const fakeDatasource: GlobalDatasourceResource = {
+  kind: 'GlobalDatasource',
+  metadata: { name: 'hello' },
+  spec: {
+    default: true,
+    plugin: {
+      kind: 'PrometheusDatasource',
+      spec: {
+        // Update to your actual datasource url
+        directUrl: 'https://prometheus.demo.do.prometheus.io',
+      },
+    },
+  },
+};
+
+class DatasourceApiImpl implements DatasourceApi {
+  getDatasource(): Promise<DatasourceResource | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  getGlobalDatasource(): Promise<GlobalDatasourceResource | undefined> {
+    return Promise.resolve(fakeDatasource);
+  }
+
+  listDatasources(): Promise<DatasourceResource[]> {
+    return Promise.resolve([]);
+  }
+
+  listGlobalDatasources(): Promise<GlobalDatasourceResource[]> {
+    return Promise.resolve([fakeDatasource]);
+  }
+
+  buildProxyUrl(): string {
+    return '/prometheus';
+  }
+}
+export const fakeDatasourceApi = new DatasourceApiImpl();
+export const fakeDashboard = {
+  kind: 'Dashboard',
+  metadata: {},
+  spec: {},
+} as DashboardResource;
+
+function App() {
+  const muiTheme = getTheme('light');
+  const chartsTheme = generateChartsTheme(muiTheme, {});
+  const pluginLoader = dynamicImportPluginLoader([
+    {
+      resource: prometheusPlugin.getPluginModule(),
+      importPlugin: () => Promise.resolve(prometheusPlugin),
+    },
+    {
+      resource: timeseriesChartPlugin.getPluginModule(),
+      importPlugin: () => Promise.resolve(timeseriesChartPlugin),
+    },
+  ]);
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: 0,
+      },
+    },
+  });
+  return (
+    <ThemeProvider theme={muiTheme}>
+      <ChartsProvider chartsTheme={chartsTheme}>
+        <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }} variant="default" content="">
+          <PluginRegistry
+            pluginLoader={pluginLoader}
+            defaultPluginKinds={{
+              Panel: 'TimeSeriesChart',
+              TimeSeriesQuery: 'PrometheusTimeSeriesQuery',
+            }}
+          >
+            <QueryClientProvider client={queryClient}>
+              <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
+                <VariableProvider>
+                  <DatasourceStoreProvider dashboardResource={fakeDashboard} datasourceApi={fakeDatasourceApi}>
+                    <DataQueriesProvider
+                      definitions={[
+                        {
+                          kind: 'PrometheusTimeSeriesQuery',
+                          spec: { query: `up{job="prometheus"}` },
+                        },
+                      ]}
+                    >
+                      <Box sx={{ width: 500, height: 300 }}>
+                        <Panel
+                          definition={{
+                            kind: 'Panel',
+                            spec: {
+                              display: { name: 'Example Panel' },
+                              plugin: {
+                                kind: 'TimeSeriesChart',
+                                spec: {
+                                  legend: {
+                                    position: 'bottom',
+                                    size: 'medium',
+                                  },
+                                },
+                              },
+                            },
+                          }}
+                        />
+                      </Box>
+                    </DataQueriesProvider>
+                  </DatasourceStoreProvider>
+                </VariableProvider>
+              </TimeRangeProvider>
+            </QueryClientProvider>
+          </PluginRegistry>
+        </SnackbarProvider>
+      </ChartsProvider>
+    </ThemeProvider>
+  );
+}
+
+export default App;

--- a/examples/embedded-react18/src/index.tsx
+++ b/examples/embedded-react18/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  const root = ReactDOM.createRoot(rootEl);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/examples/embedded-react18/tsconfig.json
+++ b/examples/embedded-react18/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "jsx": "react-jsx",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noUncheckedSideEffectImports": true,
+
+    /* type checking */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux
+
+for example in */;
+do
+  pushd $example
+
+  npm install |& tee out.log
+  if grep -q ERESOLVE out.log; then
+    exit 1
+  fi
+  npm run build
+
+  popd
+done


### PR DESCRIPTION
# Description

Added examples for embedding Perses panels in React 17 and React 18 apps, and a new e2e test to verify the examples don't have dependency problems and build successfully.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
