### PR TITLE
[BUGFIX] CUE DaC utils: rely on new closedness behavior in dashboard builder to fix SDK usage

### DIFF
--- a/cue/dac-utils/dashboard/dashboard.cue
+++ b/cue/dac-utils/dashboard/dashboard.cue
@@ -13,6 +13,7 @@
 
 // This package offers an utility to build a dashboards easily, by allowing
 // to provide panels together with their layout.
+@experiment(explicitopen)
 
 package dashboard
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

In the CUE DaC SDK I made a wrong usage of struct embeddings as they work currently, introducing "uncertainty" that breaks the exclusive choice we want for our `directURL |  proxy` XOR. You can find an example of the problem it causes in [this PR](https://github.com/perses/perses/pull/3885).

But it's actually not just me 🤓 the way struct embedding works currently in CUE is misleading & fortunately this is currently being reworked, as a new evaluation behavior is already available in experimental mode that solves our issue. More info at https://cuelang.org/docs/howto/try-explicitopen-experiment/.

By playing a bit I noticed that introducing the new behavior only in the dashboard builder (via the correct flag) is enough to solve the issue, thus this PR is just about that. Thanks to this, no breaking change for our CUE SDK users that won't have to workaround the issue like I had to do in the PR linked above.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).