### PR TITLE
Fix TLS Config CA, Cert, and Key fields to support multiline input

### DIFF
--- a/ui/app/src/components/secrets/SecretEditorForm.tsx
+++ b/ui/app/src/components/secrets/SecretEditorForm.tsx
@@ -717,8 +717,10 @@ export function SecretEditorForm({
                     <TextField
                       {...field}
                       fullWidth
+                      multiline
+                      minRows={4}
+                      maxRows={8}
                       label="CA"
-                      type="password"
                       InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
                       InputProps={{
                         readOnly: action === 'read',
@@ -761,8 +763,10 @@ export function SecretEditorForm({
                     <TextField
                       {...field}
                       fullWidth
+                      multiline
+                      minRows={4}
+                      maxRows={8}
                       label="Cert"
-                      type="password"
                       InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
                       InputProps={{
                         readOnly: action === 'read',
@@ -805,8 +809,10 @@ export function SecretEditorForm({
                     <TextField
                       {...field}
                       fullWidth
+                      multiline
+                      minRows={4}
+                      maxRows={8}
                       label="Key"
-                      type="password"
                       InputLabelProps={{ shrink: action === 'read' ? true : undefined }}
                       InputProps={{
                         readOnly: action === 'read',


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Secret Editor did not handle multi-line certificates correctly for TLS configuration fields (CA, Cert, and Key). When users input an inline certificate, newline characters (\n) were stripped or ignored, causing TLS connections to fail.

Now TLS CA, Cert, and Key fields support multi-line input with proper row limits, allowing inline PEM certificates to be submitted correctly.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
