### PR TITLE
[ENHANCEMENT] add a public path function for plugins generation for reverse proxies

### DIFF
--- a/internal/cli/cmd/plugin/generate/templates/module/rsbuild.config.ts.tmpl
+++ b/internal/cli/cmd/plugin/generate/templates/module/rsbuild.config.ts.tmpl
@@ -54,6 +54,7 @@ export default defineConfig({
       },
       dts: false,
       runtime: false,
+      getPublicPath: `function() { return (window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || "") + "${assetPrefix}"; }`,
     }),
   ],
   tools: {


### PR DESCRIPTION
# Description

Add the getPublicPath function to the plugin generation template

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).