### PR TITLE
[BUGFIX] Fix navigation after creating a new dashboard

### DIFF
--- a/ui/app/src/views/projects/dashboards/CreateDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/CreateDashboardView.tsx
@@ -21,7 +21,7 @@ import {
   DashboardSpec,
   EphemeralDashboardResource,
 } from '@perses-dev/core';
-import { ReactElement, useCallback } from 'react';
+import { ReactElement, useCallback, useState } from 'react';
 import { useCreateDashboardMutation } from '../../../model/dashboard-client';
 import { generateMetadataName } from '../../../utils/metadata';
 import { HelperDashboardView } from './HelperDashboardView';
@@ -67,20 +67,24 @@ function CreateDashboardView(): ReactElement | null {
     },
   };
 
+  const [isLeavingConfirmDialogEnabled, setIsLeavingConfirmDialogEnabled] = useState(true);
+
   const handleDashboardSave = useCallback(
     (data: DashboardResource | EphemeralDashboardResource) => {
       if (data.kind !== 'Dashboard') {
         throw new Error('Invalid kind');
       }
+      setIsLeavingConfirmDialogEnabled(false); // Disable the leaving dialog before navigating
+
       return createDashboardMutation.mutateAsync(data, {
         onSuccess: (createdDashboard: DashboardResource) => {
           successSnackbar(
             `Dashboard ${getResourceExtendedDisplayName(createdDashboard)} has been successfully created`
           );
           navigate(`/projects/${createdDashboard.metadata.project}/dashboards/${createdDashboard.metadata.name}`);
-          return createdDashboard;
         },
         onError: (err) => {
+          setIsLeavingConfirmDialogEnabled(true); // Re-enable the leaving dialog if there was an error
           exceptionSnackbar(err);
           throw err;
         },
@@ -103,6 +107,7 @@ function CreateDashboardView(): ReactElement | null {
       isReadonly={false}
       isEditing={true}
       isCreating={true}
+      isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
     />
   );
 }

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -34,13 +34,22 @@ export interface GenericDashboardViewProps {
   isReadonly: boolean;
   isEditing: boolean;
   isCreating?: boolean;
+  isLeavingConfirmDialogEnabled?: boolean;
 }
 
 /**
  * The View for displaying a Dashboard.
  */
 export function HelperDashboardView(props: GenericDashboardViewProps): ReactElement {
-  const { dashboardResource, onSave, onDiscard, isReadonly, isEditing, isCreating } = props;
+  const {
+    dashboardResource,
+    onSave,
+    onDiscard,
+    isReadonly,
+    isEditing,
+    isCreating,
+    isLeavingConfirmDialogEnabled = true,
+  } = props;
 
   const isLocalDatasourceEnabled = useIsLocalDatasourceEnabled();
   const isLocalVariableEnabled = useIsLocalVariableEnabled();
@@ -112,7 +121,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
                   isDatasourceEnabled={isLocalDatasourceEnabled}
                   isEditing={isEditing}
                   isCreating={isCreating}
-                  isLeavingConfirmDialogEnabled={true}
+                  isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
                 />
               </UsageMetricsProvider>
             </ErrorBoundary>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
The LeaveDialog was triggered on create dashboard view, blocking the redirection to the right url when the dashboard has been saved.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
