### PR TITLE
[FEATURE] proxy: drop or keep some headers

### DIFF
--- a/go-sdk/http/options.go
+++ b/go-sdk/http/options.go
@@ -75,3 +75,10 @@ func Secret(name string) Option {
 		return nil
 	}
 }
+
+func RemoveOriginAndReferer(isRemoved bool) Option {
+	return func(builder *Builder) error {
+		builder.Spec.RemoveOriginAndReferer = isRemoved
+		return nil
+	}
+}

--- a/go-sdk/http/options.go
+++ b/go-sdk/http/options.go
@@ -76,9 +76,16 @@ func Secret(name string) Option {
 	}
 }
 
-func RemoveOriginAndReferer(isRemoved bool) Option {
+func AllowHeaders(headers ...string) Option {
 	return func(builder *Builder) error {
-		builder.Spec.RemoveOriginAndReferer = isRemoved
+		builder.Spec.AllowHeaders = headers
+		return nil
+	}
+}
+
+func DropHeaders(headers ...string) Option {
+	return func(builder *Builder) error {
+		builder.Spec.DropHeaders = headers
 		return nil
 	}
 }

--- a/internal/api/impl/proxy/proxy.go
+++ b/internal/api/impl/proxy/proxy.go
@@ -282,6 +282,11 @@ func (h *httpProxy) serve(c echo.Context) error {
 		return apiinterface.InternalError
 	}
 
+	if h.config.RemoveOriginAndReferer {
+		req.Header.Del("Referer")
+		req.Header.Del("Origin")
+	}
+
 	// redirect the request to the datasource
 	req.URL.Path = h.path
 	logrus.WithFields(map[string]interface{}{

--- a/internal/api/impl/proxy/proxy.go
+++ b/internal/api/impl/proxy/proxy.go
@@ -282,9 +282,18 @@ func (h *httpProxy) serve(c echo.Context) error {
 		return apiinterface.InternalError
 	}
 
-	if h.config.RemoveOriginAndReferer {
-		req.Header.Del("Referer")
-		req.Header.Del("Origin")
+	if len(h.config.DropHeaders) > 0 {
+		for _, headerToDrop := range h.config.DropHeaders {
+			req.Header.Del(headerToDrop)
+		}
+	}
+
+	if len(h.config.AllowHeaders) > 0 {
+		headerKept := make(http.Header)
+		for _, header := range h.config.AllowHeaders {
+			headerKept.Add(header, req.Header.Get(header))
+		}
+		req.Header = headerKept
 	}
 
 	// redirect the request to the datasource

--- a/pkg/model/api/v1/datasource/http/http.go
+++ b/pkg/model/api/v1/datasource/http/http.go
@@ -81,6 +81,8 @@ type Config struct {
 	// Secret is the name of the secret that should be used for the proxy or discovery configuration
 	// It will contain any sensitive information such as password, token, certificate.
 	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+	// RemoveOriginAndReferer is removing Origin and Referer headers when proxying requests, to avoid CORS issues with some datasources
+	RemoveOriginAndReferer bool `json:"removeOriginAndReferer,omitempty" yaml:"removeOriginAndReferer,omitempty"`
 }
 
 func (h *Config) UnmarshalJSON(data []byte) error {

--- a/pkg/model/api/v1/datasource/http/http.go
+++ b/pkg/model/api/v1/datasource/http/http.go
@@ -81,8 +81,10 @@ type Config struct {
 	// Secret is the name of the secret that should be used for the proxy or discovery configuration
 	// It will contain any sensitive information such as password, token, certificate.
 	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
-	// RemoveOriginAndReferer is removing Origin and Referer headers when proxying requests, to avoid CORS issues with some datasources
-	RemoveOriginAndReferer bool `json:"removeOriginAndReferer,omitempty" yaml:"removeOriginAndReferer,omitempty"`
+	// AllowHeaders will drop all headers not in the list before forwarding the request to the datasource.
+	AllowHeaders []string `json:"allowHeaders,omitempty" yaml:"allowHeaders,omitempty"`
+	// DropHeaders will only keep headers in the list before forwarding the request to the datasource.
+	DropHeaders []string `json:"dropHeaders,omitempty" yaml:"dropHeaders,omitempty"`
 }
 
 func (h *Config) UnmarshalJSON(data []byte) error {
@@ -114,6 +116,9 @@ func (h *Config) UnmarshalYAML(unmarshal func(any) error) error {
 func (h *Config) validate() error {
 	if h.URL == nil {
 		return fmt.Errorf("url cannot be empty")
+	}
+	if len(h.AllowHeaders) > 0 && len(h.DropHeaders) > 0 {
+		return fmt.Errorf("cannot specify both allowHeaders and dropHeaders at the same time")
 	}
 	return nil
 }

--- a/ui/core/src/model/http-proxy.ts
+++ b/ui/core/src/model/http-proxy.ts
@@ -29,6 +29,8 @@ export interface HTTPProxySpec {
   // secret is the name of the secret that should be used for the proxy or discovery configuration
   // It will contain any sensitive information such as password, token, certificate.
   secret?: string;
+  // removeOriginAndReferer is removing Origin and Referer headers when proxying requests, to avoid CORS issues with some datasources
+  removeOriginAndReferer?: boolean;
 }
 
 export interface HTTPAllowedEndpoint {

--- a/ui/core/src/model/http-proxy.ts
+++ b/ui/core/src/model/http-proxy.ts
@@ -29,8 +29,10 @@ export interface HTTPProxySpec {
   // secret is the name of the secret that should be used for the proxy or discovery configuration
   // It will contain any sensitive information such as password, token, certificate.
   secret?: string;
-  // removeOriginAndReferer is removing Origin and Referer headers when proxying requests, to avoid CORS issues with some datasources
-  removeOriginAndReferer?: boolean;
+  // If set, it will drop all headers not in the list before forwarding the request to the datasource.
+  allowHeaders?: string[];
+  // If set, it will only keep headers in the list before forwarding the request to the datasource.
+  dropHeaders?: string[];
 }
 
 export interface HTTPAllowedEndpoint {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Currently all requests made by the UI have "Origin"and "Referer" headers added and it's forwarded to the datasource by the proxy. However, some datasources may check these headers and fail requests because the Origin/Referer of Perses is not defined in their conf.

TODO: Add checkbox on HTTP Proxy form (UI => shared)

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
