### PR TITLE
[BUGFIX]: Add abort signal to plugin get time series data

### DIFF
--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -30,7 +30,7 @@ type TimeSeriesQueryPluginDependencies = {
  * A plugin for running time series queries.
  */
 export interface TimeSeriesQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
-  getTimeSeriesData: (spec: Spec, ctx: TimeSeriesQueryContext) => Promise<TimeSeriesData>;
+  getTimeSeriesData: (spec: Spec, ctx: TimeSeriesQueryContext, abortSignal?: AbortSignal) => Promise<TimeSeriesData>;
 
   dependsOn?: (spec: Spec, ctx: TimeSeriesQueryContext) => TimeSeriesQueryPluginDependencies;
 }


### PR DESCRIPTION
Relates to #3340 

# Description 🖊️ 

This PR adds an abort signal specifically to plugin get_time_series_data. 
This is the 1/2 and there will be the signal usage in plugin side as well. 

## Background

When plugin http requests are pending, in case of dashboard unmount all dangling requests should be aborted. 
React Query **_QueryFn_** generates the abort signal itself. We just need to pass this signal to the actual fetch method. 
The React query has a subscription to the component life-cycle, meaning if the component is being unmounted, all queries in pending states will be aborted.   





# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
