### PR TITLE
[ENHANCEMENT] Go client updated to return PublicUser instead of User

### DIFF
--- a/cue/model/api/v1/metadata_go_gen.cue
+++ b/cue/model/api/v1/metadata_go_gen.cue
@@ -6,6 +6,12 @@ package v1
 
 #Metadata: _
 
+// PublicMetadata is a copy of classic metadata but that doesn't make any validation.
+// It is used when returning data to the API consumers.
+// It is particularly useful when the API returns some entities that are created on the fly and that doesn't necessarily
+// need validation like the kubernetes users.
+#PublicMetadata: _
+
 // This wrapping struct is required to allow defining a custom unmarshall on Metadata
 // without breaking the Project attribute (the fact Metadata is injected line in
 // ProjectMetadata caused Project string to be ignored when unmarshalling)
@@ -13,3 +19,9 @@ package v1
 
 // ProjectMetadata is the metadata struct for resources that belongs to a project.
 #ProjectMetadata: _
+
+// PublicProjectMetadata is a copy of classic project metadata but that doesn't make any validation.
+// It is used when returning data to the API consumers.
+// It is particularly useful when the API returns some entities that are created on the fly and that doesn't necessarily
+// need validation like the kubernetes users.
+#PublicProjectMetadata: _

--- a/cue/model/api/v1/public_secret_go_gen.cue
+++ b/cue/model/api/v1/public_secret_go_gen.cue
@@ -21,12 +21,12 @@ import "github.com/perses/perses/cue/model/api/v1/secret"
 
 #PublicGlobalSecret: {
 	kind:     #Kind             @go(Kind)
-	metadata: #Metadata         @go(Metadata)
+	metadata: #PublicMetadata   @go(Metadata)
 	spec:     #PublicSecretSpec @go(Spec)
 }
 
 #PublicSecret: {
-	kind:     #Kind             @go(Kind)
-	metadata: #ProjectMetadata  @go(Metadata)
-	spec:     #PublicSecretSpec @go(Spec)
+	kind:     #Kind                  @go(Kind)
+	metadata: #PublicProjectMetadata @go(Metadata)
+	spec:     #PublicSecretSpec      @go(Spec)
 }

--- a/cue/model/api/v1/public_user_go_gen.cue
+++ b/cue/model/api/v1/public_user_go_gen.cue
@@ -19,6 +19,6 @@ import "github.com/perses/perses/cue/model/api/v1/secret"
 
 #PublicUser: {
 	kind:     #Kind           @go(Kind)
-	metadata: #Metadata       @go(Metadata)
+	metadata: #PublicMetadata @go(Metadata)
 	spec:     #PublicUserSpec @go(Spec)
 }

--- a/internal/api/authorization/k8s/k8s.go
+++ b/internal/api/authorization/k8s/k8s.go
@@ -157,7 +157,7 @@ func (k *k8sImpl) GetPublicUser(ctx echo.Context) (*v1.PublicUser, error) {
 
 	return &v1.PublicUser{
 		Kind:     v1.KindUser,
-		Metadata: *v1.NewMetadata(username),
+		Metadata: v1.NewPublicMetadata(username),
 		Spec:     v1.PublicUserSpec{},
 	}, nil
 }

--- a/internal/api/e2e/framework/data.go
+++ b/internal/api/e2e/framework/data.go
@@ -176,27 +176,10 @@ func CreateAndWaitUntilEntityExists(t *testing.T, persistenceManager dependency.
 	}
 }
 
