### PR TITLE
    [BUGFIX]: Fix empty value in create variable form (#3226)

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariablePreview.tsx
@@ -77,7 +77,10 @@ export function VariablePreview(props: VariablePreviewProps): ReactElement {
       <Card variant="outlined">
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, m: 2 }}>
           {variablePreviewState}
-          {values?.slice(0, maxValues).map((val, index) => <Chip size="small" key={index} label={val} />)}
+          {values
+            ?.slice(0, maxValues)
+            .filter((val) => val)
+            .map((val, index) => <Chip size="small" key={index} label={val} />)}
           {notShown > 0 && <Chip onClick={showAll} variant="outlined" size="small" label={`+${notShown} more`} />}
         </Box>
       </Card>


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Even when a Chip has an empty label, it still renders with minimum dimensions (around 16px height) due to Material-UI's default styling.

# Screenshots

Before: 
<img width="1339" height="558" alt="image" src="https://github.com/user-attachments/assets/3376fd2b-5b3c-46af-bcc5-44da37789c50" />

After:
<img width="1077" height="620" alt="image" src="https://github.com/user-attachments/assets/3fc25f4b-329c-4e66-a5a0-1a47ce3f933f" />


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
