### PR TITLE
[BUGFIX] Remove var_preview values default value empty array

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
@@ -40,6 +40,21 @@ export function VariablePreview(props: VariablePreviewProps): ReactElement {
     notShown = values.length - maxValues;
   }
 
+  const variablePreviewState = useMemo((): JSX.Element | null => {
+    if (isLoading) {
+      return (
+        <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress />
+        </Stack>
+      );
+    } else if (error) {
+      return <Alert severity="error">{error}</Alert>;
+    } else if (!values?.length) {
+      return <Alert severity="info">No results</Alert>;
+    }
+    return null;
+  }, [error, isLoading, values]);
+
   return (
     <Box>
       <Stack direction="row" spacing={1} alignItems="center" mb={1}>
@@ -60,13 +75,7 @@ export function VariablePreview(props: VariablePreviewProps): ReactElement {
       </Stack>
       <Card variant="outlined">
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, m: 2 }}>
-          {error && <Alert severity="error">{error}</Alert>}
-          {values?.length === 0 && <Alert severity="info">No results</Alert>}
-          {isLoading && (
-            <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
-              <CircularProgress />
-            </Stack>
-          )}
+          {variablePreviewState}
           {values?.slice(0, maxValues).map((val, index) => <Chip size="small" key={index} label={val} />)}
           {notShown > 0 && <Chip onClick={showAll} variant="outlined" size="small" label={`+${notShown} more`} />}
         </Box>
@@ -83,9 +92,8 @@ export function VariableListPreview(props: VariableListPreviewProps): ReactEleme
   const { definition } = props;
   const { data, isFetching, error } = useListVariablePluginValues(definition);
   const errorMessage = (error as Error)?.message;
-
   const variablePreview = useMemo(
-    () => <VariablePreview values={data?.map((val) => val.value) || []} isLoading={isFetching} error={errorMessage} />,
+    () => <VariablePreview values={data?.map((val) => val.value)} isLoading={isFetching} error={errorMessage} />,
     [errorMessage, isFetching, data]
   );
 


### PR DESCRIPTION
# Description 🖊️ 

Closes #3240 

The default value (empty array) passed to the VariablePreview causes a bug by which `Loading` and `No Results` can be observed simultaneously.  This change is **_a fix + an improvement_**. 

1. The fix part removes the default empty array passed to the component. 
2. An improvement picks one state at the time. A component can not be in Error, Loading, and Ready states at the same time!

<img width="2262" height="1158" alt="image" src="https://github.com/user-attachments/assets/c130d779-bf36-4049-b00a-75c7c6761ba3" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
