### PR TITLE
[BUGFIX] Use '--' instead of '##' as URL safe character to encode the state for oauth/oidc

### DIFF
--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -51,7 +51,7 @@ const (
 	redirectURIQueryParam = "redirect_uri"
 	// stateSeparator is the separator used to separate the state and the redirect path in the oauth2 flow's state.
 	// It is used only in external authentication flows (oauth2 and oidc)
-	stateSeparator = "##"
+	stateSeparator = "--"
 )
 
 func getRootURL(r *http.Request, apiPrefix string) url.URL {

--- a/internal/api/impl/auth/auth_test.go
+++ b/internal/api/impl/auth/auth_test.go
@@ -51,19 +51,19 @@ func TestGetRedirectURI_WithAPIPrefix(t *testing.T) {
 func TestEncodeOAuthState(t *testing.T) {
 	redirect := "/dashboard"
 	state := encodeOAuthState(redirect)
-	assert.Contains(t, state, "##/dashboard")
+	assert.Contains(t, state, "--/dashboard")
 	assert.Len(t, state, 16+2+10)
 }
 
 // Test for decodeOAuthState: ensures correct extraction and empty string for invalid formats.
 func TestDecodeOAuthState(t *testing.T) {
 	redirect := "/dashboard"
-	state := "1234567890abcdef##" + redirect
+	state := "1234567890abcdef--" + redirect
 	assert.Equal(t, redirect, decodeOAuthState(state))
 
 	state = "invalidformat"
 	assert.Equal(t, "", decodeOAuthState(state))
 
-	state = "short##"
+	state = "short--"
 	assert.Equal(t, "", decodeOAuthState(state))
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

#3612 
#3550 

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A
