### PR TITLE
[IGNORE] getTheme: support same parameter as MUI createTheme()

### DIFF
--- a/ui/components/src/theme/theme.ts
+++ b/ui/components/src/theme/theme.ts
@@ -44,7 +44,7 @@ const getModalBackgroundStyle = ({
  * Need to reinstantiate the theme everytime to support switching between light and dark themes
  * https://github.com/mui-org/material-ui/issues/18831
  */
-export function getTheme(mode: PaletteMode, options: ThemeOptions = {}): Theme {
+export function getTheme(mode: PaletteMode, options: Parameters<typeof createTheme>[0] = {}): Theme {
   return createTheme({
     palette: getPaletteOptions(mode),
     typography,


### PR DESCRIPTION
# Description

Specifically, I wanted to set `cssVariables`, which is not part of `ThemeOptions`.

The signature of `createTheme` in MUI is a bit complex:
```
export default function createTheme(options?: Omit<ThemeOptions, 'components'> & Pick<CssVarsThemeOptions, 'defaultColorScheme' | 'colorSchemes' | 'components'> & {
    cssVariables?: boolean | Pick<CssVarsThemeOptions, 'colorSchemeSelector' | 'rootSelector' | 'disableCssColorScheme' | 'cssVarPrefix' | 'shouldSkipGeneratingVar'>;
}, // cast type to skip module augmentation test
...args: object[]): Theme;
```
therefore I'm using `Parameters<typeof createTheme>[0]` to get the type of the first parameter programmatically.

# Screenshots

No UI changes, only a minor TypeScript type change.

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
