### PR TITLE
[BUGFIX] Grafana migration: handle "transparent" color

### DIFF
--- a/cue/common/migrate/mapping.cue
+++ b/cue/common/migrate/mapping.cue
@@ -111,6 +111,8 @@ package migrate
 		"yellow":             "#fade2a"
 		"light-yellow":       "#ffee52"
 		"super-light-yellow": "#fff899"
+
+		"transparent": "#00000000"
 	}
 }
 #defaultCalc: "last"


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Currently if `transparent` is used in a Grafana dashboard you try to migrate, this is making the migration process fail with such error: `bad request: invalid panel 2_0: spec.cellSettings.1.backgroundColor: invalid value \"transparent\" (out of bound =~\"^#(?:[0-9a-fA-F]{3}){1,2}$\")`. This PR fixes that.

NB: although the 8-digits color codes are well interpreted by Perses, the color picker doesn't allow to adjust the opacity currently. Something to be considered most probably..

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).