### PR TITLE
[IGNORE] fix minor BE/FE model desync for Timerange

### DIFF
--- a/pkg/model/api/config/frontend.go
+++ b/pkg/model/api/config/frontend.go
@@ -57,7 +57,7 @@ func (b *Banner) Verify() error {
 }
 
 type TimeRange struct {
-	DisableCustomTimeRange bool              `json:"disable_custom" yaml:"disable_custom"`
+	DisableCustomTimeRange bool              `json:"disable_custom,omitempty" yaml:"disable_custom,omitempty"`
 	DisableZoomTimeRange   bool              `json:"disable_zoom,omitempty" yaml:"disable_zoom,omitempty"`
 	Options                []common.Duration `json:"options,omitempty" yaml:"options,omitempty"`
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Missed in https://github.com/perses/perses/pull/3513. Make the "disable custom" attribute of the timerange config on BE side optional, as it is on FE side: https://github.com/perses/perses/blob/afb40b73224fdc897b5bb3359ba44d9858791683/ui/app/src/model/config-client.ts#L147

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).