### PR TITLE
[IGNORE] Align k8s authorization with new implementation (GetProviderInfo)

### DIFF
--- a/internal/api/authorization/k8s/k8s.go
+++ b/internal/api/authorization/k8s/k8s.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/perses/perses/internal/api/crypto"
 	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/internal/api/utils"
 	"github.com/perses/perses/pkg/model/api/config"
@@ -137,6 +138,13 @@ func (k *k8sImpl) GetUsername(ctx echo.Context) (string, error) {
 		return "", err
 	}
 	return k8sUser.GetName(), nil
+}
+
+// GetProviderInfo implements [Authorization]
+func (k *k8sImpl) GetProviderInfo(_ echo.Context) (crypto.ProviderInfo, error) {
+	// Provider Info is essentially used to know the original type of authentication provider used when using native authorization model.
+	// For k8s authorization, the authentication is not using provider but k8s, so there won't be any provider info to retrieve.
+	return crypto.ProviderInfo{}, nil
 }
 
 // Middleware implements [Authorization]


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
