### PR TITLE
[FEATURE] Add OpenGemini datasource and query plugins

### DIFF
--- a/contrib/plugins/opengemini/.gitignore
+++ b/contrib/plugins/opengemini/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+lib/
+*.log
+.DS_Store

--- a/contrib/plugins/opengemini/README.md
+++ b/contrib/plugins/opengemini/README.md
@@ -1,0 +1,64 @@
+# OpenGemini Plugin for Perses
+
+This plugin provides OpenGemini datasource and time series query support for [Perses](https://github.com/perses/perses).
+
+## Overview
+
+[OpenGemini](https://github.com/openGemini/openGemini) is a CNCF sandbox project - an open-source distributed time-series database with high concurrency, high performance, and high scalability. It is fully compatible with InfluxDB v1.x Line Protocol, InfluxQL, and read/write APIs.
+
+## Plugins Included
+
+### OpenGeminiDatasource
+
+A datasource plugin for connecting to OpenGemini instances. Supports:
+
+- Direct URL connection
+- HTTP Proxy configuration
+
+### OpenGeminiTimeSeriesQuery
+
+A time series query plugin that uses InfluxQL to query data from OpenGemini. Features:
+
+- InfluxQL query support
+- Database selection
+- Variable substitution
+
+## Installation
+
+1. Build the plugin:
+
+   ```bash
+   cd plugins/opengemini
+   npm install
+   npm run build
+   ```
+
+2. Copy the built plugin to your Perses plugins directory.
+
+3. Restart Perses to load the plugin.
+
+## Usage
+
+### Creating a Datasource
+
+1. Go to Admin > Global Datasources or Project > Datasources
+2. Click "Add Datasource"
+3. Select "OpenGeminiDatasource"
+4. Configure the URL to your OpenGemini instance (default port: 8086)
+
+### Creating Queries
+
+1. Create or edit a dashboard panel
+2. Select "OpenGeminiTimeSeriesQuery" as the query type
+3. Enter your database name
+4. Write your InfluxQL query
+
+Example query:
+
+```sql
+SELECT mean("value") FROM "cpu" WHERE time > now() - 1h GROUP BY time(1m), "host"
+```
+
+## License
+
+Apache License 2.0

--- a/contrib/plugins/opengemini/cue.mod/module.cue
+++ b/contrib/plugins/opengemini/cue.mod/module.cue
@@ -1,0 +1,10 @@
+module: "github.com/perses/plugins/opengemini"
+language: version: "v0.9.0"
+deps: {
+	"github.com/perses/perses/cue/common@v0": {
+		v: "v0.53.0"
+	}
+	"github.com/perses/perses/cue/common/proxy@v0": {
+		v: "v0.53.0"
+	}
+}

--- a/contrib/plugins/opengemini/package-lock.json
+++ b/contrib/plugins/opengemini/package-lock.json
@@ -1,0 +1,6876 @@
+{
+    "name": "@perses-dev/opengemini-plugin",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@perses-dev/opengemini-plugin",
+            "version": "0.1.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@emotion/react": "^11.9.3",
+                "@emotion/styled": "^11.9.3",
+                "@mui/material": "^6.1.10",
+                "@perses-dev/components": "0.53.0-rc.1",
+                "@perses-dev/core": "0.53.0-rc.0",
+                "@perses-dev/dashboards": "0.53.0-rc.1",
+                "@perses-dev/explore": "0.53.0-rc.1",
+                "@perses-dev/plugin-system": "0.53.0-rc.1",
+                "lodash": "^4.17.21",
+                "react": "^18.0.0",
+                "react-dom": "^18.0.0",
+                "react-router-dom": "^6.30.1",
+                "use-resize-observer": "^9.0.0"
+            },
+            "devDependencies": {
+                "@module-federation/enhanced": "^0.8.8",
+                "@rsbuild/core": "^1.3.21",
+                "@rsbuild/plugin-react": "^1.3.3",
+                "@swc/cli": "^0.7.8",
+                "@swc/core": "^1.3.61",
+                "@types/lodash": "^4.14.182",
+                "@types/react": "^18.0.0",
+                "@types/react-dom": "^18.0.0",
+                "cross-env": "^7.0.3",
+                "rimraf": "^6.1.0",
+                "typescript": "5.4.5"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.7.7.tgz",
+            "integrity": "sha512-jX+68AoSTqO/fhCyJDTZ38Ey6/wyL2Iq+J/moanma0YyktpnoHxevjY1UNJHYp0NCburdQDZSL1ZFac1mO1osQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "raf-schd": "^4.0.3"
+            }
+        },
+        "node_modules/@atlaskit/pragmatic-drag-and-drop-hitbox": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.1.0.tgz",
+            "integrity": "sha512-JWt6eVp6Br2FPHRM8s0dUIHQk/jFInGP1f3ti5CdtM1Ji5/pt8Akm44wDC063Gv2i5RGseixtbW0z/t6RYtbdg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/pragmatic-drag-and-drop": "^1.6.0",
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
+            "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+            "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+            "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.6"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+            "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
+            "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.28.6",
+                "@babel/generator": "^7.28.6",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.6",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.28.6",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+            "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@borewit/text-codec": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
+            "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@codemirror/autocomplete": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+            "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.17.0",
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/commands": {
+            "version": "6.10.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.1.tgz",
+            "integrity": "sha512-uWDWFypNdQmz2y1LaNJzK7fL7TYKLeUAU0npEC685OKTF3KcQ2Vu3klIM78D7I6wGhktme0lh3CuQLv0ZCrD9Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.4.0",
+                "@codemirror/view": "^6.27.0",
+                "@lezer/common": "^1.1.0"
+            }
+        },
+        "node_modules/@codemirror/lang-json": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+            "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@lezer/json": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/language": {
+            "version": "6.12.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
+            "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.23.0",
+                "@lezer/common": "^1.5.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0",
+                "style-mod": "^4.0.0"
+            }
+        },
+        "node_modules/@codemirror/lint": {
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
+            "integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.35.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/search": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+            "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.37.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/state": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+            "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+            "license": "MIT",
+            "dependencies": {
+                "@marijn/find-cluster-break": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/theme-one-dark": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+            "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0",
+                "@lezer/highlight": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/view": {
+            "version": "6.39.11",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.11.tgz",
+            "integrity": "sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.5.0",
+                "crelt": "^1.0.6",
+                "style-mod": "^4.1.0",
+                "w3c-keyname": "^2.2.4"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+            "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.1.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+            "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.13.5",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/serialize": "^1.3.3",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/cache": {
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/react": {
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+            "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/cache": "^11.14.0",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/sheet": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/styled": {
+            "version": "11.14.1",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+            "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/is-prop-valid": "^1.3.0",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+                "@emotion/utils": "^1.4.2"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.0.0-rc.0",
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@emotion/utils": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/weak-memoize": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+            "license": "MIT"
+        },
+        "node_modules/@fontsource/lato": {
+            "version": "4.5.10",
+            "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
+            "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug==",
+            "license": "MIT"
+        },
+        "node_modules/@hookform/resolvers": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+            "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "react-hook-form": "^7.0.0"
+            }
+        },
+        "node_modules/@isaacs/balanced-match": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@isaacs/brace-expansion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@isaacs/balanced-match": "^4.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@juggle/resize-observer": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@lezer/common": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.0.tgz",
+            "integrity": "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA==",
+            "license": "MIT"
+        },
+        "node_modules/@lezer/highlight": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+            "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.3.0"
+            }
+        },
+        "node_modules/@lezer/json": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+            "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.2.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0"
+            }
+        },
+        "node_modules/@lezer/lr": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.7.tgz",
+            "integrity": "sha512-wNIFWdSUfX9Jc6ePMzxSPVgTVB4EOfDIwLQLWASyiUdHKaMsiilj9bYiGkGQCKVodd0x6bgQCV207PILGFCF9Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@marijn/find-cluster-break": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+            "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/bridge-react-webpack-plugin": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.8.12.tgz",
+            "integrity": "sha512-fiSf9Df4RqdKiL1WtS7eCqAWqDnLNwMZ9qU7ZMjXSAhI3wOLzycFflpVx7PWOxSoTJPtc61hwD5lkEpNoHezkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/sdk": "0.8.12",
+                "@types/semver": "7.5.8",
+                "semver": "7.6.3"
+            }
+        },
+        "node_modules/@module-federation/cli": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-0.21.6.tgz",
+            "integrity": "sha512-qNojnlc8pTyKtK7ww3i/ujLrgWwgXqnD5DcDPsjADVIpu7STaoaVQ0G5GJ7WWS/ajXw6EyIAAGW/AMFh4XUxsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/dts-plugin": "0.21.6",
+                "@module-federation/sdk": "0.21.6",
+                "chalk": "3.0.0",
+                "commander": "11.1.0",
+                "jiti": "2.4.2"
+            },
+            "bin": {
+                "mf": "bin/mf.js"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/@module-federation/dts-plugin": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.21.6.tgz",
+            "integrity": "sha512-YIsDk8/7QZIWn0I1TAYULniMsbyi2LgKTi9OInzVmZkwMC6644x/ratTWBOUDbdY1Co+feNkoYeot1qIWv2L7w==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.21.6",
+                "@module-federation/managers": "0.21.6",
+                "@module-federation/sdk": "0.21.6",
+                "@module-federation/third-party-dts-extractor": "0.21.6",
+                "adm-zip": "^0.5.10",
+                "ansi-colors": "^4.1.3",
+                "axios": "^1.12.0",
+                "chalk": "3.0.0",
+                "fs-extra": "9.1.0",
+                "isomorphic-ws": "5.0.0",
+                "koa": "3.0.3",
+                "lodash.clonedeepwith": "4.5.0",
+                "log4js": "6.9.1",
+                "node-schedule": "2.1.1",
+                "rambda": "^9.1.0",
+                "ws": "8.18.0"
+            },
+            "peerDependencies": {
+                "typescript": "^4.9.0 || ^5.0.0",
+                "vue-tsc": ">=1.0.24"
+            },
+            "peerDependenciesMeta": {
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/@module-federation/error-codes": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.21.6.tgz",
+            "integrity": "sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/cli/node_modules/@module-federation/managers": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.21.6.tgz",
+            "integrity": "sha512-BeV6m2/7kF5MDVz9JJI5T8h8lMosnXkH2bOxxFewcra7ZjvDOgQu7WIio0mgk5l1zjNPvnEVKhnhrenEdcCiWg==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/sdk": "0.21.6",
+                "find-pkg": "2.0.0",
+                "fs-extra": "9.1.0"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/@module-federation/sdk": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
+            "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/cli/node_modules/@module-federation/third-party-dts-extractor": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.21.6.tgz",
+            "integrity": "sha512-Il6x4hLsvCgZNk1DFwuMBNeoxD1BsZ5AW2BI/nUgu0k5FiAvfcz1OFawRFEHtaM/kVrCsymMOW7pCao90DaX3A==",
+            "license": "MIT",
+            "dependencies": {
+                "find-pkg": "2.0.0",
+                "fs-extra": "9.1.0",
+                "resolve": "1.22.8"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/commander": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/jiti": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+            "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/koa": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-3.0.3.tgz",
+            "integrity": "sha512-MeuwbCoN1daWS32/Ni5qkzmrOtQO2qrnfdxDHjrm6s4b59yG4nexAJ0pTEFyzjLp0pBVO80CZp0vW8Ze30Ebow==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^1.3.8",
+                "content-disposition": "~0.5.4",
+                "content-type": "^1.0.5",
+                "cookies": "~0.9.1",
+                "delegates": "^1.0.0",
+                "destroy": "^1.2.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "fresh": "~0.5.2",
+                "http-assert": "^1.5.0",
+                "http-errors": "^2.0.0",
+                "koa-compose": "^4.1.0",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@module-federation/cli/node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/@module-federation/data-prefetch": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.8.12.tgz",
+            "integrity": "sha512-YjCk6KPBQ4Ml2/2aIKQt11I4jBKOTvK3xHyAQMKPpX5aBbMEwonDhkpTitygUw3SMBdi3CP1KMRDJ3suj3O6Mg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.8.12",
+                "@module-federation/sdk": "0.8.12",
+                "fs-extra": "9.1.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.9.0",
+                "react-dom": ">=16.9.0"
+            }
+        },
+        "node_modules/@module-federation/dts-plugin": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.8.12.tgz",
+            "integrity": "sha512-BhRZsG68XtGzKM0N02/3ldiW+PTc+QaHCMNyiZnk3GcxS0qe6USu7fTQwRIPCC2GONIdoHD+GVYPN/NJWjbTFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.8.12",
+                "@module-federation/managers": "0.8.12",
+                "@module-federation/sdk": "0.8.12",
+                "@module-federation/third-party-dts-extractor": "0.8.12",
+                "adm-zip": "^0.5.10",
+                "ansi-colors": "^4.1.3",
+                "axios": "^1.7.4",
+                "chalk": "3.0.0",
+                "fs-extra": "9.1.0",
+                "isomorphic-ws": "5.0.0",
+                "koa": "2.15.3",
+                "lodash.clonedeepwith": "4.5.0",
+                "log4js": "6.9.1",
+                "node-schedule": "2.1.1",
+                "rambda": "^9.1.0",
+                "ws": "8.18.0"
+            },
+            "peerDependencies": {
+                "typescript": "^4.9.0 || ^5.0.0",
+                "vue-tsc": ">=1.0.24"
+            },
+            "peerDependenciesMeta": {
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/enhanced": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.8.12.tgz",
+            "integrity": "sha512-uJODfWqL3C87LUu1E0ZLPRqE0sUt6QFH97bMFoCWYhkf8JS7J+wMc4KSc31ApaJs7CeQICXR1CYBAZDSdxkrOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/bridge-react-webpack-plugin": "0.8.12",
+                "@module-federation/data-prefetch": "0.8.12",
+                "@module-federation/dts-plugin": "0.8.12",
+                "@module-federation/error-codes": "0.8.12",
+                "@module-federation/inject-external-runtime-core-plugin": "0.8.12",
+                "@module-federation/managers": "0.8.12",
+                "@module-federation/manifest": "0.8.12",
+                "@module-federation/rspack": "0.8.12",
+                "@module-federation/runtime-tools": "0.8.12",
+                "@module-federation/sdk": "0.8.12",
+                "btoa": "^1.2.1",
+                "upath": "2.0.1"
+            },
+            "peerDependencies": {
+                "typescript": "^4.9.0 || ^5.0.0",
+                "vue-tsc": ">=1.0.24",
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/error-codes": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.12.tgz",
+            "integrity": "sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/inject-external-runtime-core-plugin": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.8.12.tgz",
+            "integrity": "sha512-/vFW+eiBiqXOKkDYVKl5JXGI0H4Whj10P8JadowxuHcEuR+R7kkXXauYuGYKaxIFqG4zbN3r9su2qxIEEqOsOw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@module-federation/runtime-tools": "0.8.12"
+            }
+        },
+        "node_modules/@module-federation/managers": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.8.12.tgz",
+            "integrity": "sha512-+BBdBMptHiiT2ZsfPovQuHYkse6R1+dmDS6bAinw3UGpb418W8ERp5I4jHeyhEtr3t3mb/dh4sAsYM14/EWJ9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/sdk": "0.8.12",
+                "find-pkg": "2.0.0",
+                "fs-extra": "9.1.0"
+            }
+        },
+        "node_modules/@module-federation/manifest": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.8.12.tgz",
+            "integrity": "sha512-UwC6/QK37x7Xr5K+89iKxOy/uQHqFMd49axOhgDmFSrWQOULFQd51EpTOxFXgwZfiq/h0uVBYq/c0GB3Tdu8GA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/dts-plugin": "0.8.12",
+                "@module-federation/managers": "0.8.12",
+                "@module-federation/sdk": "0.8.12",
+                "chalk": "3.0.0",
+                "find-pkg": "2.0.0"
+            }
+        },
+        "node_modules/@module-federation/rspack": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.8.12.tgz",
+            "integrity": "sha512-G73Cq7VwKdpFZwMd9hEBsE2HLF7mNQEIvLSiW6HOZG/+iWRRED1opiVkrjOmkcg770rChYSqTBiLvUS7HDT5Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/bridge-react-webpack-plugin": "0.8.12",
+                "@module-federation/dts-plugin": "0.8.12",
+                "@module-federation/inject-external-runtime-core-plugin": "0.8.12",
+                "@module-federation/managers": "0.8.12",
+                "@module-federation/manifest": "0.8.12",
+                "@module-federation/runtime-tools": "0.8.12",
+                "@module-federation/sdk": "0.8.12"
+            },
+            "peerDependencies": {
+                "@rspack/core": ">=0.7",
+                "typescript": "^4.9.0 || ^5.0.0",
+                "vue-tsc": ">=1.0.24"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/runtime": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.12.tgz",
+            "integrity": "sha512-eYohRfambj/qzxz6tEakDn459ROcixWO4zL5gmTEOmwG+jCDnxGR14j1guopyrrpjb6EKFNrPVWtYZTPPfGdQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.8.12",
+                "@module-federation/runtime-core": "0.6.20",
+                "@module-federation/sdk": "0.8.12"
+            }
+        },
+        "node_modules/@module-federation/runtime-core": {
+            "version": "0.6.20",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.20.tgz",
+            "integrity": "sha512-rX7sd/i7tpkAbfMD4TtFt/57SWNC/iv7UYS8g+ad7mnCJggWE1YEKsKSFgcvp4zU3thwR+j2y+kOCwd1sQvxEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.8.12",
+                "@module-federation/sdk": "0.8.12"
+            }
+        },
+        "node_modules/@module-federation/runtime-tools": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.12.tgz",
+            "integrity": "sha512-H97wR/toSU9+UO9S0VHLmPg/7QgohMI52EZlR0Kh0F4PD6fbiWuO4kBIp7R6g0dMI9D4NVKWTKV8xA9ASU+k7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.8.12",
+                "@module-federation/webpack-bundler-runtime": "0.8.12"
+            }
+        },
+        "node_modules/@module-federation/sdk": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
+            "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "isomorphic-rslog": "0.0.7"
+            }
+        },
+        "node_modules/@module-federation/third-party-dts-extractor": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.8.12.tgz",
+            "integrity": "sha512-+ZO5XpBwEhP9v/Tqk51YgswwbAzj4TXKZ54++uVDsLnOh9yydVGJ/b5pQcSrc8B1C55+498tsDEcNsFgZODgMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-pkg": "2.0.0",
+                "fs-extra": "9.1.0",
+                "resolve": "1.22.8"
+            }
+        },
+        "node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.12.tgz",
+            "integrity": "sha512-zd343RO7/R7Xjh5ym5KdnYQ70z4LBmMxWsa44FS0nyNv04sOq6V1eZSCGKbEhbfqqhbS5Wfj8OzJyedeVvV/OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.8.12",
+                "@module-federation/sdk": "0.8.12"
+            }
+        },
+        "node_modules/@mui/core-downloads-tracker": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
+            "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            }
+        },
+        "node_modules/@mui/material": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
+            "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/core-downloads-tracker": "^6.5.0",
+                "@mui/system": "^6.5.0",
+                "@mui/types": "~7.2.24",
+                "@mui/utils": "^6.4.9",
+                "@popperjs/core": "^2.11.8",
+                "@types/react-transition-group": "^4.4.12",
+                "clsx": "^2.1.1",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1",
+                "react-is": "^19.0.0",
+                "react-transition-group": "^4.4.5"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@mui/material-pigment-css": "^6.5.0",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@mui/material-pigment-css": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/private-theming": {
+            "version": "6.4.9",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
+            "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/utils": "^6.4.9",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/styled-engine": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
+            "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/sheet": "^1.4.0",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/system": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
+            "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/private-theming": "^6.4.9",
+                "@mui/styled-engine": "^6.5.0",
+                "@mui/types": "~7.2.24",
+                "@mui/utils": "^6.4.9",
+                "clsx": "^2.1.1",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/types": {
+            "version": "7.2.24",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+            "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/utils": {
+            "version": "6.4.9",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
+            "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/types": "~7.2.24",
+                "@types/prop-types": "^15.7.14",
+                "clsx": "^2.1.1",
+                "prop-types": "^15.8.1",
+                "react-is": "^19.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/x-date-pickers": {
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.29.4.tgz",
+            "integrity": "sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+                "@mui/x-internals": "7.29.0",
+                "@types/react-transition-group": "^4.4.11",
+                "clsx": "^2.1.1",
+                "prop-types": "^15.8.1",
+                "react-transition-group": "^4.4.5"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.9.0",
+                "@emotion/styled": "^11.8.1",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+                "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+                "dayjs": "^1.10.7",
+                "luxon": "^3.0.2",
+                "moment": "^2.29.4",
+                "moment-hijri": "^2.1.2 || ^3.0.0",
+                "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "date-fns": {
+                    "optional": true
+                },
+                "date-fns-jalali": {
+                    "optional": true
+                },
+                "dayjs": {
+                    "optional": true
+                },
+                "luxon": {
+                    "optional": true
+                },
+                "moment": {
+                    "optional": true
+                },
+                "moment-hijri": {
+                    "optional": true
+                },
+                "moment-jalaali": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/x-internals": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
+            "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@napi-rs/nice": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
+            "integrity": "sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "optionalDependencies": {
+                "@napi-rs/nice-android-arm-eabi": "1.1.1",
+                "@napi-rs/nice-android-arm64": "1.1.1",
+                "@napi-rs/nice-darwin-arm64": "1.1.1",
+                "@napi-rs/nice-darwin-x64": "1.1.1",
+                "@napi-rs/nice-freebsd-x64": "1.1.1",
+                "@napi-rs/nice-linux-arm-gnueabihf": "1.1.1",
+                "@napi-rs/nice-linux-arm64-gnu": "1.1.1",
+                "@napi-rs/nice-linux-arm64-musl": "1.1.1",
+                "@napi-rs/nice-linux-ppc64-gnu": "1.1.1",
+                "@napi-rs/nice-linux-riscv64-gnu": "1.1.1",
+                "@napi-rs/nice-linux-s390x-gnu": "1.1.1",
+                "@napi-rs/nice-linux-x64-gnu": "1.1.1",
+                "@napi-rs/nice-linux-x64-musl": "1.1.1",
+                "@napi-rs/nice-openharmony-arm64": "1.1.1",
+                "@napi-rs/nice-win32-arm64-msvc": "1.1.1",
+                "@napi-rs/nice-win32-ia32-msvc": "1.1.1",
+                "@napi-rs/nice-win32-x64-msvc": "1.1.1"
+            }
+        },
+        "node_modules/@napi-rs/nice-android-arm-eabi": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm-eabi/-/nice-android-arm-eabi-1.1.1.tgz",
+            "integrity": "sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-android-arm64": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm64/-/nice-android-arm64-1.1.1.tgz",
+            "integrity": "sha512-blG0i7dXgbInN5urONoUCNf+DUEAavRffrO7fZSeoRMJc5qD+BJeNcpr54msPF6qfDD6kzs9AQJogZvT2KD5nw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-darwin-arm64": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.1.1.tgz",
+            "integrity": "sha512-s/E7w45NaLqTGuOjC2p96pct4jRfo61xb9bU1unM/MJ/RFkKlJyJDx7OJI/O0ll/hrfpqKopuAFDV8yo0hfT7A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-darwin-x64": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-x64/-/nice-darwin-x64-1.1.1.tgz",
+            "integrity": "sha512-dGoEBnVpsdcC+oHHmW1LRK5eiyzLwdgNQq3BmZIav+9/5WTZwBYX7r5ZkQC07Nxd3KHOCkgbHSh4wPkH1N1LiQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-freebsd-x64": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-freebsd-x64/-/nice-freebsd-x64-1.1.1.tgz",
+            "integrity": "sha512-kHv4kEHAylMYmlNwcQcDtXjklYp4FCf0b05E+0h6nDHsZ+F0bDe04U/tXNOqrx5CmIAth4vwfkjjUmp4c4JktQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-arm-gnueabihf": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm-gnueabihf/-/nice-linux-arm-gnueabihf-1.1.1.tgz",
+            "integrity": "sha512-E1t7K0efyKXZDoZg1LzCOLxgolxV58HCkaEkEvIYQx12ht2pa8hoBo+4OB3qh7e+QiBlp1SRf+voWUZFxyhyqg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-arm64-gnu": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-gnu/-/nice-linux-arm64-gnu-1.1.1.tgz",
+            "integrity": "sha512-CIKLA12DTIZlmTaaKhQP88R3Xao+gyJxNWEn04wZwC2wmRapNnxCUZkVwggInMJvtVElA+D4ZzOU5sX4jV+SmQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-arm64-musl": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-musl/-/nice-linux-arm64-musl-1.1.1.tgz",
+            "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-ppc64-gnu": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-ppc64-gnu/-/nice-linux-ppc64-gnu-1.1.1.tgz",
+            "integrity": "sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-riscv64-gnu": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-riscv64-gnu/-/nice-linux-riscv64-gnu-1.1.1.tgz",
+            "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-s390x-gnu": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-s390x-gnu/-/nice-linux-s390x-gnu-1.1.1.tgz",
+            "integrity": "sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-x64-gnu": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.1.1.tgz",
+            "integrity": "sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-linux-x64-musl": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-musl/-/nice-linux-x64-musl-1.1.1.tgz",
+            "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-openharmony-arm64": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-openharmony-arm64/-/nice-openharmony-arm64-1.1.1.tgz",
+            "integrity": "sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-win32-arm64-msvc": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-arm64-msvc/-/nice-win32-arm64-msvc-1.1.1.tgz",
+            "integrity": "sha512-uoTb4eAvM5B2aj/z8j+Nv8OttPf2m+HVx3UjA5jcFxASvNhQriyCQF1OB1lHL43ZhW+VwZlgvjmP5qF3+59atA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-win32-ia32-msvc": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-ia32-msvc/-/nice-win32-ia32-msvc-1.1.1.tgz",
+            "integrity": "sha512-CNQqlQT9MwuCsg1Vd/oKXiuH+TcsSPJmlAFc5frFyX/KkOh0UpBLEj7aoY656d5UKZQMQFP7vJNa1DNUNORvug==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/nice-win32-x64-msvc": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-x64-msvc/-/nice-win32-x64-msvc-1.1.1.tgz",
+            "integrity": "sha512-vB+4G/jBQCAh0jelMTY3+kgFy00Hlx2f2/1zjMoH821IbplbWZOkLiTYXQkygNTzQJTq5cvwBDgn2ppHD+bglQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+            "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.5.0",
+                "@emnapi/runtime": "^1.5.0",
+                "@tybys/wasm-util": "^0.10.1"
+            }
+        },
+        "node_modules/@nexucis/fuzzy": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@nexucis/fuzzy/-/fuzzy-0.5.1.tgz",
+            "integrity": "sha512-+swL9itqBe1rx5Pr8ihaIS7STOeFI90HpOFF8y/3wo3ryTxKs0Hf4xc+wiA4yi9nrY4wo3VC8HJOxNiekSBE4w==",
+            "license": "MIT"
+        },
+        "node_modules/@perses-dev/components": {
+            "version": "0.53.0-rc.1",
+            "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.53.0-rc.1.tgz",
+            "integrity": "sha512-yp8pzcPe2XyE21qBLAujk+gMIl07InIaY/hq19YGAeu9ycxi2hRKily0S89qEmhjS525KJHka+f6wjEztJFnlg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
+                "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+                "@codemirror/lang-json": "^6.0.1",
+                "@fontsource/lato": "^4.5.10",
+                "@mui/x-date-pickers": "^7.23.1",
+                "@perses-dev/core": "0.53.0-beta.4",
+                "@tanstack/react-table": "^8.20.5",
+                "@uiw/react-codemirror": "^4.19.1",
+                "date-fns": "^4.1.0",
+                "date-fns-tz": "^3.2.0",
+                "echarts": "5.5.0",
+                "immer": "^10.1.1",
+                "lodash": "^4.17.21",
+                "mathjs": "^10.6.4",
+                "mdi-material-ui": "^7.9.2",
+                "notistack": "^3.0.2",
+                "react-colorful": "^5.6.1",
+                "react-error-boundary": "^3.1.4",
+                "react-hook-form": "^7.51.3",
+                "react-virtuoso": "^4.12.2"
+            },
+            "peerDependencies": {
+                "@mui/material": "^6.1.10",
+                "lodash": "^4.17.21",
+                "react": "^17.0.2 || ^18.0.0",
+                "react-dom": "^17.0.2 || ^18.0.0"
+            }
+        },
+        "node_modules/@perses-dev/components/node_modules/@perses-dev/core": {
+            "version": "0.53.0-beta.4",
+            "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.53.0-beta.4.tgz",
+            "integrity": "sha512-f31l/80YHuU172BvhVLzuMShBNcv0ehMLX1K2xRIuXQ886ULwihB6Q1K6pm1duxP7KtQFFQHAgE5flKJ5gKboA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "date-fns": "^4.1.0",
+                "lodash": "^4.17.21",
+                "mathjs": "^10.6.4",
+                "numbro": "^2.3.6",
+                "zod": "^3.21.4"
+            }
+        },
+        "node_modules/@perses-dev/core": {
+            "version": "0.53.0-rc.0",
+            "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.53.0-rc.0.tgz",
+            "integrity": "sha512-hcFY/l7PlQZ9lz/uAh0J8Txw0l+W2mkalNcDu+CGvusc2sgQznrCyn7hh/UppSN7ls1JgwaCqjjVeqBEHEjsrQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "date-fns": "^4.1.0",
+                "lodash": "^4.17.21",
+                "mathjs": "^10.6.4",
+                "numbro": "^2.3.6",
+                "zod": "^3.21.4"
+            }
+        },
+        "node_modules/@perses-dev/dashboards": {
+            "version": "0.53.0-rc.1",
+            "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.53.0-rc.1.tgz",
+            "integrity": "sha512-ndpz6I+fQiHEtQyvmD/hBjinj8Hk3pdwsBCoWFuUsCgNEt+uuukL/dT1nK5F3P3QEGwIb0eMtSQ1cGl1jtKtiA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@perses-dev/components": "0.53.0-rc.1",
+                "@perses-dev/core": "0.53.0-beta.4",
+                "@perses-dev/plugin-system": "0.53.0-rc.1",
+                "@types/react-grid-layout": "^1.3.2",
+                "date-fns": "^4.1.0",
+                "immer": "^10.1.1",
+                "mdi-material-ui": "^7.9.2",
+                "react-grid-layout": "^1.3.4",
+                "react-hook-form": "^7.46.1",
+                "react-intersection-observer": "^9.4.0",
+                "use-immer": "^0.11.0",
+                "use-query-params": "^2.2.1",
+                "use-resize-observer": "^9.0.0",
+                "yaml": "^2.7.0",
+                "zustand": "^4.3.3"
+            },
+            "peerDependencies": {
+                "@mui/material": "^6.1.10",
+                "@tanstack/react-query": "^4.39.1",
+                "react": "^17.0.2 || ^18.0.0",
+                "react-dom": "^17.0.2 || ^18.0.0"
+            }
+        },
+        "node_modules/@perses-dev/dashboards/node_modules/@perses-dev/core": {
+            "version": "0.53.0-beta.4",
+            "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.53.0-beta.4.tgz",
+            "integrity": "sha512-f31l/80YHuU172BvhVLzuMShBNcv0ehMLX1K2xRIuXQ886ULwihB6Q1K6pm1duxP7KtQFFQHAgE5flKJ5gKboA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "date-fns": "^4.1.0",
+                "lodash": "^4.17.21",
+                "mathjs": "^10.6.4",
+                "numbro": "^2.3.6",
+                "zod": "^3.21.4"
+            }
+        },
+        "node_modules/@perses-dev/dashboards/node_modules/yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
+        "node_modules/@perses-dev/explore": {
+            "version": "0.53.0-rc.1",
+            "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.53.0-rc.1.tgz",
+            "integrity": "sha512-mPk4jq+yOveZ+GcmNsJuiaql9/KI5YiLINl6fSq+cajBBZMviRomidFccbQcoVFXSgtssZeY4cXLkdQFyNgT4A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@nexucis/fuzzy": "^0.5.1",
+                "@perses-dev/components": "0.53.0-rc.1",
+                "@perses-dev/core": "0.53.0-beta.4",
+                "@perses-dev/dashboards": "0.53.0-rc.1",
+                "@perses-dev/plugin-system": "0.53.0-rc.1",
+                "@types/react-grid-layout": "^1.3.2",
+                "date-fns": "^4.1.0",
+                "immer": "^10.1.1",
+                "mdi-material-ui": "^7.9.2",
+                "qs": "^6.14.0",
+                "react-grid-layout": "^1.3.4",
+                "react-hook-form": "^7.46.1",
+                "react-intersection-observer": "^9.4.0",
+                "react-virtuoso": "^4.12.2",
+                "use-immer": "^0.11.0",
+                "use-query-params": "^2.2.1",
+                "use-resize-observer": "^9.0.0",
+                "zod": "^3.21.4",
+                "zustand": "^4.3.3"
+            },
+            "peerDependencies": {
+                "@mui/material": "^6.1.10",
+                "@tanstack/react-query": "^4.39.1",
+                "react": "^17.0.2 || ^18.0.0",
+                "react-dom": "^17.0.2 || ^18.0.0"
+            }
+        },
+        "node_modules/@perses-dev/explore/node_modules/@perses-dev/core": {
+            "version": "0.53.0-beta.4",
+            "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.53.0-beta.4.tgz",
+            "integrity": "sha512-f31l/80YHuU172BvhVLzuMShBNcv0ehMLX1K2xRIuXQ886ULwihB6Q1K6pm1duxP7KtQFFQHAgE5flKJ5gKboA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "date-fns": "^4.1.0",
+                "lodash": "^4.17.21",
+                "mathjs": "^10.6.4",
+                "numbro": "^2.3.6",
+                "zod": "^3.21.4"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system": {
+            "version": "0.53.0-rc.1",
+            "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.53.0-rc.1.tgz",
+            "integrity": "sha512-RECE2Yms5fBU8+OjVNm4nu3RbPOl9eelKwrsBJpcg+iWG8cARK/IQGlICRVVuo4vv50pqaK6fijMt2TYppFtYA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@module-federation/enhanced": "^0.21.4",
+                "@perses-dev/components": "0.53.0-rc.1",
+                "@perses-dev/core": "0.53.0-beta.4",
+                "date-fns": "^4.1.0",
+                "date-fns-tz": "^3.2.0",
+                "immer": "^10.1.1",
+                "react-hook-form": "^7.46.1",
+                "use-immer": "^0.11.0",
+                "use-query-params": "^2.2.1",
+                "zod": "^3.22.2"
+            },
+            "peerDependencies": {
+                "@hookform/resolvers": "^3.2.0",
+                "@mui/material": "^6.1.10",
+                "@tanstack/react-query": "^4.39.1",
+                "react": "^17.0.2 || ^18.0.0",
+                "react-dom": "^17.0.2 || ^18.0.0"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/bridge-react-webpack-plugin": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.21.6.tgz",
+            "integrity": "sha512-lJMmdhD4VKVkeg8RHb+Jwe6Ou9zKVgjtb1inEURDG/sSS2ksdZA8pVKLYbRPRbdmjr193Y8gJfqFbI2dqoyc/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/sdk": "0.21.6",
+                "@types/semver": "7.5.8",
+                "semver": "7.6.3"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/data-prefetch": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.21.6.tgz",
+            "integrity": "sha512-8HD7ZhtWZ9vl6i3wA7M8cEeCRdtvxt09SbMTfqIPm+5eb/V4ijb8zGTYSRhNDb5RCB+BAixaPiZOWKXJ63/rVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.21.6",
+                "@module-federation/sdk": "0.21.6",
+                "fs-extra": "9.1.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.9.0",
+                "react-dom": ">=16.9.0"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/dts-plugin": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.21.6.tgz",
+            "integrity": "sha512-YIsDk8/7QZIWn0I1TAYULniMsbyi2LgKTi9OInzVmZkwMC6644x/ratTWBOUDbdY1Co+feNkoYeot1qIWv2L7w==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.21.6",
+                "@module-federation/managers": "0.21.6",
+                "@module-federation/sdk": "0.21.6",
+                "@module-federation/third-party-dts-extractor": "0.21.6",
+                "adm-zip": "^0.5.10",
+                "ansi-colors": "^4.1.3",
+                "axios": "^1.12.0",
+                "chalk": "3.0.0",
+                "fs-extra": "9.1.0",
+                "isomorphic-ws": "5.0.0",
+                "koa": "3.0.3",
+                "lodash.clonedeepwith": "4.5.0",
+                "log4js": "6.9.1",
+                "node-schedule": "2.1.1",
+                "rambda": "^9.1.0",
+                "ws": "8.18.0"
+            },
+            "peerDependencies": {
+                "typescript": "^4.9.0 || ^5.0.0",
+                "vue-tsc": ">=1.0.24"
+            },
+            "peerDependenciesMeta": {
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/enhanced": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.21.6.tgz",
+            "integrity": "sha512-8PFQxtmXc6ukBC4CqGIoc96M2Ly9WVwCPu4Ffvt+K/SB6rGbeFeZoYAwREV1zGNMJ5v5ly6+AHIEOBxNuSnzSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/bridge-react-webpack-plugin": "0.21.6",
+                "@module-federation/cli": "0.21.6",
+                "@module-federation/data-prefetch": "0.21.6",
+                "@module-federation/dts-plugin": "0.21.6",
+                "@module-federation/error-codes": "0.21.6",
+                "@module-federation/inject-external-runtime-core-plugin": "0.21.6",
+                "@module-federation/managers": "0.21.6",
+                "@module-federation/manifest": "0.21.6",
+                "@module-federation/rspack": "0.21.6",
+                "@module-federation/runtime-tools": "0.21.6",
+                "@module-federation/sdk": "0.21.6",
+                "btoa": "^1.2.1",
+                "schema-utils": "^4.3.0",
+                "upath": "2.0.1"
+            },
+            "bin": {
+                "mf": "bin/mf.js"
+            },
+            "peerDependencies": {
+                "typescript": "^4.9.0 || ^5.0.0",
+                "vue-tsc": ">=1.0.24",
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/error-codes": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.21.6.tgz",
+            "integrity": "sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==",
+            "license": "MIT"
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/inject-external-runtime-core-plugin": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.21.6.tgz",
+            "integrity": "sha512-DJQne7NQ988AVi3QB8byn12FkNb+C2lBeU1NRf8/WbL0gmHsr6kW8hiEJCm8LYaURwtsQqtsEV7i+8+51qjSmQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@module-federation/runtime-tools": "0.21.6"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/managers": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.21.6.tgz",
+            "integrity": "sha512-BeV6m2/7kF5MDVz9JJI5T8h8lMosnXkH2bOxxFewcra7ZjvDOgQu7WIio0mgk5l1zjNPvnEVKhnhrenEdcCiWg==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/sdk": "0.21.6",
+                "find-pkg": "2.0.0",
+                "fs-extra": "9.1.0"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/manifest": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.21.6.tgz",
+            "integrity": "sha512-yg93+I1qjRs5B5hOSvjbjmIoI2z3th8/yst9sfwvx4UDOG1acsE3HHMyPN0GdoIGwplC/KAnU5NmUz4tREUTGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/dts-plugin": "0.21.6",
+                "@module-federation/managers": "0.21.6",
+                "@module-federation/sdk": "0.21.6",
+                "chalk": "3.0.0",
+                "find-pkg": "2.0.0"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/rspack": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.21.6.tgz",
+            "integrity": "sha512-SB+z1P+Bqe3R6geZje9dp0xpspX6uash+zO77nodmUy8PTTBlkL7800Cq2FMLKUdoTZHJTBVXf0K6CqQWSlItg==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/bridge-react-webpack-plugin": "0.21.6",
+                "@module-federation/dts-plugin": "0.21.6",
+                "@module-federation/inject-external-runtime-core-plugin": "0.21.6",
+                "@module-federation/managers": "0.21.6",
+                "@module-federation/manifest": "0.21.6",
+                "@module-federation/runtime-tools": "0.21.6",
+                "@module-federation/sdk": "0.21.6",
+                "btoa": "1.2.1"
+            },
+            "peerDependencies": {
+                "@rspack/core": ">=0.7",
+                "typescript": "^4.9.0 || ^5.0.0",
+                "vue-tsc": ">=1.0.24"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/runtime": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.21.6.tgz",
+            "integrity": "sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.21.6",
+                "@module-federation/runtime-core": "0.21.6",
+                "@module-federation/sdk": "0.21.6"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/runtime-core": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.21.6.tgz",
+            "integrity": "sha512-5Hd1Y5qp5lU/aTiK66lidMlM/4ji2gr3EXAtJdreJzkY+bKcI5+21GRcliZ4RAkICmvdxQU5PHPL71XmNc7Lsw==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.21.6",
+                "@module-federation/sdk": "0.21.6"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/runtime-tools": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.21.6.tgz",
+            "integrity": "sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.21.6",
+                "@module-federation/webpack-bundler-runtime": "0.21.6"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/sdk": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
+            "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
+            "license": "MIT"
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/third-party-dts-extractor": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.21.6.tgz",
+            "integrity": "sha512-Il6x4hLsvCgZNk1DFwuMBNeoxD1BsZ5AW2BI/nUgu0k5FiAvfcz1OFawRFEHtaM/kVrCsymMOW7pCao90DaX3A==",
+            "license": "MIT",
+            "dependencies": {
+                "find-pkg": "2.0.0",
+                "fs-extra": "9.1.0",
+                "resolve": "1.22.8"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.21.6.tgz",
+            "integrity": "sha512-7zIp3LrcWbhGuFDTUMLJ2FJvcwjlddqhWGxi/MW3ur1a+HaO8v5tF2nl+vElKmbG1DFLU/52l3PElVcWf/YcsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.21.6",
+                "@module-federation/sdk": "0.21.6"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/@perses-dev/core": {
+            "version": "0.53.0-beta.4",
+            "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.53.0-beta.4.tgz",
+            "integrity": "sha512-f31l/80YHuU172BvhVLzuMShBNcv0ehMLX1K2xRIuXQ886ULwihB6Q1K6pm1duxP7KtQFFQHAgE5flKJ5gKboA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "date-fns": "^4.1.0",
+                "lodash": "^4.17.21",
+                "mathjs": "^10.6.4",
+                "numbro": "^2.3.6",
+                "zod": "^3.21.4"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/koa": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-3.0.3.tgz",
+            "integrity": "sha512-MeuwbCoN1daWS32/Ni5qkzmrOtQO2qrnfdxDHjrm6s4b59yG4nexAJ0pTEFyzjLp0pBVO80CZp0vW8Ze30Ebow==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^1.3.8",
+                "content-disposition": "~0.5.4",
+                "content-type": "^1.0.5",
+                "cookies": "~0.9.1",
+                "delegates": "^1.0.0",
+                "destroy": "^1.2.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "fresh": "~0.5.2",
+                "http-assert": "^1.5.0",
+                "http-errors": "^2.0.0",
+                "koa-compose": "^4.1.0",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@perses-dev/plugin-system/node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@remix-run/router": {
+            "version": "1.23.2",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+            "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rsbuild/core": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-1.7.2.tgz",
+            "integrity": "sha512-VAFO6cM+cyg2ntxNW6g3tB2Jc5J5mpLjLluvm7VtW2uceNzyUlVv41o66Yp1t1ikxd3ljtqegViXem62JqzveA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rspack/core": "~1.7.1",
+                "@rspack/lite-tapable": "~1.1.0",
+                "@swc/helpers": "^0.5.18",
+                "core-js": "~3.47.0",
+                "jiti": "^2.6.1"
+            },
+            "bin": {
+                "rsbuild": "bin/rsbuild.js"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@rsbuild/plugin-react": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/@rsbuild/plugin-react/-/plugin-react-1.4.3.tgz",
+            "integrity": "sha512-Uf9FkKk2TqYDbsypXHgjdivPmEoYFvBTHJT5fPmjCf0Sc3lR2BHtlc0WMdZTCKUJ5jTxREygMs9LbnehX98L8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rspack/plugin-react-refresh": "^1.5.3",
+                "react-refresh": "^0.18.0"
+            },
+            "peerDependencies": {
+                "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+            }
+        },
+        "node_modules/@rspack/binding": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.2.tgz",
+            "integrity": "sha512-bVssRQ39TgGA2RxKEbhUBKYRHln9sbBi0motHmqSU53aMnIkiLXjcj7tZC5dK7Okl2SrHM5KCYK9eG4UodDfdA==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "1.7.2",
+                "@rspack/binding-darwin-x64": "1.7.2",
+                "@rspack/binding-linux-arm64-gnu": "1.7.2",
+                "@rspack/binding-linux-arm64-musl": "1.7.2",
+                "@rspack/binding-linux-x64-gnu": "1.7.2",
+                "@rspack/binding-linux-x64-musl": "1.7.2",
+                "@rspack/binding-wasm32-wasi": "1.7.2",
+                "@rspack/binding-win32-arm64-msvc": "1.7.2",
+                "@rspack/binding-win32-ia32-msvc": "1.7.2",
+                "@rspack/binding-win32-x64-msvc": "1.7.2"
+            }
+        },
+        "node_modules/@rspack/binding-darwin-arm64": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.2.tgz",
+            "integrity": "sha512-EsmfzNZnuEhVPMX5jWATCHT2UCCBh6iqq448xUMmASDiKVbIOhUTN1ONTV+aMERYl7BgMNJn0iTis6ot2GWKIg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-darwin-x64": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.2.tgz",
+            "integrity": "sha512-lQLq0eNzFDzR31XD0H5oTG0y8cBoNF9hJ2gt1GgqMlYvaY+pMEeh7s4rTX1/M0c4gHpLudp86SsDuDJ53BwnaQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.2.tgz",
+            "integrity": "sha512-rtrsygVbDYw55ukdIk3NEwNQWkUemfRgeNOUvZ0k/6p7eP16020VPDvIqvcmyPtBhwFmz5vfo57GnBLisjM/kw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-musl": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.2.tgz",
+            "integrity": "sha512-zhh6ycumTHI7V/VOOT6DolvBe5RFG+Np/e5hhlhjEFtskraO9rkWg8knE9Ssu6a6Qdj4nGscqOj9ENNpc6gb+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.2.tgz",
+            "integrity": "sha512-ON9hy6OTpBOmmFp/51RPa0r9bDbZ3wTTubT54V+yhHuB+eSrlXQIOQScUGCGoGgqp6sLTwKjv2yy7YLyzd1gCA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-musl": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.2.tgz",
+            "integrity": "sha512-+2nnjwaSOStgLKtY5O7I3yfkwTkhiJLQ35CwQqWKRw+g1E4OFIKpXBfl34JDtrF/2DeS7sVVyLeuC25+43n9/A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-wasm32-wasi": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.2.tgz",
+            "integrity": "sha512-TU/aLBpm9CTR/RTLF27WlvBKGyju6gpiNTRd3XRbX2JfY3UBNUQN/Ev+gQMVeOj55y9Fruzou42/w9ncTKA0Dw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "1.0.7"
+            }
+        },
+        "node_modules/@rspack/binding-win32-arm64-msvc": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.2.tgz",
+            "integrity": "sha512-RReQN3AUu46XUZnOy5L/vSj5J+tcl/bzSnGQ2KetZ7dUOjGCC6c0Ki3EiklVM5OC1Agytz0Rz7cJqHJ+HaQbsA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-ia32-msvc": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.2.tgz",
+            "integrity": "sha512-EytrfT2sfUCnRMtXfSNv7AR65DWuY3dX/Bsn1TTin7CC6+RFEAP9nzHtCMISvFPp+c5bveok0/eY8j/f4LZ/Gg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-x64-msvc": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.2.tgz",
+            "integrity": "sha512-zLFt6cr55fjbIy6HT1xS2yLVmtvRjyZ0TbcRum7Ipp+s23gyGHVYNRuDMj34AHnhbCcX/XrxDTzCc4ba6xtYTw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/core": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.2.tgz",
+            "integrity": "sha512-Pm06phSQqbthbzl92KdnbXmwcnYRv3Ef86uE6hoADqVjsmt2WvJwNjpqgs0S6n+s9UL6QzxqaaAaKg5qeBT+3g==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime-tools": "0.22.0",
+                "@rspack/binding": "1.7.2",
+                "@rspack/lite-tapable": "1.1.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.1"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rspack/core/node_modules/@module-federation/error-codes": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+            "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+            "license": "MIT"
+        },
+        "node_modules/@rspack/core/node_modules/@module-federation/runtime": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+            "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.22.0",
+                "@module-federation/runtime-core": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
+            }
+        },
+        "node_modules/@rspack/core/node_modules/@module-federation/runtime-core": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+            "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
+            }
+        },
+        "node_modules/@rspack/core/node_modules/@module-federation/runtime-tools": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+            "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.22.0",
+                "@module-federation/webpack-bundler-runtime": "0.22.0"
+            }
+        },
+        "node_modules/@rspack/core/node_modules/@module-federation/sdk": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+            "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+            "license": "MIT"
+        },
+        "node_modules/@rspack/core/node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+            "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
+            }
+        },
+        "node_modules/@rspack/lite-tapable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+            "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+            "license": "MIT"
+        },
+        "node_modules/@rspack/plugin-react-refresh": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-1.6.0.tgz",
+            "integrity": "sha512-OO53gkrte/Ty4iRXxxM6lkwPGxsSsupFKdrPFnjwFIYrPvFLjeolAl5cTx+FzO5hYygJiGnw7iEKTmD+ptxqDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "error-stack-parser": "^2.1.4",
+                "html-entities": "^2.6.0"
+            },
+            "peerDependencies": {
+                "react-refresh": ">=0.10.0 <1.0.0",
+                "webpack-hot-middleware": "2.x"
+            },
+            "peerDependenciesMeta": {
+                "webpack-hot-middleware": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+            "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@swc/cli": {
+            "version": "0.7.10",
+            "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.7.10.tgz",
+            "integrity": "sha512-QQ36Q1VwGTT2YzvMeNe/j1x4DKS277DscNhWc57dIwQn//C+zAgvuSupMB/XkmYqPKQX+8hjn5/cHRJrMvWy0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@xhmikosr/bin-wrapper": "^13.0.5",
+                "commander": "^8.3.0",
+                "minimatch": "^9.0.3",
+                "piscina": "^4.3.1",
+                "semver": "^7.3.8",
+                "slash": "3.0.0",
+                "source-map": "^0.7.3",
+                "tinyglobby": "^0.2.13"
+            },
+            "bin": {
+                "spack": "bin/spack.js",
+                "swc": "bin/swc.js",
+                "swcx": "bin/swcx.js"
+            },
+            "engines": {
+                "node": ">= 16.14.0"
+            },
+            "peerDependencies": {
+                "@swc/core": "^1.2.66",
+                "chokidar": "^4.0.1"
+            },
+            "peerDependenciesMeta": {
+                "chokidar": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@swc/cli/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@swc/core": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.10.tgz",
+            "integrity": "sha512-udNofxftduMUEv7nqahl2nvodCiCDQ4Ge0ebzsEm6P8s0RC2tBM0Hqx0nNF5J/6t9uagFJyWIDjXy3IIWMHDJw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.25"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.15.10",
+                "@swc/core-darwin-x64": "1.15.10",
+                "@swc/core-linux-arm-gnueabihf": "1.15.10",
+                "@swc/core-linux-arm64-gnu": "1.15.10",
+                "@swc/core-linux-arm64-musl": "1.15.10",
+                "@swc/core-linux-x64-gnu": "1.15.10",
+                "@swc/core-linux-x64-musl": "1.15.10",
+                "@swc/core-win32-arm64-msvc": "1.15.10",
+                "@swc/core-win32-ia32-msvc": "1.15.10",
+                "@swc/core-win32-x64-msvc": "1.15.10"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.17"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.10.tgz",
+            "integrity": "sha512-U72pGqmJYbjrLhMndIemZ7u9Q9owcJczGxwtfJlz/WwMaGYAV/g4nkGiUVk/+QSX8sFCAjanovcU1IUsP2YulA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.10.tgz",
+            "integrity": "sha512-NZpDXtwHH083L40xdyj1sY31MIwLgOxKfZEAGCI8xHXdHa+GWvEiVdGiu4qhkJctoHFzAEc7ZX3GN5phuJcPuQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.10.tgz",
+            "integrity": "sha512-ioieF5iuRziUF1HkH1gg1r93e055dAdeBAPGAk40VjqpL5/igPJ/WxFHGvc6WMLhUubSJI4S0AiZAAhEAp1jDg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.10.tgz",
+            "integrity": "sha512-tD6BClOrxSsNus9cJL7Gxdv7z7Y2hlyvZd9l0NQz+YXzmTWqnfzLpg16ovEI7gknH2AgDBB5ywOsqu8hUgSeEQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.10.tgz",
+            "integrity": "sha512-4uAHO3nbfbrTcmO/9YcVweTQdx5fN3l7ewwl5AEK4yoC4wXmoBTEPHAVdKNe4r9+xrTgd4BgyPsy0409OjjlMw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.10.tgz",
+            "integrity": "sha512-W0h9ONNw1pVIA0cN7wtboOSTl4Jk3tHq+w2cMPQudu9/+3xoCxpFb9ZdehwCAk29IsvdWzGzY6P7dDVTyFwoqg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.10.tgz",
+            "integrity": "sha512-XQNZlLZB62S8nAbw7pqoqwy91Ldy2RpaMRqdRN3T+tAg6Xg6FywXRKCsLh6IQOadr4p1+lGnqM/Wn35z5a/0Vw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.10.tgz",
+            "integrity": "sha512-qnAGrRv5Nj/DATxAmCnJQRXXQqnJwR0trxLndhoHoxGci9MuguNIjWahS0gw8YZFjgTinbTxOwzatkoySihnmw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.10.tgz",
+            "integrity": "sha512-i4X/q8QSvzVlaRtv1xfnfl+hVKpCfiJ+9th484rh937fiEZKxZGf51C+uO0lfKDP1FfnT6C1yBYwHy7FLBVXFw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.10.tgz",
+            "integrity": "sha512-HvY8XUFuoTXn6lSccDLYFlXv1SU/PzYi4PyUqGT++WfTnbw/68N/7BdUZqglGRwiSqr0qhYt/EhmBpULj0J9rA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.18",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+            "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@swc/types": {
+            "version": "0.1.25",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+            "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            }
+        },
+        "node_modules/@szmarczak/http-timer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "defer-to-connect": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/@tanstack/query-core": {
+            "version": "4.41.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.41.1.tgz",
+            "integrity": "sha512-XZvEw2OT+Nmi+ByQjURv3ckxRfzbYXSL6Hb60lgEn4GqUXz8HQTFdySvcSuCdxashqkBLrDvn9NwOhAbMTe9ow==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/react-query": {
+            "version": "4.42.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.42.2.tgz",
+            "integrity": "sha512-KFqT8wb/d0bHbzvJEuD/vEU8lUSC5cZDurOMtAR3G+mUABqVWvVswQ/norjFXedjQe+nfQQ9CWrOabWcRP3TKA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@tanstack/query-core": "4.41.1",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-native": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tanstack/react-table": {
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+            "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/table-core": "8.21.3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
+        "node_modules/@tanstack/table-core": {
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+            "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tokenizer/inflate": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+            "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "fflate": "^0.8.2",
+                "token-types": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/http-cache-semantics": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/parse-json": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.3.27",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+            "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
+            }
+        },
+        "node_modules/@types/react-grid-layout": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.6.tgz",
+            "integrity": "sha512-Cw7+sb3yyjtmxwwJiXtEXcu5h4cgs+sCGkHwHXsFmPyV30bf14LeD/fa2LwQovuD2HWxCcjIdNhDlcYGj95qGA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@types/react-transition-group": {
+            "version": "4.4.12",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+            "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@types/semver": {
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+            "license": "MIT"
+        },
+        "node_modules/@uiw/codemirror-extensions-basic-setup": {
+            "version": "4.25.4",
+            "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.4.tgz",
+            "integrity": "sha512-YzNwkm0AbPv1EXhCHYR5v0nqfemG2jEB0Z3Att4rBYqKrlG7AA9Rhjc3IyBaOzsBu18wtrp9/+uhTyu7TXSRng==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.0.0",
+                "@codemirror/commands": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/lint": "^6.0.0",
+                "@codemirror/search": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
+            },
+            "peerDependencies": {
+                "@codemirror/autocomplete": ">=6.0.0",
+                "@codemirror/commands": ">=6.0.0",
+                "@codemirror/language": ">=6.0.0",
+                "@codemirror/lint": ">=6.0.0",
+                "@codemirror/search": ">=6.0.0",
+                "@codemirror/state": ">=6.0.0",
+                "@codemirror/view": ">=6.0.0"
+            }
+        },
+        "node_modules/@uiw/react-codemirror": {
+            "version": "4.25.4",
+            "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.4.tgz",
+            "integrity": "sha512-ipO067oyfUw+DVaXhQCxkB0ZD9b7RnY+ByrprSYSKCHaULvJ3sqWYC/Zen6zVQ8/XC4o5EPBfatGiX20kC7XGA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@codemirror/commands": "^6.1.0",
+                "@codemirror/state": "^6.1.1",
+                "@codemirror/theme-one-dark": "^6.0.0",
+                "@uiw/codemirror-extensions-basic-setup": "4.25.4",
+                "codemirror": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
+            },
+            "peerDependencies": {
+                "@babel/runtime": ">=7.11.0",
+                "@codemirror/state": ">=6.0.0",
+                "@codemirror/theme-one-dark": ">=6.0.0",
+                "@codemirror/view": ">=6.0.0",
+                "codemirror": ">=6.0.0",
+                "react": ">=17.0.0",
+                "react-dom": ">=17.0.0"
+            }
+        },
+        "node_modules/@xhmikosr/archive-type": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-7.1.0.tgz",
+            "integrity": "sha512-xZEpnGplg1sNPyEgFh0zbHxqlw5dtYg6viplmWSxUj12+QjU9SKu3U/2G73a15pEjLaOqTefNSZ1fOPUOT4Xgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "file-type": "^20.5.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/bin-check": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-7.1.0.tgz",
+            "integrity": "sha512-y1O95J4mnl+6MpVmKfMYXec17hMEwE/yeCglFNdx+QvLLtP0yN4rSYcbkXnth+lElBuKKek2NbvOfOGPpUXCvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "isexe": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/bin-wrapper": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-13.2.0.tgz",
+            "integrity": "sha512-t9U9X0sDPRGDk5TGx4dv5xiOvniVJpXnfTuynVKwHgtib95NYEw4MkZdJqhoSiz820D9m0o6PCqOPMXz0N9fIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/bin-check": "^7.1.0",
+                "@xhmikosr/downloader": "^15.2.0",
+                "@xhmikosr/os-filter-obj": "^3.0.0",
+                "bin-version-check": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/decompress": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-10.2.0.tgz",
+            "integrity": "sha512-MmDBvu0+GmADyQWHolcZuIWffgfnuTo4xpr2I/Qw5Ox0gt+e1Be7oYqJM4te5ylL6mzlcoicnHVDvP27zft8tg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/decompress-tar": "^8.1.0",
+                "@xhmikosr/decompress-tarbz2": "^8.1.0",
+                "@xhmikosr/decompress-targz": "^8.1.0",
+                "@xhmikosr/decompress-unzip": "^7.1.0",
+                "graceful-fs": "^4.2.11",
+                "strip-dirs": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/decompress-tar": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-8.1.0.tgz",
+            "integrity": "sha512-m0q8x6lwxenh1CrsTby0Jrjq4vzW/QU1OLhTHMQLEdHpmjR1lgahGz++seZI0bXF3XcZw3U3xHfqZSz+JPP2Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "file-type": "^20.5.0",
+                "is-stream": "^2.0.1",
+                "tar-stream": "^3.1.7"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/decompress-tarbz2": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-8.1.0.tgz",
+            "integrity": "sha512-aCLfr3A/FWZnOu5eqnJfme1Z1aumai/WRw55pCvBP+hCGnTFrcpsuiaVN5zmWTR53a8umxncY2JuYsD42QQEbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/decompress-tar": "^8.0.1",
+                "file-type": "^20.5.0",
+                "is-stream": "^2.0.1",
+                "seek-bzip": "^2.0.0",
+                "unbzip2-stream": "^1.4.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/decompress-targz": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-8.1.0.tgz",
+            "integrity": "sha512-fhClQ2wTmzxzdz2OhSQNo9ExefrAagw93qaG1YggoIz/QpI7atSRa7eOHv4JZkpHWs91XNn8Hry3CwUlBQhfPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/decompress-tar": "^8.0.1",
+                "file-type": "^20.5.0",
+                "is-stream": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/decompress-unzip": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-7.1.0.tgz",
+            "integrity": "sha512-oqTYAcObqTlg8owulxFTqiaJkfv2SHsxxxz9Wg4krJAHVzGWlZsU8tAB30R6ow+aHrfv4Kub6WQ8u04NWVPUpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "file-type": "^20.5.0",
+                "get-stream": "^6.0.1",
+                "yauzl": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/downloader": {
+            "version": "15.2.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-15.2.0.tgz",
+            "integrity": "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xhmikosr/archive-type": "^7.1.0",
+                "@xhmikosr/decompress": "^10.2.0",
+                "content-disposition": "^0.5.4",
+                "defaults": "^2.0.2",
+                "ext-name": "^5.0.0",
+                "file-type": "^20.5.0",
+                "filenamify": "^6.0.0",
+                "get-stream": "^6.0.1",
+                "got": "^13.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@xhmikosr/os-filter-obj": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@xhmikosr/os-filter-obj/-/os-filter-obj-3.0.0.tgz",
+            "integrity": "sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "arch": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.14.0 || >=16.0.0"
+            }
+        },
+        "node_modules/accepts": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/adm-zip": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/arch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+            "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
+        },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/axios": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.4",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/babel-plugin-macros": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/bare-events": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+            "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/bignumber.js": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/bin-version": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
+            "integrity": "sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^5.0.0",
+                "find-versions": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bin-version-check": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-5.1.0.tgz",
+            "integrity": "sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bin-version": "^6.0.0",
+                "semver": "^7.5.3",
+                "semver-truncate": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bind-event-listener": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+            "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/btoa": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+            "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+            "license": "(MIT OR Apache-2.0)",
+            "bin": {
+                "btoa": "bin/btoa.js"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/cache-content-type": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+            "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^2.1.18",
+                "ylru": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/cacheable-lookup": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/cacheable-request": {
+            "version": "10.2.14",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+            "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-cache-semantics": "^4.0.2",
+                "get-stream": "^6.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "keyv": "^4.5.3",
+                "mimic-response": "^4.0.0",
+                "normalize-url": "^8.0.0",
+                "responselike": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/codemirror": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+            "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.0.0",
+                "@codemirror/commands": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/lint": "^6.0.0",
+                "@codemirror/search": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/complex.js": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.3.tgz",
+            "integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/rawify"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "license": "MIT"
+        },
+        "node_modules/cookies": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+            "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "keygrip": "~1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/core-js": {
+            "version": "3.47.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+            "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
+        },
+        "node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/crelt": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+            "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+            "license": "MIT"
+        },
+        "node_modules/cron-parser": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+            "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+            "license": "MIT",
+            "dependencies": {
+                "luxon": "^3.2.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "license": "MIT"
+        },
+        "node_modules/date-fns": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
+            }
+        },
+        "node_modules/date-fns-tz": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+            "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "date-fns": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "node_modules/date-format": {
+            "version": "4.0.14",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+            "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "license": "MIT"
+        },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decompress-response/node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/deep-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+            "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+            "license": "MIT"
+        },
+        "node_modules/defaults": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.2.tgz",
+            "integrity": "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/defer-to-connect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+            "license": "MIT"
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/destroy": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/dom-helpers": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/echarts": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+            "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "2.3.0",
+                "zrender": "5.5.0"
+            }
+        },
+        "node_modules/echarts/node_modules/tslib": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+            "license": "0BSD"
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/error-stack-parser": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+            "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "stackframe": "^1.3.4"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
+        },
+        "node_modules/escape-latex": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+            "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
+            "license": "MIT"
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-events": "^2.7.0"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+            "license": "MIT",
+            "dependencies": {
+                "homedir-polyfill": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ext-list": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+            "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.28.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ext-name": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+            "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ext-list": "^2.0.0",
+                "sort-keys-length": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "license": "MIT"
+        },
+        "node_modules/fast-equals": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+            "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+            "license": "MIT"
+        },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/file-type": {
+            "version": "20.5.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+            "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/inflate": "^0.2.6",
+                "strtok3": "^10.2.0",
+                "token-types": "^6.0.0",
+                "uint8array-extras": "^1.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
+        },
+        "node_modules/filename-reserved-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+            "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/filenamify": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+            "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "filename-reserved-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-file-up": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-2.0.1.tgz",
+            "integrity": "sha512-qVdaUhYO39zmh28/JLQM5CoYN9byEOKEH4qfa8K1eNV17W0UUMJ9WgbR/hHFH+t5rcl+6RTb5UC7ck/I+uRkpQ==",
+            "license": "MIT",
+            "dependencies": {
+                "resolve-dir": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-pkg": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-2.0.0.tgz",
+            "integrity": "sha512-WgZ+nKbELDa6N3i/9nrHeNznm+lY3z4YfhDDWgW+5P0pdmMj26bxaxU11ookgY3NyP9GC7HvZ9etp0jRFqGEeQ==",
+            "license": "MIT",
+            "dependencies": {
+                "find-file-up": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "license": "MIT"
+        },
+        "node_modules/find-versions": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
+            "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver-regex": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "license": "ISC"
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/form-data-encoder": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+            "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.17"
+            }
+        },
+        "node_modules/fraction.js": {
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "type": "patreon",
+                "url": "https://github.com/sponsors/rawify"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/generator-function": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "license": "MIT",
+            "dependencies": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+            "license": "MIT",
+            "dependencies": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/global-prefix/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/goober": {
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+            "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "csstype": "^3.0.10"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/got": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+            "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/is": "^5.2.0",
+                "@szmarczak/http-timer": "^5.0.1",
+                "cacheable-lookup": "^7.0.0",
+                "cacheable-request": "^10.2.8",
+                "decompress-response": "^6.0.0",
+                "form-data-encoder": "^2.1.2",
+                "get-stream": "^6.0.1",
+                "http2-wrapper": "^2.1.10",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^3.0.0",
+                "responselike": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "license": "ISC"
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/hoist-non-react-statics/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "license": "MIT",
+            "dependencies": {
+                "parse-passwd": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/html-entities": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+            "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/mdevils"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://patreon.com/mdevils"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/http-assert": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+            "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+            "license": "MIT",
+            "dependencies": {
+                "deep-equal": "~1.0.1",
+                "http-errors": "~1.8.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/http-errors": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+            "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/http-errors/node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/http2-wrapper": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "quick-lru": "^5.1.1",
+                "resolve-alpn": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=10.19.0"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/immer": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
+        },
+        "node_modules/inspect-with-kind": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
+            "integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "kind-of": "^6.0.2"
+            }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "license": "MIT"
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4",
+                "generator-function": "^2.0.0",
+                "get-proto": "^1.0.1",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
+        "node_modules/isomorphic-rslog": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
+            "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.17.6"
+            }
+        },
+        "node_modules/isomorphic-ws": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+            "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "ws": "*"
+            }
+        },
+        "node_modules/javascript-natural-sort": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "license": "MIT"
+        },
+        "node_modules/jiti": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
+        "node_modules/jsonfile": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/keygrip": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+            "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "license": "MIT",
+            "dependencies": {
+                "tsscmp": "1.0.6"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/koa": {
+            "version": "2.15.3",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
+            "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^1.3.5",
+                "cache-content-type": "^1.0.0",
+                "content-disposition": "~0.5.2",
+                "content-type": "^1.0.4",
+                "cookies": "~0.9.0",
+                "debug": "^4.3.2",
+                "delegates": "^1.0.0",
+                "depd": "^2.0.0",
+                "destroy": "^1.0.4",
+                "encodeurl": "^1.0.2",
+                "escape-html": "^1.0.3",
+                "fresh": "~0.5.2",
+                "http-assert": "^1.3.0",
+                "http-errors": "^1.6.3",
+                "is-generator-function": "^1.0.7",
+                "koa-compose": "^4.1.0",
+                "koa-convert": "^2.0.0",
+                "on-finished": "^2.3.0",
+                "only": "~0.0.2",
+                "parseurl": "^1.3.2",
+                "statuses": "^1.5.0",
+                "type-is": "^1.6.16",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+            }
+        },
+        "node_modules/koa-compose": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+            "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+            "license": "MIT"
+        },
+        "node_modules/koa-convert": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+            "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "co": "^4.6.0",
+                "koa-compose": "^4.1.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.clonedeepwith": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
+            "integrity": "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==",
+            "license": "MIT"
+        },
+        "node_modules/log4js": {
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
+            "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "date-format": "^4.0.14",
+                "debug": "^4.3.4",
+                "flatted": "^3.2.7",
+                "rfdc": "^1.3.0",
+                "streamroller": "^3.1.5"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/long-timeout": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+            "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+            "license": "MIT"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lowercase-keys": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "11.2.4",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/luxon": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mathjs": {
+            "version": "10.6.4",
+            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.6.4.tgz",
+            "integrity": "sha512-omQyvRE1jIy+3k2qsqkWASOcd45aZguXZDckr3HtnTYyXk5+2xpVfC3kATgbO2Srjxlqww3TVdhD0oUdZ/hiFA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "complex.js": "^2.1.1",
+                "decimal.js": "^10.3.1",
+                "escape-latex": "^1.2.0",
+                "fraction.js": "^4.2.0",
+                "javascript-natural-sort": "^0.7.1",
+                "seedrandom": "^3.0.5",
+                "tiny-emitter": "^2.1.0",
+                "typed-function": "^2.1.0"
+            },
+            "bin": {
+                "mathjs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/mdi-material-ui": {
+            "version": "7.9.4",
+            "resolved": "https://registry.npmjs.org/mdi-material-ui/-/mdi-material-ui-7.9.4.tgz",
+            "integrity": "sha512-bk+3A6ogY3r/TveGgD/PRhFkqctG3XmPPm5rTuj81aoYuv1xw4T3Ml+A/PsrCWhbgicZbGbC6r0jYg5vcFTTXQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@mui/material": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/mimic-response": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-schedule": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
+            "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "cron-parser": "^4.2.0",
+                "long-timeout": "0.1.1",
+                "sorted-array-functions": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/normalize-url": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+            "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/notistack": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
+            "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
+            "license": "MIT",
+            "dependencies": {
+                "clsx": "^1.1.0",
+                "goober": "^2.0.33"
+            },
+            "engines": {
+                "node": ">=12.0.0",
+                "npm": ">=6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/notistack"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/notistack/node_modules/clsx": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/numbro": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.5.0.tgz",
+            "integrity": "sha512-xDcctDimhzko/e+y+Q2/8i3qNC9Svw1QgOkSkQoO0kIPI473tR9QRbo2KP88Ty9p8WbPy+3OpTaAIzehtuHq+A==",
+            "license": "MIT",
+            "dependencies": {
+                "bignumber.js": "^8 || ^9"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/only": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+            "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+            "dev": true
+        },
+        "node_modules/p-cancelable": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+            "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20"
+            }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/piscina": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.2.tgz",
+            "integrity": "sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "@napi-rs/nice": "^1.0.1"
+            }
+        },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
+        "node_modules/prop-types/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
+        },
+        "node_modules/qs": {
+            "version": "6.14.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/raf-schd": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+            "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+            "license": "MIT"
+        },
+        "node_modules/rambda": {
+            "version": "9.4.2",
+            "resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
+            "integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
+            "license": "MIT"
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-colorful": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+            "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-draggable": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+            "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+            "license": "MIT",
+            "dependencies": {
+                "clsx": "^2.1.1",
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "react": ">= 16.3.0",
+                "react-dom": ">= 16.3.0"
+            }
+        },
+        "node_modules/react-error-boundary": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+            "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "react": ">=16.13.1"
+            }
+        },
+        "node_modules/react-grid-layout": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.3.tgz",
+            "integrity": "sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==",
+            "license": "MIT",
+            "dependencies": {
+                "clsx": "^2.1.1",
+                "fast-equals": "^4.0.3",
+                "prop-types": "^15.8.1",
+                "react-draggable": "^4.4.6",
+                "react-resizable": "^3.0.5",
+                "resize-observer-polyfill": "^1.5.1"
+            },
+            "peerDependencies": {
+                "react": ">= 16.3.0",
+                "react-dom": ">= 16.3.0"
+            }
+        },
+        "node_modules/react-hook-form": {
+            "version": "7.71.1",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+            "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/react-hook-form"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17 || ^18 || ^19"
+            }
+        },
+        "node_modules/react-intersection-observer": {
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+            "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-is": {
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
+            "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
+            "license": "MIT"
+        },
+        "node_modules/react-refresh": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+            "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-resizable": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.1.3.tgz",
+            "integrity": "sha512-liJBNayhX7qA4tBJiBD321FDhJxgGTJ07uzH5zSORXoE8h7PyEZ8mLqmosST7ppf6C4zUsbd2gzDMmBCfFp9Lw==",
+            "license": "MIT",
+            "dependencies": {
+                "prop-types": "15.x",
+                "react-draggable": "^4.5.0"
+            },
+            "peerDependencies": {
+                "react": ">= 16.3",
+                "react-dom": ">= 16.3"
+            }
+        },
+        "node_modules/react-router": {
+            "version": "6.30.3",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+            "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+            "license": "MIT",
+            "dependencies": {
+                "@remix-run/router": "1.23.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
+            }
+        },
+        "node_modules/react-router-dom": {
+            "version": "6.30.3",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+            "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+            "license": "MIT",
+            "dependencies": {
+                "@remix-run/router": "1.23.2",
+                "react-router": "6.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
+        "node_modules/react-transition-group": {
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.6.0",
+                "react-dom": ">=16.6.0"
+            }
+        },
+        "node_modules/react-virtuoso": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.1.tgz",
+            "integrity": "sha512-KF474cDwaSb9+SJ380xruBB4P+yGWcVkcu26HtMqYNMTYlYbrNy8vqMkE+GpAApPPufJqgOLMoWMFG/3pJMXUA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16 || >=17 || >= 18 || >= 19",
+                "react-dom": ">=16 || >=17 || >= 18 || >=19"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resize-observer-polyfill": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+            "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+            "license": "MIT"
+        },
+        "node_modules/resolve": {
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-alpn": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+            "license": "MIT",
+            "dependencies": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/responselike": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lowercase-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/rfdc": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "license": "MIT"
+        },
+        "node_modules/rimraf": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-regex": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/seedrandom": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+            "license": "MIT"
+        },
+        "node_modules/seek-bzip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
+            "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^6.0.0"
+            },
+            "bin": {
+                "seek-bunzip": "bin/seek-bunzip",
+                "seek-table": "bin/seek-bzip-table"
+            }
+        },
+        "node_modules/seek-bzip/node_modules/commander": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/semver-regex": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+            "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semver-truncate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-3.0.0.tgz",
+            "integrity": "sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/serialize-query-params": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.4.tgz",
+            "integrity": "sha512-y9WzzDj3BsGgKLCh0ugiinufS//YqOfao/yVJjkXA4VLuyNCfHOLU/cbulGPxs3aeCqhvROw7qPL04JSZnCo0w==",
+            "license": "ISC"
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-plain-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sort-keys-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+            "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sort-keys": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sorted-array-functions": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+            "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
+            "license": "MIT"
+        },
+        "node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stackframe": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/streamroller": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+            "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
+            "license": "MIT",
+            "dependencies": {
+                "date-format": "^4.0.14",
+                "debug": "^4.3.4",
+                "fs-extra": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/streamroller/node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/streamroller/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/streamroller/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/streamx": {
+            "version": "2.23.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+            "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "events-universal": "^1.0.0",
+                "fast-fifo": "^1.3.2",
+                "text-decoder": "^1.1.0"
+            }
+        },
+        "node_modules/strip-dirs": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-3.0.0.tgz",
+            "integrity": "sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "inspect-with-kind": "^1.0.5",
+                "is-plain-obj": "^1.1.0"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/strtok3": {
+            "version": "10.3.4",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+            "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/style-mod": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+            "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+            "license": "MIT"
+        },
+        "node_modules/stylis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+            "license": "MIT"
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
+            }
+        },
+        "node_modules/tar-stream/node_modules/b4a": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/text-decoder": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "b4a": "^1.6.4"
+            }
+        },
+        "node_modules/text-decoder/node_modules/b4a": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tiny-emitter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+            "license": "MIT"
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/token-types": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+            "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@borewit/text-codec": "^0.2.1",
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "devOptional": true,
+            "license": "0BSD"
+        },
+        "node_modules/tsscmp": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+            "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.x"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/typed-function": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
+            "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.4.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/unbzip2-stream": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.2.1",
+                "through": "^2.3.8"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/upath": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+            "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4",
+                "yarn": "*"
+            }
+        },
+        "node_modules/use-immer": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.11.0.tgz",
+            "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "immer": ">=8.0.0",
+                "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/use-query-params": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.2.2.tgz",
+            "integrity": "sha512-OwGab8u8/x2xZp9uSyBsx0kXlkR9IR436zbygsYVGikPYY3OJosvve6IJVGwIJPcfyb/YHwvPrUNu65/JR++Kw==",
+            "license": "ISC",
+            "dependencies": {
+                "serialize-query-params": "^2.0.3"
+            },
+            "peerDependencies": {
+                "@reach/router": "^1.2.1",
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0",
+                "react-router-dom": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "@reach/router": {
+                    "optional": true
+                },
+                "react-router-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-resize-observer": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+            "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+            "license": "MIT",
+            "dependencies": {
+                "@juggle/resize-observer": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": "16.8.0 - 18",
+                "react-dom": "16.8.0 - 18"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/w3c-keyname": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+            "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+            "license": "MIT"
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/yaml": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+            "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "pend": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/ylru": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+            "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zrender": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+            "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tslib": "2.3.0"
+            }
+        },
+        "node_modules/zrender/node_modules/tslib": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+            "license": "0BSD"
+        },
+        "node_modules/zustand": {
+            "version": "4.5.7",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+            "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+            "license": "MIT",
+            "dependencies": {
+                "use-sync-external-store": "^1.2.2"
+            },
+            "engines": {
+                "node": ">=12.7.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16.8",
+                "immer": ">=9.0.6",
+                "react": ">=16.8"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
+            }
+        }
+    }
+}

