### PR TITLE
[FEATURE]: updates nearby-series to support yAxis:type:log TimeSeriesChart

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -17,7 +17,6 @@ import { formatValue, TimeSeriesValueTuple, FormatOptions, TimeSeries } from '@p
 import { EChartsDataFormat, OPTIMIZED_MODE_SERIES_LIMIT, TimeChartSeriesMapping, DatapointInfo } from '../model';
 import { batchDispatchNearbySeriesActions, getPointInGrid, getClosestTimestamp } from '../utils';
 import { CursorCoordinates, CursorData, EMPTY_TOOLTIP_DATA } from './tooltip-model';
-import {pow} from 'mathjs';
 // increase multipliers to show more series in tooltip
 export const INCREASE_NEARBY_SERIES_MULTIPLIER = 5.5; // adjusts how many series show in tooltip (higher == more series shown)
 export const DYNAMIC_NEARBY_SERIES_MULTIPLIER = 30; // used for adjustment after series number divisor
@@ -47,8 +46,7 @@ export function checkforNearbyTimeSeries(
   pointInGrid: number[],
   yBuffer: number,
   chart: EChartsInstance,
-  format?: FormatOptions,
-  logBase?: number,
+  format?: FormatOptions
 ): NearbySeriesArray {
   const currentNearbySeriesData: NearbySeriesArray = [];
   const cursorX: number | null = pointInGrid[0] ?? null;
@@ -340,19 +338,19 @@ export function getNearbySeriesData({
     const yAxisScale = chartModel.getComponent('yAxis').axis.scale;
     const isLogScale = yAxisScale.type === 'log';
     let yInterval = yAxisScale._interval;
-    
+
     // For logarithmic scales, convert the log interval to actual data range
     if (isLogScale && yAxisScale.base) {
       const logBase = yAxisScale.base;
       const extent = yAxisScale._extent;
       // Calculate actual data range from log extent
       // extent is in log space (e.g., [0, 2] for 10^0 to 10^2)
-      const actualMin = Math.pow(logBase, extent[0]);
-      const actualMax = Math.pow(logBase, extent[1]);
+      const actualMin = logBase ** extent[0];
+      const actualMax = logBase ** extent[1];
       // Use a fraction of the actual range as the interval
       yInterval = (actualMax - actualMin) / 100;
     }
-    
+
     const totalSeries = data.length;
     const yBuffer = getYBuffer({ yInterval, totalSeries, showAllSeries });
     return checkforNearbyTimeSeries(data, seriesMapping, pointInGrid, yBuffer, chart, format);


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This is a precondition for supporting #3434. If a user has selected a log-base for their render, this will perform a base-change to convert the log-base vector space to a linear space for the logic handling nearby series finding.

## Example
For instance If this is not present and you use a log-based chart, you end up with a "nearby-search interval" of just a few pixels. That is, if you have multiple series in the realm of ~1e4, using a log scale we would have y-values of ~4. The search interval would then be <4. But as the chart coordinates still are very large ~1e4 it would be impossible to get precise enough to hover/select a particular series.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.