### PR TITLE
[ENHANCEMENT] Home page layout when there are no important dashboards

### DIFF
--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -107,6 +107,11 @@ export function useIsSignUpDisable(): boolean {
   return config.security.authentication.disable_sign_up;
 }
 
+export function useHasImportantDashboards(): boolean {
+  const { config } = useConfigContext();
+  return Boolean(config.frontend.important_dashboards?.length);
+}
+
 export function useImportantDashboardSelectors(): DashboardSelector[] {
   const { config } = useConfigContext();
   return useMemo(() => {

--- a/ui/app/src/views/home/HomeView.tsx
+++ b/ui/app/src/views/home/HomeView.tsx
@@ -18,7 +18,7 @@ import { DashboardSelector, ProjectResource } from '@perses-dev/core';
 import { CreateProjectDialog, CreateDashboardDialog } from '../../components/dialogs';
 import { useIsMobileSize } from '../../utils/browser-size';
 import { useDashboardCreateAllowedProjects } from '../../context/Authorization';
-import { useIsEphemeralDashboardEnabled } from '../../context/Config';
+import { useIsEphemeralDashboardEnabled, useHasImportantDashboards } from '../../context/Config';
 import { RecentDashboards } from './RecentDashboards';
 import { Projects } from './Projects';
 import { ImportantDashboards } from './ImportantDashboards';
@@ -30,6 +30,7 @@ function HomeView(): ReactElement {
   const isMobileSize = useIsMobileSize();
   const userProjects = useDashboardCreateAllowedProjects();
   const isEphemeralDashboardEnabled = useIsEphemeralDashboardEnabled();
+  const hasImportantDashboards = useHasImportantDashboards();
 
   const handleAddProjectDialogSubmit = (entity: ProjectResource): void => navigate(`/projects/${entity.metadata.name}`);
   const handleAddDashboardDialogSubmit = (dashboardSelector: DashboardSelector): void =>
@@ -82,9 +83,9 @@ function HomeView(): ReactElement {
           gap: 3,
         }}
       >
-        {/* Important Dashboards - Spans 2 columns */}
+        {/* Left section - Spans 2 columns: ImportantDashboards when configured, otherwise Projects */}
         <Box sx={{ gridColumn: { lg: 'span 2' } }}>
-          <ImportantDashboards />
+          {hasImportantDashboards ? <ImportantDashboards /> : <Projects />}
         </Box>
 
         {/* Recent Dashboards - 1 column */}
@@ -92,9 +93,11 @@ function HomeView(): ReactElement {
           <RecentDashboards />
         </Box>
       </Box>
-      <Box mt={3} mb={3}>
-        <Projects />
-      </Box>
+      {hasImportantDashboards && (
+        <Box mt={3} mb={3}>
+          <Projects />
+        </Box>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR fixes https://github.com/perses/perses/issues/3886

### Home Page when there are no important dashboards configured

<img width="1512" height="761" alt="Screenshot 2026-02-19 at 09 36 12" src="https://github.com/user-attachments/assets/47b3946d-c071-42d0-807c-ba8cb0416159" />


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
