### PR TITLE
[BUGFIX] use globalThis object over global

### DIFF
--- a/ui/app/src/model/fetch.ts
+++ b/ui/app/src/model/fetch.ts
@@ -22,8 +22,8 @@ function deleteCookie(name: string): void {
 }
 
 export function enableRefreshFetch(): void {
-  global.fetch = new Proxy(global.fetch, {
-    apply: async function (target, that, args: Parameters<typeof global.fetch>): Promise<Response> {
+  globalThis.fetch = new Proxy(globalThis.fetch, {
+    apply: async function (target, that, args: Parameters<typeof globalThis.fetch>): Promise<Response> {
       return target
         .apply(that, args)
         .then((res) => {

--- a/ui/app/src/utils/browser-storage.ts
+++ b/ui/app/src/utils/browser-storage.ts
@@ -21,7 +21,7 @@ type StorageTuple<T> = [T, (next: T) => void];
  * storage does not have any data yet.
  */
 export function useLocalStorage<T>(key: string, initialValue: T): StorageTuple<T> {
-  const { value, setValueAndStore } = useStorage(global.localStorage, key, initialValue);
+  const { value, setValueAndStore } = useStorage(window.localStorage, key, initialValue);
   return [value, setValueAndStore];
 }
 

--- a/ui/core/src/utils/fetch.ts
+++ b/ui/core/src/utils/fetch.ts
@@ -12,10 +12,10 @@
 // limitations under the License.
 
 /**
- * Calls `global.fetch` and determines which type of error to show for non-200 responses.
+ * Calls `globalThis.fetch` and determines which type of error to show for non-200 responses.
  */
-export async function fetch(...args: Parameters<typeof global.fetch>): Promise<Response> {
-  const response = await global.fetch(...args);
+export async function fetch(...args: Parameters<typeof globalThis.fetch>): Promise<Response> {
+  const response = await globalThis.fetch(...args);
   if (response.ok === false) {
     const contentType = response.headers.get('content-type');
     if (contentType?.includes('application/json')) {
@@ -38,11 +38,11 @@ export async function fetch(...args: Parameters<typeof global.fetch>): Promise<R
 }
 
 /**
- * Calls `global.fetch` and throws a `FetchError` on non-200 responses, but also
+ * Calls `globalThis.fetch` and throws a `FetchError` on non-200 responses, but also
  * decodes the response body as JSON, casting it to type `T`. Returns the
  * decoded body.
  */
-export async function fetchJson<T>(...args: Parameters<typeof global.fetch>): Promise<T> {
+export async function fetchJson<T>(...args: Parameters<typeof globalThis.fetch>): Promise<T> {
   const response = await fetch(...args);
   if (!response.ok) {
     throw new FetchError(response);

--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.test.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.test.tsx
@@ -18,7 +18,7 @@ import { QueryEditorContainer } from './QueryEditorContainer';
 
 describe('QueryEditorContainer', () => {
   beforeEach(() => {
-    global.fetch = jest.fn(() =>
+    globalThis.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve({ success: true }),
       })

--- a/ui/plugin-system/src/remote/PluginLoaderComponent.test.tsx
+++ b/ui/plugin-system/src/remote/PluginLoaderComponent.test.tsx
@@ -18,7 +18,7 @@ import { PersesPlugin, RemotePluginModule } from './PersesPlugin.types';
 import { PluginLoaderComponent } from './PluginLoaderComponent';
 import * as PluginRuntime from './PluginRuntime';
 
-global.fetch = jest.fn(() => Promise.resolve({ ok: true } as Response));
+globalThis.fetch = jest.fn(() => Promise.resolve({ ok: true } as Response));
 
 jest.mock('@module-federation/enhanced/runtime', () => ({
   init: jest.fn(() => ({


### PR DESCRIPTION
# Description

Fixes #3361

Uses `globalThis` instead of `global` to ensure compatibility across different JavaScript environments. `global` is node specific, while `globalThis` is a standard that works in both Node.js and browser environments. The globalThis object is already in use in other parts of the codebase ([here](https://github.com/perses/perses/blob/9b21ce5364088dc58464c93ef62cf1875ce197b5/ui/dashboards/src/context/DashboardProvider/common.ts#L32-L36) and [here](https://github.com/perses/perses/blob/9b21ce5364088dc58464c93ef62cf1875ce197b5/ui/components/src/utils/component-ids.ts#L25-L27)) and the tests pass with this change.

# Screenshots

N/A

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] N/A ~~Changes that impact the UI include screenshots and/or screencasts of the relevant changes.~~
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
