### PR TITLE
[BUGFIX] include lint command in plugin module generation

### DIFF
--- a/internal/cli/cmd/plugin/generate/generate_test.go
+++ b/internal/cli/cmd/plugin/generate/generate_test.go
@@ -77,6 +77,7 @@ func TestPluginGenerateCMD(t *testing.T) {
 			ExpectedMessage: `module MyPluginModule created successfully, plugin MyTestDatasource generated successfully
 ` + getFileList([]string{
 				".cjs.swcrc",
+				".eslintrc.js",
 				".gitignore",
 				".swcrc",
 				"LICENSE",
@@ -115,6 +116,7 @@ func TestPluginGenerateCMD(t *testing.T) {
 			ExpectedMessage: `plugin MyTestPanel generated successfully
 ` + getFileList([]string{
 				".cjs.swcrc",
+				".eslintrc.js",
 				".gitignore",
 				".swcrc",
 				"LICENSE",

--- a/internal/cli/cmd/plugin/generate/templates/blocks/exposedModule.tmpl
+++ b/internal/cli/cmd/plugin/generate/templates/blocks/exposedModule.tmpl
@@ -1,2 +1,2 @@
 {{ define "exposedModule" }}
-  { "./{{ .ID }}" : "./{{ .Path }}" },{{ end }}
+  { "./{{ .ID }}": "./{{ .Path }}" },{{ end }}

--- a/internal/cli/cmd/plugin/generate/templates/module/.eslintrc.js.tmpl
+++ b/internal/cli/cmd/plugin/generate/templates/module/.eslintrc.js.tmpl
@@ -1,0 +1,65 @@
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:jsx-a11y/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+
+  plugins: ['import'],
+
+  env: {
+    commonjs: true,
+    es6: true,
+    jest: true,
+    node: true,
+    browser: true,
+  },
+
+  parser: '@typescript-eslint/parser',
+
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+
+  rules: {
+    'prettier/prettier': 'error',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/array-type': [
+      'error',
+      {
+        default: 'array-simple',
+      },
+    ],
+    'import/order': 'error',
+    // you must disable the base rule as it can report incorrect errors
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+
+    'react/prop-types': 'off',
+    'react-hooks/exhaustive-deps': 'error',
+    // Not necessary in React 17
+    'react/react-in-jsx-scope': 'off',
+    'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never', propElementValues: 'always' }],
+
+    // We use this rule instead of the core eslint `no-duplicate-imports`
+    // because it avoids false errors on cases where we have a regular
+    // import and an `import type`.
+    'import/no-duplicates': 'error',
+  },
+
+  ignorePatterns: ['**/dist'],
+};

--- a/internal/cli/cmd/plugin/generate/templates/module/package.json.tmpl
+++ b/internal/cli/cmd/plugin/generate/templates/module/package.json.tmpl
@@ -8,6 +8,7 @@
     "build:cjs": "swc ./src -d dist/lib/cjs --strip-leading-paths --config-file .cjs.swcrc",
     "build:esm": "swc ./src -d dist/lib --strip-leading-paths --config-file .swcrc",
     "build:types": "tsc --project tsconfig.build.json",
+    "lint": "eslint src --ext .ts,.tsx",
     "test": "cross-env LC_ALL=C TZ=UTC jest",
     "type-check": "tsc --noEmit"
   },
@@ -31,7 +32,15 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/user-event": "^13.5.0",
+    "@typescript-eslint/eslint-plugin": "^8.18.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",

--- a/internal/cli/cmd/plugin/generate/templates/module/rsbuild.config.ts.tmpl
+++ b/internal/cli/cmd/plugin/generate/templates/module/rsbuild.config.ts.tmpl
@@ -1,4 +1,7 @@
-import { ModuleFederationOptions, pluginModuleFederation } from "@module-federation/rsbuild-plugin";
+import {
+  ModuleFederationOptions,
+  pluginModuleFederation,
+} from "@module-federation/rsbuild-plugin";
 import { defineConfig } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 
@@ -12,12 +15,20 @@ const exposedModules: ModuleFederationOptions["exposes"] = [
 ];
 
 export default defineConfig({
-  server: { 
-    port: 3119,
-    printUrls: ({ urls, port }) => {
-      console.log(`[PERSES_PLUGIN] PORT="${port}"`);
-      return urls;
-    },
+  server: {
+    port: 3000 + Math.floor(Math.random() * 1000),
+    strictPort: false,
+    printUrls: process.env.PERSES_CLI
+      ? ({ port, protocol }) => {
+          // custom output for `percli plugin start` to detect port for dev server
+          console.log(
+            `[PERSES_PLUGIN] NAME="${name}" PORT="${port}" PROTOCOL="${protocol}"\n`,
+          );
+          console.log(`Local: ${protocol}://localhost:${port}`);
+          return [];
+        }
+      : true,
+    cors: { origin: "*" },
   },
   dev: { assetPrefix },
   source: { entry: { main: "./src/index-federation.ts" } },
@@ -65,5 +76,12 @@ export default defineConfig({
   ],
   tools: {
     htmlPlugin: false,
+    rspack: (config) => {
+      config.output = config.output || {};
+      if (process.env.NODE_ENV !== "development") {
+        config.output.publicPath = "auto";
+      }
+      return config;
+    },
   },
 });


### PR DESCRIPTION
# Description

This PR:

- adds eslint to the plugin module template.
- Updates the rspbuild config to match the latest plugin changes
- Updates vulnerable dependencies for the package.json included with the template

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).