### PR TITLE
[BUGFIX] Remove grid items content unnecessary re render by having a consistent scrollbar

### DIFF
--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -10,6 +10,10 @@
     <style>
       :root {
         color-scheme: light dark;
+      }
+
+      html {
+        overflow-y: hidden;
       }
 
       body {
@@ -37,45 +41,55 @@
     <div id="root">
       <div id="loader" class="loading">
         <svg width="15%" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M71.625 23H29.375C25.8542 23 23 25.8542 23 29.375C23 32.8958 25.8542 35.75 29.375 35.75H71.625C75.1458 35.75 78 32.8958 78 29.375C78 25.8542 75.1458 23 71.625 23Z"
-              fill="#DE005D">
-          <animate
-                  attributeName="fill"
-                  values="#DE005D;#f5b3ce;#DE005D"
-                  dur="1s"
-                  begin="0s"
-                  repeatCount="indefinite"/>
-        </path>
-        <path d="M91.625 43.75H49.375C45.8542 43.75 43 46.6042 43 50.125C43 53.6458 45.8542 56.5 49.375 56.5H91.625C95.1458 56.5 98 53.6458 98 50.125C98 46.6042 95.1458 43.75 91.625 43.75Z"
-              fill="#DE005D">
-          <animate
-                  attributeName="fill"
-                  values="#DE005D;#f5b3ce;#DE005D"
-                  dur="1s"
-                  begin="0.25s"
-                  repeatCount="indefinite"/>
-        </path>
-        <path d="M71.625 64.5H29.375C25.8542 64.5 23 67.3542 23 70.875C23 74.3958 25.8542 77.25 29.375 77.25H71.625C75.1458 77.25 78 74.3958 78 70.875C78 67.3542 75.1458 64.5 71.625 64.5Z"
-              fill="#DE005D">
-          <animate
-                  attributeName="fill"
-                  values="#DE005D;#f5b3ce;#DE005D"
-                  dur="1s"
-                  begin="0.5s"
-                  repeatCount="indefinite"
-          />
-        </path>
-        <path d="M36.625 85.25H29.375C25.8542 85.25 23 88.1042 23 91.625C23 95.1458 25.8542 98 29.375 98H36.625C40.1458 98 43 95.1458 43 91.625C43 88.1042 40.1458 85.25 36.625 85.25Z"
-              fill="#DE005D">
-          <animate
-                  attributeName="fill"
-                  values="#DE005D;#f5b3ce;#DE005D"
-                  dur="1s"
-                  begin="0.75s"
-                  repeatCount="indefinite"
-          />
-        </path>
-      </svg>
+          <path
+            d="M71.625 23H29.375C25.8542 23 23 25.8542 23 29.375C23 32.8958 25.8542 35.75 29.375 35.75H71.625C75.1458 35.75 78 32.8958 78 29.375C78 25.8542 75.1458 23 71.625 23Z"
+            fill="#DE005D"
+          >
+            <animate
+              attributeName="fill"
+              values="#DE005D;#f5b3ce;#DE005D"
+              dur="1s"
+              begin="0s"
+              repeatCount="indefinite"
+            />
+          </path>
+          <path
+            d="M91.625 43.75H49.375C45.8542 43.75 43 46.6042 43 50.125C43 53.6458 45.8542 56.5 49.375 56.5H91.625C95.1458 56.5 98 53.6458 98 50.125C98 46.6042 95.1458 43.75 91.625 43.75Z"
+            fill="#DE005D"
+          >
+            <animate
+              attributeName="fill"
+              values="#DE005D;#f5b3ce;#DE005D"
+              dur="1s"
+              begin="0.25s"
+              repeatCount="indefinite"
+            />
+          </path>
+          <path
+            d="M71.625 64.5H29.375C25.8542 64.5 23 67.3542 23 70.875C23 74.3958 25.8542 77.25 29.375 77.25H71.625C75.1458 77.25 78 74.3958 78 70.875C78 67.3542 75.1458 64.5 71.625 64.5Z"
+            fill="#DE005D"
+          >
+            <animate
+              attributeName="fill"
+              values="#DE005D;#f5b3ce;#DE005D"
+              dur="1s"
+              begin="0.5s"
+              repeatCount="indefinite"
+            />
+          </path>
+          <path
+            d="M36.625 85.25H29.375C25.8542 85.25 23 88.1042 23 91.625C23 95.1458 25.8542 98 29.375 98H36.625C40.1458 98 43 95.1458 43 91.625C43 88.1042 40.1458 85.25 36.625 85.25Z"
+            fill="#DE005D"
+          >
+            <animate
+              attributeName="fill"
+              values="#DE005D;#f5b3ce;#DE005D"
+              dur="1s"
+              begin="0.75s"
+              repeatCount="indefinite"
+            />
+          </path>
+        </svg>
       </div>
       <script>
         const isDarkTheme = localStorage.getItem('perses-dark-theme-enabled') === 'true';

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -32,6 +32,7 @@
     "lodash": "^4.17.21",
     "marked": "^15.0.7",
     "mdi-material-ui": "^7.9.2",
+    "overlayscrollbars-react": "^0.5.6",
     "react": "^18.0.0",
     "react-cookie": "^8.0.1",
     "react-dom": "^18.0.0",

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -11,9 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { Outlet, useLocation } from 'react-router-dom';
-import { ReactElement, Suspense } from 'react';
+import { ReactElement, Suspense, useMemo } from 'react';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
+import 'overlayscrollbars/overlayscrollbars.css';
 import { ReactRouterProvider } from '@perses-dev/plugin-system';
 import Header from './components/Header/Header';
 import Footer from './components/Footer';
@@ -26,18 +28,11 @@ function isDashboardViewRoute(pathname: string): boolean {
 
 function App(): ReactElement {
   const location = useLocation();
+  const theme = useTheme();
+  const isOverlayScrollExcluded = [SignInRoute, SignUpRoute].includes(location.pathname);
 
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '100vh',
-        backgroundColor: ({ palette }) => palette.background.default,
-      }}
-    >
-      {location.pathname !== SignInRoute && location.pathname !== SignUpRoute && <Header />}
-
+  const appContent = useMemo(() => {
+    const actualContent = (
       <Box
         sx={{
           flex: 1,
@@ -54,6 +49,35 @@ function App(): ReactElement {
           </Suspense>
         </ReactRouterProvider>
       </Box>
+    );
+    return !isOverlayScrollExcluded ? (
+      <OverlayScrollbarsComponent
+        options={{
+          scrollbars: {
+            autoHide: 'never',
+            theme: theme.palette.mode === 'dark' ? 'os-theme-light' : 'os-theme-dark',
+          },
+        }}
+        style={{ flex: 1, display: 'flex' }}
+      >
+        {actualContent}
+      </OverlayScrollbarsComponent>
+    ) : (
+      actualContent
+    );
+  }, [isOverlayScrollExcluded, theme.palette.mode]);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        backgroundColor: ({ palette }) => palette.background.default,
+      }}
+    >
+      {location.pathname !== SignInRoute && location.pathname !== SignUpRoute && <Header />}
+      {appContent}
       {!isDashboardViewRoute(location.pathname) && <Footer />}
     </Box>
   );

--- a/ui/app/src/components/Header/Header.tsx
+++ b/ui/app/src/components/Header/Header.tsx
@@ -16,7 +16,6 @@ import { AppBar, Box, Button, Divider, Toolbar } from '@mui/material';
 import Cog from 'mdi-material-ui/Cog';
 import ShieldStar from 'mdi-material-ui/ShieldStar';
 import Compass from 'mdi-material-ui/Compass';
-import React from 'react';
 import { useIsLaptopSize, useIsMobileSize } from '../../utils/browser-size';
 import { AdminRoute, ConfigRoute } from '../../model/route';
 import { useIsAuthEnabled, useIsExplorerEnabled } from '../../context/Config';

--- a/ui/dashboards/src/components/GridLayout/Row.tsx
+++ b/ui/dashboards/src/components/GridLayout/Row.tsx
@@ -56,7 +56,6 @@ export function Row({
   const ResponsiveGridLayout = useMemo(() => WidthProvider(Responsive), []);
   const theme = useTheme();
   const viewPanelItemId = useViewPanelGroup();
-
   const [isOpen, setIsOpen] = useState(!groupDefinition.isCollapsed);
 
   const hasViewPanel =

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -82,6 +82,7 @@
         "lodash": "^4.17.21",
         "marked": "^15.0.7",
         "mdi-material-ui": "^7.9.2",
+        "overlayscrollbars-react": "^0.5.6",
         "react": "^18.0.0",
         "react-cookie": "^8.0.1",
         "react-dom": "^18.0.0",
@@ -13790,6 +13791,23 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/overlayscrollbars": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.12.0.tgz",
+      "integrity": "sha512-mWJ5MOkcZ/ljHwfLw8+bN0V9ziGCoNoqULcp994j5DTGNQvnkWKWkA7rnO29Kyew5AoHxUnJ4Ndqfcl0HSQjXg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/overlayscrollbars-react": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars-react/-/overlayscrollbars-react-0.5.6.tgz",
+      "integrity": "sha512-E5To04bL5brn9GVCZ36SnfGanxa2I2MDkWoa4Cjo5wol7l+diAgi4DBc983V7l2nOk/OLJ6Feg4kySspQEGDBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "overlayscrollbars": "^2.0.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/own-keys": {


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3448

# Description 🖊️ 

One of the performance issues which has been found so far is a subtle change of the panels width when the scrollbar appears on the right side of the view port. This subtle difference changes the width of all panels, and consequently triggers an unnecessary re render. 

<img width="2519" height="849" alt="image" src="https://github.com/user-attachments/assets/5a3f44f3-2520-4ad1-87e5-faa8d9f8c86a" />



# The fix 🔧 

The fix uses a library by which overlay scrollbars are possible. So, the space is always reserved for the scrollbar and since it is overlay it doesn't affect the app visually!  



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
