### PR TITLE
[IGNORE] TraceMetaData: add hasMoreResults field

### DIFF
--- a/ui/core/src/model/trace-data.ts
+++ b/ui/core/src/model/trace-data.ts
@@ -47,6 +47,8 @@ export interface TraceData {
 }
 
 export interface TraceMetaData extends BaseMetadata {
+  /** this field indicates if there are more traces matching the search query, however not all traces were returned */
+  hasMoreResults?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
# Description

TraceMetaData: add hasMoreResults field. Technically this is not required because of the index signature, but I think it makes sense to be explicit where we can (and also add the JSDoc comment).

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
