### PR TITLE
[ENHANCEMENT] Improve display of error messages returned by the backend

### DIFF
--- a/ui/components/src/context/SnackbarProvider.tsx
+++ b/ui/components/src/context/SnackbarProvider.tsx
@@ -11,7 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
+import { styled } from '@mui/material/styles';
 import {
   SnackbarProvider as NotistackProvider,
   ProviderContext as NotistackContext,
@@ -19,6 +20,7 @@ import {
   SnackbarMessage,
   OptionsObject,
   SnackbarKey,
+  MaterialDesignContent,
 } from 'notistack';
 
 export interface SnackbarContext extends NotistackContext {
@@ -40,8 +42,27 @@ type SnackbarOptions = Omit<OptionsObject, 'variant'>;
 
 /**
  * Application-wide provider for showing snackbars/toasts.
+ * Customized to preserve formatting in error messages.
  */
-export { NotistackProvider as SnackbarProvider };
+export function SnackbarProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NotistackProvider>): React.ReactElement {
+  return (
+    <NotistackProvider
+      {...props}
+      Components={{
+        error: styled(MaterialDesignContent)(() => ({
+          '&.notistack-MuiContent-error': {
+            whiteSpace: 'pre-wrap',
+          },
+        })),
+      }}
+    >
+      {children}
+    </NotistackProvider>
+  );
+}
 
 /**
  * Gets the SnackbarContext with methods for displaying snackbars/toasts.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

The goal was to preserve the formatting (spaces and line breaks) of error messages returned by the backend, to be displayed as-is in the error toasts. This is mainly useful for the lengthy errors returned on some failed CUE validations. This is achieved by passing down the right CSS customization ([white-space: 'pre-wrap'](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#pre-wrap))
Still not ideal to have very verbose errors like this but until we have a better solution, this will be more intelligible displayed this way.

# Screenshots

Before:
<img width="1911" height="238" alt="Screenshot 2025-09-26 163926" src="https://github.com/user-attachments/assets/07f0d18a-a1ff-40c8-a080-4ead7e0f67fa" />

After:
<img width="1901" height="275" alt="Screenshot 2025-09-30 094848" src="https://github.com/user-attachments/assets/48a13378-6619-442a-9c39-3cb532fa21f3" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
