### PR TITLE
[BUGFIX] dashboard - ListVariable: limiting the max height with lot of selected values

### DIFF
--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
-import { TextField, Popper, PopperProps, Checkbox, Autocomplete, createFilterOptions } from '@mui/material';
+import { TextField, Popper, PopperProps, Checkbox, Autocomplete, createFilterOptions, Chip, Box } from '@mui/material';
 import {
   DEFAULT_ALL_VALUE,
   ListVariableDefinition,
@@ -289,6 +289,31 @@ function ListVariable({ name, source }: VariableProps): ReactElement {
               <Checkbox style={{ marginRight: 8 }} checked={selected} />
               {option.label}
             </li>
+          );
+        }}
+        renderTags={(value, getTagProps, ownerState) => {
+          // When focused, if there are too much value selected, it will use all screen place. Putting limit to 200px (~6 lines of chips)
+          if (ownerState.focused) {
+            return (
+              <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
+                {value.map((option, index) => (
+                  <Chip {...getTagProps({ index })} key={index} label={option.label} size="small" />
+                ))}
+              </Box>
+            );
+          }
+
+          const limitTags: number | undefined = ownerState.limitTags;
+          const numTags: number = value.length;
+
+          return (
+            <>
+              {value.slice(0, limitTags).map((option, index) => (
+                <Chip {...getTagProps({ index })} key={index} label={option.label} size="small" />
+              ))}
+
+              {limitTags && numTags > limitTags && ` +${numTags - limitTags}`}
+            </>
           );
         }}
       />


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Limiting the height of ListVariable, because there is currently no limit and it can cover all the screen when focused if there are lot of option selected (even worst when scrolling) 🙃

# Screenshots

<!-- If there are UI changes -->
Now:
<img width="1265" height="1266" alt="image" src="https://github.com/user-attachments/assets/e9d6fc5f-151e-4b67-ab7b-6efa6f3e6dff" />
<img width="1279" height="1235" alt="image" src="https://github.com/user-attachments/assets/63b8ec45-3ebd-457e-8dc1-66c2b61ffd87" />


Before:
<img width="1266" height="1269" alt="image" src="https://github.com/user-attachments/assets/312a6361-9812-4703-9e6a-ef144778e455" />
<img width="1263" height="1264" alt="image" src="https://github.com/user-attachments/assets/0168f751-2aa5-4f82-8ab2-4c2c5cc84c13" />


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
