### PR TITLE
[BUGFIX] Add sort functionality to the Variables

### DIFF
--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -21,7 +21,13 @@ import {
   VariableName,
   VariableValue,
 } from '@perses-dev/core';
-import { useListVariablePluginValues, VariableOption, VariableState } from '@perses-dev/plugin-system';
+import {
+  SORT_METHODS,
+  SortMethodName,
+  useListVariablePluginValues,
+  VariableOption,
+  VariableState,
+} from '@perses-dev/plugin-system';
 import { UseQueryResult } from '@tanstack/react-query';
 import { useVariableDefinitionAndState, useVariableDefinitionActions } from '../../context';
 import { MAX_VARIABLE_WIDTH, MIN_VARIABLE_WIDTH } from '../../constants';
@@ -88,23 +94,8 @@ export function useListVariableState(
     const opts = options ? [...options] : [];
 
     if (!sort || sort === 'none') return opts;
-
-    switch (sort) {
-      case 'alphabetical-asc':
-        return opts.sort((a, b) => (a.label > b.label ? 1 : -1));
-      case 'alphabetical-desc':
-        return opts.sort((a, b) => (a.label > b.label ? -1 : 1));
-      case 'numerical-asc':
-        return opts.sort((a, b) => (parseInt(a.label) > parseInt(b.label) ? 1 : -1));
-      case 'numerical-desc':
-        return opts.sort((a, b) => (parseInt(a.label) < parseInt(b.label) ? 1 : -1));
-      case 'alphabetical-ci-asc':
-        return opts.sort((a, b) => (a.label.toLowerCase() > b.label.toLowerCase() ? 1 : -1));
-      case 'alphabetical-ci-desc':
-        return opts.sort((a, b) => (a.label.toLowerCase() > b.label.toLowerCase() ? -1 : 1));
-      default:
-        return opts;
-    }
+    const sortMethod = SORT_METHODS[sort as SortMethodName];
+    return !sortMethod ? opts : sortMethod.sort(opts);
   }, [options, sort]);
 
   const viewOptions = useMemo(() => {

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -23,6 +23,7 @@ import { useValidationSchemas } from '../../../context';
 import { VARIABLE_TYPES } from '../variable-model';
 import { useTimeRange } from '../../../runtime';
 import { VariableListPreview, VariablePreview } from './VariablePreview';
+import { SORT_METHODS, SortMethodName } from './variable-editor-form-model';
 
 function FallbackPreview(): ReactElement {
   return <div>Error previewing values</div>;
@@ -108,6 +109,11 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
     name: 'spec.allowAllValue',
   });
 
+  const sortMethod = useWatch<VariableDefinition, 'spec.sort'>({
+    control: control,
+    name: 'spec.sort',
+  }) as SortMethodName;
+
   // When variable kind is selected we need to provide default values
   // TODO: check if react-hook-form has a better way to do this
   const values = form.getValues() as ListVariableDefinition;
@@ -123,6 +129,10 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
     form.setValue('spec.plugin', { kind: 'StaticListVariable', spec: {} });
   }
 
+  if (!values.spec.sort) {
+    form.setValue('spec.sort', 'none');
+  }
+
   const { refresh } = useTimeRange();
 
   return (
@@ -133,7 +143,7 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
       <Stack spacing={2} mb={2}>
         <Box>
           <ErrorBoundary FallbackComponent={FallbackPreview} resetKeys={[previewSpec]}>
-            <VariableListPreview definition={previewSpec} />
+            <VariableListPreview sortMethod={sortMethod} definition={previewSpec} />
           </ErrorBoundary>
         </Box>
         <Stack>
@@ -219,13 +229,15 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
                   field.onChange(event);
                 }}
               >
-                <MenuItem value="none">None</MenuItem>
-                <MenuItem value="alphabetical-asc">Alphabetical, asc</MenuItem>
-                <MenuItem value="alphabetical-desc">Alphabetical, desc</MenuItem>
-                <MenuItem value="numerical-asc">Numerical, asc</MenuItem>
-                <MenuItem value="numerical-desc">Numerical, desc</MenuItem>
-                <MenuItem value="alphabetical-ci-asc">Alphabetical, case-insensitive, asc</MenuItem>
-                <MenuItem value="alphabetical-ci-desc">Alphabetical, case-insensitive, desc</MenuItem>
+                {Object.keys(SORT_METHODS).map((key) => {
+                  if (!SORT_METHODS[key as SortMethodName]) return null;
+                  const { label } = SORT_METHODS[key as SortMethodName];
+                  return (
+                    <MenuItem key={key} value={key}>
+                      {label}
+                    </MenuItem>
+                  );
+                })}
               </TextField>
             )}
           />

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
@@ -18,6 +18,7 @@ import Clipboard from 'mdi-material-ui/ClipboardOutline';
 import { ListVariableDefinition } from '@perses-dev/core';
 import { TOOLTIP_TEXT } from '../../../constants';
 import { useListVariablePluginValues } from '../variable-model';
