### PR TITLE
[ignore] fix excluded folder for snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,4 +5,4 @@ patch: {}
 exclude:
   global:
     - internal/cli/cmd/dac/setup/testdata
-    - internal/cli/cmd/plugin/build/testdata/**
+    - internal/cli/cmd/plugin/build/testdata


### PR DESCRIPTION
Snyk opened PR on testdata folder while it should not. Based on this [documentation](https://docs.snyk.io/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import) it should have been excluded because the syntax is correct. 

I am trying another syntax https://github.com/perses/perses/pull/3660