### PR TITLE
[ENHANCEMENT] Add Dynamic display for Search Bar (#3573)

### DIFF
--- a/ui/app/src/components/Header/SearchBar/SearchBar.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchBar.tsx
@@ -13,6 +13,7 @@
 
 import { Alert, Box, Button, Chip, InputAdornment, Modal, Paper, TextField, Typography } from '@mui/material';
 import Magnify from 'mdi-material-ui/Magnify';
+import EmoticonSadOutline from 'mdi-material-ui/EmoticonSadOutline';
 import ViewDashboardIcon from 'mdi-material-ui/ViewDashboard';
 import Archive from 'mdi-material-ui/Archive';
 import DatabaseIcon from 'mdi-material-ui/Database';
@@ -33,15 +34,24 @@ function shortcutCTRL(): string {
   return isAppleDevice() ? '⌘' : 'ctrl';
 }
 
+type ResourceType = 'dashboards' | 'projects' | 'globalDatasources' | 'datasources';
+
 interface ResourceListProps {
   query: string;
   onClick: () => void;
+  isResources?: (type: ResourceType, available: boolean) => void;
 }
 
 function SearchProjectList(props: ResourceListProps): ReactElement {
   const projectsQueryResult = useProjectList({ refetchOnMount: false });
   return (
-    <SearchList list={projectsQueryResult.data ?? []} query={props.query} onClick={props.onClick} icon={Archive} />
+    <SearchList
+      list={projectsQueryResult.data ?? []}
+      query={props.query}
+      onClick={props.onClick}
+      icon={Archive}
+      isResource={(isAvailable) => props.isResources?.('projects', isAvailable)}
+    />
   );
 }
 
@@ -54,6 +64,7 @@ function SearchGlobalDatasource(props: ResourceListProps): ReactElement {
       onClick={props.onClick}
       icon={DatabaseIcon}
       buildRouting={() => `${AdminRoute}/datasources`}
+      isResource={(isAvailable) => props.isResources?.('globalDatasources', isAvailable)}
     />
   );
 }
@@ -100,7 +111,14 @@ function SearchDashboardList(props: ResourceListProps): ReactElement | null {
     );
 
   return dashboardListLoading || importantDashboardsLoading ? null : (
-    <SearchList list={list} query={props.query} onClick={props.onClick} icon={ViewDashboardIcon} chip={true} />
+    <SearchList
+      list={list}
+      query={props.query}
+      onClick={props.onClick}
+      icon={ViewDashboardIcon}
+      chip={true}
+      isResource={(isAvailable) => props.isResources?.('dashboards', isAvailable)}
+    />
   );
 }
 
@@ -116,6 +134,7 @@ function SearchDatasourceList(props: ResourceListProps): ReactElement | null {
       buildRouting={(resource) =>
         `${ProjectRoute}/${isProjectMetadata(resource.metadata) ? resource.metadata.project : ''}/datasources`
       }
+      isResource={(isAvailable) => props.isResources?.('datasources', isAvailable)}
     />
   );
 }
@@ -148,10 +167,18 @@ export function SearchBar(): ReactElement {
   const isMobileSize = useIsMobileSize();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const [hasResource, setHasResource] = useState<Record<ResourceType, boolean>>({
+    dashboards: false,
+    projects: false,
+    globalDatasources: false,
+    datasources: false,
+  });
+  function handleIsResourceAvailable(type: ResourceType, available: boolean): void {
+    setHasResource((prev) => (prev[type] === available ? prev : { ...prev, [type]: available }));
+  }
   const handleOpen = (): void => setOpen(true);
   const handleClose = (): void => setOpen(false);
   useHandleShortCut(handleOpen);
-
   return (
     <Paper sx={{ width: '100%', flexShrink: 1 }}>
       <Button size="small" fullWidth sx={{ display: 'flex', justifyContent: 'space-between' }} onClick={handleOpen}>
@@ -168,16 +195,18 @@ export function SearchBar(): ReactElement {
         aria-describedby="modal-modal-description"
         style={{ display: 'flex', justifyContent: 'center' }}
         disableAutoFocus={true}
+        sx={{ display: 'flex', alignItems: 'flex-start', overflowY: 'auto' }}
       >
         <Paper
           elevation={0}
           sx={{
-            height: '70%',
+            maxHeight: '70vh',
             width: isMobileSize ? '95%' : '55%',
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'flex-start',
             overflowY: 'auto',
+            height: 'auto',
           }}
           variant="outlined"
         >
@@ -209,10 +238,19 @@ export function SearchBar(): ReactElement {
               ),
             }}
           />
-          <SearchDashboardList query={query} onClick={handleClose} />
-          <SearchProjectList query={query} onClick={handleClose} />
-          <SearchGlobalDatasource query={query} onClick={handleClose} />
-          <SearchDatasourceList query={query} onClick={handleClose} />
+          {query.length && !Object.values(hasResource).some((v) => v) ? (
+            <Box sx={{ margin: 1, display: 'flex', justifyContent: 'center', gap: 1 }}>
+              <EmoticonSadOutline fontSize="medium" />
+              <Typography>No records found for {query}</Typography>
+            </Box>
+          ) : (
+            <>
+              <SearchDashboardList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
+              <SearchProjectList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
+              <SearchGlobalDatasource query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
+              <SearchDatasourceList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
+            </>
+          )}
         </Paper>
       </Modal>
     </Paper>

--- a/ui/app/src/components/Header/SearchBar/SearchList.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchList.tsx
@@ -49,6 +49,7 @@ export interface SearchListProps {
   icon: typeof Archive;
   chip?: boolean;
   buildRouting?: (resource: Resource) => string;
+  isResource?: (isAvailable: boolean) => void;
 }
 
 export function SearchList(props: SearchListProps): ReactElement | null {
@@ -73,8 +74,14 @@ export function SearchList(props: SearchListProps): ReactElement | null {
     setCurrentSizeList(SIZE_LIST);
   }, [props.query, props.list]);
 
-  return !filteredList.length ? null : (
-    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+  useEffect(() => {
+    props.isResource?.(!!filteredList.length);
+  }, [filteredList.length, props]);
+
+  if (!filteredList.length) return null;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', flexShrink: 0, height: 'auto', minHeight: 0, minWidth: 0 }}>
       <Box
         sx={{
           display: 'flex',


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

closes (#3573)

- The Search List used to take up a lot of space even though there were fewer search results. 
- The Search List had no error message if no resources were found.

# Solution

- Kept rendering of SearchList gated on the absence of errors.
- Updated the modal container to size dynamically with results, capped at 70% of the viewport height.
- Show a modal message of No Resources found


# Screenshots

- Dynamic Modal:

<img width="1783" height="745" alt="image" src="https://github.com/user-attachments/assets/626a23eb-ca41-4db5-b658-7ffaa250c3e9" />

<img width="1752" height="860" alt="image" src="https://github.com/user-attachments/assets/1ab0998b-fd2f-4db0-8453-60b2aeb4cd11" />


- Display if none of the resources are found:

<img width="1818" height="498" alt="image" src="https://github.com/user-attachments/assets/6ee37776-7266-458b-9d04-db3e1e3f8ae4" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
