### PR TITLE
[IGNORE] Validate CUE files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -175,6 +175,20 @@ jobs:
         run: make install-default-plugins
       - name: validate all data from dev/data
         run: make validate-data
+  validate-cue:
+    name: "validate CUE files"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+      - uses: perses/github-actions@v0.11.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+          enable_cue: true
+          cue_version: "v0.14.0"
+      - name: validate CUE files against corresponding test files
+        run: make validate-cue
   check-cue-gen:
     name: "check generated CUE files"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,11 @@ validate-data:
 	@echo ">> Validate all data in dev/data"
 	$(GO) run ./scripts/validate-data/validate-data.go
 
+.PHONY: validate-cue
+validate-cue:
+	@echo ">> Validate CUE files against corresponding test files"
+	$(GO) run ./scripts/validate-cue/validate-cue.go
+
 .PHONY: test
 test: generate
 	@echo ">> running all tests"

--- a/cue-test/common/transform.cue
+++ b/cue-test/common/transform.cue
@@ -1,0 +1,26 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#joinByColumnValueTransform: spec: columns: ["job", "instance"]
+
+#mergeColumnsTransform: spec: {
+	columns: ["job", "instance"]
+	name:     "job-instance"
+	disabled: true
+}
+
+#mergeIndexedColumnsTransform: spec: column: "instance"
+
+#mergeSeries: spec: disabled: false

--- a/cue-test/common/url.cue
+++ b/cue-test/common/url.cue
@@ -1,0 +1,17 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+test1: #url && "http://localhost:9090"
+test2: #url && "https://localhost:9090"

--- a/scripts/validate-cue/validate-cue.go
+++ b/scripts/validate-cue/validate-cue.go
@@ -1,0 +1,124 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+// This script goes through the CUE files and validates each of them against its
+// corresponding test file, if it exists.
+
+const (
+	schemasDir = "cue"
+	testDir    = "cue-test"
+)
+
+// dirsInScope specifies which subdirectories under cue/ to validate
+var dirsInScope = []string{"common", "dac-utils"}
+
+func findCueFiles(baseDir string, subDir string) ([]string, error) {
+	var files []string
+	dirPath := filepath.Join(baseDir, subDir)
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && filepath.Ext(path) == ".cue" {
+			// Convert to relative path from baseDir
+			relPath, err := filepath.Rel(baseDir, path)
+			if err != nil {
+				return err
+			}
+			files = append(files, relPath)
+		}
+
+		return nil
+	})
+
+	return files, err
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}
+
+func runCueVet(schemaFile, testFile string) error {
+	logrus.Debugf("Validating %s against %s", schemaFile, testFile)
+
+	cmd := exec.Command("cue", "vet", "-c=false", schemaFile, testFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to validate %s: %w", schemaFile, err)
+	}
+
+	return nil
+}
+
+func validateCueFiles() error {
+	logrus.Debugf("Starting CUE files validation")
+
+	// Check if cue command is available
+	if _, err := exec.LookPath("cue"); err != nil {
+		return fmt.Errorf("cue command not found in PATH: %w", err)
+	}
+
+	validatedCount := 0
+	skippedCount := 0
+
+	for _, subDir := range dirsInScope {
+		logrus.Debugf("Processing directory: %s", subDir)
+
+		files, err := findCueFiles(schemasDir, subDir)
+		if err != nil {
+			return fmt.Errorf("failed to find CUE files in %s/%s: %w", schemasDir, subDir, err)
+		}
+
+		for _, file := range files {
+			schemaFile := filepath.Join(schemasDir, file)
+			testFile := filepath.Join(testDir, file)
+
+			if !fileExists(testFile) {
+				logrus.Debugf("Skipping %s: test file %s not found", schemaFile, testFile)
+				skippedCount++
+				continue
+			}
+
+			if err := runCueVet(schemaFile, testFile); err != nil {
+				return err
+			}
+
+			validatedCount++
+		}
+	}
+
+	logrus.Infof("CUE files validation completed: %d validated, %d skipped", validatedCount, skippedCount)
+	return nil
+}
+
+func main() {
+	if err := validateCueFiles(); err != nil {
+		logrus.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

In the past we got [such typo](https://github.com/perses/perses/pull/3012) released before we noticed the problem when trying to rely on the schema on the plugins side.. This PR aims to address that by putting in place a proper "framework" to validate the CUE schemas hosted in this repo: the new folder `cue-test` at the root of the repository mirrors the same file structure as the `cue`  folder (= same sub directories, file names and package names). `<filename>.cue` from each side combined together (using `cue vet`) should evaluate successfully.

Only few tests are defined in this PR, to be completed later now that the base is in place.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
