### PR TITLE
[ENHANCEMENT] add custom pattern for matching plugin ports

### DIFF
--- a/internal/cli/cmd/plugin/generate/templates/module/rsbuild.config.ts.tmpl
+++ b/internal/cli/cmd/plugin/generate/templates/module/rsbuild.config.ts.tmpl
@@ -12,7 +12,13 @@ const exposedModules: ModuleFederationOptions["exposes"] = [
 ];
 
 export default defineConfig({
-  server: { port: 3119 },
+  server: { 
+    port: 3119,
+    printUrls: ({ urls, port }) => {
+      console.log(`[PERSES_PLUGIN] PORT="${port}"`);
+      return urls;
+    },
+  },
   dev: { assetPrefix },
   source: { entry: { main: "./src/index-federation.ts" } },
   output: {

--- a/internal/cli/cmd/plugin/start/devserver.go
+++ b/internal/cli/cmd/plugin/start/devserver.go
@@ -44,8 +44,8 @@ type portCapturingWriter struct {
 }
 
 func newPortCapturingWriter(writer io.Writer, portChan chan int) *portCapturingWriter {
-	// Matches patterns like "Local:	http://localhost:3000" or "Local: http://127.0.0.1:3000"
-	portRegex := regexp.MustCompile(`(?m)Local:\s*https?://(?:localhost|127\.0\.0\.1):(\d+)`)
+	// Matches patterns like "Local:	http://localhost:3000" or "Local: http://127.0.0.1:3000" or [PERSES_PLUGIN] NAME="Test" PORT="3009" PROTOCOL="https"
+	portRegex := regexp.MustCompile(`(?m)(?:Local:\s*https?://(?:localhost|127\.0\.0\.1):|\[PERSES_PLUGIN\]\s*PORT=")(\d+)`)
 
 	return &portCapturingWriter{
 		writer:    writer,

--- a/internal/cli/cmd/plugin/start/devserver_windows.go
+++ b/internal/cli/cmd/plugin/start/devserver_windows.go
@@ -50,8 +50,8 @@ type portCapturingWriter struct {
 }
 
 func newPortCapturingWriter(writer io.Writer, portChan chan int) *portCapturingWriter {
-	// Matches patterns like "Local:	http://localhost:3000" or "Local: http://127.0.0.1:3000"
-	portRegex := regexp.MustCompile(`(?m)Local:\s*https?://(?:localhost|127\.0\.0\.1):(\d+)`)
+	// Matches patterns like "Local:	http://localhost:3000" or "Local: http://127.0.0.1:3000" or [PERSES_PLUGIN] NAME="Test" PORT="3009" PROTOCOL="https"
+	portRegex := regexp.MustCompile(`(?m)(?:Local:\s*https?://(?:localhost|127\.0\.0\.1):|\[PERSES_PLUGIN\]\s*PORT=")(\d+)`)
 
 	return &portCapturingWriter{
 		writer:    writer,

--- a/internal/cli/cmd/plugin/start/start_test.go
+++ b/internal/cli/cmd/plugin/start/start_test.go
@@ -150,6 +150,18 @@ func TestPortCapturingWriter(t *testing.T) {
 			expectedPort: 0,
 			shouldDetect: false,
 		},
+		{
+			name:         "output with network only",
+			output:       `[PERSES_PLUGIN] PORT="3009"`,
+			expectedPort: 3009,
+			shouldDetect: true,
+		},
+		{
+			name:         "output with network only",
+			output:       `[PERSES_PLUGIN]`,
+			expectedPort: 0,
+			shouldDetect: false,
+		},
 	}
 
 	for _, tt := range testSuite {


### PR DESCRIPTION
# Description

Extends the regex for plugin port matching based on the following template, that will be added to plugins:

```
[PERSES_PLUGIN] PORT="3000"
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
