### PR TITLE
[FEATURE] Load plugin from multiple folders

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -825,7 +825,13 @@ path: <path> | default = ("plugins" | "/etc/perses/plugins") # Optional
 
 # The path to the folder containing the plugins archive. 
 # When Perses is starting, it will extract the content of the archive in the folder specified in the `folder` attribute.
+# DEPRECATED: use `archive_paths` instead to specify multiple folders for the archived plugins.
 archive_path: <path> | default = ("plugins-archive" | "/etc/perses/plugins-archive") # Optional
+
+# The list of paths to the directories containing the archived plugins. It allows to specify multiple directories for the archived plugins.
+# When Perses is starting, it will extract any archive found in the folders specified in this attribute in the folder specified in the `path` attribute.
+archive_paths: 
+    - <path> | default = ("plugins-archive" | "/etc/perses/plugins-archive") # Optional
 
 # Allow use of plugins in dev mode.
 enable_dev: <bool> | default = false # Optional

--- a/internal/api/plugin/plugin.go
+++ b/internal/api/plugin/plugin.go
@@ -63,8 +63,8 @@ type Plugin interface {
 func StrictLoad() Plugin {
 	projectPath := test.GetRepositoryPath()
 	cfg := config.Plugin{
-		Path:        filepath.Join(projectPath, config.DefaultPluginPath),
-		ArchivePath: filepath.Join(projectPath, config.DefaultArchivePluginPath),
+		Path:         filepath.Join(projectPath, config.DefaultPluginPath),
+		ArchivePaths: []string{filepath.Join(projectPath, config.DefaultArchivePluginPath)},
 	}
 	pluginService := New(cfg)
 	if err := pluginService.UnzipArchives(); err != nil {
@@ -80,7 +80,7 @@ func New(cfg config.Plugin) Plugin {
 	return &pluginFile{
 		path: cfg.Path,
 		archibal: &arch{
-			folder:       cfg.ArchivePath,
+			folders:      cfg.ArchivePaths,
 			targetFolder: cfg.Path,
 		},
 		sch:       schema.New(),

--- a/pkg/model/api/config/config_test.go
+++ b/pkg/model/api/config/config_test.go
@@ -161,7 +161,9 @@ func TestJSONMarshalConfig(t *testing.T) {
   },
   "plugin": {
     "path": "plugins",
-    "archive_path": "plugins-archive",
+    "archive_paths": [
+      "plugins-archive"
+    ],
     "enable_dev": false
   }
 }`,
@@ -510,8 +512,8 @@ plugin:
 					Information: "# Hello World\n## File Database setup",
 				},
 				Plugin: Plugin{
-					Path:        "custom/plugins",
-					ArchivePath: "custom/plugins/archive",
+					Path:         "custom/plugins",
+					ArchivePaths: []string{"custom/plugins/archive"},
 				},
 				Provisioning: ProvisioningConfig{
 					Folders: []string{

--- a/pkg/model/api/config/security_test.go
+++ b/pkg/model/api/config/security_test.go
@@ -350,8 +350,8 @@ security:
 					Information:         "",
 				},
 				Plugin: Plugin{
-					Path:        "plugins",
-					ArchivePath: "plugins-archive",
+					Path:         "plugins",
+					ArchivePaths: []string{"plugins-archive"},
 				},
 				Provisioning: ProvisioningConfig{
 					Interval: common.Duration(defaultInterval),


### PR DESCRIPTION
This PR is adapting the original source where we are looking for the plugin archive.

Instead of having a single source, you can specify a list of folder where Perses will look for the archives to extract.

This will allow user to inject private plugin in the container without being forced to rebuild the docker image.

fix #3881 