+import { SORT_METHODS } from './variable-editor-form-model';
 
 const DEFAULT_MAX_PREVIEW_VALUES = 50;
 
@@ -86,15 +87,19 @@ export function VariablePreview(props: VariablePreviewProps): ReactElement {
 
 interface VariableListPreviewProps {
   definition: ListVariableDefinition;
+  sortMethod?: keyof typeof SORT_METHODS;
 }
 
 export function VariableListPreview(props: VariableListPreviewProps): ReactElement {
-  const { definition } = props;
+  const { definition, sortMethod } = props;
   const { data, isFetching, error } = useListVariablePluginValues(definition);
   const errorMessage = (error as Error)?.message;
+
+  const result = !sortMethod || sortMethod === 'none' || !data ? data : SORT_METHODS[sortMethod].sort(data);
+
   const variablePreview = useMemo(
-    () => <VariablePreview values={data?.map((val) => val.value)} isLoading={isFetching} error={errorMessage} />,
-    [errorMessage, isFetching, data]
+    () => <VariablePreview values={result?.map((val) => val.value)} isLoading={isFetching} error={errorMessage} />,
+    [errorMessage, isFetching, result]
   );
 
   return variablePreview;

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/index.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/index.ts
@@ -13,3 +13,4 @@
 
 export * from './VariableEditorForm';
 export * from './VariablePreview';
+export * from './variable-editor-form-model';

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/variable-editor-form-model.ts
@@ -12,6 +12,64 @@
 // limitations under the License.
 
 import { ListVariableSpec, TextVariableDefinition, TextVariableSpec, VariableDefinition } from '@perses-dev/core';
+import { VariableOption } from '../../../model';
+
+export type SortMethodName =
+  | 'none'
+  | 'alphabetical-asc'
+  | 'alphabetical-desc'
+  | 'numerical-asc'
+  | 'numerical-desc'
+  | 'alphabetical-ci-asc'
+  | 'alphabetical-ci-desc';
+
+export const SORT_METHODS: Record<
+  SortMethodName,
+  { label: string; sort: (input: VariableOption[]) => VariableOption[] }
+> = {
+  none: {
+    label: 'None',
+    sort: (input: VariableOption[]): VariableOption[] => {
+      return input.slice();
+    },
+  },
+  'alphabetical-asc': {
+    label: 'Alphabetical, asc',
+    sort: (input: VariableOption[]): VariableOption[] => {
+      return input.slice().sort((a, b) => (a.label > b.label ? 1 : -1));
+    },
+  },
+  'alphabetical-desc': {
+    label: 'Alphabetical, desc',
+    sort: (input: VariableOption[]): VariableOption[] => {
+      return input.slice().sort((a, b) => (a.label > b.label ? -1 : 1));
+    },
+  },
+  'numerical-asc': {
+    label: 'Numerical, asc',
+    sort: (input: VariableOption[]): VariableOption[] => {
+      return input.slice().sort((a, b) => (parseInt(a.label) > parseInt(b.label) ? 1 : -1));
+    },
+  },
+  'numerical-desc': {
+    label: 'Numerical, desc',
+    sort: (input: VariableOption[]): VariableOption[] => {
+      return input.slice().sort((a, b) => (parseInt(a.label) < parseInt(b.label) ? 1 : -1));
+    },
+  },
+  'alphabetical-ci-asc': {
+    label: 'Alphabetical, case-insensitive, asc',
+    sort: (input: VariableOption[]): VariableOption[] => {
+      return input.slice().sort((a, b) => (a.label.toLowerCase() > b.label.toLowerCase() ? 1 : -1));
+    },
+  },
+  'alphabetical-ci-desc': {
+    label: 'Alphabetical, case-insensitive, desc',
+    sort: (input: VariableOption[]): VariableOption[] => {
+      return input.slice().sort((a, b) => (a.label.toLowerCase() > b.label.toLowerCase() ? -1 : 1));
+    },
+  },
+};
 
 export type VariableEditorState = {
   name: string;


### PR DESCRIPTION
Closes #3196 

# Description 🖊️ 

This change adds the sort functionality to the Variable Form Editor. 

# The Bug 🐞 

The details can be found here #3196 

# Test 🧪 

Simply add a handful of variables and sort them. Do they get sorted? Save and reload. Is everything in order?  
This should work for any kind of List Variable. 

<img width="752" height="329" alt="image" src="https://github.com/user-attachments/assets/c060f4cf-6fc4-4e3c-a28e-a60cb48318e2" />






# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