--- a/contrib/plugins/opengemini/package.json
+++ b/contrib/plugins/opengemini/package.json
@@ -1,0 +1,67 @@
+{
+    "name": "@perses-dev/opengemini-plugin",
+    "version": "0.1.0",
+    "description": "OpenGemini datasource and query plugins for Perses",
+    "license": "Apache-2.0",
+    "main": "./lib/cjs/index.js",
+    "types": "./lib/cjs/index.d.ts",
+    "files": [
+        "lib",
+        "schemas"
+    ],
+    "scripts": {
+        "clean": "rimraf dist/ lib/",
+        "build": "npm run build:lib && npm run build:plugin",
+        "build:lib": "swc ./src -d lib/cjs --config-file ../.cjs.swcrc && tsc --project tsconfig.build.json",
+        "build:plugin": "rsbuild build",
+        "start": "rsbuild dev",
+        "type-check": "tsc --noEmit",
+        "test": "cross-env TZ=UTC jest",
+        "lint": "eslint src --ext .ts,.tsx",
+        "lint:fix": "eslint --fix src --ext .ts,.tsx"
+    },
+    "dependencies": {
+        "@emotion/react": "^11.9.3",
+        "@emotion/styled": "^11.9.3",
+        "@mui/material": "^6.1.10",
+        "@perses-dev/components": "0.53.0-rc.1",
+        "@perses-dev/core": "0.53.0-rc.0",
+        "@perses-dev/dashboards": "0.53.0-rc.1",
+        "@perses-dev/explore": "0.53.0-rc.1",
+        "@perses-dev/plugin-system": "0.53.0-rc.1",
+        "lodash": "^4.17.21",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-router-dom": "^6.30.1",
+        "use-resize-observer": "^9.0.0"
+    },
+    "devDependencies": {
+        "@module-federation/enhanced": "^0.8.8",
+        "@rsbuild/core": "^1.3.21",
+        "@rsbuild/plugin-react": "^1.3.3",
+        "@swc/cli": "^0.7.8",
+        "@swc/core": "^1.3.61",
+        "@types/lodash": "^4.14.182",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "cross-env": "^7.0.3",
+        "rimraf": "^6.1.0",
+        "typescript": "5.4.5"
+    },
+    "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+    },
+    "perses": {
+        "plugins": [
+            {
+                "kind": "Datasource",
+                "name": "OpenGeminiDatasource"
+            },
+            {
+                "kind": "TimeSeriesQuery",
+                "name": "OpenGeminiTimeSeriesQuery"
+            }
+        ]
+    }
+}

