### PR TITLE
[BUGFIX]: Add RP client_id to the redirect URL when logging out

### DIFF
--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -58,8 +58,18 @@ security:
           client_id: "<secret>"
           client_secret: "<secret>"
           issuer: "https://login.microsoftonline.com/<tenant-id>/v2.0"
-          redirect_uri: "http://localhost:8080/api/auth/providers/oidc/azure/callback"
+          redirect_uri: "http://localhost:8080/api/auth/providers/oidc/msft/callback"
           scopes: [ "openid", "profile", "email", "User.read" ]
+          logout:
+            enabled: true
+        # Example with a Keycloak OIDC configuration
+        - slug_id: keycloak
+          name: "Keycloak"
+          client_id: "<secret>"
+          client_secret: "<secret>"
+          issuer: "https://<keycloak host>/realms/<realm>" // For Keycloak versions <17: https://<keycloak host>/auth/realms/<realm>
+          redirect_uri: "http://localhost:8080/api/auth/providers/oidc/keycloak/callback"
+          scopes: [ "openid", "profile", "email", "roles" ]
           logout:
             enabled: true
       oauth:

--- a/docs/configuration/oauth-configuration-helpers.md
+++ b/docs/configuration/oauth-configuration-helpers.md
@@ -52,9 +52,7 @@ security:
 !!! tip
     The **scope** used to generate a token from client credentials is different from the one used in other flows.
 
-```
-*Ref: [https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow)*
-```
+*Reference: [https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow)*
 
 ##### Logout redirection with Entra ID
 
@@ -62,7 +60,29 @@ Logout redirection is partially supported with Entra ID. When you click on logou
 But there can be some situations where Entra will not redirect you back to Perses.
 - The user logged out directly from Entra ID.
 - The user session expired.
-In this case, you will be logged out from Perses, but you will have to manually go back to Perses.
+  In this case, you will be logged out from Perses, but you will have to manually go back to Perses.
+
+#### Keycloak
+
+```yaml
+security:
+  authentication:
+    providers:
+      oidc:
+        - slug_id: keycloak
+          name: "Keycloak"
+          client_id: "<your client ID>"
+          client_secret: "<your client Secret>"
+          issuer: "https://<keycloak host>/realms/<realm>" // For Keycloak versions <17: https://<keycloak host>/auth/realms/<realm>
+          scopes: [ "openid", "profile", "email" ]
+          logout:
+            enabled: true # Generally advised, but you can disable it if you don't want to redirect to the provider's logout page
+```
+
+!!! tip
+    Keycloak uses claims `roles` or `groups` for managing user permissions. For more details check this [link](https://www.keycloak.org/docs/latest/server_admin/index.html#assigning-permissions-using-roles-and-groups). As of now, the Perses does not support `RoleBinding` or `GlobalRoleBinding` based on the roles assigned to user in the OIDC provider.
+
+*Reference: [Keycloak OpenID Connect](https://www.keycloak.org/securing-apps/oidc-layers)*
 
 #### <Place Your Provider here ...\>
 

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -170,6 +170,7 @@ func newOIDCExtraLogoutHandler(provider config.OIDCProvider, rp *RelyingPartyWit
 		queryParams := endSessionURL.Query()
 		rd := getRootURL(ctx.Request(), apiPrefix)
 		queryParams.Add("post_logout_redirect_uri", rd.String())
+		queryParams.Add("client_id", rp.OAuthConfig().ClientID)
 		endSessionURL.RawQuery = queryParams.Encode()
 		return ctx.Redirect(302, endSessionURL.String())
 	}, nil


### PR DESCRIPTION
[BUGFIX]: Add RP client_id to the redirect URL when logging out of the OIDC IDP

# Description

This PR enhances the RP-initiated logout process by appending the `client_id` to the URL when redirecting to the Identity Provider's (IDP) logout endpoint.

According to the OpenID Connect RP-Initiated Logout specification, when a `post_logout_redirect_uri` is provided, it is recommended to also include the `id_token_hint` (the ID Token previously issued by the OP). If providing the `id_token_hint` is not possible—as is the case in Perses where the original ID token is not retained for this step—the `client_id` can be passed as an alternative.

While the specification indicates that passing the `client_id` or `id_token_hint` is not strictly mandatory, certain IDPs (notably Keycloak) require at least one of these parameters to be present if a `post_logout_redirect_uri` is used. Without this, the logout process fails to correctly terminate the IDP's session.

Relates to [3766](https://github.com/perses/perses/issues/3766)

# Screenshots

No UI changes

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

No UI changes