### PR TITLE
[ENHANCEMENT] PluginEditor: improve layout + responsive

### DIFF
--- a/ui/explore/src/views/ViewExplore/ViewExploreApp.tsx
+++ b/ui/explore/src/views/ViewExplore/ViewExploreApp.tsx
@@ -14,8 +14,7 @@
 import { Box } from '@mui/material';
 import { ChartsProvider, useChartsTheme } from '@perses-dev/components';
 import { ReactElement, ReactNode } from 'react';
-import { ExploreManager } from '../../components';
-import { ExplorerManagerProviderWithQueryParams } from '../../components/ExploreManager/ExplorerManagerProviderWithQueryParams';
+import { ExploreManager, ExplorerManagerProviderWithQueryParams } from '../../components';
 
 export interface ViewAppProps {
   exploreTitleComponent?: ReactNode;

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -75,29 +75,32 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
 
   return (
     <Box {...others}>
-      <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+          mb: 1,
+        }}
+      >
         <PluginKindSelect
           fullWidth={false}
-          sx={{ mb: 2, minWidth: 120 }}
+          sx={{ minWidth: 120 }}
           margin="dense"
           label={pluginKindLabel}
           pluginTypes={pluginTypes}
           disabled={isLoading}
           value={pendingSelection ? pendingSelection : value.selection}
-          InputProps={{ readOnly: isReadonly }}
+          slotProps={{ input: { readOnly: isReadonly } }}
           error={!!error}
           helperText={error?.message}
           onChange={onSelectionChange}
         />
 
         {withRunQueryButton && !isLoading && (
-          <Button
-            data-testid="run_query_button"
-            variant="contained"
-            sx={{ marginTop: 1.5, marginBottom: 1.5, paddingTop: 0.5, marginLeft: 'auto' }}
-            startIcon={<Reload />}
-            onClick={runQueryHandler}
-          >
+          <Button data-testid="run_query_button" variant="contained" startIcon={<Reload />} onClick={runQueryHandler}>
             Run Query
           </Button>
         )}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Improve the layout and responsive of the run query button.

# Screenshots

<!-- If there are UI changes -->
BEFORE:
<img width="943" height="513" alt="image" src="https://github.com/user-attachments/assets/e7a2e72e-d425-41ca-a9ad-3f098e737238" />

<img width="403" height="697" alt="image" src="https://github.com/user-attachments/assets/5b30a045-7531-464b-9ef0-aabf5ef31622" />


AFTER:
<img width="897" height="487" alt="image" src="https://github.com/user-attachments/assets/cb1b8d09-3067-4015-9b35-be4e8d4e88cc" />

<img width="391" height="689" alt="image" src="https://github.com/user-attachments/assets/3f744048-9333-45ad-90cb-0da9048318f8" />


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