--- a/contrib/plugins/opengemini/rsbuild.config.ts
+++ b/contrib/plugins/opengemini/rsbuild.config.ts
@@ -1,0 +1,78 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+
+export default defineConfig({
+    plugins: [pluginReact()],
+    source: {
+        entry: {
+            index: './src/index.ts',
+        },
+    },
+    output: {
+        distPath: {
+            root: 'dist',
+        },
+    },
+    tools: {
+        rspack: {
+            output: {
+                uniqueName: '@perses-dev/opengemini-plugin',
+            },
+            plugins: [
+                new ModuleFederationPlugin({
+                    name: 'opengemini',
+                    filename: '__mf/remoteEntry.js',
+                    exposes: {
+                        './OpenGeminiDatasource': './src/datasources/opengemini-datasource/OpenGeminiDatasource.tsx',
+                        './OpenGeminiTimeSeriesQuery': './src/queries/opengemini-time-series-query/OpenGeminiTimeSeriesQuery.tsx',
+                    },
+                    shared: {
+                        react: {
+                            singleton: true,
+                            requiredVersion: '^18.0.0',
+                        },
+                        'react-dom': {
+                            singleton: true,
+                            requiredVersion: '^18.0.0',
+                        },
+                        '@emotion/react': {
+                            singleton: true,
+                        },
+                        '@emotion/styled': {
+                            singleton: true,
+                        },
+                        '@mui/material': {
+                            singleton: true,
+                        },
+                        '@perses-dev/core': {
+                            singleton: true,
+                        },
+                        '@perses-dev/components': {
+                            singleton: true,
+                        },
+                        '@perses-dev/plugin-system': {
+                            singleton: true,
+                        },
+                    },
+                }),
+            ],
+        },
+    },
+    server: {
+        port: 3100,
+    },
+});

