### PR TITLE
[ignore] CI: download plugins once and shared to all go job that require it

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,25 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
 
 jobs:
+  download-plugin:
+    name: "download default plugins"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - uses: perses/github-actions@v0.11.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+          enable_cue: false
+      - name: download plugin
+        run: make install-default-plugins
+      - name: store plugin to share with other jobs
+        uses: actions/upload-artifact@v5
+        with:
+          name: plugins
+          path: |
+            plugins-archive
   checklicense:
     name: "check license headers"
     runs-on: ubuntu-latest
@@ -56,6 +75,7 @@ jobs:
   test-file:
     name: "tests with file DB"
     runs-on: ubuntu-latest
+    needs: "download-plugin"
     services:
       prometheus:
         image: prom/prometheus
@@ -78,11 +98,17 @@ jobs:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
           cue_version: "v0.15.0"
+      - name: Download plugin archive
+        uses: actions/download-artifact@v6
+        with:
+          name: plugins
+          path: plugins-archive
       - name: test
         run: make integration-test
   test-windows:
     name: "tests with file DB on windows"
     runs-on: windows-latest
+    needs: "download-plugin"
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -92,6 +118,11 @@ jobs:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
           cue_version: "v0.15.0"
+      - name: Download plugin archive
+        uses: actions/download-artifact@v6
+        with:
+          name: plugins
+          path: plugins-archive
       - uses: ikalnytskyi/action-setup-postgres@v8
         with:
           username: user
@@ -107,6 +138,7 @@ jobs:
   test-mysql:
     name: "tests with mysql"
     runs-on: ubuntu-latest
+    needs: "download-plugin"
     services:
       prometheus:
         image: prom/prometheus
@@ -138,6 +170,11 @@ jobs:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
           cue_version: "v0.15.0"
+      - name: Download plugin archive
+        uses: actions/download-artifact@v6
+        with:
+          name: plugins
+          path: plugins-archive
       - name: test
         run: make mysql-integration-test
   golangci:
@@ -163,6 +200,7 @@ jobs:
   validate-dev-data:
     name: validate CUE schemas
     runs-on: ubuntu-latest
+    needs: "download-plugin"
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -171,8 +209,11 @@ jobs:
         with:
           enable_go: true
           enable_cue: false
-      - name: download plugin
-        run: make install-default-plugins
+      - name: Download plugin archive
+        uses: actions/download-artifact@v6
+        with:
+          name: plugins
+          path: plugins-archive
       - name: validate all data from dev/data
         run: make validate-data
   validate-cue:


### PR DESCRIPTION
Hopefully it will improve the CI time execution for these jobs and avoid a timeout from GitHub.