### PR TITLE
[DOC] API_PREFIX can be used again

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -82,16 +82,11 @@ Generic placeholders are defined as follows:
 * `<kind>`: a string that can take the values `Dashboard`, `Datasource`, `Folder`, `GlobalDatasource`, `GlobalRole`, `GlobalRoleBinding`, `GlobalVariable`, `GlobalSecret`, `Project`, `Role`, `RoleBinding`, `User` or `Variable` (not case-sensitive)
 
 ```yaml
-# Use it in case you want to prefix the API path. By default, the API is served with the path /api. 
+# Use it in case you want to prefix the API path.
+# This can be useful if you are running Perses behind a reverse proxy.
+# By default, the API is served with the path /api.
 # With this config, it will be served with the path <api_prefix>/api
-# Warning: This parameter does not work anymore since the version v0.51.0. The functionality has been broken when changing the plugin system and it will be fixed in a future version.
-# Until then, please avoid using it and avoid using a reverse proxy with a path prefix to serve Perses.
-# Issues raised about this:
-# - https://github.com/perses/perses/issues/3166
-# - https://github.com/perses/perses/issues/2579
-# - https://github.com/perses/perses/issues/2589
-# - https://github.com/perses/perses/issues/3384
-# - https://github.com/perses/perses/issues/3396
+# Example: "/perses"
 api_prefix: <string> # Optional
   
 # It contains any configuration that changes the API behavior like the endpoints exposed or if the permissions are activated.

--- a/pkg/model/api/config/config.go
+++ b/pkg/model/api/config/config.go
@@ -48,14 +48,10 @@ type dashboardSelector struct {
 }
 type Config struct {
 	// Use it in case you want to prefix the API path.
-	// Warning: This parameter does not work anymore since the version v0.51.0. The functionality has been broken when changing the plugin system and it will be fixed in a future version.
-	// Until then, please avoid using it and avoid using a reverse proxy with a path prefix to serve Perses.
-	// Issues raised about this:
-	// - https://github.com/perses/perses/issues/3166
-	// - https://github.com/perses/perses/issues/2579
-	// - https://github.com/perses/perses/issues/2589
-	// - https://github.com/perses/perses/issues/3384
-	// - https://github.com/perses/perses/issues/3396
+	// This can be useful if you are running Perses behind a reverse proxy.
+	// By default, the API is served with the path /api.
+	// With this config, it will be served with the path <api_prefix>/api
+	// Example: "/perses"
 	APIPrefix string `json:"api_prefix,omitempty" yaml:"api_prefix,omitempty"`
 	// Security contains any configuration that changes the API behavior like the endpoints exposed or if the permissions are activated.
 	Security Security `json:"security,omitempty" yaml:"security,omitempty"`


### PR DESCRIPTION
based on the last comment from @ibakshay in https://github.com/perses/perses/issues/2589, `api_prefix` can be used again safely. All issues around this topic has been solved and closed.