### PR TITLE
[ENHANCEMENT]: DataGrid filter and columns panel positioning

### DIFF
--- a/ui/app/src/components/DashboardList/DashboardDataGrid.tsx
+++ b/ui/app/src/components/DashboardList/DashboardDataGrid.tsx
@@ -23,6 +23,7 @@ import {
   GridToolbar,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -73,6 +74,7 @@ export function DashboardDataGrid(props: DataGridProperties<Row>): ReactElement 
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>

--- a/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardDataGrid.tsx
+++ b/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardDataGrid.tsx
@@ -23,6 +23,7 @@ import {
   GridToolbar,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -72,6 +73,7 @@ export function EphemeralDashboardDataGrid(props: DataGridProperties<Row>): Reac
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>

--- a/ui/app/src/components/datagrid.tsx
+++ b/ui/app/src/components/datagrid.tsx
@@ -64,6 +64,12 @@ export const DATA_GRID_STYLES = {
 
 export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
+export const DATA_GRID_SLOT_PROPS = {
+  panel: {
+    placement: 'top-end' as const,
+  },
+};
+
 export function GridToolbar(): ReactElement {
   return (
     <GridToolbarContainer>

--- a/ui/app/src/components/datasource/DatasourceDataGrid.tsx
+++ b/ui/app/src/components/datasource/DatasourceDataGrid.tsx
@@ -22,6 +22,7 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -75,6 +76,7 @@ export function DatasourceDataGrid(props: DataGridPropertiesWithCallback<Row>): 
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>

--- a/ui/app/src/components/rolebindings/RoleBindingDataGrid.tsx
+++ b/ui/app/src/components/rolebindings/RoleBindingDataGrid.tsx
@@ -22,6 +22,7 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -71,6 +72,7 @@ export function RoleBindingDataGrid(props: DataGridPropertiesWithCallback<Row>):
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>

--- a/ui/app/src/components/roles/RoleDataGrid.tsx
+++ b/ui/app/src/components/roles/RoleDataGrid.tsx
@@ -22,6 +22,7 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -71,6 +72,7 @@ export function RoleDataGrid(props: DataGridPropertiesWithCallback<Row>): ReactE
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>

--- a/ui/app/src/components/secrets/SecretDataGrid.tsx
+++ b/ui/app/src/components/secrets/SecretDataGrid.tsx
@@ -22,6 +22,7 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -74,6 +75,7 @@ export function SecretDataGrid(props: DataGridPropertiesWithCallback<Row>): Reac
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>

--- a/ui/app/src/components/users/UserDataGrid.tsx
+++ b/ui/app/src/components/users/UserDataGrid.tsx
@@ -22,6 +22,7 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -71,6 +72,7 @@ export function UserDataGrid(props: DataGridPropertiesWithCallback<Row>): ReactE
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>

--- a/ui/app/src/components/variable/VariableDataGrid.tsx
+++ b/ui/app/src/components/variable/VariableDataGrid.tsx
@@ -22,6 +22,7 @@ import {
   DataGridPropertiesWithCallback,
   PAGE_SIZE_OPTIONS,
   DATA_GRID_STYLES,
+  DATA_GRID_SLOT_PROPS,
 } from '../datagrid';
 
 // https://mui.com/x/react-data-grid/performance/
@@ -71,6 +72,7 @@ export function VariableDataGrid(props: DataGridPropertiesWithCallback<Row>): Re
         }
         pageSizeOptions={PAGE_SIZE_OPTIONS}
         initialState={mergedInitialState}
+        slotProps={DATA_GRID_SLOT_PROPS}
         sx={DATA_GRID_STYLES}
       />
     </div>


### PR DESCRIPTION
This PR Introduces a shared slotProps configuration to standardize and enhance the filter and columns panel positioning across all DataGrid components.

# Description

The filter and columns panels were appearing at the default bottom-start position (left-aligned below the table headers), which created an awkward visual experience where the panels overlapped table content and it did not look very nice. 

Added a centralized DATA_GRID_SLOT_PROPS configuration in datagrid.tsx that sets the panel placement to top-end, positioning both the Filters and Columns panels above the table, aligned to the right side near their respective toolbar buttons.

# Screenshots

## Before

<img width="1512" height="442" alt="Screenshot 2026-02-06 at 22 13 41" src="https://github.com/user-attachments/assets/0714463a-7396-44d6-b7b0-eae1971f58bd" />

## After

<img width="1505" height="497" alt="Screenshot 2026-02-06 at 22 13 13" src="https://github.com/user-attachments/assets/42507d45-d3eb-4798-8067-3017af85a00c" />



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
