### PR TITLE
[ENHANCEMENT] New endpoint `/api/v1/user/whoami`

### DIFF
--- a/internal/api/generate.go
+++ b/internal/api/generate.go
@@ -422,9 +422,7 @@ func generatePersistence(ept endpoint) {
 func generateClient(ept endpoint) {
 	folder := "../../pkg/client/api/v1/"
 	fileName := fmt.Sprintf("%s.go", ept.PackageName)
-	// as the endpoint is generated and not adds in git, the client that reflects exactly what is exposed by the endpoint,
-	// then should be also ignored by git, and so we can override it.
-	generateFile(folder, fileName, clientTemplate, ept, true)
+	generateFile(folder, fileName, clientTemplate, ept, false)
 }
 
 func generateFile(folder string, fileName string, tpl *template.Template, ept endpoint, shouldOverride bool) {

--- a/internal/api/utils/utils.go
+++ b/internal/api/utils/utils.go
@@ -32,7 +32,6 @@ const (
 	PathRefresh            = "refresh"
 	PathDeviceCode         = "device/code"
 	PathToken              = "token"
-	PathMe                 = "me"
 	AuthnKindNative        = "native"
 	AuthnKindOIDC          = "oidc"
 	AuthnKindOAuth         = "oauth"
@@ -53,8 +52,10 @@ const (
 	PathSecret             = "secrets"
 	PathUnsaved            = "unsaved"
 	PathUser               = "users"
+	PathCurrentUser        = "user"
 	PathVariable           = "variables"
 	PathView               = "view"
+	PathWhoAmI             = "whoami"
 	ContextKeyAnonymous    = "anonymous"
 )
 

--- a/internal/cli/cmd/login/k8s.go
+++ b/internal/cli/cmd/login/k8s.go
@@ -19,7 +19,6 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"github.com/perses/perses/internal/api/utils"
 	"github.com/perses/perses/pkg/client/api"
 	"github.com/perses/perses/pkg/client/config"
 	"golang.org/x/oauth2"
@@ -48,12 +47,8 @@ func (k *k8sLogin) Login() (*oauth2.Token, error) {
 	}
 	k.apiClient.RESTClient().Headers["Authorization"] = fmt.Sprintf("Bearer %s", kubeconfig.BearerToken)
 
-	res := k.apiClient.RESTClient().Get().
-		APIVersion("v1").
-		Resource(fmt.Sprintf("/%s/%s", utils.PathUser, utils.PathMe)).
-		Do()
-
-	if err := res.Error(); err != nil {
+	_, err = k.apiClient.V1().User().WhoAmI()
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -39,12 +39,8 @@ const (
 )
 
 const (
-	nativeAuthnProvider     = "native"
-	delegatedAuthnKindK8s   = utils.AuthnKindKubernetes
-	errAuthorizationPending = "authorization_pending"
-	errSlowDown             = "slow_down"
-	errAccessDenied         = "access_denied"
-	errExpiredToken         = "expired_token"
+	nativeAuthnProvider   = "native"
+	delegatedAuthnKindK8s = utils.AuthnKindKubernetes
 )
 
 type loginOption interface {

--- a/internal/cli/cmd/whoami/whoami.go
+++ b/internal/cli/cmd/whoami/whoami.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/perses/perses/internal/api/utils"
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/output"
@@ -74,7 +73,7 @@ func (o *option) Execute() error {
 }
 
 func (o *option) Whoami() (string, error) {
-	user, err := o.apiClient.V1().User().Get(utils.PathMe)
+	user, err := o.apiClient.V1().User().WhoAmI()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/client/api/v1/user.go
+++ b/pkg/client/api/v1/user.go
@@ -20,19 +20,23 @@ import (
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 )
 
-const userResource = "users"
+const (
+	userResource   = "users"
+	whoAmIResource = "user/whoami"
+)
 
 type UserInterface interface {
-	Create(entity *v1.User) (*v1.User, error)
-	Update(entity *v1.User) (*v1.User, error)
+	Create(entity *v1.User) (*v1.PublicUser, error)
+	Update(entity *v1.User) (*v1.PublicUser, error)
 	Delete(name string) error
 	// Get is returning an unique User.
 	// As such name is the exact value of User.metadata.name. It cannot be empty.
 	// If you want to perform a research by prefix, please use the method List
-	Get(name string) (*v1.User, error)
+	Get(name string) (*v1.PublicUser, error)
 	// prefix is a prefix of the User.metadata.name to search for.
 	// It can be empty in case you want to get the full list of User available
-	List(prefix string) ([]*v1.User, error)
+	List(prefix string) ([]*v1.PublicUser, error)
+	WhoAmI() (*v1.PublicUser, error)
 }
 
 type user struct {
@@ -46,8 +50,8 @@ func newUser(client *perseshttp.RESTClient) UserInterface {
 	}
 }
 
-func (c *user) Create(entity *v1.User) (*v1.User, error) {
-	result := &v1.User{}
+func (c *user) Create(entity *v1.User) (*v1.PublicUser, error) {
+	result := &v1.PublicUser{}
 	err := c.client.Post().
 		Resource(userResource).
 		Body(entity).
@@ -56,8 +60,8 @@ func (c *user) Create(entity *v1.User) (*v1.User, error) {
 	return result, err
 }
 
-func (c *user) Update(entity *v1.User) (*v1.User, error) {
-	result := &v1.User{}
+func (c *user) Update(entity *v1.User) (*v1.PublicUser, error) {
+	result := &v1.PublicUser{}
 	err := c.client.Put().
 		Resource(userResource).
 		Name(entity.Metadata.Name).
@@ -75,8 +79,8 @@ func (c *user) Delete(name string) error {
 		Error()
 }
 
-func (c *user) Get(name string) (*v1.User, error) {
-	result := &v1.User{}
+func (c *user) Get(name string) (*v1.PublicUser, error) {
+	result := &v1.PublicUser{}
 	err := c.client.Get().
 		Resource(userResource).
 		Name(name).
@@ -85,8 +89,8 @@ func (c *user) Get(name string) (*v1.User, error) {
 	return result, err
 }
 
-func (c *user) List(prefix string) ([]*v1.User, error) {
-	var result []*v1.User
+func (c *user) List(prefix string) ([]*v1.PublicUser, error) {
+	var result []*v1.PublicUser
 	err := c.client.Get().
 		Resource(userResource).
 		Query(&query{
@@ -94,5 +98,14 @@ func (c *user) List(prefix string) ([]*v1.User, error) {
 		}).
 		Do().
 		Object(&result)
+	return result, err
+}
+
+func (c *user) WhoAmI() (*v1.PublicUser, error) {
+	result := &v1.PublicUser{}
+	err := c.client.Get().
+		Resource(whoAmIResource).
+		Do().
+		Object(result)
 	return result, err
 }

--- a/ui/app/src/model/auth/auth-client.ts
+++ b/ui/app/src/model/auth/auth-client.ts
@@ -18,7 +18,6 @@ import { HTTPHeader, HTTPMethodPOST } from '../http';
 import { useCurrentUser } from '../user-client';
 
 export const authResource = 'auth';
-export const authnResource = 'authn';
 const redirectQueryParam = 'rd';
 
 /**
@@ -46,7 +45,7 @@ export function refreshToken(): Promise<Response> {
   });
 }
 
-// Retrieve the currently logged in user's username. Returns an empty string if the user is not
+// Retrieve the currently logged-in user's username. Returns an empty string if the user is not
 // logged in
 export function useUsername(): string {
   const me = useCurrentUser();

--- a/ui/app/src/model/user-client.ts
+++ b/ui/app/src/model/user-client.ts
@@ -19,6 +19,7 @@ import { HTTPHeader, HTTPMethodDELETE, HTTPMethodGET, HTTPMethodPOST, HTTPMethod
 import buildQueryKey from './querykey-builder';
 
 export const userResource = 'users';
+export const whoamiResource = 'user/whoami';
 export const userKey = 'user';
 
 function createUser(entity: UserResource): Promise<UserResource> {
@@ -30,16 +31,12 @@ function createUser(entity: UserResource): Promise<UserResource> {
   });
 }
 
-function getUser(name: string): Promise<UserResource> {
-  const url = buildURL({ resource: userResource, name });
+function getCurrentUser(): Promise<UserResource> {
+  const url = buildURL({ resource: whoamiResource });
   return fetchJson<UserResource>(url, {
     method: HTTPMethodGET,
     headers: HTTPHeader,
   });
-}
-
-function getCurrentUser(): Promise<UserResource> {
-  return getUser('me');
 }
 
 function getUsers(): Promise<UserResource[]> {
@@ -81,26 +78,13 @@ function getUserPermissions(username: string): Promise<Record<string, Permission
 }
 
 /**
- * Used to get a global secret from the API.
- * Will automatically be refreshed when cache is invalidated
- */
-export function useUser(name: string): UseQueryResult<UserResource, StatusError> {
-  return useQuery<UserResource, StatusError>({
-    queryKey: buildQueryKey({ resource: userResource, name }),
-    queryFn: () => {
-      return getUser(name);
-    },
-  });
-}
-
-/**
  * Used to retrieve information on the current logged in User
  * Will automatically be refreshed when cache is invalidated
  */
 export function useCurrentUser(): UseQueryResult<UserResource, StatusError> {
   const isAuthEnabled = useIsAuthEnabled();
   return useQuery<UserResource, StatusError>({
-    queryKey: buildQueryKey({ resource: userResource, name: 'me' }),
+    queryKey: buildQueryKey({ resource: whoamiResource }),
     queryFn: () => {
       return getCurrentUser();
     },
@@ -109,7 +93,7 @@ export function useCurrentUser(): UseQueryResult<UserResource, StatusError> {
 }
 
 /**
- * Used to get global secrets from the API.
+ * Used to get users from the API.
  * Will automatically be refreshed when cache is invalidated
  */
 export function useUserList(): UseQueryResult<UserResource[], StatusError> {
@@ -122,7 +106,7 @@ export function useUserList(): UseQueryResult<UserResource[], StatusError> {
 }
 
 /**
- * Returns a mutation that can be used to create a global secret.
+ * Returns a mutation that can be used to create a user.
  * Will automatically refresh the cache for all the list.
  */
 export function useCreateUserMutation(): UseMutationResult<UserResource, StatusError, UserResource> {
@@ -141,7 +125,7 @@ export function useCreateUserMutation(): UseMutationResult<UserResource, StatusE
 }
 
 /**
- * Returns a mutation that can be used to update a global secret.
+ * Returns a mutation that can be used to update a user.
  * Will automatically refresh the cache for all the list.
  */
 export function useUpdateUserMutation(): UseMutationResult<UserResource, StatusError, UserResource> {
@@ -163,7 +147,7 @@ export function useUpdateUserMutation(): UseMutationResult<UserResource, StatusE
 }
 
 /**
- * Returns a mutation that can be used to delete a global secret.
+ * Returns a mutation that can be used to delete a user.
  * Will automatically refresh the cache for all the list.
  */
 export function useDeleteUserMutation(): UseMutationResult<UserResource, StatusError, UserResource> {
@@ -184,7 +168,7 @@ export function useDeleteUserMutation(): UseMutationResult<UserResource, StatusE
 }
 
 /**
- * Used to get users from the API.
+ * Used to get user permissions from the API.
  * Will automatically be refreshed when cache is invalidated
  */
 export function useUserPermissions(username: string): UseQueryResult<Record<string, Permission[]>, StatusError> {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR aims to fix a problem with the ``/api/v1/users/me`` introduced previously in the k8s feature branch. 
Indeed it cancel the possibility for the users to be named "me".

I propose to create a totally new "whoami" endpoint that would retrieve exactly the same data than  ``/api/v1/users/me``.

# Screenshots

<img width="1901" height="352" alt="image" src="https://github.com/user-attachments/assets/3e9f01dd-cdd0-4ac0-a2c5-ed10e0e055e0" />
<img width="559" height="121" alt="image" src="https://github.com/user-attachments/assets/6dc3e1b1-c373-4e1e-9df4-73f7fd4139ef" />


<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
