### PR TITLE
[ignore] update codeowners with frontend maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 /internal/cli @Nexucis
 /pkg/client @Nexucis @celian-garcia
 /pkg/model @Nexucis @AntoineThebaud
-/ui @Gladorme @jgbernalp @shahrokni
+/ui @perses/frontend-maintainers


### PR DESCRIPTION
I have created a frontend-maintainers team where I have added all of you. I think it will be easier to manage like that.

Let me know if you agree and like this way