--- a/contrib/plugins/opengemini/schemas/datasources/opengemini-datasource/opengemini-datasource.cue
+++ b/contrib/plugins/opengemini/schemas/datasources/opengemini-datasource/opengemini-datasource.cue
@@ -1,0 +1,32 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/perses/perses/cue/common"
+	commonProxy "github.com/perses/perses/cue/common/proxy"
+)
+
+kind: "OpenGeminiDatasource"
+spec: {
+	#directUrl | #proxy
+}
+
+#directUrl: {
+	directUrl: common.#url
+}
+
+#proxy: {
+	proxy: commonProxy.#HTTPProxy
+}

--- a/contrib/plugins/opengemini/schemas/datasources/opengemini-datasource/opengemini-datasource.json
+++ b/contrib/plugins/opengemini/schemas/datasources/opengemini-datasource/opengemini-datasource.json
@@ -1,0 +1,6 @@
+{
+    "kind": "OpenGeminiDatasource",
+    "spec": {
+        "directUrl": "http://localhost:8086"
+    }
+}

--- a/contrib/plugins/opengemini/schemas/queries/opengemini-time-series-query/query.cue
+++ b/contrib/plugins/opengemini/schemas/queries/opengemini-time-series-query/query.cue
@@ -1,0 +1,29 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"strings"
+)
+
+kind: "OpenGeminiTimeSeriesQuery"
+spec: close({
+	datasource?: {
+		kind: "OpenGeminiDatasource"
+	}
+	// InfluxQL query string
+	query: strings.MinRunes(1)
+	// Database name to query
+	database: strings.MinRunes(1)
+})

