### PR TITLE
[ENHANCEMENT] fix wrong formatting in datasource's HTTP settings editor

### DIFF
--- a/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
+++ b/ui/plugin-system/src/components/HTTPSettingsEditor/HTTPSettingsEditor.tsx
@@ -92,7 +92,7 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
               />
             )}
           />
-          <Typography variant="h4" mb={2}>
+          <Typography variant="h5" mb={2}>
             Allowed endpoints
           </Typography>
           <Grid container spacing={2} mb={2}>
@@ -244,7 +244,7 @@ export function HTTPSettingsEditor(props: HTTPSettingsEditor): ReactElement {
               </IconButton>
             </Grid>
           </Grid>
-          <Typography variant="h4" mb={2}>
+          <Typography variant="h5" mb={2}>
             Request Headers
           </Typography>
           <Grid container spacing={2} mb={2}>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

`h4` is used by the "HTTP settings" title, thus the sub-sections within it should rely on `h5`

# Screenshots

| Before |  After   |
|--|--|
| <img width="1063" height="742" alt="image" src="https://github.com/user-attachments/assets/3d90ad3e-812a-41c1-bb9e-2e97d513604f" /> | <img width="1059" height="738" alt="image" src="https://github.com/user-attachments/assets/b50c91e4-22f1-460f-a0e8-e1dc2187a654" /> |

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
