### PR TITLE
[ENHANCEMENT] Allow UI to select default datasource during migration

### DIFF
--- a/ui/app/src/model/migrate-client.ts
+++ b/ui/app/src/model/migrate-client.ts
@@ -21,6 +21,7 @@ const resource = 'migrate';
 export interface MigrateBodyRequest {
   input?: Record<string, string>;
   grafanaDashboard: Record<string, unknown>;
+  useDefaultDatasource?: boolean;
 }
 
 export function useMigrate(): UseMutationResult<DashboardResource, StatusError, MigrateBodyRequest> {
@@ -33,7 +34,7 @@ export function useMigrate(): UseMutationResult<DashboardResource, StatusError, 
         headers: HTTPHeader,
         body: `{"input":${body.input ? JSON.stringify(body.input) : '{}'}, "grafanaDashboard": ${JSON.stringify(
           body.grafanaDashboard
-        )}}`,
+        )}, "useDefaultDatasource": ${body.useDefaultDatasource ? 'true' : 'false'}}`,
       });
     },
   });

--- a/ui/app/src/model/migrate-client.ts
+++ b/ui/app/src/model/migrate-client.ts
@@ -29,12 +29,15 @@ export function useMigrate(): UseMutationResult<DashboardResource, StatusError, 
     mutationKey: [resource],
     mutationFn: (body) => {
       const url = buildURL({ apiPrefix: '/api', resource: resource });
+      const requestBody = {
+        input: body.input || {},
+        grafanaDashboard: body.grafanaDashboard,
+        useDefaultDatasource: !!body.useDefaultDatasource,
+      };
       return fetchJson<DashboardResource>(url, {
         method: HTTPMethodPOST,
         headers: HTTPHeader,
-        body: `{"input":${body.input ? JSON.stringify(body.input) : '{}'}, "grafanaDashboard": ${JSON.stringify(
-          body.grafanaDashboard
-        )}, "useDefaultDatasource": ${body.useDefaultDatasource ? 'true' : 'false'}}`,
+        body: JSON.stringify(requestBody),
       });
     },
   });

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -11,7 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Alert, Autocomplete, Button, CircularProgress, Stack, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Autocomplete,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+  FormControlLabel,
+  Checkbox,
+} from '@mui/material';
 import { ReactElement, useState } from 'react';
 import Import from 'mdi-material-ui/Import';
 import { useNavigate } from 'react-router-dom';
@@ -48,6 +58,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
   const { exceptionSnackbar } = useSnackbar();
   const [projectName, setProjectName] = useState<string>('');
   const [grafanaInput, setGrafanaInput] = useState<Record<string, string>>({});
+  const [useDefaultDatasource, setUseDefaultDatasource] = useState<boolean>(false);
   const { data, isLoading, error } = useProjectList();
   const dashboardMutation = useCreateDashboardMutation((data) => {
     navigate(`/projects/${data.metadata.project}/dashboards/${data.metadata.name}`);
@@ -100,16 +111,32 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
           structure.
         </Typography>
       </Alert>
-      <Button
-        variant="contained"
-        disabled={migrateMutation.isPending}
-        startIcon={<AutoFix />}
-        onClick={() => {
-          migrateMutation.mutate({ input: grafanaInput, grafanaDashboard: dashboard ?? {} });
-        }}
-      >
-        Migrate
-      </Button>
+      <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={useDefaultDatasource}
+              onChange={(e) => setUseDefaultDatasource(e.target.checked)}
+              color="primary"
+            />
+          }
+          label="Use default datasource in Perses"
+        />
+        <Button
+          variant="contained"
+          disabled={migrateMutation.isPending}
+          startIcon={<AutoFix />}
+          onClick={() => {
+            migrateMutation.mutate({
+              input: grafanaInput,
+              grafanaDashboard: dashboard ?? {},
+              useDefaultDatasource: useDefaultDatasource,
+            });
+          }}
+        >
+          Migrate
+        </Button>
+      </Stack>
       {migrateMutation.isPending && <CircularProgress sx={{ alignSelf: 'center' }} />}
       {migrateMutation.isError && (
         <Alert variant="outlined" severity="error">

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -120,7 +120,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
               color="primary"
             />
           }
-          label="Select this box to use the default datasource for all the panels in the migrated dashboard"
+          label="Use default datasource in Perses"
         />
         <Button
           fullWidth

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -111,7 +111,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
           structure.
         </Typography>
       </Alert>
-      <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
+      <Stack direction="column" gap={1} width="100%">
         <FormControlLabel
           control={
             <Checkbox
@@ -120,9 +120,10 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
               color="primary"
             />
           }
-          label="Use default datasource in Perses"
+          label="Select this box to use the default datasource for all the panels in the migrated dashboard"
         />
         <Button
+          fullWidth
           variant="contained"
           disabled={migrateMutation.isPending}
           startIcon={<AutoFix />}
@@ -166,10 +167,12 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
               })}
             />
             <Button
+              fullWidth
               variant="contained"
               disabled={dashboardMutation.isPending || projectName.length === 0 || isReadonly}
               startIcon={<Import />}
               onClick={importOnClick}
+              sx={{ alignSelf: 'stretch' }}
             >
               Import
             </Button>

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -58,7 +58,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
   const { exceptionSnackbar } = useSnackbar();
   const [projectName, setProjectName] = useState<string>('');
   const [grafanaInput, setGrafanaInput] = useState<Record<string, string>>({});
-  const [useDefaultDatasource, setUseDefaultDatasource] = useState<boolean>(false);
+  const [useDefaultDatasource, setUseDefaultDatasource] = useState(false);
   const { data, isLoading, error } = useProjectList();
   const dashboardMutation = useCreateDashboardMutation((data) => {
     navigate(`/projects/${data.metadata.project}/dashboards/${data.metadata.name}`);


### PR DESCRIPTION
UI implementation of https://github.com/perses/perses/pull/3358
- Added a checkbox for using default datasource in Perses


<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

https://github.com/user-attachments/assets/38e4d7db-5ce7-4a64-9d0b-87ce11320b6f




# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
