### PR TITLE
[BUGFIX] Simplify the panels key management

### DIFF
--- a/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { StateCreator } from 'zustand';
-import { getValidPanelKey, insertPanelInLayout, UnpositionedPanelGroupItemLayout } from '../../utils/panelUtils';
+import { insertPanelInLayout, UnpositionedPanelGroupItemLayout } from '../../utils/panelUtils';
 import { generateId, Middleware } from './common';
 import { PanelGroupSlice, PanelGroupItemId } from './panel-group-slice';
 import { PanelSlice } from './panel-slice';
@@ -68,7 +68,7 @@ export function createDuplicatePanelSlice(): StateCreator<
           throw new Error(`Cannot find layout for Panel with key '${panelKey}'`);
         }
 
-        const dupePanelKey = getValidPanelKey(panelKey, panels);
+        const dupePanelKey = crypto.randomUUID().replaceAll('-', '');
 
         state.panels[dupePanelKey] = panelToDupe;
 

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -13,7 +13,7 @@
 
 import { Action, PanelEditorValues, PanelGroupId } from '@perses-dev/core';
 import { StateCreator } from 'zustand';
-import { getYForNewRow, getValidPanelKey } from '../../utils';
+import { getYForNewRow } from '../../utils';
 import { generateId, Middleware, createPanelDefinition } from './common';
 import {
   PanelGroupSlice,
@@ -186,9 +186,7 @@ export function createPanelEditorSlice(): StateCreator<
           panelDefinition: get().initialValues?.panelDefinition ?? createPanelDefinition(),
         },
         applyChanges: (next) => {
-          const name = next.panelDefinition.spec.display.name;
-          const panelKey = getValidPanelKey(name, get().panels);
-
+          const panelKey = crypto.randomUUID().replaceAll('-', '');
           set((state) => {
             // Add a panel
             state.panels[panelKey] = next.panelDefinition;

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -152,10 +152,14 @@ export function insertPanelInLayout(
 }
 
 /**
+ * @deprecated
+ *
  * Get a valid panel key, where a valid key:
  * - does not include invalid characters
  * - is unique
+ * TODO: It is not clear why too much complexity is needed for generating a panel key
  */
+
 export function getValidPanelKey(panelKey: string, panels: Record<string, PanelDefinition>): string {
   const uniquePanelKeys = getUniquePanelKeys(panels);
   let normalizedPanelKey = getPanelKeyParts(removeWhiteSpaces(panelKey)).name;


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3285

## Description 🖊️ 
This change decouples the display name of a panel from its so-called metadata key. 
With this fix you should be able to use characters like !@#$%^&*()_+=-/.,? in the display name. 


## What does this change do ❓ 

This change simply uses the randomUUID from browser crypto API to generate a  UUID V4
This value is used to maintain an object of panels. 

## What is Random UUID

crypto.randomUUID() generates a UUID v4, which is statistically unique. UUIDs (Universally Unique Identifiers) are designed to be globally unique, and the randomness in UUID v4 ensures that the likelihood of a collision is extremely low.

## Test 🧪 

1. You should be able to create a panel with a display name which may include !@#$%^&*()_+=-/.,:;|}{[]\
2. You should be able to edit your panels with no issue
3. You should be able to clone your panels with no issue

<img width="938" height="224" alt="image" src="https://github.com/user-attachments/assets/57a5329f-c96f-4a9f-b209-0edf829cd7d7" />



## Final note ℹ️ 

Still it is not clear why such a complex login was used to generate a key for the panels object, while it could be any unique generated id. I talked to some colleagues, though no one knew if there was any valid reason behind such a complex logic. 


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
