### PR TITLE
[BUGFIX] Add abort signal to the plugin queries

### DIFF
--- a/ui/plugin-system/src/model/log-queries.ts
+++ b/ui/plugin-system/src/model/log-queries.ts
@@ -34,6 +34,6 @@ type LogQueryPluginDependencies = {
 };
 
 export interface LogQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
-  getLogData: (spec: Spec, ctx: LogQueryContext) => Promise<LogQueryResult>;
+  getLogData: (spec: Spec, ctx: LogQueryContext, abortSignal?: AbortSignal) => Promise<LogQueryResult>;
   dependsOn?: (spec: Spec, ctx: LogQueryContext) => LogQueryPluginDependencies;
 }

--- a/ui/plugin-system/src/model/profile-queries.ts
+++ b/ui/plugin-system/src/model/profile-queries.ts
@@ -20,7 +20,7 @@ import { Plugin } from './plugin-base';
  * A plugin for running profile queries.
  */
 export interface ProfileQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
-  getProfileData: (spec: Spec, ctx: ProfileQueryContext) => Promise<ProfileData>;
+  getProfileData: (spec: Spec, ctx: ProfileQueryContext, abortSignal?: AbortSignal) => Promise<ProfileData>;
 }
 
 /**

--- a/ui/plugin-system/src/model/trace-queries.ts
+++ b/ui/plugin-system/src/model/trace-queries.ts
@@ -30,7 +30,7 @@ type TraceQueryQueryPluginDependencies = {
  * A plugin for running trace queries.
  */
 export interface TraceQueryPlugin<Spec = UnknownSpec> extends Plugin<Spec> {
-  getTraceData: (spec: Spec, ctx: TraceQueryContext) => Promise<TraceData>;
+  getTraceData: (spec: Spec, ctx: TraceQueryContext, abortSignal?: AbortSignal) => Promise<TraceData>;
   dependsOn?: (spec: Spec, ctx: TraceQueryContext) => TraceQueryQueryPluginDependencies;
 }
 

--- a/ui/plugin-system/src/runtime/log-queries.ts
+++ b/ui/plugin-system/src/runtime/log-queries.ts
@@ -41,9 +41,9 @@ export function useLogQueries(definitions: LogQueryDefinition[]): Array<UseQuery
       const logQueryKind = definition?.spec?.plugin?.kind;
       return {
         queryKey: queryKey,
-        queryFn: async (): Promise<LogQueryResult> => {
+        queryFn: async ({ signal }: { signal?: AbortSignal }): Promise<LogQueryResult> => {
           const plugin = await getPlugin(LOG_QUERY_KEY, logQueryKind);
-          const data = await plugin.getLogData(definition.spec.plugin.spec, context);
+          const data = await plugin.getLogData(definition.spec.plugin.spec, context, signal);
           return data;
         },
 

--- a/ui/plugin-system/src/runtime/profile-queries.ts
+++ b/ui/plugin-system/src/runtime/profile-queries.ts
@@ -41,9 +41,9 @@ export function useProfileQueries(definitions: ProfileQueryDefinition[]): Array<
       const profileQueryKind = definition?.spec?.plugin?.kind;
       return {
         queryKey: queryKey,
-        queryFn: async (): Promise<ProfileData> => {
+        queryFn: async ({ signal }: { signal?: AbortSignal }): Promise<ProfileData> => {
           const plugin = await getPlugin(PROFILE_QUERY_KEY, profileQueryKind);
-          const data = await plugin.getProfileData(definition.spec.plugin.spec, context);
+          const data = await plugin.getProfileData(definition.spec.plugin.spec, context, signal);
           return data;
         },
 

--- a/ui/plugin-system/src/runtime/trace-queries.ts
+++ b/ui/plugin-system/src/runtime/trace-queries.ts
@@ -46,9 +46,9 @@ export function useTraceQueries(definitions: TraceQueryDefinition[]): Array<UseQ
       return {
         enabled: queryEnabled,
         queryKey: queryKey,
-        queryFn: async (): Promise<TraceData> => {
+        queryFn: async ({ signal }: { signal?: AbortSignal }): Promise<TraceData> => {
           const plugin = await getPlugin(TRACE_QUERY_KEY, traceQueryKind);
-          const data = await plugin.getTraceData(definition.spec.plugin.spec, context);
+          const data = await plugin.getTraceData(definition.spec.plugin.spec, context, signal);
           return data;
         },
       };


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3340

# Description 🖊️ 
This change adds Abort Signals to the plugin queries. 
When released, from the plugin side the abort signals should could be consumed accordingly. 


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
