### PR TITLE
[ENHANCEMENT] Add query jitter to prevent request bursts on dashboard refresh

### DIFF
--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -46,7 +46,6 @@ export interface TimeSeriesQueryContext {
   timeRange: AbsoluteTimeRange;
   variableState: VariableStateMap;
   datasourceStore: DatasourceStore;
-  refreshKey: string;
 }
 
 export type TimeSeriesDataQuery = Query<TimeSeriesData, unknown, TimeSeriesData, QueryKey>;

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeProvider.tsx
@@ -98,15 +98,6 @@ export function TimeRangeProvider(props: TimeRangeProviderProps): ReactElement {
   }, [setRefreshCounter]);
 
   const refreshIntervalInMs = getRefreshIntervalInMs(localRefreshInterval);
-  useEffect(() => {
-    if (refreshIntervalInMs > 0) {
-      const interval = setInterval(() => {
-        refresh();
-      }, refreshIntervalInMs);
-
-      return (): void => clearInterval(interval);
-    }
-  }, [refresh, refreshIntervalInMs]);
 
   const ctx = useMemo(() => {
     const absoluteTimeRange = isRelativeTimeRange(localTimeRange)


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR improves auto refresh behaviour of dashboads adding query jitter to prevent request bursts when multiple panels refresh simultaneously in dashboards.

**Problem:**
When dashboards have many panels with refresh interval turned on all queries refresh at the same time based on the refresh interval, causing:
- Request bursts that can overwhelm backend services
- Poor user experience with potential timeouts

1. Removed the centralized timer from `TimeRangeProvider` that was triggering all queries simultaneously
2. Added jitter (0-1000ms random delay) to TanStack query native option - `refetchInterval` for batch queries in `useTimeSeriesQueries`
3. Removed `refreshKey` from queryKey and added `keepPreviousData: true` to prevent cache thrashing and unnecessary re-renders. This ensures smooth UI transitions without skeleton loader flashing between refetches, providing a seamless monitoring experience. And minimizing chart rerenders.
4. Added `refetchIntervalInBackground: false` to respect visibility optimizations (intersection observer)

This addresses production 502 errors we've observed when dashboards with many panels refresh simultaneously (e.g., 5s intervals). The backend gets overwhelmed by synchronized request bursts, though it recovers on subsequent refreshes. After investigating Grafana's approach to this problem, I found they use jitter to stagger refreshes, which this implementation adopts. 

I'm open to discussion and alternative solutions. Please let me know if I've missed anything or if there's a better approach to handle this scenario.

# Screenshots

<!-- No UI visual changes - performance improvement only -->
No visual UI changes. The improvement is in network behavior and performance.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete