### PR TITLE
[BUGFIX] Add default spec plugin kind

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -119,6 +119,10 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
     form.setValue('spec.allowMultiple', false);
   }
 
+  if (!values.spec.plugin) {
+    form.setValue('spec.plugin', { kind: 'StaticListVariable', spec: {} });
+  }
+
   const { refresh } = useTimeRange();
 
   return (
@@ -127,15 +131,11 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
         List Options
       </Typography>
       <Stack spacing={2} mb={2}>
-        {kind ? (
-          <Box>
-            <ErrorBoundary FallbackComponent={FallbackPreview} resetKeys={[previewSpec]}>
-              <VariableListPreview definition={previewSpec} />
-            </ErrorBoundary>
-          </Box>
-        ) : (
-          <VariablePreview isLoading={true} />
-        )}
+        <Box>
+          <ErrorBoundary FallbackComponent={FallbackPreview} resetKeys={[previewSpec]}>
+            <VariableListPreview definition={previewSpec} />
+          </ErrorBoundary>
+        </Box>
         <Stack>
           <ErrorBoundary FallbackComponent={ErrorAlert}>
             <Controller


### PR DESCRIPTION
Closes #3233 
# Description 🖊️ 

This change simply adds the default StaticListVariable plugin for the ListVariable.


# Test 🧪 

1. Go to a dashboard
2. Try to create a variable
3. Select List
4. The default Source is Static List Variable
5. You should not see the infinite loading
6. Save your changes and reload, all good? 
7. Switch between different sources, all good? 
 



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
