### PR TITLE
[ignore] fix usage of apiPrefix vs apiURL

### DIFF
--- a/ui/app/src/model/auth-client.ts
+++ b/ui/app/src/model/auth-client.ts
@@ -101,7 +101,7 @@ export function useNativeAuthMutation(): UseMutationResult<void, Error, NativeAu
 }
 
 export function nativeAuth(body: NativeAuthBody): Promise<void> {
-  const url = buildURL({ resource: `${authResource}/providers/native/login`, apiPrefix: '/api' });
+  const url = buildURL({ resource: `${authResource}/providers/native/login`, apiURL: '/api' });
   return fetchJson<void>(url, {
     method: HTTPMethodPOST,
     headers: HTTPHeader,
@@ -110,7 +110,7 @@ export function nativeAuth(body: NativeAuthBody): Promise<void> {
 }
 
 export function refreshToken(): Promise<Response> {
-  const url = buildURL({ resource: `${authResource}/refresh`, apiPrefix: '/api' });
+  const url = buildURL({ resource: `${authResource}/refresh`, apiURL: '/api' });
   return fetch(url, {
     method: HTTPMethodPOST,
     headers: HTTPHeader,

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -215,6 +215,6 @@ export function useConfig(options?: ConfigOptions): UseQueryResult<ConfigModel, 
 }
 
 export function fetchConfig(): Promise<ConfigModel> {
-  const url = buildURL({ resource: resource, apiUrl: '/api', apiPrefix: PERSES_APP_CONFIG.api_prefix });
+  const url = buildURL({ resource: resource, apiURL: '/api', apiPrefix: PERSES_APP_CONFIG.api_prefix });
   return fetchJson<ConfigModel>(url);
 }

--- a/ui/app/src/model/migrate-client.ts
+++ b/ui/app/src/model/migrate-client.ts
@@ -28,7 +28,7 @@ export function useMigrate(): UseMutationResult<DashboardResource, StatusError, 
   return useMutation<DashboardResource, StatusError, MigrateBodyRequest>({
     mutationKey: [resource],
     mutationFn: (body) => {
-      const url = buildURL({ apiPrefix: '/api', resource: resource });
+      const url = buildURL({ resource: resource, apiURL: '/api' });
       const requestBody = {
         input: body.input || {},
         grafanaDashboard: body.grafanaDashboard,

--- a/ui/app/src/model/plugin-client.ts
+++ b/ui/app/src/model/plugin-client.ts
@@ -29,6 +29,6 @@ export function usePlugins(
 }
 
 export function fetchPlugins(): Promise<PluginModuleResource[]> {
-  const url = buildURL({ resource, apiPrefix: '/api/v1' });
+  const url = buildURL({ resource });
   return fetchJson<PluginModuleResource[]>(url);
 }

--- a/ui/app/src/model/url-builder.ts
+++ b/ui/app/src/model/url-builder.ts
@@ -22,12 +22,12 @@ export type URLParams = {
   pathSuffix?: string[];
   queryParams?: URLSearchParams;
   apiPrefix?: string;
-  apiUrl?: string;
+  apiURL?: string;
 };
 
 export default function buildURL(params: URLParams): string {
   const basePath = params.apiPrefix !== undefined ? params.apiPrefix : getBasePathName();
-  let url = params.apiUrl === undefined ? apiUrl : params.apiUrl;
+  let url = params.apiURL === undefined ? apiUrl : params.apiURL;
   if (params.project !== undefined && params.project.length > 0) {
     url = `${url}/projects/${encodeURIComponent(params.project)}`;
   }


### PR DESCRIPTION
The PR #3377 broke few functionalities like getting the list of the plugins in app.
This PR aims to fix that.

As a side effect I have renamed the field `apiUrl` by `apiURL` as URL is not a word.

/cc @lachieh