### PR TITLE
[ignore] e2e should not exceed 10min to be executed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,7 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run Playwright tests
         working-directory: ./ui
+        timeout-minutes: 10
         run: npm run e2e:ci
         env:
           # Outputs information from webservers started in the background by


### PR DESCRIPTION
it will avoid the situation that happened in https://github.com/perses/perses/pull/3670 where you have the e2e tests running during 2 hours and failed.