### PR TITLE
[BUGFIX] Fix search bar wrongly returning no results

### DIFF
--- a/ui/app/src/components/Header/SearchBar/SearchBar.tsx
+++ b/ui/app/src/components/Header/SearchBar/SearchBar.tsx
@@ -44,27 +44,29 @@ interface ResourceListProps {
 
 function SearchProjectList(props: ResourceListProps): ReactElement {
   const projectsQueryResult = useProjectList({ refetchOnMount: false });
+  const { query, onClick, isResources } = props;
   return (
     <SearchList
       list={projectsQueryResult.data ?? []}
-      query={props.query}
-      onClick={props.onClick}
+      query={query}
+      onClick={onClick}
       icon={Archive}
-      isResource={(isAvailable) => props.isResources?.('projects', isAvailable)}
+      isResource={(isAvailable) => isResources?.('projects', isAvailable)}
     />
   );
 }
 
 function SearchGlobalDatasource(props: ResourceListProps): ReactElement {
   const globalDatasourceQueryResult = useGlobalDatasourceList({ refetchOnMount: false });
+  const { query, onClick, isResources } = props;
   return (
     <SearchList
       list={globalDatasourceQueryResult.data ?? []}
-      query={props.query}
-      onClick={props.onClick}
+      query={query}
+      onClick={onClick}
       icon={DatabaseIcon}
       buildRouting={() => `${AdminRoute}/datasources`}
-      isResource={(isAvailable) => props.isResources?.('globalDatasources', isAvailable)}
+      isResource={(isAvailable) => isResources?.('globalDatasources', isAvailable)}
     />
   );
 }
@@ -84,8 +86,10 @@ function SearchDashboardList(props: ResourceListProps): ReactElement | null {
     error: importantDashboardsError,
   } = useImportantDashboardList();
 
+  const { query, isResources, onClick } = props;
+
   const list: Array<Resource & { highlight: boolean }> = useMemo(() => {
-    if (props.query.length && dashboardList) {
+    if (query.length && dashboardList) {
       return dashboardList.map((d) => {
         const highlight = !!importantDashboards.some(
           (importantDashboard) =>
@@ -97,7 +101,7 @@ function SearchDashboardList(props: ResourceListProps): ReactElement | null {
     } else {
       return importantDashboards.map((imp) => ({ ...imp, highlight: true }));
     }
-  }, [importantDashboards, dashboardList, props.query]);
+  }, [importantDashboards, dashboardList, query]);
 
   if (dashboardListError || importantDashboardsError)
     return (
@@ -113,28 +117,29 @@ function SearchDashboardList(props: ResourceListProps): ReactElement | null {
   return dashboardListLoading || importantDashboardsLoading ? null : (
     <SearchList
       list={list}
-      query={props.query}
-      onClick={props.onClick}
+      query={query}
+      onClick={onClick}
       icon={ViewDashboardIcon}
       chip={true}
-      isResource={(isAvailable) => props.isResources?.('dashboards', isAvailable)}
+      isResource={(isAvailable) => isResources?.('dashboards', isAvailable)}
     />
   );
 }
 
 function SearchDatasourceList(props: ResourceListProps): ReactElement | null {
   const datasourceQueryResult = useDatasourceList({ refetchOnMount: false });
+  const { isResources, onClick, query } = props;
   return (
     <SearchList
       list={datasourceQueryResult.data ?? []}
-      query={props.query}
-      onClick={props.onClick}
+      query={query}
+      onClick={onClick}
       icon={DatabaseIcon}
       chip={true}
       buildRouting={(resource) =>
         `${ProjectRoute}/${isProjectMetadata(resource.metadata) ? resource.metadata.project : ''}/datasources`
       }
-      isResource={(isAvailable) => props.isResources?.('datasources', isAvailable)}
+      isResource={(isAvailable) => isResources?.('datasources', isAvailable)}
     />
   );
 }
@@ -173,9 +178,11 @@ export function SearchBar(): ReactElement {
     globalDatasources: false,
     datasources: false,
   });
+
   function handleIsResourceAvailable(type: ResourceType, available: boolean): void {
     setHasResource((prev) => (prev[type] === available ? prev : { ...prev, [type]: available }));
   }
+
   const handleOpen = (): void => setOpen(true);
   const handleClose = (): void => setOpen(false);
   useHandleShortCut(handleOpen);
@@ -238,19 +245,16 @@ export function SearchBar(): ReactElement {
               ),
             }}
           />
-          {query.length && !Object.values(hasResource).some((v) => v) ? (
+          {!!query.length && !Object.values(hasResource).some((v) => v) && (
             <Box sx={{ margin: 1, display: 'flex', justifyContent: 'center', gap: 1 }}>
               <EmoticonSadOutline fontSize="medium" />
               <Typography>No records found for {query}</Typography>
             </Box>
-          ) : (
-            <>
-              <SearchDashboardList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
-              <SearchProjectList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
-              <SearchGlobalDatasource query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
-              <SearchDatasourceList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
-            </>
           )}
+          <SearchDashboardList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
+          <SearchProjectList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
+          <SearchGlobalDatasource query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
+          <SearchDatasourceList query={query} onClick={handleClose} isResources={handleIsResourceAvailable} />
         </Paper>
       </Modal>
     </Paper>


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3638
Closes https://github.com/perses/perses/issues/3643

# Description 🖊️ 
If no important project is added into the config, the search returns no results. This is due to a conditional short-circuit which doesn't let a proper initialization happen. Details can be found here => https://github.com/perses/perses/pull/3644#discussion_r2564745954

## Test  Case 1 🧪 

Remove the important projects from config. Run the app, and check if you can search any projects

<img width="2087" height="1132" alt="image" src="https://github.com/user-attachments/assets/e64b42e9-1380-484a-8102-cb9556b7bad7" />

## Tesst Case 2 🧪 

This test is similar to the first test case but with important projects added to the config. (**You have to reset the server**)

<img width="2117" height="827" alt="image" src="https://github.com/user-attachments/assets/1d4cf7f0-b329-48f2-bd4f-ae70270b9e8c" />

<img width="2222" height="741" alt="image" src="https://github.com/user-attachments/assets/9123351e-d0c1-4918-90dc-244026f8243a" />


## Test Case 3 #3643  🧪 

1. Start typing a valid project name 
2. You should see the results in the Search Bar
3. Add some improper trailing characters to see the _no data found_ message
4. Remove the trailing characters
5. You should see the results again




# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
