### PR TITLE
[BUGFIX] Fix plugin path in Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,10 +8,10 @@ FROM golang:1.25 AS go-builder
 WORKDIR /go/src/github.com/perses/perses
 COPY . .
 COPY --from=node-builder /app/ui/app/dist ui/app/dist
-RUN mkdir /perses
-RUN mkdir /plugins
-RUN make build-api
-RUN make build-cli
+RUN mkdir /perses \
+  && mkdir /plugins \
+  && make build-api \
+  && make build-cli
 
 FROM gcr.io/distroless/static-debian12
 
@@ -22,7 +22,7 @@ USER nobody
 COPY --from=go-builder --chown=nobody:nobody  /go/src/github.com/perses/perses/bin/perses        /bin/perses
 COPY --from=go-builder --chown=nobody:nobody  /go/src/github.com/perses/perses/bin/percli        /bin/percli
 COPY --chown=nobody:nobody                    LICENSE            /LICENSE
-COPY --chown=nobody:nobody                    plugins-archive/   /etc/perses/plugins-archive/
+COPY --from=go-builder --chown=nobody:nobody  /go/src/github.com/perses/perses/plugins-archive/   /etc/perses/plugins-archive/
 COPY --chown=nobody:nobody                    docs/examples/config.docker.yaml     /etc/perses/config.yaml
 COPY --from=go-builder --chown=nobody:nobody  /perses            /perses
 COPY --from=go-builder --chown=nobody:nobody  /plugins           /etc/perses/plugins


### PR DESCRIPTION
# Description

The dev Dockerfile downloads the plugins, but it doesn't use the download directory as a COPY source. This commit fixes that.

I am not sure if the prod Dockerfile should behave like this as well, since it is built in CI. Thoughts?

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