--- a/contrib/plugins/opengemini/src/datasources/index.ts
+++ b/contrib/plugins/opengemini/src/datasources/index.ts
@@ -1,0 +1,14 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './opengemini-datasource';

--- a/contrib/plugins/opengemini/src/datasources/opengemini-datasource/OpenGeminiDatasource.tsx
+++ b/contrib/plugins/opengemini/src/datasources/opengemini-datasource/OpenGeminiDatasource.tsx
@@ -1,0 +1,90 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fetch } from '@perses-dev/core';
+import { DatasourcePlugin } from '@perses-dev/plugin-system';
+import {
+    OpenGeminiDatasourceSpec,
+    OpenGeminiClient,
+    OpenGeminiQueryParams,
+    OpenGeminiQueryResponse,
+} from './opengemini-datasource-types';
+import { OpenGeminiDatasourceEditor } from './OpenGeminiDatasourceEditor';
+
+/**
+ * Creates an OpenGemini client that connects to the OpenGemini HTTP API.
+ * OpenGemini is InfluxDB v1.x compatible, so we use the standard /query endpoint.
+ */
+const createClient: DatasourcePlugin<OpenGeminiDatasourceSpec, OpenGeminiClient>['createClient'] = (spec, options) => {
+    const { directUrl, proxy } = spec;
+    const { proxyUrl } = options;
+
+    // Use the direct URL if specified, but fallback to the proxyUrl by default if not specified
+    const datasourceUrl = directUrl ?? proxyUrl;
+    if (datasourceUrl === undefined) {
+        throw new Error(
+            'No URL specified for OpenGemini client. You can use directUrl in the spec to configure it.'
+        );
+    }
+
+    const specHeaders = proxy?.spec.headers;
+
+    return {
+        options: {
+            datasourceUrl,
+        },
+        query: async (params: OpenGeminiQueryParams, headers): Promise<OpenGeminiQueryResponse> => {
+            // Build the query URL with parameters
+            const queryParams = new URLSearchParams({
+                db: params.db,
+                q: params.q,
+            });
+
+            if (params.epoch) {
+                queryParams.set('epoch', params.epoch);
+            }
+
+            const url = `${datasourceUrl}/query?${queryParams.toString()}`;
+
+            const init = {
+                method: 'GET',
+                headers: headers ?? specHeaders,
+            };
+
+            const response = await fetch(url, init);
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`OpenGemini query failed: ${response.status} ${response.statusText} - ${errorText}`);
+            }
+
+            try {
+                const body = await response.json();
+                return body as OpenGeminiQueryResponse;
+            } catch (e) {
+                console.error('Invalid response from OpenGemini server', e);
+                throw new Error('Invalid response from OpenGemini server');
+            }
+        },
+    };
+};
+
+/**
+ * OpenGemini Datasource Plugin.
+ * Provides connectivity to OpenGemini time-series database using InfluxDB-compatible HTTP API.
+ */
+export const OpenGeminiDatasource: DatasourcePlugin<OpenGeminiDatasourceSpec, OpenGeminiClient> = {
+    createClient,
+    OptionsEditorComponent: OpenGeminiDatasourceEditor,
+    createInitialOptions: () => ({ directUrl: '' }),
+};

