### PR TITLE
[BUGFIX] Disable refetch on group onmount

### DIFF
--- a/ui/plugin-system/src/runtime/log-queries.ts
+++ b/ui/plugin-system/src/runtime/log-queries.ts
@@ -41,6 +41,10 @@ export function useLogQueries(definitions: LogQueryDefinition[]): Array<UseQuery
       const logQueryKind = definition?.spec?.plugin?.kind;
       return {
         queryKey: queryKey,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
         queryFn: async ({ signal }: { signal?: AbortSignal }): Promise<LogQueryResult> => {
           const plugin = await getPlugin(LOG_QUERY_KEY, logQueryKind);
           const data = await plugin.getLogData(definition.spec.plugin.spec, context, signal);

--- a/ui/plugin-system/src/runtime/profile-queries.ts
+++ b/ui/plugin-system/src/runtime/profile-queries.ts
@@ -41,6 +41,10 @@ export function useProfileQueries(definitions: ProfileQueryDefinition[]): Array<
       const profileQueryKind = definition?.spec?.plugin?.kind;
       return {
         queryKey: queryKey,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
         queryFn: async ({ signal }: { signal?: AbortSignal }): Promise<ProfileData> => {
           const plugin = await getPlugin(PROFILE_QUERY_KEY, profileQueryKind);
           const data = await plugin.getProfileData(definition.spec.plugin.spec, context, signal);

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -126,7 +126,6 @@ export function useTimeSeriesQueries(
     TIME_SERIES_QUERY_KEY,
     definitions.map((d) => ({ kind: d.spec.plugin.kind }))
   );
-
   return useQueries({
     queries: definitions.map((definition, idx) => {
       const plugin = pluginLoaderResponse[idx]?.data;
@@ -134,6 +133,10 @@ export function useTimeSeriesQueries(
       return {
         ...queryOptions,
         enabled: (queryOptions?.enabled ?? true) && queryEnabled,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
         queryKey: queryKey,
         queryFn: async ({ signal }: { signal: AbortSignal }): Promise<TimeSeriesData> => {
           const plugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);

--- a/ui/plugin-system/src/runtime/trace-queries.ts
+++ b/ui/plugin-system/src/runtime/trace-queries.ts
@@ -46,6 +46,10 @@ export function useTraceQueries(definitions: TraceQueryDefinition[]): Array<UseQ
       return {
         enabled: queryEnabled,
         queryKey: queryKey,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
         queryFn: async ({ signal }: { signal?: AbortSignal }): Promise<TraceData> => {
           const plugin = await getPlugin(TRACE_QUERY_KEY, traceQueryKind);
           const data = await plugin.getTraceData(definition.spec.plugin.spec, context, signal);


### PR DESCRIPTION
Closes #3499 

# Description 🖊️ 

> Bug details can be found in the issue. I strongly recommend to take a look at the issue first. Thank you

When a group of panels is closed and opened again NO new POST query should be sent to the backend.
If you check the queries you will see that the query keys are identical which means the result should be read from the cache. 

## Why does a refetch happen ❓ 🦆
The Collapse wrapper destroys its children when it is closed due to unmountOnExit. Deep down, Panel.tsx is hooked to to useTimeSeriesQueries which fetches results. Given that, when the Collapse is opened again the query is executed , in spite of the identical keys.


This changes sets the following attributes to false and set the stale time to infinity. (The default value is 0)
```typescript
        refetchOnMount: false,
        refetchOnWindowFocus: false,
        refetchOnReconnect: false,
        staleTime: Infinity,
```

## Test 1 🧪 

After the initial load closing and opening a group should NOT dispatch any new request.

## Test 2 🧪 

Dashboard refresh button should immediately dispatch a new request.

## Test 3 🧪 

Interval should work as expected.


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
