### PR TITLE
[BUGFIX] Save the refresh interval chnages from UI

### DIFF
--- a/ui/components/src/RefreshIntervalPicker/RefreshIntervalPicker.tsx
+++ b/ui/components/src/RefreshIntervalPicker/RefreshIntervalPicker.tsx
@@ -25,7 +25,6 @@ interface RefreshIntervalPickerProps {
 
 export function RefreshIntervalPicker(props: RefreshIntervalPickerProps): ReactElement {
   const { value, onChange, timeOptions, height } = props;
-  const formattedValue = value;
 
   // If the dashboard refresh interval is not provided in timeOptions, it will create a specific option for the select
   const customInterval = useMemo(() => {
@@ -39,13 +38,13 @@ export function RefreshIntervalPicker(props: RefreshIntervalPickerProps): ReactE
       <Box>
         <Select
           id="refreshInterval"
-          value={formattedValue}
+          value={value}
           onChange={(event) => {
             const duration = event.target.value as DurationString;
             onChange(duration);
           }}
           inputProps={{
-            'aria-label': `Select refresh interval. Currently set to ${formattedValue}`,
+            'aria-label': `Select refresh interval. Currently set to ${value}`,
           }}
           sx={{
             '.MuiSelect-select': height ? { lineHeight: height, paddingY: 0 } : {},

--- a/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/SaveChangesConfirmationDialog/SaveChangesConfirmationDialog.tsx
@@ -13,7 +13,7 @@
 
 import { ReactElement, useState } from 'react';
 import { Checkbox, FormGroup, FormControlLabel, Typography } from '@mui/material';
-import { useTimeRange } from '@perses-dev/plugin-system';
+import { DEFAULT_REFRESH_INTERVAL_OPTIONS, useTimeRange } from '@perses-dev/plugin-system';
 import { isRelativeTimeRange } from '@perses-dev/core';
 import { Dialog } from '@perses-dev/components';
 import { useSaveChangesConfirmationDialog, useVariableDefinitionActions } from '../../context';
@@ -25,24 +25,34 @@ export const SaveChangesConfirmationDialog = (): ReactElement => {
   const { saveChangesConfirmationDialog: dialog } = useSaveChangesConfirmationDialog();
   const isSavedDurationModified = dialog?.isSavedDurationModified ?? true;
   const isSavedVariableModified = dialog?.isSavedVariableModified ?? true;
+  const isSavedRefreshIntervalModified = dialog?.isSavedRefreshIntervalModified ?? true;
+
   const [saveDefaultTimeRange, setSaveDefaultTimeRange] = useState(isSavedDurationModified);
   const [saveDefaultVariables, setSaveDefaultVariables] = useState(isSavedVariableModified);
+  const [saveDefaultRefreshInterval, setDefaultRefreshInterval] = useState(isSavedRefreshIntervalModified);
 
   const { getSavedVariablesStatus } = useVariableDefinitionActions();
   const { modifiedVariableNames } = getSavedVariablesStatus();
 
   const isOpen = dialog !== undefined;
 
-  const { timeRange } = useTimeRange();
+  const { timeRange, refreshInterval } = useTimeRange();
+
   const currentTimeRangeText = isRelativeTimeRange(timeRange)
     ? `(Last ${timeRange.pastDuration})`
     : '(Absolute time ranges can not be saved)';
 
-  const saveTimeRangeText = `Save current time range as new default ${currentTimeRangeText}`;
+  const saveTimeRangeMessage = `Save current time range as new default ${currentTimeRangeText}`;
 
-  const saveVariablesText = `Save current variable values as new default (${
+  const saveVariableMessage = `Save current variable values as new default (${
     modifiedVariableNames.length > 0 ? modifiedVariableNames.join(', ') : 'No modified variables'
   })`;
+
+  const refreshIntervalDisplay = DEFAULT_REFRESH_INTERVAL_OPTIONS.some((i) => i.display === refreshInterval)
+    ? refreshInterval
+    : DEFAULT_REFRESH_INTERVAL_OPTIONS.find((i) => i.value.pastDuration === refreshInterval)?.display;
+
+  const saveRefreshIntervalMessage = `Save current refresh interval as new default ${refreshIntervalDisplay ? `(${refreshIntervalDisplay})` : 'refresh interval not modified'}`;
 
   return (
     <Dialog open={isOpen}>
@@ -61,7 +71,17 @@ export const SaveChangesConfirmationDialog = (): ReactElement => {
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSaveDefaultTimeRange(e.target.checked)}
                   />
                 }
-                label={saveTimeRangeText}
+                label={saveTimeRangeMessage}
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    disabled={!isSavedRefreshIntervalModified}
+                    checked={saveDefaultRefreshInterval && isSavedRefreshIntervalModified}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDefaultRefreshInterval(e.target.checked)}
+                  />
+                }
+                label={saveRefreshIntervalMessage}
               />
               <FormControlLabel
                 control={
@@ -71,7 +91,7 @@ export const SaveChangesConfirmationDialog = (): ReactElement => {
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSaveDefaultVariables(e.target.checked)}
                   />
                 }
-                label={saveVariablesText}
+                label={saveVariableMessage}
               />
             </FormGroup>
           </Dialog.Content>
@@ -79,7 +99,7 @@ export const SaveChangesConfirmationDialog = (): ReactElement => {
           <Dialog.Actions>
             <Dialog.PrimaryButton
               onClick={() => {
-                return dialog.onSaveChanges(saveDefaultTimeRange, saveDefaultVariables);
+                return dialog.onSaveChanges(saveDefaultTimeRange, saveDefaultRefreshInterval, saveDefaultVariables);
               }}
             >
               Save Changes

--- a/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
+++ b/ui/dashboards/src/components/SaveDashboardButton/SaveDashboardButton.tsx
@@ -38,7 +38,7 @@ export const SaveDashboardButton = ({
   const { dashboard, setDashboard } = useDashboard();
   const { getSavedVariablesStatus, setVariableDefaultValues } = useVariableDefinitionActions();
   const { isSavedVariableModified } = getSavedVariablesStatus();
-  const { timeRange } = useTimeRange();
+  const { timeRange, refreshInterval } = useTimeRange();
   const { setEditMode } = useEditMode();
   const { openSaveChangesConfirmationDialog, closeSaveChangesConfirmationDialog } = useSaveChangesConfirmationDialog();
 
@@ -46,18 +46,23 @@ export const SaveDashboardButton = ({
     const isSavedDurationModified =
       isRelativeTimeRange(timeRange) && dashboard.spec.duration !== timeRange.pastDuration;
 
+    const isSavedRefreshIntervalModified = dashboard.spec.refreshInterval !== refreshInterval;
+
     // Save dashboard
     // - if active timeRange from plugin-system is relative and different from currently saved
     // - or if the saved variables are different from currently saved
-    if (isSavedDurationModified || isSavedVariableModified) {
+    if (isSavedDurationModified || isSavedVariableModified || isSavedRefreshIntervalModified) {
       openSaveChangesConfirmationDialog({
-        onSaveChanges: (saveDefaultTimeRange, saveDefaultVariables) => {
-          if (isRelativeTimeRange(timeRange) && saveDefaultTimeRange === true) {
+        onSaveChanges: (saveDefaultTimeRange, saveDefaultRefreshInterval, saveDefaultVariables) => {
+          if (isRelativeTimeRange(timeRange) && saveDefaultTimeRange) {
             dashboard.spec.duration = timeRange.pastDuration;
           }
-          if (saveDefaultVariables === true) {
+          if (saveDefaultVariables) {
             const variables = setVariableDefaultValues();
             dashboard.spec.variables = variables;
+          }
+          if (saveDefaultRefreshInterval && isSavedRefreshIntervalModified) {
+            dashboard.spec.refreshInterval = refreshInterval;
           }
           setDashboard(dashboard);
           saveDashboard();
@@ -67,6 +72,7 @@ export const SaveDashboardButton = ({
         },
         isSavedDurationModified,
         isSavedVariableModified,
+        isSavedRefreshIntervalModified,
       });
     } else {
       saveDashboard();

--- a/ui/dashboards/src/context/DashboardProvider/save-changes-dialog-slice.tsx
+++ b/ui/dashboards/src/context/DashboardProvider/save-changes-dialog-slice.tsx
@@ -21,9 +21,14 @@ export interface SaveChangesConfirmationDialogSlice {
 }
 
 export interface SaveChangesConfirmationDialogState {
-  onSaveChanges: (saveDefaultTimeRange: boolean, saveDefaultVariables: boolean) => void;
+  onSaveChanges: (
+    saveDefaultTimeRange: boolean,
+    saveDefaultRefreshInterval: boolean,
+    saveDefaultVariables: boolean
+  ) => void;
   onCancel: () => void;
   isSavedDurationModified: boolean;
+  isSavedRefreshIntervalModified: boolean;
   isSavedVariableModified: boolean;
   description?: string;
 }

--- a/ui/plugin-system/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/plugin-system/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -195,7 +195,16 @@ export function TimeRangeControls({
         <InfoTooltip description={TOOLTIP_TEXT.refreshInterval}>
           <RefreshIntervalPicker
             timeOptions={DEFAULT_REFRESH_INTERVAL_OPTIONS}
-            value={refreshInterval}
+            value={
+              /* TODO: There is a bug here which should be fixed in a proper way. (This is only a quick remedy)
+                 display: 1m has the pastDuration of 60s. Initially (if the persisted value is 1m) when the page is loaded, instead of 60s, 1m is passed down.              
+                 This only happens for 1m, because for other items the display and the pastDuration are the same.  Example 30s-30s
+                 HERE The value MUST always be pastDuration, otherwise the component would not work as expected. 
+              */
+              DEFAULT_REFRESH_INTERVAL_OPTIONS.some((i) => i.value.pastDuration === refreshInterval)
+                ? refreshInterval
+                : DEFAULT_REFRESH_INTERVAL_OPTIONS.find((i) => i.display === refreshInterval)?.value.pastDuration
+            }
             onChange={handleRefreshIntervalChange}
             height={height}
           />


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3484

# Description 🖊️ 

This change adds the `refresh interval` into the Save Dialog of the dashboard. If approved by the user, the new value is saved as the default value. 

<img width="2062" height="830" alt="image" src="https://github.com/user-attachments/assets/50c2cda2-5284-48dc-8964-72deaf43f01f" />

# Test 🧪 

- [X] **1-** The refresh interval message should always appear in the dialog (Whether it changed or not)
- [X] **2-** If it was intact, the text should and the textbox should appear disabled
- [X] **3-** If it had changed, the text and the textbox should appear enabled
- [X] **3-1** User may choose to check/uncheck the change to be persisted as the default value
- [X] **4-** After the page is saved and reloaded, the according changes should be observed


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
