### PR TITLE
[ENHANCEMENT] app: enable keepPreviousData by default

### DIFF
--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -67,6 +67,7 @@ const queryClient = new QueryClient({
       // This sets the default to 0 retries.
       // If needed, the number of retries can be overridden in individual useQuery calls.
       retry: 0,
+      keepPreviousData: true,
     },
   },
 });


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Nice idea of @abelyakin [PR](https://github.com/perses/perses/pull/3493) adding `keepPreviousData` to time-series, I propose to add tanstack-query `keepPreviousData` option by default for Perses app. 

For embedded usage (panel), we will need to add the option to query type fetching functions like in PR #3493 or add it in global client as in this PR.

> keepPreviousData: true to prevent cache thrashing and unnecessary re-renders. This ensures smooth UI transitions without skeleton loader flashing between refetches, providing a seamless monitoring experience. And minimizing chart rerenders.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
