### PR TITLE
[BUGFIX] Dockerfile: Switch user to `nonroot`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 LABEL maintainer="The Perses Authors <perses-team@googlegroups.com>"
 
-COPY --chown=nonroot:nonroot perses                            /bin/perses
-COPY --chown=nonroot:nonroot percli                            /bin/percli
-COPY --chown=nonroot:nonroot LICENSE                           /LICENSE
-COPY --chown=nonroot:nonroot plugins-archive/                  /etc/perses/plugins-archive/
-COPY --chown=nonroot:nonroot docs/examples/config.docker.yaml  /etc/perses/config.yaml
-COPY --from=build-env --chown=nonroot:nonroot                  /perses         /perses
-COPY --from=build-env --chown=nonroot:nonroot                  /plugins        /etc/perses/plugins
-COPY --from=build-env --chown=nonroot:nonroot                  /etc/mime.types /etc/mime.types
+COPY perses                                   /bin/perses
+COPY percli                                   /bin/percli
+COPY LICENSE                                  /LICENSE
+COPY plugins-archive/                         /etc/perses/plugins-archive/
+COPY docs/examples/config.docker.yaml         /etc/perses/config.yaml
+COPY --from=build-env --chown=nonroot:nonroot /perses         /perses
+COPY --from=build-env --chown=nonroot:nonroot /plugins        /etc/perses/plugins
+COPY --from=build-env                         /etc/mime.types /etc/mime.types
 
 WORKDIR /perses
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,14 +17,14 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 LABEL maintainer="The Perses Authors <perses-team@googlegroups.com>"
 
-COPY --from=go-builder --chown=nonroot:nonroot  /go/src/github.com/perses/perses/bin/perses        /bin/perses
-COPY --from=go-builder --chown=nonroot:nonroot  /go/src/github.com/perses/perses/bin/percli        /bin/percli
-COPY --chown=nonroot:nonroot                    LICENSE            /LICENSE
+COPY --from=go-builder                          /go/src/github.com/perses/perses/bin/perses        /bin/perses
+COPY --from=go-builder                          /go/src/github.com/perses/perses/bin/percli        /bin/percli
+COPY                                            LICENSE            /LICENSE
 COPY --from=go-builder --chown=nonroot:nonroot  /go/src/github.com/perses/perses/plugins-archive/   /etc/perses/plugins-archive/
-COPY --chown=nonroot:nonroot                    docs/examples/config.docker.yaml     /etc/perses/config.yaml
+COPY                                            docs/examples/config.docker.yaml     /etc/perses/config.yaml
 COPY --from=go-builder --chown=nonroot:nonroot  /perses            /perses
 COPY --from=go-builder --chown=nonroot:nonroot  /plugins           /etc/perses/plugins
-COPY --from=go-builder --chown=nonroot:nonroot  /etc/mime.types    /etc/mime.types
+COPY --from=go-builder                          /etc/mime.types    /etc/mime.types
 
 WORKDIR /perses
 

--- a/distroless-debug.Dockerfile
+++ b/distroless-debug.Dockerfile
@@ -7,14 +7,14 @@ FROM gcr.io/distroless/static-debian12:debug-nonroot
 
 LABEL maintainer="The Perses Authors <perses-team@googlegroups.com>"
 
-COPY --chown=nonroot:nonroot perses                            /bin/perses
-COPY --chown=nonroot:nonroot percli                            /bin/percli
-COPY --chown=nonroot:nonroot LICENSE                           /LICENSE
-COPY --chown=nonroot:nonroot plugins-archive/                  /etc/perses/plugins-archive/
-COPY --chown=nonroot:nonroot docs/examples/config.docker.yaml  /etc/perses/config.yaml
-COPY --from=build-env --chown=nonroot:nonroot                  /perses         /perses
-COPY --from=build-env --chown=nonroot:nonroot                  /plugins        /etc/perses/plugins
-COPY --from=build-env --chown=nonroot:nonroot                  /etc/mime.types /etc/mime.types
+COPY                                          perses                            /bin/perses
+COPY                                          percli                            /bin/percli
+COPY                                          LICENSE                           /LICENSE
+COPY                                          plugins-archive/                  /etc/perses/plugins-archive/
+COPY                                          docs/examples/config.docker.yaml  /etc/perses/config.yaml
+COPY --from=build-env --chown=nonroot:nonroot /perses         /perses
+COPY --from=build-env --chown=nonroot:nonroot /plugins        /etc/perses/plugins
+COPY --from=build-env                         /etc/mime.types /etc/mime.types
 
 WORKDIR /perses
 


### PR DESCRIPTION
# Description

This PR switch the Dockerfiles to a dedicated `nonroot` user, which is a better default than `nobody`. The distroless images already have it built in. The second commit fixes file ownership so the user running Perses only has write access to the things it needs.

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