--- a/contrib/plugins/opengemini/src/datasources/opengemini-datasource/OpenGeminiDatasourceEditor.tsx
+++ b/contrib/plugins/opengemini/src/datasources/opengemini-datasource/OpenGeminiDatasourceEditor.tsx
@@ -1,0 +1,63 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { HTTPSettingsEditor } from '@perses-dev/plugin-system';
+import React, { ReactElement } from 'react';
+import { OpenGeminiDatasourceSpec } from './opengemini-datasource-types';
+
+export interface OpenGeminiDatasourceEditorProps {
+    value: OpenGeminiDatasourceSpec;
+    onChange: (next: OpenGeminiDatasourceSpec) => void;
+    isReadonly?: boolean;
+}
+
+/**
+ * Editor component for OpenGemini datasource configuration.
+ * Allows users to configure either a direct URL or proxy settings.
+ */
+export function OpenGeminiDatasourceEditor(props: OpenGeminiDatasourceEditorProps): ReactElement {
+    const { value, onChange, isReadonly } = props;
+
+    const initialSpecDirect: OpenGeminiDatasourceSpec = {
+        directUrl: '',
+    };
+
+    const initialSpecProxy: OpenGeminiDatasourceSpec = {
+        proxy: {
+            kind: 'HTTPProxy',
+            spec: {
+                allowedEndpoints: [
+                    {
+                        endpointPattern: '/query',
+                        method: 'GET',
+                    },
+                    {
+                        endpointPattern: '/write',
+                        method: 'POST',
+                    },
+                ],
+                url: '',
+            },
+        },
+    };
+
+    return (
+        <HTTPSettingsEditor
+            value={value}
+            onChange={onChange}
+            isReadonly={isReadonly}
+            initialSpecDirect={initialSpecDirect}
+            initialSpecProxy={initialSpecProxy}
+        />
+    );
+}

