### PR TITLE
[ENHANCEMENT] Allow to configure login property from OIDC via ``custom_login_property``

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -271,6 +271,11 @@ logout:
   # Setting this to true will redirect the user to the provider's logout endpoint after the logout process.
   # If false, the user will be logged out from Perses only.
   enabled: <boolean> | default = false # Optional
+
+# Name of the property to get "login" from user infos API and id token.
+# If not provided, it will use the first part of the address mail before the @ symbol.
+# If no email is found, it will use the "sub" value, that may not be very readable.
+custom_login_property: <string> # Optional
 ```
 
 ##### OAuth provider

--- a/internal/api/impl/auth/service.go
+++ b/internal/api/impl/auth/service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/perses/perses/internal/api/authorization"
 	databaseModel "github.com/perses/perses/internal/api/database/model"
+	"github.com/perses/perses/internal/api/impl/auth/userinfo"
 	"github.com/perses/perses/internal/api/interface/v1/user"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
@@ -35,7 +36,7 @@ func useNewIfPresent(old, new string) (string, bool) { // nolint: revive
 
 // saveProfileInfo build a user spec merging the old spec with a given user profile
 // Return a boolean saying if the result is different from old value.
-func saveProfileInfo(old v1.UserSpec, uInfoProfile externalUserInfoProfile) (v1.UserSpec, bool) {
+func saveProfileInfo(old v1.UserSpec, uInfoProfile userinfo.ExternalUserInfoProfile) (v1.UserSpec, bool) {
 	firstChanged := false
 	lastChanged := false
 	old.FirstName, firstChanged = useNewIfPresent(old.FirstName, uInfoProfile.GivenName)
@@ -68,7 +69,7 @@ func saveProviderInfo(old v1.UserSpec, uInfoProvider v1.OAuthProvider) (v1.UserS
 	return old, !foundPerfectMatch, nil
 }
 
-func newSpecIfChanged(old v1.UserSpec, uInfo externalUserInfo) (v1.UserSpec, bool, error) {
+func newSpecIfChanged(old v1.UserSpec, uInfo userinfo.ExternalUserInfo) (v1.UserSpec, bool, error) {
 	specWithProfile, profileChanged := saveProfileInfo(old, uInfo.GetProfile())
 	newSpec, providerChanged, err := saveProviderInfo(specWithProfile, uInfo.GetProviderContext())
 	return newSpec, profileChanged || providerChanged, err
@@ -91,7 +92,7 @@ func (s *service) getOrPrepareUserEntity(login string) (*v1.User, bool, error) {
 	return result, false, nil
 }
 
-func (s *service) syncUser(uInfo externalUserInfo) (*v1.User, error) {
+func (s *service) syncUser(uInfo userinfo.ExternalUserInfo) (*v1.User, error) {
 	login := uInfo.GetLogin()
 	if len(login) == 0 {
 		return nil, errors.New("the user login cannot be empty")

--- a/internal/api/impl/auth/service_test.go
+++ b/internal/api/impl/auth/service_test.go
@@ -16,26 +16,27 @@ package auth
 import (
 	"testing"
 
+	"github.com/perses/perses/internal/api/impl/auth/userinfo"
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSaveProviderInfo(t *testing.T) {
-	uInfoA := oidcUserInfo{
-		externalUserInfoProfile: externalUserInfoProfile{
+	uInfoA := userinfo.OIDCUserInfo{
+		ExternalUserInfoProfile: userinfo.ExternalUserInfoProfile{
 			Email: "email",
 		},
 		Subject: "subject",
-		issuer:  "issuer",
 	}
+	uInfoA.SetIssuer("issuer")
 
-	uInfoB := oidcUserInfo{
-		externalUserInfoProfile: externalUserInfoProfile{
+	uInfoB := userinfo.OIDCUserInfo{
+		ExternalUserInfoProfile: userinfo.ExternalUserInfoProfile{
 			Email: "differentEmail",
 		},
 		Subject: "subject",
-		issuer:  "issuer",
 	}
+	uInfoB.SetIssuer("issuer")
 
 	initialSpec := v1.UserSpec{
 		FirstName:      "",

--- a/internal/api/impl/auth/userinfo/oauth.go
+++ b/internal/api/impl/auth/userinfo/oauth.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userinfo
+
+import (
+	"net/url"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type oAuthUserInfo struct {
+	ExternalUserInfoProfile
+	loginProps []string
+	authURL    url.URL
+}
+
+func NewOAuthUserInfo(authURL url.URL, loginProps []string) ExternalUserInfo {
+	return &oAuthUserInfo{authURL: authURL, loginProps: loginProps}
+}
+
+// GetLogin implements [externalUserInfo]
+func (u *oAuthUserInfo) GetLogin() string {
+	return u.getLogin(u.loginProps)
+}
+
+// GetProfile implements [externalUserInfo]
+func (u *oAuthUserInfo) GetProfile() ExternalUserInfoProfile {
+	return u.ExternalUserInfoProfile
+}
+
+// GetProviderContext implements [externalUserInfo]
+func (u *oAuthUserInfo) GetProviderContext() v1.OAuthProvider {
+	return v1.OAuthProvider{
+		// As there's no particular issuer in oauth2 generic, we recreate a fake issuer from authURL
+		Issuer:  u.authURL.Hostname(),
+		Email:   u.Email,
+		Subject: u.GetLogin(),
+	}
+}

--- a/internal/api/impl/auth/userinfo/oidc.go
+++ b/internal/api/impl/auth/userinfo/oidc.go
@@ -1,0 +1,106 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userinfo
+
+import (
+	"encoding/json"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+// OIDCUserInfo implements the externalUserInfo interface for OIDC providers.
+//
+// This struct has unexported fields that cannot be set via a constructor.
+// It is designed to be initialized exclusively through JSON unmarshaling
+// performed by the OIDC library.
+//
+// Why no constructor?
+// The OIDC library expects this type to be populated directly from JSON responses,
+// so the usual constructor pattern is not applicable.
+//
+// Usage pattern:
+//  1. Initialization:
+//     The struct is created during JSON unmarshaling of OIDC user information.
+//  2. Setters:
+//     After unmarshaling, certain fields must be set using the provided setter methods.
+//     These setters should be called before any getter methods are used.
+//  3. Getters:
+//     Once all required setters have been invoked, getters can safely retriev
+type OIDCUserInfo struct {
+	ExternalUserInfoProfile
+	Subject string
+	// issuer is not supposed to be taken from json, but instead it must be set right before the db sync.
+	issuer string
+	// loginProps is not supposed to be taken from json, but instead it must be set right before the db sync.
+	loginProps []string
+}
+
+func (u *OIDCUserInfo) SetLoginProps(props []string) {
+	u.loginProps = props
+}
+
+func (u *OIDCUserInfo) SetIssuer(issuer string) {
+	u.issuer = issuer
+}
+
+// GetSubject implements [rp.SubjectGetter]
+func (u *OIDCUserInfo) GetSubject() string {
+	return u.Subject
+}
+
+// GetLogin implements [externalUserInfo]
+// It uses the first part of the email to create the username.
+func (u *OIDCUserInfo) GetLogin() string {
+	if login := u.getLogin(u.loginProps); len(login) > 0 {
+		return login
+	}
+	return u.Subject
+}
+
+// GetProfile implements [externalUserInfo]
+func (u *OIDCUserInfo) GetProfile() ExternalUserInfoProfile {
+	return u.ExternalUserInfoProfile
+}
+
+// GetProviderContext implements [externalUserInfo]
+func (u *OIDCUserInfo) GetProviderContext() v1.OAuthProvider {
+	return v1.OAuthProvider{
+		Issuer:  u.issuer,
+		Email:   u.Email,
+		Subject: u.Subject,
+	}
+}
+
+// UnmarshalJSON handles the unmarshalling of OIDCUserInfo by ensuring both the embedded
+// ExternalUserInfoProfile fields and the Subject field are properly populated.
+// Note that `json:",inline"` would work only if the unmarshalled structure is initialized,
+// and it's not the case in the OIDC library we use.
+func (u *OIDCUserInfo) UnmarshalJSON(bytes []byte) error {
+	// First, unmarshal into the embedded ExternalUserInfoProfile to get all the profile fields
+	if err := json.Unmarshal(bytes, &u.ExternalUserInfoProfile); err != nil {
+		return err
+	}
+
+	// Then extract the Subject field separately
+	type subjectOnly struct {
+		Subject string `json:"sub,omitempty"`
+	}
+	var s subjectOnly
+	if err := json.Unmarshal(bytes, &s); err != nil {
+		return err
+	}
+	u.Subject = s.Subject
+
+	return nil
+}

--- a/internal/api/impl/auth/userinfo/oidc_test.go
+++ b/internal/api/impl/auth/userinfo/oidc_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userinfo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOIDCUserInfoUnmarshalJSON tests the unmarshalling of OIDCUserInfo from JSON.
+func TestOIDCUserInfoUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonData    string
+		expectedErr bool
+		validate    func(t *testing.T, user *OIDCUserInfo)
+	}{
+		{
+			name: "complete OIDC user info",
+			jsonData: `{
+				"sub": "user123",
+				"email": "john.doe@example.com",
+				"name": "John Doe",
+				"given_name": "John",
+				"family_name": "Doe",
+				"picture": "https://example.com/photo.jpg"
+			}`,
+			expectedErr: false,
+			validate: func(t *testing.T, user *OIDCUserInfo) {
+				require.Equal(t, "user123", user.Subject)
+				require.Equal(t, "john.doe@example.com", user.Email)
+				require.Equal(t, "John Doe", user.Name)
+				require.Equal(t, "John", user.GivenName)
+				require.Equal(t, "Doe", user.FamilyName)
+				require.Equal(t, "https://example.com/photo.jpg", user.Picture)
+			},
+		},
+		{
+			name: "minimal OIDC user info",
+			jsonData: `{
+				"sub": "user456",
+				"email": "jane@example.com"
+			}`,
+			expectedErr: false,
+			validate: func(t *testing.T, user *OIDCUserInfo) {
+				require.Equal(t, "user456", user.Subject)
+				require.Equal(t, "jane@example.com", user.Email)
+				require.Empty(t, user.Name)
+				require.Empty(t, user.GivenName)
+			},
+		},
+		{
+			name: "OIDC user info with custom properties",
+			jsonData: `{
+				"sub": "user789",
+				"email": "custom@example.com",
+				"name": "Custom User",
+				"custom_field": "custom_value",
+				"department": "engineering"
+			}`,
+			expectedErr: false,
+			validate: func(t *testing.T, user *OIDCUserInfo) {
+				require.Equal(t, "user789", user.Subject)
+				require.Equal(t, "custom@example.com", user.Email)
+				require.Equal(t, "Custom User", user.Name)
+				// Verify that custom properties are stored in rawProperties
+				require.Equal(t, "custom_value", user.rawProperties["custom_field"])
+				require.Equal(t, "engineering", user.rawProperties["department"])
+			},
+		},
+		{
+			name: "OIDC user info with preferred_username",
+			jsonData: `{
+				"sub": "user999",
+				"email": "user@example.com",
+				"preferred_username": "custom_username"
+			}`,
+			expectedErr: false,
+			validate: func(t *testing.T, user *OIDCUserInfo) {
+				require.Equal(t, "user999", user.Subject)
+				require.Equal(t, "custom_username", user.PreferredUsername)
+			},
+		},
+		{
+			name: "empty JSON object",
+			jsonData: `{
+				"sub": "minimal_user"
+			}`,
+			expectedErr: false,
+			validate: func(t *testing.T, user *OIDCUserInfo) {
+				require.Equal(t, "minimal_user", user.Subject)
+				require.Empty(t, user.Email)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var user OIDCUserInfo
+			err := json.Unmarshal([]byte(tt.jsonData), &user)
+
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				tt.validate(t, &user)
+			}
+		})
+	}
+}
+
+// TestOIDCUserInfoSetters tests the setter methods for OIDCUserInfo.
+func TestOIDCUserInfoSetters(t *testing.T) {
+	user := &OIDCUserInfo{
+		Subject: "test_user",
+	}
+
+	// Test SetIssuer
+	user.SetIssuer("https://issuer.example.com")
+	require.Equal(t, "https://issuer.example.com", user.issuer)
+
+	// Test SetLoginProps
+	loginProps := []string{"preferred_username", "name"}
+	user.SetLoginProps(loginProps)
+	require.Equal(t, loginProps, user.loginProps)
+}
+
+// TestOIDCUserInfoGetters tests the getter methods for OIDCUserInfo.
+func TestOIDCUserInfoGetters(t *testing.T) {
+	jsonData := `{
+		"sub": "user123",
+		"email": "john@example.com",
+		"name": "John Doe",
+		"preferred_username": "john.doe"
+	}`
+
+	var user OIDCUserInfo
+	err := json.Unmarshal([]byte(jsonData), &user)
+	require.NoError(t, err)
+
+	// Configure the user with issuer and login props
+	user.SetIssuer("https://issuer.example.com")
+	user.SetLoginProps([]string{"preferred_username"})
+
+	// Test GetSubject
+	require.Equal(t, "user123", user.GetSubject())
+
+	// Test GetLogin - should use preferred_username since it's in loginProps
+	require.Equal(t, "john.doe", user.GetLogin())
+
+	// Test GetProfile
+	profile := user.GetProfile()
+	require.Equal(t, "john@example.com", profile.Email)
+	require.Equal(t, "John Doe", profile.Name)
+
+	// Test GetProviderContext
+	providerContext := user.GetProviderContext()
+	require.Equal(t, "https://issuer.example.com", providerContext.Issuer)
+	require.Equal(t, "john@example.com", providerContext.Email)
+	require.Equal(t, "user123", providerContext.Subject)
+}
+
+// TestOIDCUserInfoGetLoginFallback tests that GetLogin falls back to using Subject when no login props match.
+func TestOIDCUserInfoGetLoginFallback(t *testing.T) {
+	jsonData := `{
+		"sub": "user123",
+		"email": "nousername@example.com"
+	}`
+
+	var user OIDCUserInfo
+	err := json.Unmarshal([]byte(jsonData), &user)
+	require.NoError(t, err)
+
+	user.SetLoginProps([]string{"non_existent_property"})
+
+	// Should fall back to Subject when no login props match and email doesn't have a username part
+	login := user.GetLogin()
+	require.NotEmpty(t, login)
+}
+
+// TestOIDCUserInfoGetLoginFromEmail tests that GetLogin extracts username from email when no login props match.
+func TestOIDCUserInfoGetLoginFromEmail(t *testing.T) {
+	jsonData := `{
+		"sub": "user456",
+		"email": "alice.smith@example.com"
+	}`
+
+	var user OIDCUserInfo
+	err := json.Unmarshal([]byte(jsonData), &user)
+	require.NoError(t, err)
+
+	user.SetLoginProps([]string{})
+
+	// Should extract username from email (part before @)
+	require.Equal(t, "alice.smith", user.GetLogin())
+}

--- a/internal/api/impl/auth/userinfo/userinfo.go
+++ b/internal/api/impl/auth/userinfo/userinfo.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,16 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package userinfo
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
-// externalUserInfoProfile is a subset of oidc.UserInfoProfile structure with only the interesting information.
-type externalUserInfoProfile struct {
+// ExternalUserInfoProfile is a subset of oidc.UserInfoProfile structure with only the interesting information.
+type ExternalUserInfoProfile struct {
 	Name              string `json:"name,omitempty"`
 	GivenName         string `json:"given_name,omitempty"`
 	FamilyName        string `json:"family_name,omitempty"`
@@ -30,19 +32,50 @@ type externalUserInfoProfile struct {
 	Picture           string `json:"picture,omitempty"`
 	PreferredUsername string `json:"preferred_username,omitempty"`
 	Email             string `json:"email,omitempty"`
+	rawProperties     map[string]interface{}
 }
 
-// externalUserInfo defines the way to build user info which is different according to each provider kind.
-type externalUserInfo interface {
+// ExternalUserInfo defines the way to build user info which is different according to each provider kind.
+type ExternalUserInfo interface {
 	// GetLogin returns the login designating the ``metadata.name`` of the user entity.
 	GetLogin() string
 	// GetProfile returns various user information that may be set in the ``specs`` of the user entity.
-	GetProfile() externalUserInfoProfile
+	GetProfile() ExternalUserInfoProfile
 	// GetProviderContext returns the provider context. It identifies the external provider used to collect this user
 	// information, as well as the identity of the user in that context.
 	GetProviderContext() v1.OAuthProvider
 }
 
-func buildLoginFromEmail(email string) string {
-	return strings.Split(email, "@")[0]
+func (u *ExternalUserInfoProfile) UnmarshalJSON(bytes []byte) error {
+	rawProperties := make(map[string]interface{})
+	if err := json.Unmarshal(bytes, &rawProperties); err != nil {
+		return err
+	}
+
+	type plain ExternalUserInfoProfile
+	var tmp ExternalUserInfoProfile
+	if err := json.Unmarshal(bytes, (*plain)(&tmp)); err != nil {
+		return err
+	}
+	*u = tmp
+	u.rawProperties = rawProperties
+
+	return nil
+}
+
+func (u *ExternalUserInfoProfile) getLogin(loginProps []string) string {
+	if login := u.getProperty(loginProps); login != "" {
+		return login
+	}
+	return strings.Split(u.Email, "@")[0]
+}
+
+func (u *ExternalUserInfoProfile) getProperty(keys []string) string {
+	for _, key := range keys {
+		if value, ok := u.rawProperties[key]; ok {
+			// Ensure it is a string. This makes sure for example that an int is well transformed into a string
+			return fmt.Sprint(value)
+		}
+	}
+	return ""
 }

--- a/pkg/model/api/config/authentication.go
+++ b/pkg/model/api/config/authentication.go
@@ -80,15 +80,16 @@ func (h *HTTP) Verify() error {
 }
 
 type Provider struct {
-	SlugID            string         `json:"slug_id" yaml:"slug_id"`
-	Name              string         `json:"name" yaml:"name"`
-	ClientID          secret.Hidden  `json:"client_id" yaml:"client_id"`
-	ClientSecret      secret.Hidden  `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
-	DeviceCode        *OAuthOverride `json:"device_code,omitempty" yaml:"device_code,omitempty"`
-	ClientCredentials *OAuthOverride `json:"client_credentials,omitempty" yaml:"client_credentials,omitempty"`
-	RedirectURI       common.URL     `json:"redirect_uri,omitempty" yaml:"redirect_uri,omitempty"`
-	Scopes            []string       `json:"scopes,omitempty" yaml:"scopes,omitempty"`
-	HTTP              HTTP           `json:"http" yaml:"http"`
+	SlugID              string         `json:"slug_id" yaml:"slug_id"`
+	Name                string         `json:"name" yaml:"name"`
+	ClientID            secret.Hidden  `json:"client_id" yaml:"client_id"`
+	ClientSecret        secret.Hidden  `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	DeviceCode          *OAuthOverride `json:"device_code,omitempty" yaml:"device_code,omitempty"`
+	ClientCredentials   *OAuthOverride `json:"client_credentials,omitempty" yaml:"client_credentials,omitempty"`
+	RedirectURI         common.URL     `json:"redirect_uri,omitempty" yaml:"redirect_uri,omitempty"`
+	Scopes              []string       `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	HTTP                HTTP           `json:"http" yaml:"http"`
+	CustomLoginProperty string         `json:"custom_login_property,omitempty" yaml:"custom_login_property,omitempty"`
 }
 
 func (p *Provider) Verify() error {
@@ -125,12 +126,11 @@ func (p *OIDCProvider) Verify() error {
 }
 
 type OAuthProvider struct {
-	Provider            `json:",inline" yaml:",inline"`
-	AuthURL             common.URL `json:"auth_url" yaml:"auth_url"`
-	TokenURL            common.URL `json:"token_url" yaml:"token_url"`
-	UserInfosURL        common.URL `json:"user_infos_url" yaml:"user_infos_url"`
-	DeviceAuthURL       common.URL `json:"device_auth_url" yaml:"device_auth_url"`
-	CustomLoginProperty string     `json:"custom_login_property,omitempty" yaml:"custom_login_property,omitempty"`
+	Provider      `json:",inline" yaml:",inline"`
+	AuthURL       common.URL `json:"auth_url" yaml:"auth_url"`
+	TokenURL      common.URL `json:"token_url" yaml:"token_url"`
+	UserInfosURL  common.URL `json:"user_infos_url" yaml:"user_infos_url"`
+	DeviceAuthURL common.URL `json:"device_auth_url" yaml:"device_auth_url"`
 }
 
 func (p *OAuthProvider) Verify() error {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

We discussed about that in #3612. It's currently not possible to override the way we collect login when we use OIDC provider. 

The default behaviour is to get the first part of the mail, or take subject. But it means that in the case the provider doesn't return a mail, the result (sub claim) might be an id not very readable. 

With this PR, administrator can specify the field used to retrieve the login info.
The fields are taken from /userinfo endpoint result and id token claims.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A
