### PR TITLE
[BUGFIX] Add abort signal to datasource variables query

### DIFF
--- a/ui/plugin-system/src/components/Variables/variable-model.test.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.test.ts
@@ -117,7 +117,11 @@ describe('useListVariablePluginValues', () => {
       timeRange: expect.any(Object),
     };
 
-    expect(getVariableOptionsMock).toHaveBeenCalledWith(definition.spec.plugin.spec, expectedCtx);
+    expect(getVariableOptionsMock).toHaveBeenCalledWith(
+      definition.spec.plugin.spec,
+      expectedCtx,
+      expect.any(AbortSignal)
+    );
   });
 
   it('should filter self variable from deps and ctx when dependsOn is passed', () => {
@@ -154,6 +158,10 @@ describe('useListVariablePluginValues', () => {
       timeRange: expect.any(Object),
     };
 
-    expect(getVariableOptionsMock).toHaveBeenCalledWith(definition.spec.plugin.spec, expectedCtx);
+    expect(getVariableOptionsMock).toHaveBeenCalledWith(
+      definition.spec.plugin.spec,
+      expectedCtx,
+      expect.any(AbortSignal)
+    );
   });
 });

--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -70,8 +70,8 @@ export function useListVariablePluginValues(definition: ListVariableDefinition):
 
   return useQuery({
     queryKey: [definition, variablesValueKey, timeRange, refreshKey],
-    queryFn: async () => {
-      const resp = await variablePlugin?.getVariableOptions(spec, { datasourceStore, variables, timeRange });
+    queryFn: async ({ signal }) => {
+      const resp = await variablePlugin?.getVariableOptions(spec, { datasourceStore, variables, timeRange }, signal);
       if (resp === undefined) {
         return [];
       }

--- a/ui/plugin-system/src/model/variables.ts
+++ b/ui/plugin-system/src/model/variables.ts
@@ -37,7 +37,11 @@ type VariablePluginDependencies = {
  * Plugin for handling custom VariableDefinitions.
  */
 export interface VariablePlugin<Spec = UnknownSpec> extends Plugin<Spec> {
-  getVariableOptions: (definition: Spec, ctx: GetVariableOptionsContext) => Promise<{ data: VariableOption[] }>;
+  getVariableOptions: (
+    definition: Spec,
+    ctx: GetVariableOptionsContext,
+    abortSignal?: AbortSignal
+  ) => Promise<{ data: VariableOption[] }>;
 
   /**
    * Returns a list of variables name this variable depends on. Used to optimize fetching


### PR DESCRIPTION
Relates to #3340 

## Description 🖊️ 

This PR adds the Abort Signal to the fetch data source variables. (Just missed)

## Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
