### PR TITLE
[ENHANCEMENT]: Improve link editor component

### DIFF
--- a/ui/components/src/LinksEditor/LinkEditorForm.tsx
+++ b/ui/components/src/LinksEditor/LinkEditorForm.tsx
@@ -1,0 +1,103 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Checkbox, FormControlLabel, Stack } from '@mui/material';
+import { ReactElement } from 'react';
+import { TextField } from '../controls';
+
+export interface LinkEditorFormField<T> {
+  value: T;
+  onChange: (value: T) => void;
+  placeholder?: string;
+  label: string;
+  error: { hasError?: boolean; helperText?: string };
+}
+
+export interface LinkEditorFormProps {
+  mode: 'inline' | 'modalEmbedded';
+  url: LinkEditorFormField<string>;
+  name?: Omit<LinkEditorFormField<string>, 'error'>;
+  tooltip?: Omit<LinkEditorFormField<string>, 'error'>;
+  newTabOpen: Omit<LinkEditorFormField<boolean>, 'error'>;
+  renderVariables?: Omit<LinkEditorFormField<boolean>, 'error'>;
+}
+
+export const LinkEditorForm = (props: LinkEditorFormProps): ReactElement => {
+  const { mode, url, name, newTabOpen, renderVariables, tooltip } = props;
+
+  return (
+    <Stack direction="column" gap={2} flexGrow={1}>
+      <TextField
+        label={url.label}
+        error={url.error?.hasError}
+        helperText={url.error?.helperText}
+        onChange={url.onChange}
+        placeholder={url.placeholder}
+        multiline
+        maxRows={5}
+        required
+        fullWidth
+        value={url.value}
+      />
+      {(name || tooltip) && (
+        <Stack gap={1} direction={mode === 'inline' ? 'row' : 'column'}>
+          {name && (
+            <TextField
+              sx={{ flexGrow: '1' }}
+              label={name.label}
+              onChange={name?.onChange}
+              placeholder={name?.placeholder}
+              value={name?.value}
+            />
+          )}
+          {tooltip && (
+            <TextField
+              sx={{ flexGrow: '1' }}
+              label={tooltip.label}
+              onChange={tooltip?.onChange}
+              placeholder={tooltip?.placeholder}
+              value={tooltip?.value}
+            />
+          )}
+        </Stack>
+      )}
+      <Stack direction="row" gap={1}>
+        {renderVariables && (
+          <FormControlLabel
+            label={renderVariables.label}
+            control={
+              <Checkbox
+                checked={renderVariables.value}
+                onChange={(e) => {
+                  renderVariables?.onChange(e.target.checked);
+                }}
+              />
+            }
+          />
+        )}
+
+        <FormControlLabel
+          label={newTabOpen.label}
+          control={
+            <Checkbox
+              checked={newTabOpen.value}
+              onChange={(e) => {
+                newTabOpen?.onChange(e.target.checked);
+              }}
+            />
+          }
+        />
+      </Stack>
+    </Stack>
+  );
+};

--- a/ui/components/src/LinksEditor/LinksEditor.tsx
+++ b/ui/components/src/LinksEditor/LinksEditor.tsx
@@ -12,11 +12,12 @@
 // limitations under the License.
 
 import { Fragment, HTMLAttributes, ReactElement } from 'react';
-import { Checkbox, Divider, FormControlLabel, IconButton, Stack, TextField, Typography } from '@mui/material';
+import { Divider, IconButton, Stack, Typography } from '@mui/material';
 import { Controller, useFieldArray, Control } from 'react-hook-form';
 import PlusIcon from 'mdi-material-ui/Plus';
 import MinusIcon from 'mdi-material-ui/Minus';
 import { PanelEditorValues } from '@perses-dev/core';
