### PR TITLE
[DOC] Add a concept doc about the open-specification and being compatible with Perses

### DIFF
--- a/docs/concepts/open-specification.md
+++ b/docs/concepts/open-specification.md
@@ -7,13 +7,13 @@ We believe that having an open specification is a key factor to ensure interoper
 
 This open specification is described in detail in the [Dashboard Specification documentation](../api/dashboard.md).
 
-This open specification is currently implemented in the following language:
+This open specification is currently implemented in the following languages:
 - [Golang](https://go.dev/) available in [pkg/model/api/v1/dashboard.go](https://github.com/perses/perses/blob/main/pkg/model/api/v1/dashboard.go#L93-L104)
 - [Cuelang](https://cuelang.org/) available in [cue/common/api/v1/dashboard.cue](https://github.com/perses/perses/blob/main/cue/model/api/v1/dashboard_patch.cue#L38-L50)
 - [Typescript](https://www.typescriptlang.org/) available in [ui/core/src/model/dashboard.ts](https://github.com/perses/perses/blob/main/ui/core/src/model/dashboard.ts#L28-L35) via the npm package [@perses-dev/core](https://www.npmjs.com/package/@perses-dev/core)
 
-We aim also to be backward compatible as much as possible. This means when we release a new version of Perses, we try to ensure that dashboards created with previous versions are still compatible with the new version.
-This is not always possible mainly because of the plugin evolution. But we try to minimize the impact of such changes, and we aim to provide automatic migration soon. If you are interested in this feature, please read the discussion [here](https://github.com/perses/perses/discussions/1186).
+We aim also to be backward compatible as much as possible. This means that when we release a new version of Perses, we try to ensure that dashboards created with previous versions are still compatible with the new version.
+This is not always possible, mainly due to the plugins evolutions. But we try to minimize the impact of such changes, and we aim to provide automatic migration soon. If you are interested in this feature, please read the discussion [here](https://github.com/perses/perses/discussions/1186).
 Once this discussion is closed, we will be able to guarantee backward compatibility for future releases.
 
 ## Being compatible with Perses
@@ -28,8 +28,8 @@ This section is here to explain what means for a software or a tool to be compat
 For the moment, being compatible with Perses means that your software is able to create dashboards that follow the Perses dashboard specification.
 This means that the dashboards created with your software can be used directly in Perses without any modification. And vice versa, dashboards created with Perses can be used directly in your software without any modification.
 
-Note that the dashboard definition is including the datasource definition. So being compatible with Perses also means that your software needs to support and manage the data-sources.
-But it does not imply that your software needs to support the same datasource as Perses.
+Note that the dashboard definition is including the datasource definition. So being compatible with Perses also means that your software needs to support and manage data-sources.
+But it does not imply that your software needs to support the same data source as Perses.
 
 ### What value does it bring?
 


### PR DESCRIPTION
Perses is being adopted and used by many vendors now and I think it is nice to explain what does it mean to be compatible with Perses and what features it brings on the table once you are announcing that.