### PR TITLE
[BUGFIX] Fix otlpcommonv1.AnyValue: arrayValue.values is optional

### DIFF
--- a/ui/core/src/model/otlp/common/v1/common.ts
+++ b/ui/core/src/model/otlp/common/v1/common.ts
@@ -22,7 +22,7 @@ export type AnyValue =
   | { stringValue: string }
   | { intValue: string }
   | { boolValue: boolean }
-  | { arrayValue: { values: AnyValue[] } };
+  | { arrayValue: { values?: AnyValue[] } };
 
 export interface InstrumentationScope {
   name?: string;


### PR DESCRIPTION
# Description

For empty arrays, `arrayValue.values` is not defined.
Example:
```
"attributes": [
  {
    "key": "string-array",
    "value": {
      "arrayValue": {
        "values": [
          {
            "stringValue": "a"
          },
          {
            "stringValue": "b"
          },
          {
            "stringValue": "c"
          }
        ]
      }
    }
  },
  {
    "key": "empty-string-array",
    "value": {
      "arrayValue": {}
    }
  }
]
```

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
