### PR TITLE
[ENHANCEMENT] add PERSES_CLI env var for plugin dev server

### DIFF
--- a/internal/cli/cmd/plugin/start/devserver.go
+++ b/internal/cli/cmd/plugin/start/devserver.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -85,6 +86,8 @@ func newDevServer(pluginName, pluginPath, rsbuildScriptName string, writer, errW
 	cmd.Stdout = portCapturingWriter
 	cmd.Stderr = streamErrWriter
 	cmd.Dir = pluginPath
+	// PERSES_CLI indicates to the plugin dev server that it is run by the perses CLI
+	cmd.Env = append(os.Environ(), "PERSES_CLI=true")
 	// Request the OS to assign a process group to the new process, to which all its children will belong
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 


### PR DESCRIPTION
# Description

Follows on from #3425 and perses/plugins#391 to add a `PERSES_CLI` environment variable to the plugin dev server process. This allows the dev server to detect that it is being run by the perses CLI, altering output for better readability.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
