### PR TITLE
[ENHANCEMENT] Add new ESLINT rule to avoid nested ternary operators and fix

### DIFF
--- a/ui/.eslintrc.base.js
+++ b/ui/.eslintrc.base.js
@@ -71,7 +71,8 @@ module.exports = {
         caughtErrorsIgnorePattern: '^_',
       },
     ],
-
+    
+    'no-nested-ternary': 'error',
     'react/prop-types': 'off',
     'react-hooks/exhaustive-deps': 'error',
     // Not necessary in React 17

--- a/ui/app/src/components/Footer.tsx
+++ b/ui/app/src/components/Footer.tsx
@@ -24,6 +24,32 @@ const style: SxProps<Theme> = {
   },
 };
 
+function VersionInfo({
+  isLoading,
+  data,
+}: {
+  isLoading: boolean;
+  data?: { version?: string; commit?: string };
+}): ReactElement {
+  if (isLoading) {
+    return <CircularProgress size="1rem" />;
+  }
+
+  if (!data?.version) {
+    return <>development version</>;
+  }
+
+  const href = data.version.startsWith('main')
+    ? `https://github.com/perses/perses/tree/${data.commit}`
+    : `https://github.com/perses/perses/releases/tag/v${data.version}`;
+
+  return (
+    <Link color="inherit" underline="hover" target="_blank" rel="noreferrer" href={href}>
+      {data.version}
+    </Link>
+  );
+}
+
 export default function Footer(): ReactElement {
   const { exceptionSnackbar } = useSnackbar();
   const { data, isLoading, error } = useHealth();
@@ -46,25 +72,7 @@ export default function Footer(): ReactElement {
           </a>
         </li>
         <li>
-          {isLoading ? (
-            <CircularProgress size="1rem" />
-          ) : data !== undefined && data.version !== '' ? (
-            <Link
-              color="inherit"
-              underline="hover"
-              target="_blank"
-              rel="noreferrer"
-              href={
-                data.version.startsWith('main')
-                  ? `https://github.com/perses/perses/tree/${data.commit}`
-                  : `https://github.com/perses/perses/releases/tag/v${data.version}`
-              }
-            >
-              {data.version}
-            </Link>
-          ) : (
-            'development version'
-          )}
+          <VersionInfo isLoading={isLoading} data={data} />
         </li>
       </ul>
     </Box>

--- a/ui/app/src/components/Header/SearchBar/SearchList.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchList.tsx
@@ -14,7 +14,7 @@
 import { isProjectMetadata, Resource } from '@perses-dev/core';
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { KVSearch, KVSearchConfiguration, KVSearchResult } from '@nexucis/kvsearch';
-import { Box, Button, Chip, Typography } from '@mui/material';
+import { Box, Button, Chip, Theme, Typography } from '@mui/material';
 import Archive from 'mdi-material-ui/Archive';
 import MiddleAlertIcon from 'mdi-material-ui/StarFourPointsOutline';
 import { Link as RouterLink } from 'react-router-dom';
@@ -40,6 +40,24 @@ function buildRouting(resource: Resource): string {
   return isProjectMetadata(resource.metadata)
     ? `${ProjectRoute}/${resource.metadata.project}/${resource.kind.toLowerCase()}s/${resource.metadata.name}`
     : `/${resource.kind.toLowerCase()}s/${resource.metadata.name}`;
+}
+
+function getHighlightBackgroundColor(theme: Theme, isHighlighted: boolean): string {
+  if (!isHighlighted) {
+    return 'inherit';
+  }
+  return theme.palette.mode === 'dark' ? 'rgba(255, 165, 0, 0.2)' : 'rgba(255, 223, 186, 0.3)';
+}
+
+function getHighlightBorderColor(theme: Theme, isHighlighted: boolean): string {
+  if (!isHighlighted) {
+    return 'inherit';
+  }
+  return theme.palette.mode === 'dark' ? 'orange' : 'darkorange';
+}
+
+function getHighlightTextColor(theme: Theme, isHighlighted: boolean): string {
+  return isHighlighted && theme.palette.mode === 'dark' ? theme.palette.warning.light : 'inherit';
 }
 
 export interface SearchListProps {
@@ -96,54 +114,46 @@ export function SearchList(props: SearchListProps): ReactElement | null {
         <props.icon sx={{ marginRight: 0.5 }} fontSize="medium" />
         <Typography variant="h3">{filteredList[0]?.original.kind}s</Typography>
       </Box>
+      {filteredList.slice(0, currentSizeList).map((search) => {
+        const isHighlighted = Boolean(search.original.highlight);
 
-      {filteredList.slice(0, currentSizeList).map((search) => (
-        <Button
-          variant="outlined"
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            marginBottom: 1,
-            marginLeft: 1,
-            marginRight: 1,
-            backgroundColor: (theme) =>
-              search.original.highlight
-                ? theme.palette.mode === 'dark'
-                  ? 'rgba(255, 165, 0, 0.2)'
-                  : 'rgba(255, 223, 186, 0.3)'
-                : 'inherit',
-            borderColor: (theme) =>
-              search.original.highlight ? (theme.palette.mode === 'dark' ? 'orange' : 'darkorange') : 'inherit',
-            fontWeight: search.original.highlight ? 'bold' : 'normal',
-            color: (theme) =>
-              search.original.highlight
-                ? theme.palette.mode === 'dark'
-                  ? theme.palette.warning.light
-                  : 'inherit'
-                : 'inherit',
-          }}
-          component={RouterLink}
-          onClick={props.onClick}
-          to={`${props.buildRouting ? props.buildRouting(search.original) : buildRouting(search.original)}`}
-          key={`${buildBoxSearchKey(search.original)}`}
-        >
-          <Box sx={{ display: 'flex' }} flexDirection="row" alignItems="center">
-            {search.original.highlight && <MiddleAlertIcon sx={{ marginRight: 0.5 }} />}
-            <span
-              dangerouslySetInnerHTML={{
-                __html: kvSearch.render(search.original, search.matched, {
-                  pre: '<strong style="color:darkorange">',
-                  post: '</strong>',
-                  escapeHTML: true,
-                }).metadata.name,
-              }}
-            />
-          </Box>
-          {isProjectMetadata(search.original.metadata) && props.chip && (
-            <Chip label={`${search.original.metadata.project}`} size="small" variant="outlined" />
-          )}
-        </Button>
-      ))}
+        return (
+          <Button
+            variant="outlined"
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginBottom: 1,
+              marginLeft: 1,
+              marginRight: 1,
+              backgroundColor: (theme) => getHighlightBackgroundColor(theme, isHighlighted),
+              borderColor: (theme) => getHighlightBorderColor(theme, isHighlighted),
+              fontWeight: isHighlighted ? 'bold' : 'normal',
+              color: (theme) => getHighlightTextColor(theme, isHighlighted),
+            }}
+            component={RouterLink}
+            onClick={props.onClick}
+            to={`${props.buildRouting ? props.buildRouting(search.original) : buildRouting(search.original)}`}
+            key={`${buildBoxSearchKey(search.original)}`}
+          >
+            <Box sx={{ display: 'flex' }} flexDirection="row" alignItems="center">
+              {isHighlighted && <MiddleAlertIcon sx={{ marginRight: 0.5 }} />}
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: kvSearch.render(search.original, search.matched, {
+                    pre: '<strong style="color:darkorange">',
+                    post: '</strong>',
+                    escapeHTML: true,
+                  }).metadata.name,
+                }}
+              />
+            </Box>
+            {isProjectMetadata(search.original.metadata) && props.chip && (
+              <Chip label={`${search.original.metadata.project}`} size="small" variant="outlined" />
+            )}
+          </Button>
+        );
+      })}
       {filteredList.length > currentSizeList && (
         <Button onClick={() => setCurrentSizeList(currentSizeList + 10)}> see more...</Button>
       )}

