### PR TITLE
[ENHANCEMENT] Add label value for the variable preview

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
@@ -98,7 +98,13 @@ export function VariableListPreview(props: VariableListPreviewProps): ReactEleme
   const result = !sortMethod || sortMethod === 'none' || !data ? data : SORT_METHODS[sortMethod].sort(data);
 
   const variablePreview = useMemo(
-    () => <VariablePreview values={result?.map((val) => val.value)} isLoading={isFetching} error={errorMessage} />,
+    () => (
+      <VariablePreview
+        values={result?.map((val) => val.label || val.value)}
+        isLoading={isFetching}
+        error={errorMessage}
+      />
+    ),
     [errorMessage, isFetching, result]
   );
 


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3393

# Description 🖊️ 

Variable Preview should try to show the label by default. If the label doesn't exist, the value should be used. 

# Screenshots
<img width="1757" height="872" alt="image" src="https://github.com/user-attachments/assets/27536cc6-7358-4e73-a950-2fe60d30f21e" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
