### PR TITLE
[FEATURE] Add temperature units

### DIFF
--- a/cue/common/format.cue
+++ b/cue/common/format.cue
@@ -13,7 +13,7 @@
 
 package common
 
-#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat | #currencyFormat
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat | #currencyFormat | #temperatureFormat
 
 #timeFormat: {
 	unit?:          "nanoseconds" | "microseconds" | "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
@@ -45,5 +45,10 @@ package common
 
 #currencyFormat: {
 	unit?:          "aud" | "cad" | "chf" | "cny" | "eur" | "gbp" | "hkd" | "inr" | "jpy" | "krw" | "nok" | "nzd" | "sek" | "sgd" | "usd"
+	decimalPlaces?: number
+}
+
+#temperatureFormat: {
+	unit: "celsius" | "fahrenheit"
 	decimalPlaces?: number
 }

--- a/ui/core/src/model/units/temperature.test.ts
+++ b/ui/core/src/model/units/temperature.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { UnitTestCase } from './types';
+import { formatValue } from './units';
+
+const TEMPERATURE_TESTS: UnitTestCase[] = [
+  {
+    value: 10,
+    format: { unit: 'celsius', decimalPlaces: 1 },
+    expected: '10.0°C',
+  },
+  {
+    value: -5.678,
+    format: { unit: 'celsius', decimalPlaces: 2 },
+    expected: '-5.68°C',
+  },
+  {
+    value: 25.5,
+    format: { unit: 'fahrenheit', decimalPlaces: 1 },
+    expected: '25.5°F',
+  },
+  {
+    value: 0,
+    format: { unit: 'fahrenheit', decimalPlaces: 0 },
+    expected: '0°F',
+  },
+];
+
+describe('temperature formatValue', () => {
+  it.each(TEMPERATURE_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
+    const { value, format: format, expected } = args;
+    expect(formatValue(value, format)).toEqual(expected);
+  });
+});

--- a/ui/core/src/model/units/temperature.ts
+++ b/ui/core/src/model/units/temperature.ts
@@ -1,0 +1,58 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { MAX_SIGNIFICANT_DIGITS } from './constants';
+import { UnitConfig, UnitGroupConfig } from './types';
+import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
+
+const TEMPERATURE_GROUP = 'Temperature';
+
+type TemperatureUnits = 'celsius' | 'fahrenheit';
+
+export type TemperatureFormatOptions = {
+  unit: TemperatureUnits;
+  decimalPlaces?: number;
+};
+
+export const TEMPERATURE_GROUP_CONFIG: UnitGroupConfig = {
+  label: TEMPERATURE_GROUP,
+  decimalPlaces: true,
+};
+
+export const TEMPERATURE_UNIT_CONFIG: Readonly<Record<TemperatureUnits, UnitConfig>> = {
+  celsius: {
+    group: TEMPERATURE_GROUP,
+    label: 'Celsius (°C)',
+  },
+  fahrenheit: {
+    group: TEMPERATURE_GROUP,
+    label: 'Fahrenheit (°F)',
+  },
+};
+
+export const formatTemperature = (value: number, { unit, decimalPlaces }: TemperatureFormatOptions): string => {
+  const formatterOptions: Intl.NumberFormatOptions = {
+    unit,
+    style: 'unit',
+  };
+
+  if (hasDecimalPlaces(decimalPlaces)) {
+    formatterOptions.minimumFractionDigits = limitDecimalPlaces(decimalPlaces);
+    formatterOptions.maximumFractionDigits = limitDecimalPlaces(decimalPlaces);
+  } else {
+    formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
+  }
+
+  const locals = unit === 'celsius' ? 'en-GB' : 'en-US';
+  return Intl.NumberFormat(locals, formatterOptions).format(value);
+};

--- a/ui/core/src/model/units/types.ts
+++ b/ui/core/src/model/units/types.ts
@@ -18,7 +18,7 @@ import { Duration } from 'date-fns';
 import { AbsoluteTimeRange, DurationString } from '../time';
 import { FormatOptions } from './units';
 