--- a/ui/app/src/components/secrets/SecretEditorForm.tsx
+++ b/ui/app/src/components/secrets/SecretEditorForm.tsx
@@ -46,6 +46,19 @@ const basicAuthIndex = 'basicAuth';
 const authorizationIndex = 'authorization';
 const oauthIndex = 'oauth';
 
+function getTooltipTitle(value: number | undefined): string {
+  if (value === 0 || value === undefined) {
+    return 'Automatically detect the best auth style to use based on the provider';
+  }
+  if (value === 1) {
+    return 'Send OAuth credentials as URL parameters';
+  }
+  if (value === 2) {
+    return 'Send OAuth credentials using HTTP Basic Authorization';
+  }
+  return '';
+}
+
 type SecretEditorFormProps = FormEditorProps<Secret>;
 
 type EndpointParams = Record<string, string[]> | undefined;
@@ -111,15 +124,12 @@ export function SecretEditorForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form.formState.isValid]);
 
-  const [tabValue, setTabValue] = useState<string>(
-    initialSecretClean.spec.basicAuth
-      ? basicAuthIndex
-      : initialSecretClean.spec.authorization
-        ? authorizationIndex
-        : initialSecretClean.spec.oauth
-          ? oauthIndex
-          : noAuthIndex
-  );
+  const [tabValue, setTabValue] = useState<string>(() => {
+    if (initialSecretClean.spec.basicAuth) return basicAuthIndex;
+    if (initialSecretClean.spec.authorization) return authorizationIndex;
+    if (initialSecretClean.spec.oauth) return oauthIndex;
+    return noAuthIndex;
+  });
 
   const handleTabChange = (event: SyntheticEvent, newValue: string): void => {
     form.setValue('spec.authorization', undefined);
@@ -652,18 +662,7 @@ export function SecretEditorForm({
                   control={form.control}
                   name="spec.oauth.authStyle"
                   render={({ field, fieldState }) => (
-                    <Tooltip
-                      title={
-                        field.value === 0
-                          ? 'Automatically detect the best auth style to use based on the provider'
-                          : field.value === 1
-                            ? 'Send OAuth credentials as URL parameters'
-                            : field.value === 2
-                              ? 'Send OAuth credentials using HTTP Basic Authorization'
-                              : ''
-                      }
-                      placement="right"
-                    >
+                    <Tooltip title={getTooltipTitle(field.value)} placement="right">
                       <FormControl fullWidth error={!!fieldState.error}>
                         <InputLabel id="auth-style-label" shrink={action === 'read' ? true : undefined}>
                           Auth Style

--- a/ui/app/src/views/auth/SignWrapper.tsx
+++ b/ui/app/src/views/auth/SignWrapper.tsx
@@ -120,6 +120,24 @@ function computeSocialButtonFromURL(theme: Theme, url: string) {
   return SOCIAL_BUTTONS_MAPPING[''](theme);
 }
 
+function PersesLogo({
+  isLaptopSize,
+  isDarkModeEnabled,
+}: {
+  isLaptopSize: boolean;
+  isDarkModeEnabled: boolean;
+}): ReactElement {
+  if (!isLaptopSize) {
+    return <PersesLogoCropped />;
+  }
+
+  if (isDarkModeEnabled) {
+    return <DarkThemePersesLogo />;
+  }
+
+  return <LightThemePersesLogo />;
+}
+
 export function SignWrapper(props: { children: ReactNode }): ReactElement {
   const { isDarkModeEnabled } = useDarkMode();
   const isLaptopSize = useIsLaptopSize();
@@ -147,7 +165,7 @@ export function SignWrapper(props: { children: ReactNode }): ReactElement {
       justifyContent="center"
       gap={2}
     >
-      {!isLaptopSize ? <PersesLogoCropped /> : isDarkModeEnabled ? <DarkThemePersesLogo /> : <LightThemePersesLogo />}
+      <PersesLogo isLaptopSize={isLaptopSize} isDarkModeEnabled={isDarkModeEnabled} />
       <Divider
         orientation={isLaptopSize ? 'vertical' : 'horizontal'}
         variant="middle"


### PR DESCRIPTION
closes(#3580)

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

To avoid using Nested Ternary Operators in Perses/Perses. 
The pattern has been used in different places making it difficult to debug apart from the author itself
This is a refactor of all the places where it has been used along with a rule added in the ESLINT config to block such code in the future.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
