### PR TITLE
[FEATURE] Implement port capturing for plugin dev servers

### DIFF
--- a/internal/cli/cmd/plugin/start/devserver.go
+++ b/internal/cli/cmd/plugin/start/devserver.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"syscall"
 
 	"github.com/fatih/color"
@@ -31,14 +33,56 @@ type devserver struct {
 	async.SimpleTask
 	cmd        *exec.Cmd
 	pluginName string
+	portChan   chan int
+}
+
+type portCapturingWriter struct {
+	writer    io.Writer
+	portChan  chan int
+	portSent  bool
+	portRegex *regexp.Regexp
+}
+
+func newPortCapturingWriter(writer io.Writer, portChan chan int) *portCapturingWriter {
+	// Matches patterns like "Local:	http://localhost:3000" or "Local: http://127.0.0.1:3000"
+	portRegex := regexp.MustCompile(`(?m)Local:\s*https?://(?:localhost|127\.0\.0\.1):(\d+)`)
+
+	return &portCapturingWriter{
+		writer:    writer,
+		portChan:  portChan,
+		portRegex: portRegex,
+	}
+}
+
+func (p *portCapturingWriter) Write(data []byte) (int, error) {
+	n, err := p.writer.Write(data)
+
+	// Only extract port once
+	if !p.portSent {
+		if matches := p.portRegex.FindSubmatch(data); len(matches) > 1 {
+			if port, err := strconv.Atoi(string(matches[1])); err == nil {
+				p.portChan <- port
+				p.portSent = true
+			}
+		}
+	}
+
+	return n, err
+}
+
+func (d *devserver) GetPort() <-chan int {
+	return d.portChan
 }
 
 func newDevServer(pluginName, pluginPath, rsbuildScriptName string, writer, errWriter io.Writer, c *color.Color) *devserver {
+	portChan := make(chan int)
+
 	streamWriter := newPrefixedStream(pluginName, writer, c)
 	streamErrWriter := newPrefixedStream(pluginName, errWriter, c)
+	portCapturingWriter := newPortCapturingWriter(streamWriter, portChan)
 
 	cmd := exec.Command("npm", "run", rsbuildScriptName)
-	cmd.Stdout = streamWriter
+	cmd.Stdout = portCapturingWriter
 	cmd.Stderr = streamErrWriter
 	cmd.Dir = pluginPath
 	// Request the OS to assign a process group to the new process, to which all its children will belong
@@ -47,6 +91,7 @@ func newDevServer(pluginName, pluginPath, rsbuildScriptName string, writer, errW
 	return &devserver{
 		cmd:        cmd,
 		pluginName: pluginName,
+		portChan:   portChan,
 	}
 }
 
@@ -55,6 +100,8 @@ func (d *devserver) Execute(ctx context.Context, _ context.CancelFunc) error {
 		return err
 	}
 	<-ctx.Done()
+	// Close the port channel when the dev server is shutting down
+	close(d.portChan)
 	// Send kill signal to the process group instead of a single process
 	// (it gets the same value as the PID, only negative)
 	// This will ensure the process and all its children are killed.

--- a/internal/cli/cmd/plugin/start/start_test.go
+++ b/internal/cli/cmd/plugin/start/start_test.go
@@ -14,13 +14,16 @@
 package start
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/perses/perses/internal/test"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetServerPortAndExactPluginName(t *testing.T) {
@@ -87,5 +90,128 @@ func TestPreparePlugin(t *testing.T) {
 			assert.NotNil(t, devServer)
 			assert.Equal(t, tt.expectedPluginInDevelopment, pluginInDevelopment)
 		})
+	}
+}
+
+func TestPortCapturingWriter(t *testing.T) {
+	testSuite := []struct {
+		name         string
+		output       string
+		expectedPort int
+		shouldDetect bool
+	}{
+		{
+			name: "rsbuild local output",
+			output: `
+  Rsbuild v1.4.15
+
+  ➜  Local:    http://localhost:3001
+  ➜  Network:  http://192.168.178.173:3001
+`,
+			expectedPort: 3001,
+			shouldDetect: true,
+		},
+		{
+			name: "rsbuild with 127.0.0.1",
+			output: `
+  Rsbuild v1.4.15
+
+  ➜  Local:    http://127.0.0.1:3005
+  ➜  Network:  http://192.168.178.173:3005
+`,
+			expectedPort: 3005,
+			shouldDetect: true,
+		},
+		{
+			name: "rsbuild with tabs",
+			output: `
+  Rsbuild v1.4.15
+
+  ➜  Local:	http://localhost:8080
+  ➜  Network:	http://192.168.178.173:8080
+`,
+			expectedPort: 8080,
+			shouldDetect: true,
+		},
+		{
+			name: "output without port",
+			output: `
+  Rsbuild v1.4.15
+  Starting development server...
+`,
+			expectedPort: 0,
+			shouldDetect: false,
+		},
+		{
+			name: "output with network only",
+			output: `
+  ➜  Network:  http://192.168.178.173:3001
+`,
+			expectedPort: 0,
+			shouldDetect: false,
+		},
+	}
+
+	for _, tt := range testSuite {
+		t.Run(tt.name, func(t *testing.T) {
+			portChan := make(chan int, 1)
+			var buf bytes.Buffer
+			writer := newPortCapturingWriter(&buf, portChan)
+
+			// Write the output
+			n, err := writer.Write([]byte(tt.output))
+			require.NoError(t, err)
+			assert.Equal(t, len(tt.output), n)
+			assert.Equal(t, tt.output, buf.String())
+
+			// Check if port was detected
+			if tt.shouldDetect {
+				select {
+				case port := <-portChan:
+					assert.Equal(t, tt.expectedPort, port)
+				case <-time.After(100 * time.Millisecond):
+					t.Fatal("expected port to be detected but timeout occurred")
+				}
+			} else {
+				select {
+				case port := <-portChan:
+					t.Fatalf("expected no port detection but got port %d", port)
+				case <-time.After(100 * time.Millisecond):
+					// Success - no port detected
+				}
+			}
+		})
+	}
+}
+
+func TestPortCapturingWriterOnlyDetectsOnce(t *testing.T) {
+	portChan := make(chan int, 2) // Buffer for 2 to see if it sends twice
+	var buf bytes.Buffer
+	writer := newPortCapturingWriter(&buf, portChan)
+
+	// Write multiple outputs with ports
+	output1 := "  ➜  Local:    http://localhost:3001\n"
+	output2 := "  ➜  Local:    http://localhost:3002\n"
+
+	_, err := writer.Write([]byte(output1))
+	require.NoError(t, err)
+
+	_, err = writer.Write([]byte(output2))
+	require.NoError(t, err)
+
+	// Should only get the first port
+	select {
+	case port := <-portChan:
+		assert.Equal(t, 3001, port)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected port to be detected")
+	}
+
+	// Should not get a second port
+	select {
+	case port := <-portChan:
+		t.Fatalf("expected only one port detection but got second port %d", port)
+	case <-time.After(100 * time.Millisecond):
+		// Success - only one port detected
 	}
 }


### PR DESCRIPTION
# Description

This allows `percli plugins start` command to detect the port used by the plugin(s). This will allow to remove the manual port configuration from the plugins side. The current port discovery reading the plugin configuration was kept for backwards compatibility.

This requires that the plugin dev server reports its port adding some configuration on the plugin side. (Follow up PR)

```
  server: {
    printUrls: ({ urls }) => urls,
    cors: { origin: '*' },
  },
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).