-export type UnitGroup = 'Time' | 'Percent' | 'Decimal' | 'Bytes' | 'Throughput' | 'Currency';
+export type UnitGroup = 'Time' | 'Percent' | 'Decimal' | 'Bytes' | 'Throughput' | 'Currency' | 'Temperature';
 
 /**
  * Configuration for rendering units that are part of a group.

--- a/ui/core/src/model/units/units.ts
+++ b/ui/core/src/model/units/units.ts
@@ -24,6 +24,12 @@ import {
   PERCENT_GROUP_CONFIG,
   PERCENT_UNIT_CONFIG,
 } from './percent';
+import {
+  TEMPERATURE_GROUP_CONFIG,
+  formatTemperature,
+  TEMPERATURE_UNIT_CONFIG,
+  TemperatureFormatOptions,
+} from './temperature';
 import { formatTime, TimeFormatOptions as TimeFormatOptions, TIME_GROUP_CONFIG, TIME_UNIT_CONFIG } from './time';
 import { UnitGroup, UnitGroupConfig, UnitConfig } from './types';
 import {
@@ -49,6 +55,7 @@ export const UNIT_GROUP_CONFIG: Readonly<Record<UnitGroup, UnitGroupConfig>> = {
   Bytes: BYTES_GROUP_CONFIG,
   Throughput: THROUGHPUT_GROUP_CONFIG,
   Currency: CURRENCY_GROUP_CONFIG,
+  Temperature: TEMPERATURE_GROUP_CONFIG,
 };
 export const UNIT_CONFIG = {
   ...TIME_UNIT_CONFIG,
@@ -57,6 +64,7 @@ export const UNIT_CONFIG = {
   ...BYTES_UNIT_CONFIG,
   ...THROUGHPUT_UNIT_CONFIG,
   ...CURRENCY_UNIT_CONFIG,
+  ...TEMPERATURE_UNIT_CONFIG,
 } as const;
 
 export type FormatOptions =
@@ -65,13 +73,14 @@ export type FormatOptions =
   | DecimalFormatOptions
   | BytesFormatOptions
   | ThroughputFormatOptions
-  | CurrencyFormatOptions;
+  | CurrencyFormatOptions
+  | TemperatureFormatOptions;
 
 type HasDecimalPlaces<UnitOpt> = UnitOpt extends { decimalPlaces?: number } ? UnitOpt : never;
 type HasShortValues<UnitOpt> = UnitOpt extends { shortValues?: boolean } ? UnitOpt : never;
 
 export function formatValue(value: number, formatOptions?: FormatOptions): string {
-  if (formatOptions === undefined) {
+  if (!formatOptions) {
     return value.toString();
   }
 
@@ -97,6 +106,10 @@ export function formatValue(value: number, formatOptions?: FormatOptions): strin
 
   if (isCurrencyUnit(formatOptions)) {
     return formatCurrency(value, formatOptions);
+  }
+
+  if (isTemperatureUnit(formatOptions)) {
+    return formatTemperature(value, formatOptions);
   }
 
   const exhaustive: never = formatOptions;
@@ -154,4 +167,8 @@ export function isThroughputUnit(formatOptions: FormatOptions): formatOptions is
 
 export function isCurrencyUnit(formatOptions: FormatOptions): formatOptions is CurrencyFormatOptions {
   return getUnitGroup(formatOptions) === 'Currency';
+}
+
+export function isTemperatureUnit(formatOptions: FormatOptions): formatOptions is TemperatureFormatOptions {
+  return getUnitGroup(formatOptions) === 'Temperature';
 }


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3529

# Description 🖊️ 

This feature adds temperature units including Celsius and Fahrenheit. 
>⚠️  To have this feature when, the core version should be updated in plugins


<img width="788" height="269" alt="image" src="https://github.com/user-attachments/assets/98f263c6-5bc8-4ac7-82e1-b0ba835171a0" />

<img width="790" height="269" alt="image" src="https://github.com/user-attachments/assets/7470a2eb-4901-4a01-95e8-df1e47da78e2" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
