### PR TITLE
[Feature] Display default dashboards when query is empty (#3539)

### DIFF
--- a/ui/app/src/components/Header/SearchBar/SearchBar.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchBar.tsx
@@ -74,18 +74,19 @@ function SearchDashboardList(props: ResourceListProps): ReactElement | null {
   } = useImportantDashboardList();
 
   const list: Array<Resource & { highlight: boolean }> = useMemo(() => {
-    return (
-      dashboardList?.map((d) => {
+    if (props.query.length && dashboardList) {
+      return dashboardList.map((d) => {
         const highlight = !!importantDashboards.some(
           (importantDashboard) =>
             importantDashboard.metadata.name === d.metadata.name &&
             importantDashboard.metadata.project === d.metadata.project
         );
-
         return { ...d, highlight };
-      }) || []
-    );
-  }, [importantDashboards, dashboardList]);
+      });
+    } else {
+      return importantDashboards.map((imp) => ({ ...imp, highlight: true }));
+    }
+  }, [importantDashboards, dashboardList, props.query]);
 
   if (dashboardListError || importantDashboardsError)
     return (

--- a/ui/app/src/components/Header/SearchBar/SearchList.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchList.tsx
@@ -55,7 +55,16 @@ export function SearchList(props: SearchListProps): ReactElement | null {
   const [currentSizeList, setCurrentSizeList] = useState<number>(SIZE_LIST);
   const kvSearch = useRef(new KVSearch<Resource>(kvSearchConfig)).current;
   const filteredList: Array<KVSearchResult<Resource & { highlight?: boolean }>> = useMemo(() => {
-    return props.query ? kvSearch.filter(props.query, props.list) : [];
+    if (!props.query && props.list?.[0]?.kind === 'Dashboard') {
+      return props.list.map((item, idx) => ({
+        original: item,
+        rendered: item,
+        score: 0,
+        index: idx,
+        matched: [],
+      }));
+    }
+    return kvSearch.filter(props.query, props.list);
   }, [kvSearch, props.list, props.query]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #3539 

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
The Search Bar initially had a fallback to an empty list if there is no query to search for dashboards, projects etc.
Now with this change even though the search bar is empty, on Click it will present the "Important Dashboards List" to the user.

# Screenshots

<img width="1888" height="911" alt="image" src="https://github.com/user-attachments/assets/e9e3e764-441a-4fb6-9a5b-891f451cfa1b" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
