### PR TITLE
[ENHANCEMENT] Preventing DB Ping from hanging forever

### DIFF
--- a/internal/api/database/sql/sql.go
+++ b/internal/api/database/sql/sql.go
@@ -14,10 +14,12 @@
 package databasesql
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/huandu/go-sqlbuilder"
 	databaseModel "github.com/perses/perses/internal/api/database/model"
@@ -392,7 +394,9 @@ func (d *DAO) DeleteByQuery(query databaseModel.Query) error {
 }
 
 func (d *DAO) HealthCheck() bool {
-	if err := d.DB.Ping(); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := d.DB.PingContext(ctx); err != nil {
 		logrus.WithError(err).Error("unable to ping the database")
 		return false
 	}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Previously, DB.Ping() could hang indefinitely if the connection pool was exhausted.
<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
