### PR TITLE
[BREAKINGCHANGE] Improve support for reverse proxy configuration

### DIFF
--- a/ui/app/rspack.config.mjs
+++ b/ui/app/rspack.config.mjs
@@ -98,6 +98,7 @@ export default defineConfig({
   plugins: [
     new rspack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.API_PREFIX': JSON.stringify(isDev ? '' : 'PREFIX_PATH_PLACEHOLDER'),
     }),
     new rspack.ProgressPlugin({}),
     new rspack.HtmlRspackPlugin({

--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -13,15 +13,11 @@
 
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { Datasource, DatasourceDefinition } from '@perses-dev/core';
-import {
-  DatasourceEditorForm,
-  PluginRegistry,
-  ValidationProvider,
-  remotePluginLoader,
-} from '@perses-dev/plugin-system';
+import { DatasourceEditorForm, PluginRegistry, ValidationProvider } from '@perses-dev/plugin-system';
 import { ReactElement, useState } from 'react';
 import { DeleteResourceDialog } from '../dialogs';
 import { DrawerProps } from '../form-drawers';
+import { useRemotePluginLoader } from '../../model/remote-plugin-loader';
 
 interface DatasourceDrawerProps<T extends Datasource> extends DrawerProps<T> {
   datasource: T;
@@ -38,6 +34,7 @@ export function DatasourceDrawer<T extends Datasource>({
   onDelete,
 }: DatasourceDrawerProps<T>): ReactElement {
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
+  const pluginLoader = useRemotePluginLoader();
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
   // -> TODO find a way to enable closing by clicking-out in edit view, with a discard confirmation modal popping up
@@ -56,7 +53,7 @@ export function DatasourceDrawer<T extends Datasource>({
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="datasource-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <PluginRegistry pluginLoader={remotePluginLoader()}>
+        <PluginRegistry pluginLoader={pluginLoader}>
           <ValidationProvider>
             {isOpen && (
               <DatasourceEditorForm

--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -20,12 +20,12 @@ import {
   ValidationProvider,
   VariableEditorForm,
   useInitialTimeRange,
-  remotePluginLoader,
 } from '@perses-dev/plugin-system';
 import { ReactElement, useMemo, useState } from 'react';
 import { useDatasourceApi } from '../../model/datasource-api';
 import { DeleteResourceDialog } from '../dialogs';
 import { DrawerProps } from '../form-drawers';
+import { useRemotePluginLoader } from '../../model/remote-plugin-loader';
 
 interface VariableDrawerProps<T extends Variable> extends DrawerProps<T> {
   variable: T;
@@ -45,6 +45,7 @@ export function VariableDrawer<T extends Variable>({
   const [isDeleteVariableDialogStateOpened, setDeleteVariableDialogStateOpened] = useState<boolean>(false);
 
   const datasourceApi = useDatasourceApi();
+  const pluginLoader = useRemotePluginLoader();
 
   const variableDef = useMemo(() => {
     const result = structuredClone(variable.spec);
@@ -71,7 +72,7 @@ export function VariableDrawer<T extends Variable>({
   return (
     <Drawer isOpen={isOpen} onClose={handleClickOut} data-testid="variable-editor">
       <ErrorBoundary FallbackComponent={ErrorAlert}>
-        <PluginRegistry pluginLoader={remotePluginLoader()}>
+        <PluginRegistry pluginLoader={pluginLoader}>
           <ValidationProvider>
             <DatasourceStoreProvider datasourceApi={datasourceApi} projectName={projectName}>
               <TimeRangeProviderWithQueryParams initialTimeRange={initialTimeRange}>

--- a/ui/app/src/config.ts
+++ b/ui/app/src/config.ts
@@ -1,0 +1,41 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Variables here are injected at build time by rspack, see `rspack.config.ts`
+export const PERSES_APP_CONFIG = {
+  api_prefix: process.env.API_PREFIX,
+};
+
+// Make it available in the global window for non-module code
+window.PERSES_APP_CONFIG ??= PERSES_APP_CONFIG;
+
+// Allow TypeScript to understand the global
+declare global {
+  interface Window {
+    /**
+     * Injected at build time by rspack, see `rspack.config.ts`
+     * If you are using this in a module, prefer to import the variable from
+     * `<root>/config.ts` instead.
+     *
+     * @example ```js
+     * // in es module code
+     * import { PERSES_APP_CONFIG } from '../config';
+     * const apiPrefix = PERSES_APP_CONFIG.api_prefix;
+     *
+     * // in non-module code
+     * const apiPrefix = window.PERSES_APP_CONFIG.api_prefix;
+     * ```
+     */
+    PERSES_APP_CONFIG: typeof PERSES_APP_CONFIG;
+  }
+}

--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -52,6 +52,11 @@ export function useConfigContext(): ConfigContextType {
   return ctx;
 }
 
+export function useApiPrefix(): string {
+  const { config } = useConfigContext();
+  return config.api_prefix ?? '';
+}
+
 export function useIsGlobalDatasourceEnabled(): boolean {
   const { config } = useConfigContext();
   return !config.datasource.global.disable;

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -215,6 +215,6 @@ export function useConfig(options?: ConfigOptions): UseQueryResult<ConfigModel, 
 }
 
 export function fetchConfig(): Promise<ConfigModel> {
-  const url = buildURL({ resource: resource, apiPrefix: `${PERSES_APP_CONFIG.api_prefix}/api` });
+  const url = buildURL({ resource: resource, apiUrl: '/api', apiPrefix: PERSES_APP_CONFIG.api_prefix });
   return fetchJson<ConfigModel>(url);
 }

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -190,6 +190,7 @@ export interface DatasourceConfig {
 }
 
 export interface ConfigModel {
+  api_prefix?: string;
   security: SecurityConfig;
   database: Database;
   schemas: ConfigSchemasModel;

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -14,6 +14,7 @@
 import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import { DashboardSelector, DurationString, fetchJson, Permission, StatusError } from '@perses-dev/core';
 import { Duration } from 'date-fns';
+import { PERSES_APP_CONFIG } from '../config';
 import buildURL from './url-builder';
 
 const resource = 'config';
@@ -214,6 +215,6 @@ export function useConfig(options?: ConfigOptions): UseQueryResult<ConfigModel, 
 }
 
 export function fetchConfig(): Promise<ConfigModel> {
-  const url = buildURL({ resource: resource, apiPrefix: '/api' });
+  const url = buildURL({ resource: resource, apiPrefix: `${PERSES_APP_CONFIG.api_prefix}/api` });
   return fetchJson<ConfigModel>(url);
 }

--- a/ui/app/src/model/remote-plugin-loader.ts
+++ b/ui/app/src/model/remote-plugin-loader.ts
@@ -1,0 +1,26 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PluginLoader, remotePluginLoader } from '@perses-dev/plugin-system';
+import { useMemo } from 'react';
+import { useApiPrefix } from '../context/Config';
+import { getBasePathName } from './route';
+
+export function useRemotePluginLoader(): PluginLoader {
+  const apiPrefix = useApiPrefix();
+  const baseUrl = getBasePathName();
+
+  const pluginLoader = useMemo(() => remotePluginLoader({ baseUrl, apiPrefix }), [apiPrefix, baseUrl]);
+
+  return pluginLoader;
+}

--- a/ui/app/src/model/url-builder.ts
+++ b/ui/app/src/model/url-builder.ts
@@ -13,7 +13,7 @@
 
 import { getBasePathName } from './route';
 
-const apiPrefix = '/api/v1';
+const apiUrl = '/api/v1';
 
 export type URLParams = {
   resource: string;
@@ -22,11 +22,12 @@ export type URLParams = {
   pathSuffix?: string[];
   queryParams?: URLSearchParams;
   apiPrefix?: string;
+  apiUrl?: string;
 };
 
 export default function buildURL(params: URLParams): string {
-  const basePath = getBasePathName();
-  let url = params.apiPrefix === undefined ? apiPrefix : params.apiPrefix;
+  const basePath = params.apiPrefix !== undefined ? params.apiPrefix : getBasePathName();
+  let url = params.apiUrl === undefined ? apiUrl : params.apiUrl;
   if (params.project !== undefined && params.project.length > 0) {
     url = `${url}/projects/${encodeURIComponent(params.project)}`;
   }

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -15,12 +15,7 @@ import { Box, CircularProgress, Stack } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DashboardResource, EphemeralDashboardResource, getResourceDisplayName } from '@perses-dev/core';
 import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard } from '@perses-dev/dashboards';
-import {
-  PluginRegistry,
-  UsageMetricsProvider,
-  ValidationProvider,
-  remotePluginLoader,
-} from '@perses-dev/plugin-system';
+import { PluginRegistry, UsageMetricsProvider, ValidationProvider } from '@perses-dev/plugin-system';
 import { ReactElement, useMemo } from 'react';
 import ProjectBreadcrumbs from '../../../components/breadcrumbs/ProjectBreadcrumbs';
 import { useDatasourceApi } from '../../../model/datasource-api';
@@ -30,6 +25,7 @@ import { useVariableList } from '../../../model/variable-client';
 import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
 import { useIsLocalDatasourceEnabled, useIsLocalVariableEnabled } from '../../../context/Config';
 import { getBasePathName } from '../../../model/route';
+import { useRemotePluginLoader } from '../../../model/remote-plugin-loader';
 
 export interface GenericDashboardViewProps {
   dashboardResource: DashboardResource | EphemeralDashboardResource;
@@ -49,6 +45,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
   const isLocalDatasourceEnabled = useIsLocalDatasourceEnabled();
   const isLocalVariableEnabled = useIsLocalVariableEnabled();
   const datasourceApi = useDatasourceApi();
+  const pluginLoader = useRemotePluginLoader();
 
   // Collect the Project variables and setup external variables from it
   const { data: project, isLoading: isLoadingProject } = useProject(dashboardResource.metadata.project);
@@ -84,7 +81,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
     >
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry
-          pluginLoader={remotePluginLoader()}
+          pluginLoader={pluginLoader}
           defaultPluginKinds={{
             Panel: 'TimeSeriesChart',
             TimeSeriesQuery: 'PrometheusTimeSeriesQuery',

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -29,6 +29,7 @@ import { useProject } from '../../../model/project-client';
 import { useVariableList } from '../../../model/variable-client';
 import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
 import { useIsLocalDatasourceEnabled, useIsLocalVariableEnabled } from '../../../context/Config';
+import { getBasePathName } from '../../../model/route';
 
 export interface GenericDashboardViewProps {
   dashboardResource: DashboardResource | EphemeralDashboardResource;
@@ -91,7 +92,11 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
         >
           <ValidationProvider>
             <ErrorBoundary FallbackComponent={ErrorAlert}>
-              <UsageMetricsProvider project={project.metadata.name} dashboard={dashboardResource.metadata.name}>
+              <UsageMetricsProvider
+                apiPrefix={getBasePathName()}
+                project={project.metadata.name}
+                dashboard={dashboardResource.metadata.name}
+              >
                 <ViewDashboard
                   dashboardResource={dashboardResource}
                   datasourceApi={datasourceApi}

--- a/ui/app/src/views/projects/explore/ProjectExploreView.tsx
+++ b/ui/app/src/views/projects/explore/ProjectExploreView.tsx
@@ -15,12 +15,13 @@ import { CircularProgress, Stack } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { ExternalVariableDefinition } from '@perses-dev/dashboards';
 import { ViewExplore } from '@perses-dev/explore';
-import { PluginRegistry, ProjectStoreProvider, useProjectStore, remotePluginLoader } from '@perses-dev/plugin-system';
+import { PluginRegistry, ProjectStoreProvider, useProjectStore } from '@perses-dev/plugin-system';
 import React, { ReactElement, useMemo } from 'react';
 import { useGlobalVariableList } from '../../../model/global-variable-client';
 import { useVariableList } from '../../../model/variable-client';
 import { buildGlobalVariableDefinition, buildProjectVariableDefinition } from '../../../utils/variables';
 import { useDatasourceApi } from '../../../model/datasource-api';
+import { useRemotePluginLoader } from '../../../model/remote-plugin-loader';
 
 export interface ProjectExploreViewProps {
   exploreTitleComponent?: React.ReactNode;
@@ -40,6 +41,7 @@ function HelperExploreView(props: ProjectExploreViewProps): ReactElement {
   const projectName = project?.metadata.name === 'none' ? '' : project?.metadata.name;
 
   const datasourceApi = useDatasourceApi();
+  const pluginLoader = useRemotePluginLoader();
 
   // Collect the Project variables and setup external variables from it
   const { data: globalVars, isLoading: isLoadingGlobalVars } = useGlobalVariableList();
@@ -62,7 +64,7 @@ function HelperExploreView(props: ProjectExploreViewProps): ReactElement {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorAlert}>
-      <PluginRegistry pluginLoader={remotePluginLoader()}>
+      <PluginRegistry pluginLoader={pluginLoader}>
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <ViewExplore
             datasourceApi={datasourceApi}

--- a/ui/plugin-system/src/remote/remotePluginLoader.test.ts
+++ b/ui/plugin-system/src/remote/remotePluginLoader.test.ts
@@ -49,36 +49,27 @@ describe('remotePluginLoader', () => {
   });
 
   describe('getInstalledPlugins', () => {
-    it('should fetch plugins from correct endpoint without baseURL', async () => {
-      const mockResponse = { json: jest.fn().mockResolvedValue([MOCK_VALID_PLUGIN_MODULE_RESOURCE]) };
-      mockFetch.mockResolvedValue(mockResponse as unknown as Response);
-
-      const loader = remotePluginLoader();
-      await loader.getInstalledPlugins();
-
-      expect(mockFetch).toHaveBeenCalledWith('/api/v1/plugins');
-    });
-
-    it('should fetch plugins from correct endpoint with baseURL', async () => {
-      const baseURL = 'https://example.com';
-      const mockResponse = { json: jest.fn().mockResolvedValue([MOCK_VALID_PLUGIN_MODULE_RESOURCE]) };
-      mockFetch.mockResolvedValue(mockResponse as unknown as Response);
-
-      const loader = remotePluginLoader(baseURL);
-      await loader.getInstalledPlugins();
-
-      expect(mockFetch).toHaveBeenCalledWith(`${baseURL}/api/v1/plugins`);
-    });
-
-    it('should return valid plugin modules when fetch succeeds', async () => {
+    it('should fetch plugins from correct endpoint without options', async () => {
       const mockResponse = { json: jest.fn().mockResolvedValue([MOCK_VALID_PLUGIN_MODULE_RESOURCE]) };
       mockFetch.mockResolvedValue(mockResponse as unknown as Response);
 
       const loader = remotePluginLoader();
       const result = await loader.getInstalledPlugins();
 
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/plugins');
       expect(result).toEqual([MOCK_VALID_PLUGIN_MODULE_RESOURCE]);
       expect(mockConsoleError).not.toHaveBeenCalled();
+    });
+
+    it('should fetch plugins from correct endpoint with apiPrefix', async () => {
+      const apiPrefix = 'https://example.com';
+      const mockResponse = { json: jest.fn().mockResolvedValue([MOCK_VALID_PLUGIN_MODULE_RESOURCE]) };
+      mockFetch.mockResolvedValue(mockResponse as unknown as Response);
+
+      const loader = remotePluginLoader({ apiPrefix });
+      await loader.getInstalledPlugins();
+
+      expect(mockFetch).toHaveBeenCalledWith(`${apiPrefix}/api/v1/plugins`);
     });
 
     it('should filter out invalid plugin modules and return only valid ones', async () => {
@@ -137,40 +128,38 @@ describe('remotePluginLoader', () => {
       const loader = remotePluginLoader();
       const result = await loader.importPluginModule(MOCK_VALID_PLUGIN_MODULE_RESOURCE);
 
-      expect(mockLoadPlugin).toHaveBeenCalledWith('test-module', 'testPlugin', undefined);
+      expect(mockLoadPlugin).toHaveBeenCalledWith('test-module', 'testPlugin', '/plugins');
       expect(result).toEqual(MOCK_REMOTE_PLUGIN_MODULE);
       expect(mockConsoleError).not.toHaveBeenCalled();
     });
 
-    it('should pass baseURL to loadPlugin when provided', async () => {
-      const baseURL = 'https://example.com';
-      mockLoadPlugin.mockResolvedValue(MOCK_REMOTE_PLUGIN_MODULE);
-
-      const loader = remotePluginLoader(baseURL);
-      const result = await loader.importPluginModule(MOCK_VALID_PLUGIN_MODULE_RESOURCE);
-
-      expect(mockLoadPlugin).toHaveBeenCalledWith('test-module', 'testPlugin', baseURL);
-      expect(result).toEqual(MOCK_REMOTE_PLUGIN_MODULE);
-    });
-
-    it('should handle different baseURL formats', async () => {
-      const testCases = [
-        { baseURL: 'https://example.com', expected: 'https://example.com/api/v1/plugins' },
-        { baseURL: 'https://example.com/', expected: 'https://example.com//api/v1/plugins' },
-        { baseURL: 'http://localhost:3000', expected: 'http://localhost:3000/api/v1/plugins' },
-        { baseURL: '', expected: '/api/v1/plugins' },
+    it('should handle options object variations', async () => {
+      const testCases: Array<{
+        options?: { apiPrefix?: string; baseUrl?: string };
+        expected: string;
+      }> = [
+        // object with baseUrl only
+        { options: { baseUrl: 'https://example.com' }, expected: 'https://example.com/plugins' },
+        { options: { baseUrl: 'https://example.com/' }, expected: 'https://example.com//plugins' },
+        { options: { baseUrl: 'http://localhost:3000' }, expected: 'http://localhost:3000/plugins' },
+        { options: { baseUrl: '' }, expected: '/plugins' },
+        // object with nothing or undefined
+        { options: {}, expected: '/plugins' },
+        { options: undefined, expected: '/plugins' },
       ];
 
+      mockLoadPlugin.mockResolvedValue(MOCK_REMOTE_PLUGIN_MODULE);
+
       for (const testCase of testCases) {
-        const mockResponse = { json: jest.fn().mockResolvedValue([]) };
-        mockFetch.mockResolvedValue(mockResponse as unknown as Response);
+        const loader = remotePluginLoader(testCase.options);
+        const result = await loader.importPluginModule(MOCK_VALID_PLUGIN_MODULE_RESOURCE);
 
-        const loader = remotePluginLoader(testCase.baseURL || undefined);
-        await loader.getInstalledPlugins();
-
-        expect(mockFetch).toHaveBeenCalledWith(testCase.expected);
-        mockFetch.mockClear();
+        expect(mockLoadPlugin).toHaveBeenCalledWith('test-module', 'testPlugin', testCase.expected);
+        expect(result).toEqual(MOCK_REMOTE_PLUGIN_MODULE);
+        expect(mockConsoleError).not.toHaveBeenCalled();
       }
+
+      mockLoadPlugin.mockClear();
     });
 
     it('should handle multiple plugins in a module', async () => {
@@ -185,8 +174,8 @@ describe('remotePluginLoader', () => {
       const result = await loader.importPluginModule(multiPluginModule);
 
       expect(mockLoadPlugin).toHaveBeenCalledTimes(2);
-      expect(mockLoadPlugin).toHaveBeenNthCalledWith(1, 'multi-plugin-module', 'plugin1', undefined);
-      expect(mockLoadPlugin).toHaveBeenNthCalledWith(2, 'multi-plugin-module', 'plugin2', undefined);
+      expect(mockLoadPlugin).toHaveBeenNthCalledWith(1, 'multi-plugin-module', 'plugin1', '/plugins');
+      expect(mockLoadPlugin).toHaveBeenNthCalledWith(2, 'multi-plugin-module', 'plugin2', '/plugins');
       expect(result).toEqual({
         plugin1: { component: expect.any(Function) },
         plugin2: { component: expect.any(Function) },

--- a/ui/plugin-system/src/remote/remotePluginLoader.ts
+++ b/ui/plugin-system/src/remote/remotePluginLoader.ts
@@ -41,10 +41,51 @@ const isPluginModuleResource = (pluginModule: unknown): pluginModule is PluginMo
   );
 };
 
-export const remotePluginLoader = (baseURL?: string): PluginLoader => {
+type RemotePluginLoaderOptions = {
+  /**
+   * The API path for fetching available Perses plugins. Used to construct the full URL to the `/api/v1/plugins` endpoint.
+   * @default ''
+   **/
+  apiPrefix?: string;
+  /**
+   * The base URL for loading plugin assets (e.g., JavaScript files). Used to construct the full URL to the `/plugins` directory
+   * @default ''
+   **/
+  baseUrl?: string;
+};
+
+type ParsedPluginOptions = {
+  pluginsApiPath: string;
+  pluginsAssetsPath: string;
+};
+
+const DEFAULT_PLUGINS_API_PATH = '/api/v1/plugins';
+const DEFAULT_PLUGINS_ASSETS_PATH = '/plugins';
+
+const paramToOptions = (options?: RemotePluginLoaderOptions): ParsedPluginOptions => {
+  if (options === undefined) {
+    return {
+      pluginsApiPath: DEFAULT_PLUGINS_API_PATH,
+      pluginsAssetsPath: DEFAULT_PLUGINS_ASSETS_PATH,
+    };
+  }
+
+  return {
+    pluginsApiPath: `${options?.apiPrefix ?? ''}${DEFAULT_PLUGINS_API_PATH}`,
+    pluginsAssetsPath: `${options?.baseUrl ?? ''}${DEFAULT_PLUGINS_ASSETS_PATH}`,
+  };
+};
+
+/**
+ * Get a PluginLoader that fetches the list of installed plugins from a remote server and loads them as needed.
+ * @param options - Optional configuration options for the remote plugin loader.
+ */
+export function remotePluginLoader(options?: RemotePluginLoaderOptions): PluginLoader {
+  const { pluginsApiPath, pluginsAssetsPath } = paramToOptions(options);
+
   return {
     getInstalledPlugins: async (): Promise<PluginModuleResource[]> => {
-      const pluginsResponse = await fetch(`${baseURL ? baseURL : ''}/api/v1/plugins`);
+      const pluginsResponse = await fetch(pluginsApiPath);
 
       const plugins = await pluginsResponse.json();
 
@@ -68,7 +109,7 @@ export const remotePluginLoader = (baseURL?: string): PluginLoader => {
       const pluginModule: RemotePluginModule = {};
 
       for (const plugin of resource.spec.plugins) {
-        const remotePluginModule = await loadPlugin(pluginModuleName, plugin.spec.name, baseURL);
+        const remotePluginModule = await loadPlugin(pluginModuleName, plugin.spec.name, pluginsAssetsPath);
 
         const remotePlugin = remotePluginModule?.[plugin.spec.name];
         if (remotePlugin) {
@@ -81,4 +122,4 @@ export const remotePluginLoader = (baseURL?: string): PluginLoader => {
       return pluginModule;
     },
   };
-};
+}

--- a/ui/plugin-system/src/runtime/UsageMetricsProvider.tsx
+++ b/ui/plugin-system/src/runtime/UsageMetricsProvider.tsx
@@ -23,11 +23,13 @@ interface UsageMetrics {
   renderDurationMs: number;
   renderErrorCount: number;
   pendingQueries: Map<string, QueryState>;
+  apiPrefix?: string;
 }
 
 interface UsageMetricsProps {
   project: string;
   dashboard: string;
+  apiPrefix?: string;
   children: ReactNode;
 }
 
@@ -73,7 +75,7 @@ export const useUsageMetrics = (): UseUsageMetricsResults => {
 };
 
 const submitMetrics = async (stats: UsageMetrics): Promise<void> => {
-  await fetch('/api/v1/view', {
+  await fetch(`${stats.apiPrefix ?? ''}/api/v1/view`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -87,14 +89,15 @@ const submitMetrics = async (stats: UsageMetrics): Promise<void> => {
   });
 };
 
-export const UsageMetricsProvider = ({ project, dashboard, children }: UsageMetricsProps): ReactElement => {
-  const ctx = {
+export const UsageMetricsProvider = ({ apiPrefix, project, dashboard, children }: UsageMetricsProps): ReactElement => {
+  const ctx: UsageMetrics = {
     project: project,
     dashboard: dashboard,
     renderErrorCount: 0,
     startRenderTime: Date.now(),
     renderDurationMs: 0,
     pendingQueries: new Map(),
+    apiPrefix,
   };
 
   return <UsageMetricsContext.Provider value={ctx}>{children}</UsageMetricsContext.Provider>;


### PR DESCRIPTION
# Description

This PR adds some necessary changes to enable reverse proxy support, allowing the application to work correctly when deployed behind a reverse proxy with a custom base path.

There is still an issue with the plugin files having been compiled with a specific base path (`/`) but this will be tackled in a future PR.

Closes #2579

## Summary of Changes

**Plugin System Updates:**
- **`remotePluginLoader.ts`**: Modified to accept an options object in addition to a single string so that the baseUrl is handled correctly while maintaining the original behavior of the original implementation.
- **Multiple React components**: Updated to pass `getBasePathName()` to remotePluginLoader for consistent base path handling

**API Request Updates:**
- **`UsageMetricsProvider.tsx`**: Added `baseUrl` parameter to ensure API requests use the correct base path when behind a proxy

# Screenshots

N/A

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
