### PR TITLE
[IGNORE] add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/cue @AntoineThebaud
+/go-sdk @Gladorme
+/internal @Nexucis
+/internal/api/impl/auth @Nexucis @celian-garcia
+/internal/api/plugin/migrate @Nexucis @AntoineThebaud
+/internal/api/plugin/schema @Nexucis @AntoineThebaud
+/ui @Gladorme @jgbernalp @shahrokni


### PR DESCRIPTION
I am adding a codeowner file to propose to automatically assign PR based on the folder modified.

This is based on the feeling I have where I think the people are the most expert on.

Please let me know if I am wrong and/or you don't feel comfortable by being an owner of a particular part of the code.