### PR TITLE
[BUGFIX] Add back piechart removed by mistake

### DIFF
--- a/scripts/plugin/plugin.yaml
+++ b/scripts/plugin/plugin.yaml
@@ -19,7 +19,7 @@
 - name: "Markdown"
   version: "0.10.0"
 - name: "PieChart"
-  version: "0.11.0"
+  version: "0.12.0"
 - name: "Prometheus"
   version: "0.55.0"
 - name: "Pyroscope"


### PR DESCRIPTION
I made a mistake in the PieChart version, v0.11.0 does not exist and so in beta.2, piechart does not exist anymore