### PR TITLE
[BUGFIX] Resove infinite loading for Variable Preview Static List

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -134,9 +134,8 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
             </ErrorBoundary>
           </Box>
         ) : (
-          <VariablePreview isLoading={true} />
+          <VariablePreview values={[]} />
         )}
-
         <Stack>
           <ErrorBoundary FallbackComponent={ErrorAlert}>
             <Controller

--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -72,7 +72,7 @@ export function useListVariablePluginValues(definition: ListVariableDefinition):
     queryKey: [definition, variablesValueKey, timeRange, refreshKey],
     queryFn: async ({ signal }) => {
       const resp = await variablePlugin?.getVariableOptions(spec, { datasourceStore, variables, timeRange }, signal);
-      if (resp === undefined) {
+      if (!resp?.data?.length) {
         return [];
       }
       if (!capturingRegexp) {


### PR DESCRIPTION
Closes #3233 

# Description 🖊️ 

This change resolves the infinite loading of the Static List Variable Preview, and adds a safety check on top of data reading, because for the Static List Variable the data is undefined. 


# The Bug 🐞 

<img width="1847" height="752" alt="image" src="https://github.com/user-attachments/assets/2721b6e1-1040-49f6-b6ab-56e64011c5c2" />



# Screenshots (After Fix)

<img width="2162" height="783" alt="image" src="https://github.com/user-attachments/assets/59e5eefb-405f-40e3-a430-48cf91802642" />



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
