### PR TITLE
[IGNORE] use contenthash to generate the js files

### DIFF
--- a/ui/app/rspack.config.mjs
+++ b/ui/app/rspack.config.mjs
@@ -22,6 +22,8 @@ export default defineConfig({
   output: {
     path: resolve(import.meta.dirname, './dist'),
     publicPath: isDev ? undefined : 'PREFIX_PATH_PLACEHOLDER/',
+    filename: '[name].[contenthash].js',
+    clean: true,
   },
   mode: isDev ? 'development' : 'production',
   devtool: isDev ? 'cheap-module-source-map' : false,
@@ -89,7 +91,7 @@ export default defineConfig({
         client: {
           // By default, the error overlay is not shown because it can get in the
           // way of e2e tests and can be annoying for some developer workflows.
-          // If you like the overlay, you can enable it by setting the the specified
+          // If you like the overlay, you can enable it by setting the specified
           // env var.
           overlay: process.env.ERROR_OVERLAY === 'true',
         },


### PR DESCRIPTION
I am changing a bit the `rspack` config so it generates a hash for each js and css file, including the file `main.js`.

So instead of having the file `main.js`, the build will generate a file that looks like that `main.711f0be76544895a.js`

Hopefully it will help to mitigate the issues https://github.com/perses/perses/issues/3533 and https://github.com/perses/perses/issues/3498