+import { LinkEditorForm } from './LinkEditorForm';
 
 export interface LinksEditorProps extends HTMLAttributes<HTMLDivElement> {
   control: Control<PanelEditorValues>;
@@ -59,80 +60,50 @@ export function LinksEditor({ control, ...props }: LinksEditorProps): ReactEleme
 
 function LinkControl({ control, index }: { control: Control<PanelEditorValues>; index: number }): ReactElement {
   return (
-    <Stack gap={2} flexGrow={1}>
-      <Stack direction="row" gap={2}>
-        <Controller
-          control={control}
-          name={`panelDefinition.spec.links.${index}.url`}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              required
-              fullWidth
-              label="URL"
-              error={!!fieldState.error}
-              helperText={fieldState.error?.message}
-              onChange={(event) => {
-                field.onChange(event);
-              }}
-            />
-          )}
+    <Controller
+      control={control}
+      name={`panelDefinition.spec.links.${index}`}
+      render={({ field, field: { value: link }, fieldState }) => (
+        <LinkEditorForm
+          mode="inline"
+          url={{
+            value: link.url,
+            label: 'URL',
+            error: { hasError: !!fieldState.error, helperText: fieldState.error?.message },
+            onChange: (url) => {
+              field.onChange({ ...link, url });
+            },
+          }}
+          newTabOpen={{
+            value: !!link.targetBlank,
+            onChange: (targetBlank) => {
+              field.onChange({ ...link, targetBlank });
+            },
+            label: 'Open in new tab',
+          }}
+          name={{
+            value: link.name ?? '',
+            label: 'Name',
+            onChange: (name) => {
+              field.onChange({ ...link, name });
+            },
+          }}
+          renderVariables={{
+            value: !!link.renderVariables,
+            label: 'Render variables',
+            onChange: (renderVariables) => {
+              field.onChange({ ...link, renderVariables });
+            },
+          }}
+          tooltip={{
+            value: link.tooltip ?? '',
+            label: 'Tooltip',
+            onChange: (tooltip) => {
+              field.onChange({ ...link, tooltip });
+            },
+          }}
         />
-        <Controller
-          control={control}
-          name={`panelDefinition.spec.links.${index}.name`}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              fullWidth
-              label="Name"
-              error={!!fieldState.error}
-              helperText={fieldState.error?.message}
-              onChange={(event) => {
-                field.onChange(event);
-              }}
-            />
-          )}
-        />
-        <Controller
-          control={control}
-          name={`panelDefinition.spec.links.${index}.tooltip`}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              fullWidth
-              label="Tooltip"
-              error={!!fieldState.error}
-              helperText={fieldState.error?.message}
-              onChange={(event) => {
-                field.onChange(event);
-              }}
-            />
-          )}
-        />
-      </Stack>
-      <Stack gap={2} direction="row" alignItems="center">
-        <Controller
-          control={control}
-          name={`panelDefinition.spec.links.${index}.renderVariables`}
-          render={({ field }) => (
-            <FormControlLabel
-              label="Render Variables"
-              control={<Checkbox {...field} checked={field.value} onChange={(e) => field.onChange(e.target.checked)} />}
-            />
-          )}
-        />
-        <Controller
-          control={control}
-          name={`panelDefinition.spec.links.${index}.targetBlank`}
-          render={({ field }) => (
-            <FormControlLabel
-              label="Open in new tab"
-              control={<Checkbox {...field} checked={field.value} onChange={(e) => field.onChange(e.target.checked)} />}
-            />
-          )}
-        />
-      </Stack>
-    </Stack>
+      )}
+    />
   );
 }

--- a/ui/components/src/LinksEditor/index.ts
+++ b/ui/components/src/LinksEditor/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 
 export * from './LinksEditor';
+export * from './LinkEditorForm';


### PR DESCRIPTION
Relates to [#3648 ](https://github.com/perses/perses/issues/3483)

# Description 🖊️ 
This PR pursues three goals. 

## First Goal 🎯  User experience improvement with Link Editor
Under the Spec Editor Setting there is a tab where users can add/edit/delete panel links. The current implementation is cramped and there is no ample space for the URL text field. Usually URLs are lengthy and may include dynamic parameters. To improve the experience the layout has been changed to give more space to the URL.  The change allots the entire row to the URL textfield and enables its **multiline** feature. The second and third rows are occupied by the rest of inputs which require less space. 

## Second Goal 🎯 Link Editor Form Abstraction
To be able to use the same component in a form (react hook form) or individually (later in plugins), the controls were abstracted and wrapped by a component called **LinkEditorForm** 
Now the LinkEditorForm can be used as a part of a **form** or individual as an isolated component.

## Third Goal 🎯 Dynamic structure
LinkEditorForm has been designed to be dynamic and responsive to the layout requirements. The design can be embedded in modals or  used inline. The following screenshot depicts the component usage in **inline** mode. 

<img width="941" height="422" alt="image" src="https://github.com/user-attachments/assets/7ef6c082-a07a-4ef7-8b3f-edfaabc71bae" />


## Tests 🧪 

1. You should be able to add/edit/delete a link
2. Assure an empty URL can not be persisted  (From spec editor the apply button becomes disabled)
3. Apart from the URL, all the other fields are optional
4. Open the links and assure they really work



# Screenshots

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