-func newProjectMetadata(projectName string, name string) v1.ProjectMetadata {
-	return v1.ProjectMetadata{
-		Metadata: v1.Metadata{
-			Name: name,
-		},
-		ProjectMetadataWrapper: v1.ProjectMetadataWrapper{
-			Project: projectName,
-		},
-	}
-}
-
-func newMetadata(name string) v1.Metadata {
-	return v1.Metadata{
-		Name: name,
-	}
-}
-
 func NewProject(name string) *v1.Project {
 	entity := &v1.Project{
 		Kind:     v1.KindProject,
-		Metadata: newMetadata(name),
+		Metadata: *v1.NewMetadata(name),
 	}
 	entity.Metadata.CreateNow()
 	return entity
@@ -264,7 +247,7 @@ func newDatasourceSpec(t *testing.T) v1.DatasourceSpec {
 func NewDatasource(t *testing.T, projectName string, name string) *v1.Datasource {
 	entity := &v1.Datasource{
 		Kind:     v1.KindDatasource,
-		Metadata: newProjectMetadata(projectName, name),
+		Metadata: *v1.NewProjectMetadata(projectName, name),
 		Spec:     newDatasourceSpec(t),
 	}
 	entity.Metadata.CreateNow()
@@ -274,7 +257,7 @@ func NewDatasource(t *testing.T, projectName string, name string) *v1.Datasource
 func NewGlobalDatasource(t *testing.T, name string) *v1.GlobalDatasource {
 	entity := &v1.GlobalDatasource{
 		Kind:     v1.KindGlobalDatasource,
-		Metadata: newMetadata(name),
+		Metadata: *v1.NewMetadata(name),
 		Spec:     newDatasourceSpec(t),
 	}
 	entity.Metadata.CreateNow()
@@ -284,7 +267,7 @@ func NewGlobalDatasource(t *testing.T, name string) *v1.GlobalDatasource {
 func NewVariable(projectName string, name string) *v1.Variable {
 	entity := &v1.Variable{
 		Kind:     v1.KindVariable,
-		Metadata: newProjectMetadata(projectName, name),
+		Metadata: *v1.NewProjectMetadata(projectName, name),
 		Spec: v1.VariableSpec{
 			Kind: variable.KindList,
 			Spec: &variable.ListSpec{
@@ -306,7 +289,7 @@ func NewVariable(projectName string, name string) *v1.Variable {
 func NewGlobalVariable(name string) *v1.GlobalVariable {
 	entity := &v1.GlobalVariable{
 		Kind:     v1.KindGlobalVariable,
-		Metadata: newMetadata(name),
+		Metadata: *v1.NewMetadata(name),
 		Spec: v1.VariableSpec{
 			Kind: variable.KindList,
 			Spec: &variable.ListSpec{
@@ -369,7 +352,7 @@ func newGlobalRoleSpec() v1.RoleSpec {
 func NewGlobalRole(name string) *v1.GlobalRole {
 	entity := &v1.GlobalRole{
 		Kind:     v1.KindGlobalRole,
-		Metadata: newMetadata(name),
+		Metadata: *v1.NewMetadata(name),
 		Spec:     newGlobalRoleSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -379,7 +362,7 @@ func NewGlobalRole(name string) *v1.GlobalRole {
 func NewRole(projectName string, name string) *v1.Role {
 	entity := &v1.Role{
 		Kind:     v1.KindRole,
-		Metadata: newProjectMetadata(projectName, name),
+		Metadata: *v1.NewProjectMetadata(projectName, name),
 		Spec:     newRoleSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -401,7 +384,7 @@ func newRoleBindingSpec() v1.RoleBindingSpec {
 func NewGlobalRoleBinding(name string) *v1.GlobalRoleBinding {
 	entity := &v1.GlobalRoleBinding{
 		Kind:     v1.KindGlobalRoleBinding,
-		Metadata: newMetadata(name),
+		Metadata: *v1.NewMetadata(name),
 		Spec:     newRoleBindingSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -411,7 +394,7 @@ func NewGlobalRoleBinding(name string) *v1.GlobalRoleBinding {
 func NewRoleBinding(projectName string, name string) *v1.RoleBinding {
 	entity := &v1.RoleBinding{
 		Kind:     v1.KindRoleBinding,
-		Metadata: newProjectMetadata(projectName, name),
+		Metadata: *v1.NewProjectMetadata(projectName, name),
 		Spec:     newRoleBindingSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -441,7 +424,7 @@ func newPublicSecretSpec() v1.PublicSecretSpec {
 func NewSecret(projectName string, name string) *v1.Secret {
 	entity := &v1.Secret{
 		Kind:     v1.KindSecret,
-		Metadata: newProjectMetadata(projectName, name),
+		Metadata: *v1.NewProjectMetadata(projectName, name),
 		Spec:     newSecretSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -451,7 +434,7 @@ func NewSecret(projectName string, name string) *v1.Secret {
 func NewPublicSecret(projectName string, name string) *v1.PublicSecret {
 	entity := &v1.PublicSecret{
 		Kind:     v1.KindSecret,
-		Metadata: newProjectMetadata(projectName, name),
+		Metadata: v1.NewPublicProjectMetadata(projectName, name),
 		Spec:     newPublicSecretSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -461,7 +444,7 @@ func NewPublicSecret(projectName string, name string) *v1.PublicSecret {
 func NewGlobalSecret(name string) *v1.GlobalSecret {
 	entity := &v1.GlobalSecret{
 		Kind:     v1.KindGlobalSecret,
-		Metadata: newMetadata(name),
+		Metadata: *v1.NewMetadata(name),
 		Spec:     newSecretSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -471,7 +454,7 @@ func NewGlobalSecret(name string) *v1.GlobalSecret {
 func NewPublicGlobalSecret(name string) *v1.PublicGlobalSecret {
 	entity := &v1.PublicGlobalSecret{
 		Kind:     v1.KindGlobalSecret,
-		Metadata: newMetadata(name),
+		Metadata: v1.NewPublicMetadata(name),
 		Spec:     newPublicSecretSpec(),
 	}
 	entity.Metadata.CreateNow()
@@ -481,7 +464,7 @@ func NewPublicGlobalSecret(name string) *v1.PublicGlobalSecret {
 func NewUser(name string, password string) *v1.User {
 	entity := &v1.User{
 		Kind:     v1.KindUser,
-		Metadata: newMetadata(name),
+		Metadata: *v1.NewMetadata(name),
 		Spec: v1.UserSpec{
 			NativeProvider: v1.NativeProvider{
 				Password: password,
@@ -495,7 +478,7 @@ func NewUser(name string, password string) *v1.User {
 func NewPublicUser(name string) *v1.PublicUser {
 	entity := &v1.PublicUser{
 		Kind:     v1.KindUser,
-		Metadata: newMetadata(name),
+		Metadata: v1.NewPublicMetadata(name),
 		Spec: v1.PublicUserSpec{
 			NativeProvider: v1.PublicNativeProvider{Password: "<secret>"},
 		},

--- a/pkg/client/api/v1/user.go
+++ b/pkg/client/api/v1/user.go
@@ -23,16 +23,16 @@ import (
 const userResource = "users"
 
 type UserInterface interface {
-	Create(entity *v1.User) (*v1.PublicUser, error)
-	Update(entity *v1.User) (*v1.PublicUser, error)
+	Create(entity *v1.User) (*v1.User, error)
+	Update(entity *v1.User) (*v1.User, error)
 	Delete(name string) error
 	// Get is returning an unique User.
 	// As such name is the exact value of User.metadata.name. It cannot be empty.
 	// If you want to perform a research by prefix, please use the method List
-	Get(name string) (*v1.PublicUser, error)
+	Get(name string) (*v1.User, error)
 	// prefix is a prefix of the User.metadata.name to search for.
 	// It can be empty in case you want to get the full list of User available
-	List(prefix string) ([]*v1.PublicUser, error)
+	List(prefix string) ([]*v1.User, error)
 }
 
 type user struct {
@@ -46,8 +46,8 @@ func newUser(client *perseshttp.RESTClient) UserInterface {
 	}
 }
 
-func (c *user) Create(entity *v1.User) (*v1.PublicUser, error) {
-	result := &v1.PublicUser{}
+func (c *user) Create(entity *v1.User) (*v1.User, error) {
+	result := &v1.User{}
 	err := c.client.Post().
 		Resource(userResource).
 		Body(entity).
@@ -56,8 +56,8 @@ func (c *user) Create(entity *v1.User) (*v1.PublicUser, error) {
 	return result, err
 }
 
-func (c *user) Update(entity *v1.User) (*v1.PublicUser, error) {
-	result := &v1.PublicUser{}
+func (c *user) Update(entity *v1.User) (*v1.User, error) {
+	result := &v1.User{}
 	err := c.client.Put().
 		Resource(userResource).
 		Name(entity.Metadata.Name).
@@ -75,8 +75,8 @@ func (c *user) Delete(name string) error {
 		Error()
 }
 
-func (c *user) Get(name string) (*v1.PublicUser, error) {
-	result := &v1.PublicUser{}
+func (c *user) Get(name string) (*v1.User, error) {
+	result := &v1.User{}
 	err := c.client.Get().
 		Resource(userResource).
 		Name(name).
@@ -85,8 +85,8 @@ func (c *user) Get(name string) (*v1.PublicUser, error) {
 	return result, err
 }
 
-func (c *user) List(prefix string) ([]*v1.PublicUser, error) {
-	var result []*v1.PublicUser
+func (c *user) List(prefix string) ([]*v1.User, error) {
+	var result []*v1.User
 	err := c.client.Get().
 		Resource(userResource).
 		Query(&query{

--- a/pkg/model/api/v1/public_secret.go
+++ b/pkg/model/api/v1/public_secret.go
@@ -39,7 +39,7 @@ func NewPublicSecretSpec(s SecretSpec) PublicSecretSpec {
 
 type PublicGlobalSecret struct {
 	Kind     Kind             `json:"kind" yaml:"kind"`
-	Metadata Metadata         `json:"metadata" yaml:"metadata"`
+	Metadata PublicMetadata   `json:"metadata" yaml:"metadata"`
 	Spec     PublicSecretSpec `json:"spec" yaml:"spec"`
 }
 
@@ -49,7 +49,7 @@ func NewPublicGlobalSecret(s *GlobalSecret) *PublicGlobalSecret {
 	}
 	return &PublicGlobalSecret{
 		Kind:     s.Kind,
-		Metadata: s.Metadata,
+		Metadata: PublicMetadata(s.Metadata),
 		Spec:     NewPublicSecretSpec(s.Spec),
 	}
 }
@@ -67,9 +67,9 @@ func (g *PublicGlobalSecret) GetSpec() any {
 }
 
 type PublicSecret struct {
-	Kind     Kind             `json:"kind" yaml:"kind"`
-	Metadata ProjectMetadata  `json:"metadata" yaml:"metadata"`
-	Spec     PublicSecretSpec `json:"spec" yaml:"spec"`
+	Kind     Kind                  `json:"kind" yaml:"kind"`
+	Metadata PublicProjectMetadata `json:"metadata" yaml:"metadata"`
+	Spec     PublicSecretSpec      `json:"spec" yaml:"spec"`
 }
 
 func NewPublicSecret(s *Secret) *PublicSecret {
@@ -78,7 +78,7 @@ func NewPublicSecret(s *Secret) *PublicSecret {
 	}
 	return &PublicSecret{
 		Kind:     s.Kind,
-		Metadata: s.Metadata,
+		Metadata: NewPublicProjectMetadataFromCopy(s.Metadata),
 		Spec:     NewPublicSecretSpec(s.Spec),
 	}
 }

--- a/pkg/model/api/v1/public_secret_test.go
+++ b/pkg/model/api/v1/public_secret_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// We make this test just to ensure that the metadata validation is not called.
+// It makes no sense in reality.
+func TestUnmarshal_PublicGlobalSecret_SpecialCharName(t *testing.T) {
+	jsonData := []byte(`{
+		"kind": "GlobalSecret",
+		"metadata": {
+			"name": "system:serviceaccount:perses:user",
+			"createdAt": "2024-01-01T00:00:00Z",
+			"updatedAt": "2024-01-01T00:00:00Z",
+			"version": 1
+		},
+		"spec": {
+			"basic_auth": {
+				"username": "user",
+				"password": "<secret>"
+			}
+		}
+	}`)
+
+	var secret PublicGlobalSecret
+	err := json.Unmarshal(jsonData, &secret)
+	assert.NoError(t, err, "Unmarshal should not fail for secret name invalid")
+	assert.Equal(t, "system:serviceaccount:perses:user", secret.GetMetadata().GetName())
+}
+
+// We make this test just to ensure that the metadata validation is not called.
+// It makes no sense in reality.
+func TestUnmarshal_PublicSecret_SpecialCharName(t *testing.T) {
+	jsonData := []byte(`{
+		"kind": "Secret",
+		"metadata": {
+            "project": "default",
+			"name": "system:serviceaccount:perses:user",
+			"createdAt": "2024-01-01T00:00:00Z",
+			"updatedAt": "2024-01-01T00:00:00Z",
+			"version": 1
+		},
+		"spec": {
+			"basic_auth": {
+				"username": "user",
+				"password": "<secret>"
+			}
+		}
+	}`)
+
+	var secret PublicSecret
+	err := json.Unmarshal(jsonData, &secret)
+	assert.NoError(t, err, "Unmarshal should not fail for secret name invalid")
+	assert.Equal(t, "system:serviceaccount:perses:user", secret.GetMetadata().GetName())
+}

--- a/pkg/model/api/v1/public_user.go
+++ b/pkg/model/api/v1/public_user.go
@@ -42,7 +42,7 @@ func NewPublicUserSpec(u UserSpec) PublicUserSpec {
 
 type PublicUser struct {
 	Kind     Kind           `json:"kind"`
-	Metadata Metadata       `json:"metadata"`
+	Metadata PublicMetadata `json:"metadata"`
 	Spec     PublicUserSpec `json:"spec"`
 }
 
@@ -64,7 +64,7 @@ func NewPublicUser(u *User) *PublicUser {
 	}
 	return &PublicUser{
 		Kind:     u.Kind,
-		Metadata: u.Metadata,
+		Metadata: PublicMetadata(u.Metadata),
 		Spec:     NewPublicUserSpec(u.Spec),
 	}
 }

--- a/pkg/model/api/v1/public_user_test.go
+++ b/pkg/model/api/v1/public_user_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshal_PublicUser_ServiceAccountName(t *testing.T) {
+	jsonData := []byte(`{
+		"kind": "User",
+		"metadata": {
+			"name": "system:serviceaccount:perses:user",
+			"createdAt": "2024-01-01T00:00:00Z",
+			"updatedAt": "2024-01-01T00:00:00Z",
+			"version": 1
+		},
+		"spec": {
+			"firstName": "",
+			"lastName": "",
+			"nativeProvider": {},
+			"oauthProviders": []
+		}
+	}`)
+
+	var user PublicUser
+	err := json.Unmarshal(jsonData, &user)
+	assert.NoError(t, err, "Unmarshal should not fail for service account user name")
+	assert.Equal(t, "system:serviceaccount:perses:user", user.GetMetadata().GetName())
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

### Summary

Duplicate of **#3820**, but using a different strategy.  
Same context and same goal, except instead of removing unmarshal validation from all structs using `Metadata`, this PR introduces a dedicated `PublicMetadata` type for the `Public*` structs.

### Why

`Public*` structs are only used for **response payloads**, never for **create/update** operations. They don’t need unmarshal‑time validation.

### What this PR does

*   Add `PublicMetadata`.
*   Use it in all `Public*` structs that contains metadata.
*   Keep validation untouched for internal/write structs.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A
