### PR TITLE
[ignore] set a deadline for dropping react 17 support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,8 @@
 
 ## More data sources
 
-With the new plugin system now available, we have unblocked the possibility to support other data sources besides Prometheus
+With the new plugin system now available, we have unblocked the possibility to support other data sources besides
+Prometheus
 and Tempo.
 
 1. We are working on supporting Logs Datasource, starting with OpenSearch and Loki.
@@ -18,6 +19,7 @@ and Tempo.
 ## Marketplace
 
 A plugin and dashboard marketplace is planned to facilitate community sharing of:
+
 - Plugins
 - Dashboards
 - Dashboard-as-Code libraries
@@ -26,6 +28,12 @@ Development hasn't started yet. Join the discussion: https://github.com/perses/p
 
 ## Alert View
 
-An integrated alert view is under consideration for future releases. This feature will be prioritized after completing the current roadmap items.
+An integrated alert view is under consideration for future releases. This feature will be prioritized after completing
+the current roadmap items.
 
 Interested in contributing? Start by opening a discussion with your design proposal.
+
+## Dropping support for React 17
+
+We are planning to drop support for React 17 the 15th of July 2026. It will help us to keep our dependencies up to date
+and to be able to use libraries that only support React 18 and above.


### PR DESCRIPTION
as agreed during the Perses sync meeting, we are setting a deadline for dropping react 17 support.