### PR TITLE
[BUGFIX]: Apply plugin filter over Multi Query Editor

### DIFF
--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
@@ -28,6 +28,7 @@ interface QueryEditorContainerProps {
   queryTypes: QueryPluginType[];
   index: number;
   query: QueryDefinition;
+  filteredQueryPlugins?: string[];
   onChange: (index: number, query: QueryDefinition) => void;
   onCollapseExpand: (index: number) => void;
   isCollapsed?: boolean;
@@ -49,7 +50,7 @@ interface QueryEditorContainerProps {
 
 export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorContainerProps>(
   (props, ref): ReactElement => {
-    const { queryTypes, index, query, isCollapsed, onDelete, onChange, onCollapseExpand } = props;
+    const { queryTypes, filteredQueryPlugins, index, query, isCollapsed, onDelete, onChange, onCollapseExpand } = props;
     return (
       <Stack key={index} spacing={1}>
         <Stack direction="row" alignItems="center" borderBottom={1} borderColor={(theme) => theme.palette.divider}>
@@ -69,7 +70,13 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
           </IconButton>
         </Stack>
         {!isCollapsed && (
-          <QueryEditor ref={ref} queryTypes={queryTypes} value={query} onChange={(next) => onChange(index, next)} />
+          <QueryEditor
+            filteredQueryPlugins={filteredQueryPlugins}
+            ref={ref}
+            queryTypes={queryTypes}
+            value={query}
+            onChange={(next) => onChange(index, next)}
+          />
         )}
       </Stack>
     );
@@ -83,6 +90,7 @@ QueryEditorContainer.displayName = 'QueryEditorContainer';
 type OmittedMuiProps = 'children' | 'value' | 'onChange';
 interface QueryEditorProps extends Omit<BoxProps, OmittedMuiProps> {
   queryTypes: QueryPluginType[];
+  filteredQueryPlugins?: string[];
   value: QueryDefinition;
   onChange: (next: QueryDefinition) => void;
 }
@@ -96,7 +104,7 @@ interface QueryEditorProps extends Omit<BoxProps, OmittedMuiProps> {
  */
 
 const QueryEditor = forwardRef<PluginEditorRef, QueryEditorProps>((props, ref): ReactElement => {
-  const { value, onChange, queryTypes, ...others } = props;
+  const { value, onChange, queryTypes, filteredQueryPlugins, ...others } = props;
   const { refresh } = useTimeRange();
   const handlePluginChange: PluginEditorProps['onChange'] = (next) => {
     onChange(
@@ -124,6 +132,7 @@ const QueryEditor = forwardRef<PluginEditorRef, QueryEditorProps>((props, ref): 
           spec: value.spec.plugin.spec,
         }}
         onChange={handlePluginChange}
+        filteredQueryPlugins={filteredQueryPlugins}
       />
     </Box>
   );

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -38,6 +38,7 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
     onChange: _,
     isReadonly,
     postExecuteRunQuery: refresh,
+    filteredQueryPlugins,
     ...others
   } = props;
   const { pendingSelection, isLoading, error, onSelectionChange, onSpecChange } = usePluginEditor(props);
@@ -97,6 +98,7 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
           error={!!error}
           helperText={error?.message}
           onChange={onSelectionChange}
+          filteredQueryPlugins={filteredQueryPlugins}
         />
 
         {withRunQueryButton && !isLoading && (

--- a/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
+++ b/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
@@ -41,6 +41,7 @@ export interface PluginEditorProps extends Omit<BoxProps, OmittedMuiProps> {
   value: PluginEditorValue;
   isReadonly?: boolean;
   withRunQueryButton?: boolean;
+  filteredQueryPlugins?: string[];
   onChange: (next: PluginEditorValue) => void;
   postExecuteRunQuery?: () => void;
 }

--- a/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
+++ b/ui/plugin-system/src/components/PluginKindSelect/PluginKindSelect.tsx
@@ -18,6 +18,7 @@ import { useListPluginMetadata } from '../../runtime';
 import { PluginEditorSelection } from '../PluginEditor';
 
 export interface PluginKindSelectProps extends Omit<TextFieldProps, 'value' | 'onChange' | 'children'> {
+  filteredQueryPlugins?: string[];
   pluginTypes: PluginType[];
   value?: PluginEditorSelection;
   onChange?: (s: PluginEditorSelection) => void;
@@ -31,13 +32,18 @@ export interface PluginKindSelectProps extends Omit<TextFieldProps, 'value' | 'o
  * when the user changes the plugin type (it fires at start for the default value.)
  */
 export const PluginKindSelect = forwardRef((props: PluginKindSelectProps, ref): ReactElement => {
-  const { pluginTypes, value: propValue, onChange, ...others } = props;
+  const { pluginTypes, value: propValue, onChange, filteredQueryPlugins, ...others } = props;
   const { data, isLoading } = useListPluginMetadata(pluginTypes);
 
-  const sortedData = useMemo(
-    () => data?.sort((a, b) => a.spec.display.name.localeCompare(b.spec.display.name)),
-    [data]
-  );
+  const sortedData = useMemo(() => {
+    if (filteredQueryPlugins?.length) {
+      return data
+        ?.filter((i) => filteredQueryPlugins.includes(i.spec.name))
+        ?.sort((a, b) => a.spec.display.name.localeCompare(b.spec.display.name));
+    }
+
+    return data?.sort((a, b) => a.spec.display.name.localeCompare(b.spec.display.name));
+  }, [data, filteredQueryPlugins]);
 
   // Pass an empty value while options are still loading so MUI doesn't complain about us using an "out of range" value
   const value = !propValue || isLoading ? '' : selectionToOptionValue(propValue);


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3459

# WARNING ⚠️ 
> This PR should be reviewed with its plugin counterpart to be effective!

> This PR should be merged first. The other PR has a decency to plugin-system 

https://github.com/perses/plugins/pull/428

# Description 🖊️ 

To load **Query Plugins**, the **Multi Query Editor** component only takes the **Query Types** into account . 
This means, all Query Plugins which are grouped under the same query type will be shown in the component. 
For instance, if the query type  is set to **TimeSeriesQuery**, both **Locki** and **Prometheus** Time Series Queries will be exposed from the component. 

The mentioned behavior is not correct in the Prometheus Explorer. As the issue points out in the Prometheus Explorer only Prometheus related plugins should be available. 


# Solution 🔧 

To be able to filter out a subgroup of Query Plugins, an optional filter has been added. 
To solve this issue, we can feed the filter from the **PrometheusExplorer** and expect to see the desired values. 
This filter is **optional**, so the change is backward compatible. 

```typescript
export function PrometheusExplorer(): ReactElement {
  const {
    data: { tab = 'table', queries = [], datasource = DEFAULT_PROM, filters = [], exploredMetric = undefined },
    setData,
    explorer,
  } = useExplorerManagerContext<MetricsExplorerQueryParams>();

  const filteredQueryPlugins = explorer ? ['PrometheusTimeSeriesQuery'] : [];
```

# Test 🧪 

## WARNING ⚠️ 
To test this fix you need to 

1. **Build** plugin-system (turbo run build)
2. **Move** the built package to the plugins \node_modules\@perses-dev
3. Run the client and server
4. Run the Prometheus plugin locally 

## Test 1 Check the Prometheus Explorer

1. You should not see Loki anymore in Table and Graph 
2. Run a Query and make sure it is working
3. Not necessary, but if you feel better take a look at the other explorers as well

## Test 2 Check the Query Editor in dashboard

1. The Query Editor in Panel Editor forms MUS HSOW both Loki  and Prometheus 


<img width="865" height="453" alt="image" src="https://github.com/user-attachments/assets/86e6b86b-f11d-47b5-a4e0-df95a7219b53" />


<img width="923" height="440" alt="image" src="https://github.com/user-attachments/assets/dfad3be6-620e-467b-bbe4-5ecfceb74827" />




# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