--- a/contrib/plugins/opengemini/src/datasources/opengemini-datasource/index.ts
+++ b/contrib/plugins/opengemini/src/datasources/opengemini-datasource/index.ts
@@ -1,0 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './OpenGeminiDatasource';
+export * from './OpenGeminiDatasourceEditor';
+export * from './opengemini-datasource-types';

--- a/contrib/plugins/opengemini/src/datasources/opengemini-datasource/opengemini-datasource-types.ts
+++ b/contrib/plugins/opengemini/src/datasources/opengemini-datasource/opengemini-datasource-types.ts
@@ -1,0 +1,75 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { HTTPProxy, RequestHeaders } from '@perses-dev/core';
+import { DatasourceClient } from '@perses-dev/plugin-system';
+
+/**
+ * OpenGemini datasource specification.
+ * Supports either direct URL connection or proxy configuration.
+ */
+export interface OpenGeminiDatasourceSpec {
+    directUrl?: string;
+    proxy?: HTTPProxy;
+}
+
+/**
+ * Query request parameters for OpenGemini (InfluxDB compatible).
+ */
+export interface OpenGeminiQueryParams {
+    db: string;
+    q: string;
+    epoch?: 'ns' | 'u' | 'ms' | 's' | 'm' | 'h';
+}
+
+/**
+ * OpenGemini client options.
+ */
+export interface OpenGeminiClientOptions {
+    datasourceUrl: string;
+    headers?: RequestHeaders;
+}
+
+/**
+ * Single series result from OpenGemini.
+ */
+export interface OpenGeminiSeries {
+    name: string;
+    columns: string[];
+    values: Array<Array<number | string | null>>;
+    tags?: Record<string, string>;
+}
+
+/**
+ * Single statement result from OpenGemini.
+ */
+export interface OpenGeminiStatementResult {
+    statement_id: number;
+    series?: OpenGeminiSeries[];
+    error?: string;
+}
+
+/**
+ * Full response from OpenGemini query endpoint.
+ */
+export interface OpenGeminiQueryResponse {
+    results: OpenGeminiStatementResult[];
+}
+
+/**
+ * OpenGemini datasource client interface.
+ */
+export interface OpenGeminiClient extends DatasourceClient {
+    options: OpenGeminiClientOptions;
+    query(params: OpenGeminiQueryParams, headers?: RequestHeaders): Promise<OpenGeminiQueryResponse>;
+}

