### PR TITLE
[BUGFIX] Fix navigation after creating a new ephemeral dashboard

### DIFF
--- a/ui/app/src/views/projects/dashboards/CreateEphemeralDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/CreateEphemeralDashboardView.tsx
@@ -22,7 +22,7 @@ import {
   EphemeralDashboardSpec,
   DurationString,
 } from '@perses-dev/core';
-import { ReactElement, useCallback } from 'react';
+import { ReactElement, useCallback, useState } from 'react';
 import { useCreateEphemeralDashboardMutation } from '../../../model/ephemeral-dashboard-client';
 import { generateMetadataName } from '../../../utils/metadata';
 import { HelperDashboardView } from './HelperDashboardView';
@@ -69,11 +69,15 @@ function CreateEphemeralDashboardView(): ReactElement | null {
     },
   };
 
+  const [isLeavingConfirmDialogEnabled, setIsLeavingConfirmDialogEnabled] = useState(true);
+
   const handleEphemeralDashboardSave = useCallback(
     (data: DashboardResource | EphemeralDashboardResource) => {
       if (data.kind !== 'EphemeralDashboard') {
         throw new Error('Invalid kind');
       }
+      setIsLeavingConfirmDialogEnabled(false); // Disable the leaving dialog before navigating
+
       return createEphemeralDashboardMutation.mutateAsync(data, {
         onSuccess: (createdEphemeralDashboard: EphemeralDashboardResource) => {
           successSnackbar(
@@ -84,9 +88,9 @@ function CreateEphemeralDashboardView(): ReactElement | null {
           navigate(
             `/projects/${createdEphemeralDashboard.metadata.project}/ephemeralDashboards/${createdEphemeralDashboard.metadata.name}`
           );
-          return createdEphemeralDashboard;
         },
         onError: (err) => {
+          setIsLeavingConfirmDialogEnabled(true); // Re-enable the leaving dialog if there was an error
           exceptionSnackbar(err);
           throw err;
         },
@@ -109,6 +113,7 @@ function CreateEphemeralDashboardView(): ReactElement | null {
       isReadonly={false}
       isEditing={true}
       isCreating={true}
+      isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
     />
   );
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Just spotted this issue; the fix is the same as what was done for regular dashboards with https://github.com/perses/perses/pull/3422.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).