### PR TITLE
[ignore] check and fix license containing a date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/pkg/license/license_test.go
+++ b/scripts/pkg/license/license_test.go
@@ -42,6 +42,7 @@ func TestCollectFilesNotContainingLicense(t *testing.T) {
 		filepath.Join("dir1", "nested_without.go"): "// something else\npackage main\n",
 		filepath.Join("excludeDir", "skip.go"):     "// nothing\npackage main\n",
 		"excluded_pattern_test.go":                 "// no license\npackage main\n",
+		"file_with_license_and_date.go":            "// Copyright 2024 The Perses Authors\npackage main\n",
 	}
 
 	for name, content := range files {
@@ -59,9 +60,10 @@ func TestCollectFilesNotContainingLicense(t *testing.T) {
 		AddExcludedDir("excludeDir").
 		AddExcludedFile("excluded.go")
 
-	res := l.(*license).collectFilesNotContainingLicense(".")
+	res, resWithDate := l.(*license).collectFiles(".")
 
 	// Expect these files to be reported as missing the license
 	want := []string{filepath.Join("dir1", "nested_without.go"), "file_without_license.go"}
 	assert.Equal(t, res, want)
+	assert.Equal(t, resWithDate, []string{"file_with_license_and_date.go"})
 }

--- a/ui/app/src/components/EmptyState/EmptyState.tsx
+++ b/ui/app/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 The Perses Authors
+// Copyright The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/app/src/views/home/HomeViewHeroSection.tsx
+++ b/ui/app/src/views/home/HomeViewHeroSection.tsx
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
This will make the CI failed if someone is putting a license header with a date. And it can fix any license header containing the wrong pattern.