### PR TITLE
[ignore] add dependabot post workflows

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,38 @@
+name: dependabot
+on:
+  pull_request:
+    paths:
+      - '**/go.mod'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  go-update:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: perses/github-actions@v0.11.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+          enable_cue: false
+      - name: Run go mod tidy
+        run: |
+          go mod tidy
+          cd internal/cli/cmd/dac/build/testdata/go
+          go mod tidy
+          cd -
+          cd go-sdk/test
+          go mod tidy
+          cd -
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
+        with:
+          commit_message: '[dependabot skip] apply go mod tidy'
+          commit_options: '--no-verify --signoff'


### PR DESCRIPTION
I am adding a little workflows that should run when dependabot is creating a PR when updating the go dependencies.

This should avoid the situations where I need to manually opening a PR to update other go sub modules that depends on the main module.