### PR TITLE
[BUGFIX] Remove deprecated info displayed on UI

### DIFF
--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -115,9 +115,6 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
                   dashboardTitleComponent={
                     <ProjectBreadcrumbs dashboardName={getResourceDisplayName(dashboardResource)} project={project} />
                   }
-                  emptyDashboardProps={{
-                    additionalText: 'In order to save this dashboard, you need to add at least one panel!',
-                  }}
                   onSave={onSave}
                   onDiscard={onDiscard}
                   isInitialVariableSticky={true}


### PR DESCRIPTION
# Description

the len(panels) > 0 constraint was removed a while ago with https://github.com/perses/perses/issues/1536, thus this "you need to add at least one panel" message shown on empty dashboard is actually wrong since.

# Screenshots

| Before | After |
|-|-|
| <img width="686" height="645" alt="image" src="https://github.com/user-attachments/assets/169e422e-e414-4c32-8834-359801f21ac7" /> | <img width="741" height="688" alt="Screenshot 2025-12-17 154154" src="https://github.com/user-attachments/assets/45beac0c-c0c2-42a9-89eb-fcc149a89bc6" /> |

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
