### PR TITLE
[BREAKINGCHANGE] Improve SQL proxy error handling and switch to JSON responses

### DIFF
--- a/pkg/model/api/v1/datasource/sql/sql.go
+++ b/pkg/model/api/v1/datasource/sql/sql.go
@@ -25,6 +25,7 @@ type Driver string
 
 const (
 	DriverMySQL      Driver = "mysql"
+	DriverMariaDB    Driver = "mariadb"
 	DriverPostgreSQL Driver = "postgres"
 )
 
@@ -149,7 +150,7 @@ func (s *Config) validate() error {
 		return errors.New("driver is required")
 	}
 
-	if s.Driver != DriverMySQL && s.Driver != DriverPostgreSQL {
+	if s.Driver != DriverMySQL && s.Driver != DriverMariaDB && s.Driver != DriverPostgreSQL {
 		return fmt.Errorf("driver %s is not supported", s.Driver)
 	}
 


### PR DESCRIPTION
# Description

This PR improves error handling and response format for SQL proxy data sources in Perses. The changes make SQL proxy errors more informative and user-friendly, and switch the response format from CSV to JSON for better frontend integration.

<details>
<summary>Implementation details</summary>

## Changes

### 1. Enhanced Error Messaging for SQL Proxy

Previously, SQL proxy errors returned generic `InternalError` responses that didn't provide useful information to users. This PR replaces them with detailed HTTP error responses that include:

- **Authentication errors**: Returns `400 Bad Request` with message "Authentication setup failed" and the specific error
- **TLS configuration errors**: Returns `400 Bad Request` with message "TLS configuration failed" and the specific error  
- **Database connection errors**: Returns `400 Bad Request` with message "Database connection failed" and the specific error
- **SQL query errors**: Returns `400 Bad Request` with message "SQL query failed" and the specific error

**Before:**
```go
if err := s.setupAuthentication(); err != nil {
    logrus.WithError(err).Error("unable to setup authentication")
    return apiinterface.InternalError
}
```

**After:**
```go
if err := s.setupAuthentication(); err != nil {
    logrus.WithError(err).Error("unable to setup authentication")
    return echo.NewHTTPError(http.StatusBadRequest, map[string]interface{}{
        "message": "Authentication setup failed",
        "error":   err.Error(),
    })
}
```

This applies to all SQL proxy error scenarios: authentication setup, TLS configuration, database connection, and query execution.

### 2. Switch SQL Proxy Response Format from CSV to JSON

Changed the default response format for SQL queries from CSV to JSON with structured column metadata and rows.

**Response Format:**
```json
{
  "columns": [
    {"name": "id", "type": "INT"},
    {"name": "username", "type": "VARCHAR"},
    {"name": "email", "type": "VARCHAR"}
  ],
  "rows": [
    {"id": 1, "username": "admin", "email": "admin@example.com"},
    {"id": 2, "username": "user", "email": "user@example.com"}
  ]
}
```

**Benefits:**
- Better frontend integration - JSON is the standard for API responses
- Column metadata included - the response includes column names and database types
- Type preservation - numeric and boolean values maintain their types
- Easier to parse - frontends can directly consume the JSON without parsing CSV

The CSV writer function (`writeCSVResponse`) is retained for potential future use but is no longer called by default.

### 3. Implementation Details

**New Function: `writeJSONResponse`**
- Extracts column names and types using `rows.ColumnTypes()`
- Builds structured column metadata array
- Collects all rows into a slice of maps
- Handles `[]byte` to `string` conversion for better JSON serialization
- Returns JSON with proper `Content-Type` header

**Error Response Structure:**
All SQL proxy errors now return a consistent structure:
```json
{
  "message": "Human-readable error category",
  "error": "Detailed error message"
}
```

</details>

## Testing

- Verified error messages are properly returned for authentication, TLS, connection, and query failures
- Tested JSON response format with various SQL queries (PostgreSQL)
- Confirmed column metadata is correctly extracted and included
- Validated backward compatibility - CSV function remains available if needed

## Breaking Changes

**This is a breaking change** for any clients that expect CSV responses from the SQL proxy endpoint.

- SQL proxy responses now return JSON instead of CSV by default
- Error responses now have a structured format with `message` and `error` fields instead of generic internal errors

**Migration Path:**
Frontends consuming SQL proxy responses should:
1. Update to parse JSON instead of CSV
2. Use the `columns` array for metadata
3. Iterate over the `rows` array for data
4. Update error handling to use the new structured error format

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention.
- [x] All commits have DCO signoffs.

## UI Changes

- [ ] N/A - This is a backend change only. However, frontends consuming SQL proxy responses will need to be updated to handle the new JSON format.
