### PR TITLE
[ENHANCEMENT] add specific project creation permission check for auth providers

### DIFF
--- a/internal/api/authorization/authorization.go
+++ b/internal/api/authorization/authorization.go
@@ -64,6 +64,13 @@ type Authorization interface {
 	// In case the endpoint is anonymous, or the context is empty, it will return true.
 	// In case the user information is not found in the context, the implementation should return false.
 	HasPermission(ctx echo.Context, requestAction v1Role.Action, requestProject string, requestScope v1Role.Scope) bool
+	// HasCreateProjectPermission checks if the user has the permission to create a Perses project.
+	// This is separated from HasPermission because the way project creation permission is evaluated differs
+	// between authorization providers:
+	//   - For native auth, creating a project requires a global permission (i.e. a GlobalRole granting create on ProjectScope).
+	//   - For delegated auth (e.g. k8s), creating a project is driven by having write access to the corresponding
+	//     namespace rather than a global permission, since Perses projects map 1:1 to k8s namespaces.
+	HasCreateProjectPermission(ctx echo.Context, projectName string) bool
 	// GetPermissions returns the permissions of the user found in the context.
 	// Be aware that this function cannot be called from an anonymous endpoint.
 	// In case the user information is not found in the context, the implementation should return an error.

--- a/internal/api/authorization/disabled.go
+++ b/internal/api/authorization/disabled.go
@@ -59,6 +59,10 @@ func (r *disabledImpl) HasPermission(_ echo.Context, _ v1Role.Action, _ string, 
 	return true
 }
 
+func (r *disabledImpl) HasProjectCreatePermission(_ echo.Context, _ string) bool {
+	return true
+}
+
 func (r *disabledImpl) GetPermissions(_ echo.Context) (map[string][]*v1Role.Permission, error) {
 	return nil, nil
 }

--- a/internal/api/authorization/k8s/k8s.go
+++ b/internal/api/authorization/k8s/k8s.go
@@ -261,6 +261,14 @@ func (k *k8sImpl) HasPermission(ctx echo.Context, requestAction v1Role.Action, r
 	return authorized == authorizer.DecisionAllow
 }
 
+// For k8s auth, the permission to create a project is driven by having write access
+// to the corresponding namespace, since Perses projects map 1:1 to k8s namespaces.
+// We check if the user can create a dashboard in the target namespace as a proxy for
+// editor/admin access.
+func (k *k8sImpl) HasCreateProjectPermission(ctx echo.Context, projectName string) bool {
+	return k.HasPermission(ctx, v1Role.CreateAction, projectName, v1Role.DashboardScope)
+}
+
 // GetPermissions implements [Authorization]
 func (k *k8sImpl) GetPermissions(ctx echo.Context) (map[string][]*v1Role.Permission, error) {
 	// If the context is nil, it means the function is called internally without a request context.

--- a/internal/api/authorization/native/native.go
+++ b/internal/api/authorization/native/native.go
@@ -221,6 +221,11 @@ func (n *native) HasPermission(ctx echo.Context, requestAction v1Role.Action, re
 	return n.cache.hasPermission(username, requestAction, requestProject, requestScope)
 }
 
+// For native auth, creating a project requires a global permission.
+func (n *native) HasCreateProjectPermission(ctx echo.Context, projectName string) bool {
+	return n.HasPermission(ctx, v1Role.CreateAction, v1.WildcardProject, v1Role.ProjectScope)
+}
+
 func (n *native) GetPermissions(ctx echo.Context) (map[string][]*v1Role.Permission, error) {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()

--- a/internal/api/impl/v1/view/endpoint_test.go
+++ b/internal/api/impl/v1/view/endpoint_test.go
@@ -76,6 +76,10 @@ func (t *testRBAC) HasPermission(_ echo.Context, _ role.Action, _ string, _ role
 	return t.allow
 }
 
+func (t *testRBAC) HasCreateProjectPermission(_ echo.Context, _ string) bool {
+	return t.allow
+}
+
 func (t *testRBAC) IsEnabled() bool {
 	return true
 }


### PR DESCRIPTION
# Description

We ran into the problem, that a user with editor access into a specific namespace cannot create a Perses project. The cause was a direct check of project creation tied to a global role, this behaves differently in k8s as users with an existing namespace and editor access over it, should be able to create the corresponding Perses project. This happens when the namespace exists first than a perses project, in the opposite case the Perses operator can create the namespace based on a Perses project.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).