### PR TITLE
[BUGFIX] Don't pass queryResults wo/ supportedQueryTypes 

### DIFF
--- a/ui/dashboards/src/components/Panel/PanelPluginLoader.tsx
+++ b/ui/dashboards/src/components/Panel/PanelPluginLoader.tsx
@@ -29,6 +29,8 @@ export function PanelPluginLoader(props: PanelPluginProps): ReactElement {
   const { data: plugin, isLoading: isPanelLoading } = usePlugin('Panel', kind, { useErrorBoundary: true });
   const PanelComponent = plugin?.PanelComponent;
   const supportedQueryTypes = plugin?.supportedQueryTypes || [];
+  // Clear out the queryResults parameter for plugins which don't support any query types
+  const supportedQueryResults = supportedQueryTypes.length > 0 ? queryResults : [];
 
   // Show fullsize skeleton if the panel plugin is loading.
   if (isPanelLoading) {
@@ -46,7 +48,7 @@ export function PanelPluginLoader(props: PanelPluginProps): ReactElement {
     throw new Error(`Missing PanelComponent from panel plugin for kind '${kind}'`);
   }
 
-  for (const queryResult of queryResults) {
+  for (const queryResult of supportedQueryResults) {
     if (!supportedQueryTypes.includes(queryResult.definition.kind)) {
       throw new Error(
         `This panel does not support queries of type '${queryResult.definition.kind}'. Supported query types: ${supportedQueryTypes.join(', ')}.`
@@ -59,7 +61,7 @@ export function PanelPluginLoader(props: PanelPluginProps): ReactElement {
       spec={spec}
       contentDimensions={contentDimensions}
       definition={definition}
-      queryResults={queryResults}
+      queryResults={supportedQueryResults}
     />
   );
 }


### PR DESCRIPTION
# Description
Since the `PanelPluginLoader` is responsible for loading the plugin which containers the the `supportedQueryTypes` information, parent components of the `PanelPluginLoader` are unable to determine if passing down the query results is required by the child plugin. As such, plugins which don't support query types (such as the markdown plugin) still receive the `queryResults` parameter despite not needing them.

While this could be solved by loading the plugin ahead of time in in the parent component and checking the `supportedQueryTypes`, I believe filtering the `queryResults` from the plugins which don't need them will provider better performance and DX for components looking to embed other plugins.

# Screenshots
<img width="1767" height="269" alt="screenshot showing markdown panel embedded in the table plugin" src="https://github.com/user-attachments/assets/eb7732ec-ab98-4e0b-8aac-1556557550be" />

_Screenshot showing an embedded markdown plugin using the $instance variable of the dashboard as a link_

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.