--- a/contrib/plugins/opengemini/src/index.ts
+++ b/contrib/plugins/opengemini/src/index.ts
@@ -1,0 +1,34 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * OpenGemini Plugin Module for Perses.
+ *
+ * This module provides datasource and query plugins for connecting to OpenGemini,
+ * a CNCF sandbox project for time-series data storage that is compatible with
+ * InfluxDB v1.x APIs.
+ */
+
+// Datasource exports
+export { OpenGeminiDatasource, OpenGeminiDatasourceEditor } from './datasources/opengemini-datasource';
+export type {
+    OpenGeminiDatasourceSpec,
+    OpenGeminiClient,
+    OpenGeminiQueryParams,
+    OpenGeminiQueryResponse,
+    OpenGeminiSeries,
+} from './datasources/opengemini-datasource';
+
+// Query exports
+export { OpenGeminiTimeSeriesQuery, OpenGeminiTimeSeriesQueryEditor } from './queries/opengemini-time-series-query';
+export type { OpenGeminiTimeSeriesQuerySpec } from './queries/opengemini-time-series-query';

--- a/contrib/plugins/opengemini/src/queries/index.ts
+++ b/contrib/plugins/opengemini/src/queries/index.ts
@@ -1,0 +1,14 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './opengemini-time-series-query';

--- a/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/OpenGeminiTimeSeriesQuery.tsx
+++ b/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/OpenGeminiTimeSeriesQuery.tsx
@@ -1,0 +1,39 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TimeSeriesQueryPlugin, parseVariables } from '@perses-dev/plugin-system';
+import { getTimeSeriesData } from './get-time-series-data';
+import { OpenGeminiTimeSeriesQueryEditor } from './OpenGeminiTimeSeriesQueryEditor';
+import { OpenGeminiTimeSeriesQuerySpec } from './opengemini-time-series-query-types';
+
+/**
+ * OpenGemini Time Series Query Plugin.
+ * Allows querying OpenGemini using InfluxQL and displaying results in time series panels.
+ */
+export const OpenGeminiTimeSeriesQuery: TimeSeriesQueryPlugin<OpenGeminiTimeSeriesQuerySpec> = {
+    getTimeSeriesData,
+    OptionsEditorComponent: OpenGeminiTimeSeriesQueryEditor,
+    createInitialOptions: () => ({
+        query: '',
+        database: '',
+    }),
+    dependsOn: (spec) => {
+        // Parse variables from the query string
+        const queryVariables = parseVariables(spec.query);
+        const databaseVariables = parseVariables(spec.database);
+        const allVariables = [...new Set([...queryVariables, ...databaseVariables])];
+        return {
+            variables: allVariables,
+        };
+    },
+};

--- a/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/OpenGeminiTimeSeriesQueryEditor.tsx
+++ b/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/OpenGeminiTimeSeriesQueryEditor.tsx
@@ -1,0 +1,73 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { ReactElement, ChangeEvent } from 'react';
+import { Stack, TextField, Typography } from '@mui/material';
+import { OptionsEditorProps } from '@perses-dev/plugin-system';
+import { OpenGeminiTimeSeriesQuerySpec } from './opengemini-time-series-query-types';
+
+export type OpenGeminiTimeSeriesQueryEditorProps = OptionsEditorProps<OpenGeminiTimeSeriesQuerySpec>;
+
+/**
+ * Editor component for OpenGemini time series queries.
+ * Provides fields for database selection and InfluxQL query input.
+ */
+export function OpenGeminiTimeSeriesQueryEditor(props: OpenGeminiTimeSeriesQueryEditorProps): ReactElement {
+    const { value, onChange, isReadonly } = props;
+
+    const handleDatabaseChange = (event: ChangeEvent<HTMLInputElement>) => {
+        onChange({
+            ...value,
+            database: event.target.value,
+        });
+    };
+
+    const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
+        onChange({
+            ...value,
+            query: event.target.value,
+        });
+    };
+
+    return (
+        <Stack spacing={2}>
+            <TextField
+                label="Database"
+                value={value.database}
+                onChange={handleDatabaseChange}
+                disabled={isReadonly}
+                placeholder="Enter database name"
+                fullWidth
+                size="small"
+                helperText="The OpenGemini database to query"
+            />
+            <div>
+                <Typography variant="subtitle2" gutterBottom>
+                    InfluxQL Query
+                </Typography>
+                <TextField
+                    value={value.query}
+                    onChange={handleQueryChange}
+                    disabled={isReadonly}
+                    placeholder='SELECT mean("value") FROM "measurement" WHERE $timeFilter GROUP BY time($__interval)'
+                    fullWidth
+                    multiline
+                    minRows={3}
+                    maxRows={10}
+                    size="small"
+                    helperText="Enter an InfluxQL query. Use $timeFilter for time range and $__interval for auto-interval."
+                />
+            </div>
+        </Stack>
+    );
+}

--- a/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/constants.ts
+++ b/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/constants.ts
@@ -1,0 +1,22 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DatasourceSelector } from '@perses-dev/core';
+
+/**
+ * Default datasource selector for OpenGemini.
+ * Used when no specific datasource is selected in a query.
+ */
+export const DEFAULT_OPENGEMINI_DATASOURCE: DatasourceSelector = {
+    kind: 'OpenGeminiDatasource',
+};

--- a/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/get-time-series-data.ts
+++ b/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/get-time-series-data.ts
@@ -1,0 +1,125 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TimeSeriesData, TimeSeries } from '@perses-dev/core';
+import { TimeSeriesQueryPlugin, replaceVariables } from '@perses-dev/plugin-system';
+import { OpenGeminiTimeSeriesQuerySpec } from './opengemini-time-series-query-types';
+import { OpenGeminiQueryResponse, OpenGeminiSeries, OpenGeminiClient } from '../../datasources/opengemini-datasource';
+import { DEFAULT_OPENGEMINI_DATASOURCE } from './constants';
+
+/**
+ * Transforms an OpenGemini series to a Perses TimeSeries.
+ * OpenGemini returns data in InfluxDB format with columns and values arrays.
+ */
+function transformSeries(series: OpenGeminiSeries): TimeSeries[] {
+    const timeIndex = series.columns.indexOf('time');
+    if (timeIndex === -1) {
+        console.warn('No time column found in OpenGemini response');
+        return [];
+    }
+
+    // Find value columns (all columns except 'time')
+    const valueColumns = series.columns
+        .map((col, idx) => ({ col, idx }))
+        .filter(({ col }) => col !== 'time');
+
+    // Generate a TimeSeries for each value column
+    return valueColumns.map(({ col, idx }) => {
+        // Build series name including tags if present
+        let name = series.name;
+        if (series.tags) {
+            const tagStr = Object.entries(series.tags)
+                .map(([k, v]) => `${k}=${v}`)
+                .join(', ');
+            name = `${name}{${tagStr}}`;
+        }
+        if (valueColumns.length > 1) {
+            name = `${name}.${col}`;
+        }
+
+        // Transform values to [timestamp, value] tuples
+        const values: Array<[number, number | null]> = series.values.map((row) => {
+            const timestamp = row[timeIndex] as number;
+            const value = row[idx] as number | null;
+            return [timestamp, value];
+        });
+
+        return {
+            name,
+            values,
+        };
+    });
+}
+
+/**
+ * Builds time series data from an OpenGemini query response.
+ */
+function buildTimeSeries(response: OpenGeminiQueryResponse): TimeSeries[] {
+    const allSeries: TimeSeries[] = [];
+
+    for (const result of response.results) {
+        if (result.error) {
+            console.error('OpenGemini query error:', result.error);
+            continue;
+        }
+
+        if (result.series) {
+            for (const series of result.series) {
+                allSeries.push(...transformSeries(series));
+            }
+        }
+    }
+
+    return allSeries;
+}
+
+/**
+ * Fetches time series data from OpenGemini.
+ */
+export const getTimeSeriesData: TimeSeriesQueryPlugin<OpenGeminiTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
+    spec,
+    context
+) => {
+    // Return empty data if the query is empty
+    if (!spec.query || !spec.database) {
+        return { series: [] };
+    }
+
+    // Replace variables in the query
+    const query = replaceVariables(spec.query, context.variableState);
+    const database = replaceVariables(spec.database, context.variableState);
+
+    // Get the OpenGemini client
+    const client = (await context.datasourceStore.getDatasourceClient(
+        spec.datasource ?? DEFAULT_OPENGEMINI_DATASOURCE
+    )) as OpenGeminiClient;
+
+    // Execute the query with epoch=ms for millisecond timestamps
+    const response = await client.query({
+        db: database,
+        q: query,
+        epoch: 'ms',
+    });
+
+    // Transform the response to Perses format
+    const { start, end } = context.timeRange;
+    const chartData: TimeSeriesData = {
+        series: buildTimeSeries(response),
+        timeRange: { start, end },
+        metadata: {
+            executedQueryString: query,
+        },
+    };
+
+    return chartData;
+};

--- a/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/index.ts
+++ b/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/index.ts
@@ -1,0 +1,17 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './OpenGeminiTimeSeriesQuery';
+export * from './OpenGeminiTimeSeriesQueryEditor';
+export * from './opengemini-time-series-query-types';
+export * from './constants';

--- a/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/opengemini-time-series-query-types.ts
+++ b/contrib/plugins/opengemini/src/queries/opengemini-time-series-query/opengemini-time-series-query-types.ts
@@ -1,0 +1,35 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DatasourceSelector } from '@perses-dev/core';
+
+/**
+ * OpenGemini time series query specification.
+ */
+export interface OpenGeminiTimeSeriesQuerySpec {
+    /**
+     * Optional datasource selector. If not provided, the default OpenGemini datasource will be used.
+     */
+    datasource?: DatasourceSelector;
+
+    /**
+     * InfluxQL query string.
+     * Example: SELECT mean("value") FROM "cpu" WHERE time > now() - 1h GROUP BY time(1m)
+     */
+    query: string;
+
+    /**
+     * Database name to query against.
+     */
+    database: string;
+}

--- a/contrib/plugins/opengemini/tsconfig.build.json
+++ b/contrib/plugins/opengemini/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "declaration": true,
+        "declarationMap": true,
+        "emitDeclarationOnly": true
+    }
+}

--- a/contrib/plugins/opengemini/tsconfig.json
+++ b/contrib/plugins/opengemini/tsconfig.json
@@ -1,0 +1,33 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "lib": [
+            "ES2020",
+            "DOM",
+            "DOM.Iterable"
+        ],
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true,
+        "baseUrl": ".",
+        "outDir": "./lib/cjs",
+        "rootDir": "./src"
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "lib",
+        "dist",
+        "**/*.test.ts",
+        "**/*.test.tsx"
+    ]
+}


### PR DESCRIPTION
[FEATURE] Add OpenGemini datasource and query plugins

This PR adds support for **OpenGemini**, a CNCF sandbox project for distributed time-series data storage. Since OpenGemini is fully compatible with InfluxDB v1.x APIs, this plugin implements the necessary logic to connect to OpenGemini instances and execute InfluxQL queries.

### Plugins Included:
- **OpenGeminiDatasource**: Allows users to configure connections using direct URLs or HTTP proxies.
- **OpenGeminiTimeSeriesQuery**: Enables fetching time-series data using InfluxQL with support for database selection and variable substitution (e.g., `$timeFilter`, `$__interval`).

Closes #3716

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

The implementation follows the Perses plugin architecture:
- **CUE Schemas**: Defined in [schemas/](cci:7://file:///Users/aviralgarg/Everything/perses/internal/cli/cmd/plugin/generate/templates/datasource/schemas:0:0-0:0) for validation of datasource and query configurations.
- **Datasource Client**: Implemented in [src/datasources/](cci:7://file:///Users/aviralgarg/Everything/perses/internal/cli/cmd/plugin/generate/templates/datasource/src/datasources:0:0-0:0) to interact with the `/query` endpoint of OpenGemini using the InfluxDB v1.x compatible API.
- **Query Editor**: Provides a React-based interface for inputting InfluxQL queries and selecting databases.
- **Data Transformation**: Robust logic in [get-time-series-data.ts](cci:7://file:///Users/aviralgarg/Everything/perses/plugins/opengemini/src/queries/opengemini-time-series-query/get-time-series-data.ts:0:0-0:0) to map OpenGemini's column/value response format to Perses `TimeSeries`.

The plugin module is placed in `contrib/plugins/opengemini` and includes a full build setup using Rsbuild and Module Federation.

# Screenshots

N/A - Standard form and editor components used.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[FEATURE] Add OpenGemini datasource and query plugins` naming convention.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Verified build and type checks pass locally using `npm run build` and `npm run type-check`.