### PR TITLE
[ENHANCEMENT] CLI/LINT: extract plugin archive when provided

### DIFF
--- a/internal/cli/cmd/lint/lint.go
+++ b/internal/cli/cmd/lint/lint.go
@@ -52,8 +52,12 @@ func (o *option) Complete(args []string) error {
 	}
 	if len(o.pluginPath) > 0 {
 		pl := plugin.New(apiConfig.Plugin{
-			Path: o.pluginPath,
+			ArchivePath: o.pluginPath,
+			Path:        o.pluginPath,
 		})
+		if err := pl.UnzipArchives(); err != nil {
+			return err
+		}
 		if err := pl.Load(); err != nil {
 			return err
 		}


### PR DESCRIPTION
when you using local plugin for the command `percli lint`, the CLI is now able to extract the plugin from the archive. Before it was expecting to have the plugins extracted.