### PR TITLE
[ENHANCEMENT] Add clear button to search bar

### DIFF
--- a/ui/app/src/components/Header/SearchBar/SearchBar.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchBar.tsx
@@ -18,6 +18,8 @@ import Archive from 'mdi-material-ui/Archive';
 import DatabaseIcon from 'mdi-material-ui/Database';
 import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { isProjectMetadata } from '@perses-dev/core';
+import IconButton from '@mui/material/IconButton';
+import Close from 'mdi-material-ui/Close';
 import { useIsMobileSize } from '../../../utils/browser-size';
 import { isAppleDevice } from '../../../utils/os';
 import { useDashboardList } from '../../../model/dashboard-client';
@@ -26,8 +28,6 @@ import { AdminRoute, ProjectRoute } from '../../../model/route';
 import { useDatasourceList } from '../../../model/datasource-client';
 import { useGlobalDatasourceList } from '../../../model/global-datasource-client';
 import { SearchList } from './SearchList';
-import IconButton from '@mui/material/IconButton';
-import Close from 'mdi-material-ui/Close';
 
 function shortcutCTRL(): string {
   return isAppleDevice() ? '⌘' : 'ctrl';


### PR DESCRIPTION
# Description

### Summary
This PR adds a clear (x) icon to the search bar, allowing users to reset the input query with a single click.

### Changes
- Added a close/cross icon to the right side of the search bar, beside the `esc` button.
- Icon is only visible when the query input has a value.
- Clicking the icon resets the query to an empty string.

### Motivation
Improves UX by providing a quick way to clear the search input, aligning with common patterns in modern UIs (Google, GitHub, VS Code).

Resolves #3336

# Screenshots
[Screencast from 2025-09-12 01-20-22.webm](https://github.com/user-attachments/assets/b3de5087-4900-4c3d-a918-d0b2f0d8e229) 



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
