### PR TITLE
[ENHANCEMENT] Update the debug plugin CLI + API output

### DIFF
--- a/internal/api/plugin/npm.go
+++ b/internal/api/plugin/npm.go
@@ -97,9 +97,12 @@ func ReadPackageFromNetwork(url *common.URL, pluginName string) (*NPMPackage, er
 func readFile[T any](filePath string, result *T) error {
 	data, err := os.ReadFile(filePath) //nolint: gosec
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", filePath, err)
 	}
-	return json.Unmarshal(data, result)
+	if err := json.Unmarshal(data, result); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON from %q: %w", filePath, err)
+	}
+	return nil
 }
 
 func readFileFromNetwork[T any](url *common.URL, pluginName string, fileName string, result *T) error {

--- a/internal/cli/cmd/plugin/generate/generate.go
+++ b/internal/cli/cmd/plugin/generate/generate.go
@@ -14,6 +14,7 @@
 package generate
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -172,7 +173,7 @@ func (o *generateOptions) Execute() error {
 	currentPlugins := []apiv1.Plugin{}
 
 	if err != nil || currentModule == nil {
-		if err != nil && os.IsNotExist(err) {
+		if err != nil && errors.Is(err, os.ErrNotExist) {
 			if o.pluginModuleName == "" || o.pluginModuleOrg == "" {
 				return fmt.Errorf("module.name and module.org are required when creating a new module as none was found under %q", o.outputDir)
 			}

--- a/internal/cli/cmd/plugin/generate/generate_test.go
+++ b/internal/cli/cmd/plugin/generate/generate_test.go
@@ -52,6 +52,7 @@ func getFileList(filePaths []string) string {
 
 func TestPluginGenerateCMD(t *testing.T) {
 	removeTestFiles()
+	defer removeTestFiles()
 
 	testSuite := []cmdTest.Suite{
 		{
@@ -62,7 +63,7 @@ func TestPluginGenerateCMD(t *testing.T) {
 				testFolder,
 			},
 			IsErrorExpected:      true,
-			ExpectedRegexMessage: "module.name and module.org are required when creating a new module as none was found under",
+			ExpectedRegexMessage: `module\.name and module\.org are required when creating a new module as none was found under`,
 		},
 		{
 			Title: "Build module with a plugin",

--- a/internal/cli/cmd/plugin/start/start.go
+++ b/internal/cli/cmd/plugin/start/start.go
@@ -319,7 +319,7 @@ func (o *option) preparePlugin(pluginPath string, c *color.Color) (*devserver, *
 	// First, we need to find the command to start the dev server.
 	npmPackageData, readErr := plugin.ReadPackage(pluginPath)
 	if readErr != nil {
-		return nil, nil, fmt.Errorf("failed to read package for the plugin %q", pluginPath)
+		return nil, nil, fmt.Errorf("failed to read package for the plugin %q: %w", pluginPath, readErr)
 	}
 	var rsbuildCMD string
 	for scriptName, script := range npmPackageData.Scripts {

--- a/internal/cli/test/test.go
+++ b/internal/cli/test/test.go
@@ -15,7 +15,6 @@ package test
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -58,7 +57,7 @@ func ExecuteSuiteTest(t *testing.T, newCMD func() *cobra.Command, suites []Suite
 				if assert.NotNil(t, err) {
 					if len(test.ExpectedRegexMessage) > 0 {
 						matched, _ := regexp.MatchString(test.ExpectedRegexMessage, err.Error())
-						assert.True(t, matched, "Expected error message to match regex: %s", test.ExpectedRegexMessage)
+						assert.True(t, matched, "Expected error message to match regex: %s\nActual error: %s", test.ExpectedRegexMessage, err.Error())
 					} else {
 						assert.Equal(t, test.ExpectedMessage, err.Error())
 					}
@@ -66,8 +65,7 @@ func ExecuteSuiteTest(t *testing.T, newCMD func() *cobra.Command, suites []Suite
 			} else if assert.Nil(t, err) {
 				if len(test.ExpectedRegexMessage) > 0 {
 					matched, _ := regexp.MatchString(test.ExpectedRegexMessage, buffer.String())
-					assert.True(t, matched, "Expected output to match regex: %s", test.ExpectedRegexMessage)
-					fmt.Println("output message: ", buffer.String())
+					assert.True(t, matched, "Expected output to match regex: %s\nActual output: %s", test.ExpectedRegexMessage, buffer.String())
 				} else {
 					assert.Equal(t, test.ExpectedMessage, buffer.String())
 				}


### PR DESCRIPTION
# Description

This PR improves error handling and error reporting in the plugin management system by adding more context to error messages. This makes debugging plugin-related issues significantly easier for both developers and users.

## Why These Changes?

### 1. **Better Debugging Experience**
When plugin loading fails, users and developers will now see:
- Which specific file caused the issue
- What type of failure occurred (file read vs JSON parsing)
- The complete error chain showing root cause

### 2. **Proper Error Wrapping**
Using `%w` instead of `%v` or concatenation allows:
- Error chain inspection with `errors.Is()` and `errors.As()`
- Proper error unwrapping for programmatic error handling
- Better integration with Go's error handling best practices

### 3. **Contextual Information**
Including file paths and operation descriptions in errors helps:
- Quickly identify which plugin or configuration file is problematic
- Reduce time spent debugging file system issues
- Provide actionable error messages to users

<details>
<summary>Improvement details</summary>

## Error Message Improvements - Before/After Comparisons

### Scenario 1: File Read Failure

**Before:**
```
open /path/to/plugin/package.json: no such file or directory
```

**After:**
```
failed to read file "/path/to/plugin/package.json": open /path/to/plugin/package.json: no such file or directory
```

✅ **Improvement:** Now explicitly states it's a file read operation failure with the file path quoted.

---

### Scenario 2: JSON Parsing Error

**Before:**
```
invalid character '}' looking for beginning of object key string
```

**After:**
```
failed to unmarshal JSON from "/path/to/plugin/package.json": invalid character '}' looking for beginning of object key string
```

✅ **Improvement:** Clearly indicates it's a JSON parsing issue and shows which file has the malformed JSON.

---

### Scenario 3: Plugin Package Read Error (Full Chain)

**Before:**
```
failed to read package for the plugin "/path/to/plugin"
```

**After:**
```
failed to read package for the plugin "/path/to/plugin": failed to unmarshal JSON from "/path/to/plugin/package.json": invalid character '}' looking for beginning of object key string
```

✅ **Improvement:** Complete error chain showing:
1. High-level operation: reading package for plugin
2. Specific file operation: unmarshaling JSON from package.json
3. Root cause: exact JSON syntax error

---

### Scenario 4: Permission Denied Error

**Before:**
```
open /var/lib/perses/plugins/myplugin/package.json: permission denied
```

**After:**
```
failed to read file "/var/lib/perses/plugins/myplugin/package.json": open /var/lib/perses/plugins/myplugin/package.json: permission denied
```

✅ **Improvement:** Explicitly identifies the operation type (file read) and highlights the problematic file path.

---

### Scenario 5: Plugin Loading with Nested Error (CLI)

**Before:**
```
failed to read package for the plugin "custom-panel"
```

**After:**
```
failed to read package for the plugin "custom-panel": failed to read file "/home/user/plugins/custom-panel/package.json": open /home/user/plugins/custom-panel/package.json: no such file or directory
```

✅ **Improvement:** Full error chain from plugin loading down to the OS-level error, making it immediately clear:
- Which plugin failed to load
- What file was being accessed
- Why it failed (file doesn't exist)
</details>

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A - This PR only affects backend error handling and logging.
