### PR TITLE
[FEATURE] new `percli dac watch` command

### DIFF
--- a/docs/dac/getting-started.md
+++ b/docs/dac/getting-started.md
@@ -242,7 +242,7 @@ percli dac build -d my_dashboards
 
 ## Development workflow with auto-reload
 
-For an improved development experience, you can use the `dac watch` command that automatically rebuilds your dashboards whenever you save changes to your DaC files. This provides a workflow similar to frontend hot-reload development.
+For an improved development experience, instead of building the files each time manually with `dac build`, you can use the `dac watch` command that automatically rebuilds your dashboards whenever you save changes to your DaC files. This provides a workflow similar to frontend hot-reload development.
 
 ### Basic watch mode
 
@@ -262,7 +262,7 @@ percli dac watch ./my-dashboards -ojson
 The watcher will:
 - Perform an initial build of all dashboards
 - Monitor all `.go` and `.cue` files in the source directory
-- Automatically rebuild when files are modified (with a 500ms debounce)
+- Automatically rebuild when files are modified
 - Output results to the `built` folder (or custom location via `--dac.output_folder`)
 
 ### Integrated development workflow

--- a/docs/dac/getting-started.md
+++ b/docs/dac/getting-started.md
@@ -292,8 +292,8 @@ security:
 # Terminal 1: Start Perses server with provisioning
 perses --config perses-dev.yaml
 
-# Terminal 2: Start the DaC watcher
-percli dac watch ./my-dashboards
+# Terminal 2: At the root of your DaC repo, start the DaC watcher
+percli dac watch
 ```
 
 **Step 3: Develop with instant feedback**:

--- a/docs/dac/getting-started.md
+++ b/docs/dac/getting-started.md
@@ -240,6 +240,76 @@ If you want to develop multiple dashboards as code, you should have **1 dashboar
 percli dac build -d my_dashboards
 ```
 
+## Development workflow with auto-reload
+
+For an improved development experience, you can use the `dac watch` command that automatically rebuilds your dashboards whenever you save changes to your DaC files. This provides a workflow similar to frontend hot-reload development.
+
+### Basic watch mode
+
+Start watching your DaC files for changes:
+
+```bash
+# Watch current directory
+percli dac watch
+
+# Watch specific directory
+percli dac watch ./my-dashboards
+
+# Watch and output as JSON
+percli dac watch ./my-dashboards -ojson
+```
+
+The watcher will:
+- Perform an initial build of all dashboards
+- Monitor all `.go` and `.cue` files in the source directory
+- Automatically rebuild when files are modified (with a 500ms debounce)
+- Output results to the `built` folder (or custom location via `--dac.output_folder`)
+
+### Integrated development workflow
+
+To get a direct visual feedback of your changes when coding dashboards, you can run Perses with provisioning configured to watch your build directory:
+
+**Step 1: Create a Perses config file** (`perses-dev.yaml`):
+
+```yaml
+database:
+  file:
+    folder: /tmp/perses-dac-dev
+    extension: yaml
+
+provisioning:
+  interval: 5s  # Check for changes every 5 seconds
+  folders:
+    - /absolute/path/to/your/built  # Your build output folder
+
+security:
+  enable_auth: false  # Disable auth for local development
+```
+
+**Step 2: Start both processes**:
+
+```bash
+# Terminal 1: Start Perses server with provisioning
+perses --config perses-dev.yaml
+
+# Terminal 2: Start the DaC watcher
+percli dac watch ./my-dashboards
+```
+
+**Step 3: Develop with instant feedback**:
+
+1. Open `http://localhost:8080` in your browser
+2. Navigate to your dashboards
+3. Edit your DaC files (`.go` or `.cue`)
+4. Watch the terminal show automatic rebuild
+5. Refresh your browser to see changes (provisioning picks them up within 5 seconds)
+
+!!! tip
+    The provisioning interval of `5s` provides a good balance between responsiveness and system load. You can adjust it based on your needs.
+
+!!! tip
+    The watch command uses a 500ms debounce delay by default to avoid excessive rebuilds while you're actively editing. You can customize this with the `--debounce` flag.
+
 ## Deploy dashboards
 
 Once you are satisfied with the result of your DaC definition for a given dashboard, you can finally deploy it to Perses with the `apply` command:

--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -56,7 +56,7 @@ func isGoMainPackage(path string) bool {
 	return f.Name.Name == "main"
 }
 
-type option struct {
+type Option struct {
 	persesCMD.Option
 	opt.FileOption
 	opt.DirectoryOption
@@ -67,7 +67,7 @@ type option struct {
 	Mode      string
 }
 
-func (o *option) Complete(args []string) error {
+func (o *Option) Complete(args []string) error {
 	o.args = args
 	if outputErr := o.OutputOption.Complete(); outputErr != nil {
 		return outputErr
@@ -75,7 +75,7 @@ func (o *option) Complete(args []string) error {
 	return nil
 }
 
-func (o *option) Validate() error {
+func (o *Option) Validate() error {
 	if o.Mode != modeFile && o.Mode != modeStdout {
 		return fmt.Errorf("invalid mode provided: must be either `file` or `stdout`")
 	}
@@ -86,7 +86,7 @@ func (o *option) Validate() error {
 	return o.DirectoryOption.Validate()
 }
 
-func (o *option) Execute() error {
+func (o *Option) Execute() error {
 	if o.File != "" {
 		return o.processFile(o.File, filepath.Ext(o.File))
 	}
@@ -142,7 +142,7 @@ func (o *option) Execute() error {
 	return nil
 }
 
-func (o *option) processFile(file string, extension string) error {
+func (o *Option) processFile(file string, extension string) error {
 	var cmd *exec.Cmd
 
 	if extension == goExtension { //nolint: staticcheck
@@ -201,23 +201,35 @@ func (o *option) processFile(file string, extension string) error {
 }
 
 // buildOutputFilePath generates the output file path based on the input file path
-func (o *option) buildOutputFilePath(inputFilePath string) string {
+func (o *Option) buildOutputFilePath(inputFilePath string) string {
 	// Extract the file name without extension
 	baseName := strings.TrimSuffix(inputFilePath, filepath.Ext(inputFilePath))
 	// Build the output file path in the "built" folder with the same name as the input file
 	return filepath.Join(config.Global.Dac.OutputFolder, fmt.Sprintf("%s_output.%s", baseName, o.Output)) // Change the extension as needed
 }
 
-func (o *option) SetWriter(writer io.Writer) {
+func (o *Option) SetWriter(writer io.Writer) {
 	o.writer = writer
 }
 
-func (o *option) SetErrWriter(errWriter io.Writer) {
+func (o *Option) SetErrWriter(errWriter io.Writer) {
 	o.errWriter = errWriter
 }
 
+// Run executes the build process programmatically.
+// This is useful for tools that need to trigger builds without going through the CLI.
+func (o *Option) Run() error {
+	if err := o.Complete(nil); err != nil {
+		return err
+	}
+	if err := o.Validate(); err != nil {
+		return err
+	}
+	return o.Execute()
+}
+
 func NewCMD() *cobra.Command {
-	o := &option{}
+	o := &Option{}
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Build the given DaC file(s)",

--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -191,7 +191,7 @@ func (o *Option) processFile(file string, extension string) error {
 	}
 
 	// Build the path of the file where to store the command output
-	outputFilePath := o.buildOutputFilePath(file)
+	outputFilePath := o.BuildOutputFilePath(file)
 
 	// Write the output to the file
 	if writeErr := os.WriteFile(outputFilePath, cmdOutput, 0644); writeErr != nil { // nolint: gosec
@@ -200,8 +200,13 @@ func (o *Option) processFile(file string, extension string) error {
 	return output.HandleString(o.writer, fmt.Sprintf("Successfully built %s at %s", file, outputFilePath))
 }
 
-// buildOutputFilePath generates the output file path based on the input file path
-func (o *Option) buildOutputFilePath(inputFilePath string) string {
+// BuildOutputFilePath generates the output file path based on the input file path
+// Example when the dac output folder is "built", and the output format is "yaml":
+//   - inputFilePath: "dashboards/my_dashboard.cue"
+//   - outputFilePath: "built/dashboards/my_dashboard_output.yaml"
+//
+// /!\ Be sure to be in a DaC context so config.Global.Dac.OutputFolder is correctly set when calling this function.
+func (o *Option) BuildOutputFilePath(inputFilePath string) string {
 	// Extract the file name without extension
 	baseName := strings.TrimSuffix(inputFilePath, filepath.Ext(inputFilePath))
 	// Build the output file path in the "built" folder with the same name as the input file

--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -216,18 +216,6 @@ func (o *Option) SetErrWriter(errWriter io.Writer) {
 	o.errWriter = errWriter
 }
 
-// Run executes the build process programmatically.
-// This is useful for other commands to trigger builds without going through the CLI (e.g watch command).
-func (o *Option) Run() error {
-	if err := o.Complete(nil); err != nil {
-		return err
-	}
-	if err := o.Validate(); err != nil {
-		return err
-	}
-	return o.Execute()
-}
-
 func NewCMD() *cobra.Command {
 	o := &Option{}
 	cmd := &cobra.Command{

--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -217,7 +217,7 @@ func (o *Option) SetErrWriter(errWriter io.Writer) {
 }
 
 // Run executes the build process programmatically.
-// This is useful for tools that need to trigger builds without going through the CLI.
+// This is useful for other commands to trigger builds without going through the CLI (e.g watch command).
 func (o *Option) Run() error {
 	if err := o.Complete(nil); err != nil {
 		return err

--- a/internal/cli/cmd/dac/dac.go
+++ b/internal/cli/cmd/dac/dac.go
@@ -18,6 +18,7 @@ import (
 	"github.com/perses/perses/internal/cli/cmd/dac/diff"
 	"github.com/perses/perses/internal/cli/cmd/dac/preview"
 	"github.com/perses/perses/internal/cli/cmd/dac/setup"
+	"github.com/perses/perses/internal/cli/cmd/dac/watch"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/spf13/cobra"
 )
@@ -37,6 +38,7 @@ func NewCMD() *cobra.Command {
 	cmd.AddCommand(diff.NewCMD())
 	cmd.AddCommand(preview.NewCMD())
 	cmd.AddCommand(setup.NewCMD())
+	cmd.AddCommand(watch.NewCMD())
 
 	cmd.PersistentFlags().StringVar(&dacOutputFolder, "dac.output_folder", config.DefaultOutputFolder, "Path to the folder where the dac-generated files are stored.")
 

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/cue.mod/module.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/cue.mod/module.cue
@@ -1,0 +1,2 @@
+module: "test-dac-cue.com/m"
+language: version: "v0.11.0"

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/dash1.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/dash1.cue
@@ -6,6 +6,6 @@ import (
 )
 
 dashboardBuilder & {
-	#name: "test-dashboard"
+	#name:   "test-dashboard"
 	#panels: panels
 }

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/dash1.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/dash1.cue
@@ -1,3 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dashboard
 
 import (

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/dash1.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/dash1.cue
@@ -1,0 +1,11 @@
+package dashboard
+
+import (
+	dashboardBuilder "github.com/perses/perses/cue/dac-utils/dashboard"
+	panels "test-dac-cue.com/m/panels"
+)
+
+dashboardBuilder & {
+	#name: "test-dashboard"
+	#panels: panels
+}

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/my-dashboard.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/my-dashboard.cue
@@ -7,6 +7,6 @@ import (
 // This file has "dashboard" in filename (my-dashboard.cue)
 // so it should be detected as a dashboard
 #dashboard: {
-	name: "my-dashboard"
+	name:   "my-dashboard"
 	panels: panels
 }

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/my-dashboard.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/my-dashboard.cue
@@ -1,3 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package myproject
 
 import (

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/my-dashboard.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/dashboards/my-dashboard.cue
@@ -1,0 +1,12 @@
+package myproject
+
+import (
+	panels "test-dac-cue.com/m/panels"
+)
+
+// This file has "dashboard" in filename (my-dashboard.cue)
+// so it should be detected as a dashboard
+#dashboard: {
+	name: "my-dashboard"
+	panels: panels
+}

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/panels/panel.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/panels/panel.cue
@@ -1,0 +1,7 @@
+package panels
+
+// Simple panel definition (library file)
+#panel: {
+	title: string
+	type:  string
+}

--- a/internal/cli/cmd/dac/watch/testdata/cue-simple/panels/panel.cue
+++ b/internal/cli/cmd/dac/watch/testdata/cue-simple/panels/panel.cue
@@ -1,3 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package panels
 
 // Simple panel definition (library file)

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash1/main.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash1/main.go
@@ -1,3 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash1/main.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash1/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"test-dac.com/m/mylibrary"
+)
+
+func main() {
+	// Dashboard 1 imports mylibrary directly
+	_ = mylibrary.GetValue()
+}

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash2/main.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash2/main.go
@@ -1,3 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash2/main.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/dashboards/dash2/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"test-dac.com/m/mylibrary"
+)
+
+func main() {
+	// Dashboard 2 also imports mylibrary
+	_ = mylibrary.GetValue()
+}

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/go.mod
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/go.mod
@@ -1,0 +1,5 @@
+module test-dac.com/m
+
+go 1.25
+
+require github.com/perses/perses v0.53.0

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/lib.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/lib.go
@@ -1,0 +1,10 @@
+package mylibrary
+
+import (
+	"test-dac.com/m/mylibrary/nested"
+)
+
+// GetValue returns a value, importing nested library (transitive dependency)
+func GetValue() string {
+	return nested.GetNestedValue()
+}

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/lib.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/lib.go
@@ -1,3 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mylibrary
 
 import (

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/nested/deep.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/nested/deep.go
@@ -1,0 +1,6 @@
+package nested
+
+// GetNestedValue returns a nested value (transitive dependency)
+func GetNestedValue() string {
+	return "nested"
+}

--- a/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/nested/deep.go
+++ b/internal/cli/cmd/dac/watch/testdata/go-simple/mylibrary/nested/deep.go
@@ -1,3 +1,16 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nested
 
 // GetNestedValue returns a nested value (transitive dependency)

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -34,6 +34,7 @@ type option struct {
 	persesCMD.Option
 	opt.OutputOption
 	sourceDir     string
+	buildArgs     []string
 	debounceDelay time.Duration
 	writer        io.Writer
 	errWriter     io.Writer
@@ -43,6 +44,9 @@ type option struct {
 func (o *option) Complete(args []string) error {
 	if len(args) > 0 {
 		o.sourceDir = args[0]
+		if len(args) > 1 {
+			o.buildArgs = args[1:]
+		}
 	} else {
 		o.sourceDir = "."
 	}
@@ -82,6 +86,7 @@ func (o *option) Execute() error {
 		o.sourceDir,
 		buildDir,
 		o.Output,
+		o.buildArgs,
 		o.debounceDelay,
 		o.writer,
 		o.errWriter,
@@ -157,7 +162,6 @@ percli dac watch ./my-dashboards --dac.output_folder=./provisioning/dashboards
 
 # Pass extra arguments to Go programs
 percli dac watch ./my-dashboards -- --arg1=value1 --arg2=value2`,
-		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return persesCMD.Run(o, cmd, args)
 		},

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -35,7 +35,6 @@ type option struct {
 	opt.OutputOption
 	sourceDir     string
 	debounceDelay time.Duration
-	buildArgs     []string
 	writer        io.Writer
 	errWriter     io.Writer
 }
@@ -83,7 +82,6 @@ func (o *option) Execute() error {
 		o.sourceDir,
 		buildDir,
 		o.Output,
-		o.buildArgs,
 		o.debounceDelay,
 		o.writer,
 		o.errWriter,

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -1,0 +1,166 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/perses/common/async"
+	"github.com/perses/common/async/taskhelper"
+	persesCMD "github.com/perses/perses/internal/cli/cmd"
+	"github.com/perses/perses/internal/cli/config"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	persesCMD.Option
+	sourceDir     string
+	output        string
+	debounceDelay time.Duration
+	buildArgs     []string
+	writer        io.Writer
+	errWriter     io.Writer
+}
+
+// Complete initializes the watch command with the provided arguments
+func (o *option) Complete(args []string) error {
+	if len(args) > 0 {
+		o.sourceDir = args[0]
+	} else {
+		o.sourceDir = "."
+	}
+	return nil
+}
+
+// Validate ensures the output directory is properly configured and exists
+func (o *option) Validate() error {
+	// Use the configured output folder from dac command
+	if config.Global.Dac.OutputFolder == "" {
+		config.Global.Dac.OutputFolder = "built"
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(config.Global.Dac.OutputFolder, 0750); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+	return nil
+}
+
+// Execute starts the file watcher and manages the watch lifecycle
+func (o *option) Execute() error {
+	buildDir := config.Global.Dac.OutputFolder
+
+	fmt.Fprintf(o.writer, "📦 Dashboard-as-Code Watcher\n")
+	fmt.Fprintf(o.writer, "   Source: %s\n", o.sourceDir)
+	fmt.Fprintf(o.writer, "   Output: %s\n", buildDir)
+	fmt.Fprintf(o.writer, "   Format: %s\n", o.output)
+	fmt.Fprintln(o.writer)
+
+	// Create the primary context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create watcher task
+	watcher := newWatcher(
+		o.sourceDir,
+		buildDir,
+		o.output,
+		o.buildArgs,
+		o.debounceDelay,
+		o.writer,
+		o.errWriter,
+	)
+
+	// Wrap tasks with taskhelper
+	var tasks []taskhelper.Helper
+
+	// Setup signal listener
+	signalListener, _ := taskhelper.New(async.NewSignalListener(syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL))
+	tasks = append(tasks, signalListener)
+
+	// Add watcher task
+	watcherTask, _ := taskhelper.New(watcher)
+	tasks = append(tasks, watcherTask)
+
+	// Run all tasks
+	for _, task := range tasks {
+		taskhelper.Run(ctx, cancel, task)
+	}
+
+	// Wait for all tasks to finish
+	taskhelper.JoinAll(ctx, time.Second*30, tasks)
+	return nil
+}
+
+// SetWriter sets the standard output writer for the watch command
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+// SetErrWriter sets the error output writer for the watch command
+func (o *option) SetErrWriter(errWriter io.Writer) {
+	o.errWriter = errWriter
+}
+
+// NewCMD creates the watch command for automatic Dashboard-as-Code rebuilding
+func NewCMD() *cobra.Command {
+	o := &option{
+		debounceDelay: 500 * time.Millisecond,
+		output:        "yaml",
+	}
+
+	cmd := &cobra.Command{
+		Use:   "watch [source-dir]",
+		Short: "Watch Dashboard-as-Code files and auto-rebuild on changes",
+		Long: `Watch Go/CUE files in the specified directory and automatically rebuild JSON/YAML outputs when files are saved.
+
+This command provides a development workflow similar to frontend hot-reload, where changes to your Dashboard-as-Code files are immediately compiled and made available for provisioning.
+
+The watcher will:
+- Perform an initial build
+- Monitor all .go and .cue files in the source directory
+- Rebuild automatically when files are modified
+- Output results to the build directory (default: ./built)
+
+Combine this with Perses provisioning to see your dashboard changes reflected in the UI automatically.`,
+		Example: `# Watch current directory, output to ./built
+percli dac watch
+
+# Watch specific directory
+percli dac watch ./my-dashboards
+
+# Watch and output as JSON
+percli dac watch ./my-dashboards -ojson
+
+# Watch with custom output directory
+percli dac watch ./my-dashboards --dac.output_folder=./provisioning/dashboards
+
+# Pass extra arguments to Go programs
+percli dac watch ./my-dashboards -- --arg1=value1 --arg2=value2`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return persesCMD.Run(o, cmd, args)
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.output, "output", "o", "yaml", "Output format (json or yaml)")
+	cmd.Flags().DurationVar(&o.debounceDelay, "debounce", 500*time.Millisecond, "Debounce delay for file changes")
+
+	return cmd
+}

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/perses/common/async/taskhelper"
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/config"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -66,11 +67,13 @@ func (o *option) Validate() error {
 func (o *option) Execute() error {
 	buildDir := config.Global.Dac.OutputFolder
 
-	fmt.Fprintf(o.writer, "📦 Dashboard-as-Code Watcher\n")
-	fmt.Fprintf(o.writer, "   Source: %s\n", o.sourceDir)
-	fmt.Fprintf(o.writer, "   Output: %s\n", buildDir)
-	fmt.Fprintf(o.writer, "   Format: %s\n", o.output)
-	fmt.Fprintln(o.writer)
+	logrus.Info("📦 Dashboard-as-Code Watcher")
+	logrus.Infof("   Source: %s", o.sourceDir)
+	logrus.Infof("   Output: %s", buildDir)
+	logrus.Infof("   Format: %s", o.output)
+	logrus.Info("")
+	logrus.Info("👀 Watching for changes... (Ctrl+C to stop)")
+	logrus.Info("")
 
 	// Create the primary context
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -25,14 +25,15 @@ import (
 	"github.com/perses/common/async/taskhelper"
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/config"
+	"github.com/perses/perses/internal/cli/opt"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 type option struct {
 	persesCMD.Option
+	opt.OutputOption
 	sourceDir     string
-	output        string
 	debounceDelay time.Duration
 	buildArgs     []string
 	writer        io.Writer
@@ -46,16 +47,14 @@ func (o *option) Complete(args []string) error {
 	} else {
 		o.sourceDir = "."
 	}
+	if outputErr := o.OutputOption.Complete(); outputErr != nil {
+		return outputErr
+	}
 	return nil
 }
 
 // Validate ensures the output directory is properly configured and exists
 func (o *option) Validate() error {
-	// Use the configured output folder from dac command
-	if config.Global.Dac.OutputFolder == "" {
-		config.Global.Dac.OutputFolder = "built"
-	}
-
 	// Ensure output directory exists
 	if err := os.MkdirAll(config.Global.Dac.OutputFolder, 0750); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
@@ -70,7 +69,7 @@ func (o *option) Execute() error {
 	logrus.Info("📦 Dashboard-as-Code Watcher")
 	logrus.Infof("   Source: %s", o.sourceDir)
 	logrus.Infof("   Output: %s", buildDir)
-	logrus.Infof("   Format: %s", o.output)
+	logrus.Infof("   Format: %s", o.Output)
 	logrus.Info("")
 	logrus.Info("👀 Watching for changes... (Ctrl+C to stop)")
 	logrus.Info("")
@@ -83,7 +82,7 @@ func (o *option) Execute() error {
 	watcher := newWatcher(
 		o.sourceDir,
 		buildDir,
-		o.output,
+		o.Output,
 		o.buildArgs,
 		o.debounceDelay,
 		o.writer,
@@ -125,7 +124,6 @@ func (o *option) SetErrWriter(errWriter io.Writer) {
 func NewCMD() *cobra.Command {
 	o := &option{
 		debounceDelay: 500 * time.Millisecond,
-		output:        "yaml",
 	}
 
 	cmd := &cobra.Command{
@@ -167,7 +165,7 @@ percli dac watch ./my-dashboards -- --arg1=value1 --arg2=value2`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.output, "output", "o", "yaml", "Output format (json or yaml)")
+	opt.AddOutputFlags(cmd, &o.OutputOption)
 	cmd.Flags().DurationVar(&o.debounceDelay, "debounce", 500*time.Millisecond, "Debounce delay for file changes")
 
 	return cmd

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -141,6 +141,11 @@ The watcher will:
 - Rebuild automatically when files are modified
 - Output results to the build directory (default: ./built)
 
+File identification:
+- Go files: Must be "package main" to be built as dashboards
+- CUE files: Identified as dashboards if they have a named import "dashboardBuilder" OR if the filename contains "dashboard"
+- Library files: Other .go/.cue files are treated as libraries and trigger rebuilds of dependent dashboards
+
 Combine this with Perses provisioning to see your dashboard changes reflected in the UI automatically.`,
 		Example: `# Watch current directory, output to ./built
 percli dac watch

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/opt"
+	"github.com/perses/spec/go/common"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -33,11 +35,13 @@ import (
 type option struct {
 	persesCMD.Option
 	opt.OutputOption
-	sourceDir     string
-	buildArgs     []string
-	debounceDelay time.Duration
-	writer        io.Writer
-	errWriter     io.Writer
+	sourceDir             string
+	absoluteBuildDir      string
+	buildArgs             []string
+	debounceDelay         common.Duration
+	debounceDelayAsString string
+	writer                io.Writer
+	errWriter             io.Writer
 }
 
 // Complete initializes the watch command with the provided arguments
@@ -52,6 +56,22 @@ func (o *option) Complete(args []string) error {
 	}
 	if outputErr := o.OutputOption.Complete(); outputErr != nil {
 		return outputErr
+	}
+
+	debounceDelay, err := common.ParseDuration(o.debounceDelayAsString)
+	if err != nil {
+		return err
+	}
+	o.debounceDelay = debounceDelay
+
+	// Precompute the absolute path of the build directory once, so directory
+	// checks during file walks don't have to recompute it every time.
+	buildDir := config.Global.Dac.OutputFolder
+	var errBuildDir error
+	o.absoluteBuildDir, errBuildDir = filepath.Abs(buildDir)
+	if errBuildDir != nil {
+		logrus.Errorf("Failed to resolve absolute path for build directory %q: %v", buildDir, errBuildDir)
+		return errBuildDir
 	}
 	return nil
 }
@@ -76,11 +96,10 @@ func (o *option) Validate() error {
 
 // Execute starts the file watcher and manages the watch lifecycle
 func (o *option) Execute() error {
-	buildDir := config.Global.Dac.OutputFolder
 
 	logrus.Info("📦 Dashboard-as-Code Watcher")
 	logrus.Infof("   Source: %s", o.sourceDir)
-	logrus.Infof("   Output: %s", buildDir)
+	logrus.Infof("   Output: %s", o.absoluteBuildDir)
 	logrus.Infof("   Format: %s", o.Output)
 	logrus.Info("")
 	logrus.Info("👀 Watching for changes... (Ctrl+C to stop)")
@@ -93,7 +112,7 @@ func (o *option) Execute() error {
 	// Create watcher task
 	watcher := newWatcher(
 		o.sourceDir,
-		buildDir,
+		o.absoluteBuildDir,
 		o.Output,
 		o.buildArgs,
 		o.debounceDelay,
@@ -134,9 +153,7 @@ func (o *option) SetErrWriter(errWriter io.Writer) {
 
 // NewCMD creates the watch command for automatic Dashboard-as-Code rebuilding
 func NewCMD() *cobra.Command {
-	o := &option{
-		debounceDelay: 500 * time.Millisecond,
-	}
+	o := &option{}
 
 	cmd := &cobra.Command{
 		Use:   "watch [source-dir]",
@@ -177,7 +194,7 @@ percli dac watch ./my-dashboards -- --arg1=value1 --arg2=value2`,
 	}
 
 	opt.AddOutputFlags(cmd, &o.OutputOption)
-	cmd.Flags().DurationVar(&o.debounceDelay, "debounce", 500*time.Millisecond, "Debounce delay for file changes")
+	cmd.Flags().StringVar(&o.debounceDelayAsString, "debounce", "500ms", "Debounce delay for file changes")
 
 	return cmd
 }

--- a/internal/cli/cmd/dac/watch/watch.go
+++ b/internal/cli/cmd/dac/watch/watch.go
@@ -56,8 +56,17 @@ func (o *option) Complete(args []string) error {
 	return nil
 }
 
-// Validate ensures the output directory is properly configured and exists
+// Validate ensures the source and output directories are properly configured and exist
 func (o *option) Validate() error {
+	// Ensure source directory exists and is a directory
+	info, err := os.Stat(o.sourceDir)
+	if err != nil {
+		return fmt.Errorf("source directory %q does not exist or is not accessible: %w", o.sourceDir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source path %q is not a directory", o.sourceDir)
+	}
+
 	// Ensure output directory exists
 	if err := os.MkdirAll(config.Global.Dac.OutputFolder, 0750); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)

--- a/internal/cli/cmd/dac/watch/watch_test.go
+++ b/internal/cli/cmd/dac/watch/watch_test.go
@@ -281,6 +281,7 @@ func TestNewWatcher(t *testing.T) {
 		filepath.Join("testdata", "go-simple"),
 		"built",
 		"yaml",
+		nil,
 		500*time.Millisecond,
 		&buf,
 		&buf,

--- a/internal/cli/cmd/dac/watch/watch_test.go
+++ b/internal/cli/cmd/dac/watch/watch_test.go
@@ -281,7 +281,6 @@ func TestNewWatcher(t *testing.T) {
 		filepath.Join("testdata", "go-simple"),
 		"built",
 		"yaml",
-		nil,
 		500*time.Millisecond,
 		&buf,
 		&buf,

--- a/internal/cli/cmd/dac/watch/watch_test.go
+++ b/internal/cli/cmd/dac/watch/watch_test.go
@@ -285,7 +285,6 @@ func TestNewWatcher(t *testing.T) {
 		500*time.Millisecond,
 		&buf,
 		&buf,
-
 	)
 
 	if w == nil {

--- a/internal/cli/cmd/dac/watch/watch_test.go
+++ b/internal/cli/cmd/dac/watch/watch_test.go
@@ -285,6 +285,7 @@ func TestNewWatcher(t *testing.T) {
 		500*time.Millisecond,
 		&buf,
 		&buf,
+
 	)
 
 	if w == nil {

--- a/internal/cli/cmd/dac/watch/watch_test.go
+++ b/internal/cli/cmd/dac/watch/watch_test.go
@@ -1,0 +1,324 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"bytes"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestParseGoImports(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		expected []string
+	}{
+		{
+			name: "dashboard with single import",
+			file: filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+			expected: []string{
+				"test-dac.com/m/mylibrary",
+			},
+		},
+		{
+			name: "library with nested import",
+			file: filepath.Join("testdata", "go-simple", "mylibrary", "lib.go"),
+			expected: []string{
+				"test-dac.com/m/mylibrary/nested",
+			},
+		},
+		{
+			name:     "nested library with no imports",
+			file:     filepath.Join("testdata", "go-simple", "mylibrary", "nested", "deep.go"),
+			expected: nil,
+		},
+	}
+
+	w := &watcher{
+		sourceDir: filepath.Join("testdata", "go-simple"),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := w.parseGoImports(tt.file)
+			if !equalStringSlices(result, tt.expected) {
+				t.Errorf("parseGoImports(%s) = %v, expected %v", tt.file, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseCueImports(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		expected []string
+	}{
+		{
+			name: "dashboard with multiple imports",
+			file: filepath.Join("testdata", "cue-simple", "dashboards", "dash1.cue"),
+			expected: []string{
+				"github.com/perses/perses/cue/dac-utils/dashboard",
+				"test-dac-cue.com/m/panels",
+			},
+		},
+		{
+			name: "dashboard with single import",
+			file: filepath.Join("testdata", "cue-simple", "dashboards", "my-dashboard.cue"),
+			expected: []string{
+				"test-dac-cue.com/m/panels",
+			},
+		},
+		{
+			name:     "library with no imports",
+			file:     filepath.Join("testdata", "cue-simple", "panels", "panel.cue"),
+			expected: nil,
+		},
+	}
+
+	w := &watcher{
+		sourceDir: filepath.Join("testdata", "cue-simple"),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := w.parseCueImports(tt.file)
+			if !equalStringSlices(result, tt.expected) {
+				t.Errorf("parseCueImports(%s) = %v, expected %v", tt.file, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindDashboardFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		sourceDir string
+		expected  []string
+	}{
+		{
+			name:      "Go project with 2 dashboards",
+			sourceDir: filepath.Join("testdata", "go-simple"),
+			expected: []string{
+				filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+				filepath.Join("testdata", "go-simple", "dashboards", "dash2", "main.go"),
+			},
+		},
+		{
+			name:      "CUE project with 2 dashboards",
+			sourceDir: filepath.Join("testdata", "cue-simple"),
+			expected: []string{
+				filepath.Join("testdata", "cue-simple", "dashboards", "dash1.cue"),
+				filepath.Join("testdata", "cue-simple", "dashboards", "my-dashboard.cue"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := &watcher{
+				sourceDir: tt.sourceDir,
+				buildDir:  "built",
+				writer:    &buf,
+			}
+			result := w.findDashboardFiles()
+
+			// Sort both slices for comparison
+			sort.Strings(result)
+			sort.Strings(tt.expected)
+
+			if !equalStringSlices(result, tt.expected) {
+				t.Errorf("findDashboardFiles() found %d files, expected %d", len(result), len(tt.expected))
+				t.Errorf("  Got: %v", result)
+				t.Errorf("  Expected: %v", tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildDependencyMap(t *testing.T) {
+	tests := []struct {
+		name             string
+		sourceDir        string
+		expectedLibCount int
+		libraryChecks    map[string][]string // library file -> expected dashboards
+	}{
+		{
+			name:             "Go project dependencies",
+			sourceDir:        filepath.Join("testdata", "go-simple"),
+			expectedLibCount: 2, // mylibrary/lib.go and mylibrary/nested/deep.go
+			libraryChecks: map[string][]string{
+				filepath.Join("testdata", "go-simple", "mylibrary", "lib.go"): {
+					filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+					filepath.Join("testdata", "go-simple", "dashboards", "dash2", "main.go"),
+				},
+				filepath.Join("testdata", "go-simple", "mylibrary", "nested", "deep.go"): {
+					filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+					filepath.Join("testdata", "go-simple", "dashboards", "dash2", "main.go"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := &watcher{
+				sourceDir:     tt.sourceDir,
+				buildDir:      "built",
+				writer:        &buf,
+				dependencyMap: make(map[string][]string),
+				allDashboards: make(map[string]bool),
+			}
+
+			w.buildDependencyMap()
+
+			if len(w.dependencyMap) != tt.expectedLibCount {
+				t.Errorf("buildDependencyMap() found %d libraries, expected %d", len(w.dependencyMap), tt.expectedLibCount)
+			}
+
+			for libFile, expectedDashboards := range tt.libraryChecks {
+				dashboards, exists := w.dependencyMap[libFile]
+				if !exists {
+					t.Errorf("Expected dependency map to contain %s", libFile)
+					continue
+				}
+
+				sort.Strings(dashboards)
+				sort.Strings(expectedDashboards)
+
+				if !equalStringSlices(dashboards, expectedDashboards) {
+					t.Errorf("Library %s has wrong dashboards", libFile)
+					t.Errorf("  Got: %v", dashboards)
+					t.Errorf("  Expected: %v", expectedDashboards)
+				}
+			}
+		})
+	}
+}
+
+func TestFindAffectedDashboards(t *testing.T) {
+	var buf bytes.Buffer
+	w := &watcher{
+		sourceDir:     filepath.Join("testdata", "go-simple"),
+		buildDir:      "built",
+		writer:        &buf,
+		dependencyMap: make(map[string][]string),
+		allDashboards: make(map[string]bool),
+	}
+
+	// Build dependency map first
+	w.buildDependencyMap()
+
+	tests := []struct {
+		name               string
+		changedFiles       []string
+		expectedDashboards []string
+	}{
+		{
+			name: "changing library affects both dashboards",
+			changedFiles: []string{
+				filepath.Join("testdata", "go-simple", "mylibrary", "lib.go"),
+			},
+			expectedDashboards: []string{
+				filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+				filepath.Join("testdata", "go-simple", "dashboards", "dash2", "main.go"),
+			},
+		},
+		{
+			name: "changing nested library affects both dashboards (transitive)",
+			changedFiles: []string{
+				filepath.Join("testdata", "go-simple", "mylibrary", "nested", "deep.go"),
+			},
+			expectedDashboards: []string{
+				filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+				filepath.Join("testdata", "go-simple", "dashboards", "dash2", "main.go"),
+			},
+		},
+		{
+			name: "changing dashboard file returns no dashboards",
+			changedFiles: []string{
+				filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+			},
+			expectedDashboards: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := w.findAffectedDashboards(tt.changedFiles)
+
+			sort.Strings(result)
+			sort.Strings(tt.expectedDashboards)
+
+			if !equalStringSlices(result, tt.expectedDashboards) {
+				t.Errorf("findAffectedDashboards() returned wrong dashboards")
+				t.Errorf("  Got: %v", result)
+				t.Errorf("  Expected: %v", tt.expectedDashboards)
+			}
+		})
+	}
+}
+
+func TestNewWatcher(t *testing.T) {
+	var buf bytes.Buffer
+	w := newWatcher(
+		filepath.Join("testdata", "go-simple"),
+		"built",
+		"yaml",
+		nil,
+		500*time.Millisecond,
+		&buf,
+		&buf,
+	)
+
+	if w == nil {
+		t.Fatal("newWatcher() returned nil")
+	}
+
+	if w.sourceDir != filepath.Join("testdata", "go-simple") {
+		t.Errorf("sourceDir = %v, expected %v", w.sourceDir, filepath.Join("testdata", "go-simple"))
+	}
+
+	if w.debounceDelay != 500*time.Millisecond {
+		t.Errorf("debounceDelay = %v, expected %v", w.debounceDelay, 500*time.Millisecond)
+	}
+
+	// Check that dependency map was built
+	if len(w.dependencyMap) == 0 {
+		t.Error("Expected dependency map to be built on initialization")
+	}
+
+	// Check that dashboards were found
+	if len(w.allDashboards) == 0 {
+		t.Error("Expected dashboards to be found on initialization")
+	}
+}
+
+// Helper function to compare string slices
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/cmd/dac/watch/watch_test.go
+++ b/internal/cli/cmd/dac/watch/watch_test.go
@@ -108,11 +108,13 @@ func TestFindDashboardFiles(t *testing.T) {
 	tests := []struct {
 		name      string
 		sourceDir string
+		buildDir  string
 		expected  []string
 	}{
 		{
 			name:      "Go project with 2 dashboards",
 			sourceDir: filepath.Join("testdata", "go-simple"),
+			buildDir:  "built",
 			expected: []string{
 				filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
 				filepath.Join("testdata", "go-simple", "dashboards", "dash2", "main.go"),
@@ -121,20 +123,42 @@ func TestFindDashboardFiles(t *testing.T) {
 		{
 			name:      "CUE project with 2 dashboards",
 			sourceDir: filepath.Join("testdata", "cue-simple"),
+			buildDir:  "built",
 			expected: []string{
 				filepath.Join("testdata", "cue-simple", "dashboards", "dash1.cue"),
 				filepath.Join("testdata", "cue-simple", "dashboards", "my-dashboard.cue"),
 			},
+		},
+		{
+			// The build directory must be skipped: pointing it at dash2 excludes it.
+			name:      "Go project with build dir inside dashboards",
+			sourceDir: filepath.Join("testdata", "go-simple"),
+			buildDir:  filepath.Join("testdata", "go-simple", "dashboards", "dash2"),
+			expected: []string{
+				filepath.Join("testdata", "go-simple", "dashboards", "dash1", "main.go"),
+			},
+		},
+		{
+			// Pointing the build dir at the whole dashboards folder skips everything.
+			name:      "CUE project with build dir on dashboards folder",
+			sourceDir: filepath.Join("testdata", "cue-simple"),
+			buildDir:  filepath.Join("testdata", "cue-simple", "dashboards"),
+			expected:  nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
+			buildDirAbs, err := filepath.Abs(tt.buildDir)
+			if err != nil {
+				t.Fatalf("failed to resolve build dir abs path: %v", err)
+			}
 			w := &watcher{
-				sourceDir: tt.sourceDir,
-				buildDir:  "built",
-				writer:    &buf,
+				sourceDir:   tt.sourceDir,
+				buildDir:    tt.buildDir,
+				buildDirAbs: buildDirAbs,
+				writer:      &buf,
 			}
 			result := w.findDashboardFiles()
 
@@ -297,6 +321,15 @@ func TestNewWatcher(t *testing.T) {
 
 	if w.debounceDelay != 500*time.Millisecond {
 		t.Errorf("debounceDelay = %v, expected %v", w.debounceDelay, 500*time.Millisecond)
+	}
+
+	// Check that the build directory absolute path was precomputed
+	expectedBuildDirAbs, err := filepath.Abs("built")
+	if err != nil {
+		t.Fatalf("failed to resolve expected build dir abs path: %v", err)
+	}
+	if w.buildDirAbs != expectedBuildDirAbs {
+		t.Errorf("buildDirAbs = %v, expected %v", w.buildDirAbs, expectedBuildDirAbs)
 	}
 
 	// Check that dependency map was built

--- a/internal/cli/cmd/dac/watch/watch_test.go
+++ b/internal/cli/cmd/dac/watch/watch_test.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/perses/spec/go/common"
 )
 
 func TestParseGoImports(t *testing.T) {
@@ -150,15 +152,14 @@ func TestFindDashboardFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			buildDirAbs, err := filepath.Abs(tt.buildDir)
+			absoluteBuildDir, err := filepath.Abs(tt.buildDir)
 			if err != nil {
 				t.Fatalf("failed to resolve build dir abs path: %v", err)
 			}
 			w := &watcher{
-				sourceDir:   tt.sourceDir,
-				buildDir:    tt.buildDir,
-				buildDirAbs: buildDirAbs,
-				writer:      &buf,
+				sourceDir:        tt.sourceDir,
+				absoluteBuildDir: absoluteBuildDir,
+				writer:           &buf,
 			}
 			result := w.findDashboardFiles()
 
@@ -204,7 +205,6 @@ func TestBuildDependencyMap(t *testing.T) {
 			var buf bytes.Buffer
 			w := &watcher{
 				sourceDir:     tt.sourceDir,
-				buildDir:      "built",
 				writer:        &buf,
 				dependencyMap: make(map[string][]string),
 				allDashboards: make(map[string]bool),
@@ -240,7 +240,6 @@ func TestFindAffectedDashboards(t *testing.T) {
 	var buf bytes.Buffer
 	w := &watcher{
 		sourceDir:     filepath.Join("testdata", "go-simple"),
-		buildDir:      "built",
 		writer:        &buf,
 		dependencyMap: make(map[string][]string),
 		allDashboards: make(map[string]bool),
@@ -306,7 +305,7 @@ func TestNewWatcher(t *testing.T) {
 		"built",
 		"yaml",
 		nil,
-		500*time.Millisecond,
+		common.Duration(500*time.Millisecond),
 		&buf,
 		&buf,
 	)
@@ -324,12 +323,9 @@ func TestNewWatcher(t *testing.T) {
 	}
 
 	// Check that the build directory absolute path was precomputed
-	expectedBuildDirAbs, err := filepath.Abs("built")
-	if err != nil {
-		t.Fatalf("failed to resolve expected build dir abs path: %v", err)
-	}
-	if w.buildDirAbs != expectedBuildDirAbs {
-		t.Errorf("buildDirAbs = %v, expected %v", w.buildDirAbs, expectedBuildDirAbs)
+	expectedAbsoluteBuildDir := "built" // use a non-absolute build dir here as not the purpose of that test
+	if w.absoluteBuildDir != expectedAbsoluteBuildDir {
+		t.Errorf("absoluteBuildDir = %v, expected %v", w.absoluteBuildDir, expectedAbsoluteBuildDir)
 	}
 
 	// Check that dependency map was built

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -96,6 +96,7 @@ type watcher struct {
 	async.SimpleTask
 	sourceDir     string
 	buildDir      string
+	buildArgs     []string
 	debounceDelay time.Duration
 	writer        io.Writer
 	errWriter     io.Writer
@@ -107,7 +108,7 @@ type watcher struct {
 }
 
 // newWatcher creates a new file watcher that monitors DaC files and triggers rebuilds
-func newWatcher(sourceDir, buildDir, outputFormat string, debounceDelay time.Duration, writer, errWriter io.Writer) *watcher {
+func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, debounceDelay time.Duration, writer, errWriter io.Writer) *watcher {
 	// Create build option to reuse build logic
 	buildOpt := &build.Option{
 		DirectoryOption: opt.DirectoryOption{Directory: sourceDir},
@@ -120,6 +121,7 @@ func newWatcher(sourceDir, buildDir, outputFormat string, debounceDelay time.Dur
 	w := &watcher{
 		sourceDir:     sourceDir,
 		buildDir:      buildDir,
+		buildArgs:     buildArgs,
 		debounceDelay: debounceDelay,
 		writer:        writer,
 		errWriter:     errWriter,
@@ -385,7 +387,12 @@ func (w *watcher) buildFile(file string) (string, error) {
 	fileOpt.SetWriter(io.Discard)
 	fileOpt.SetErrWriter(w.errWriter)
 
-	err := fileOpt.Run()
+	// Pass build args to the build option
+	if err := fileOpt.Complete(w.buildArgs); err != nil {
+		return "", err
+	}
+
+	err := fileOpt.Execute()
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -152,7 +152,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 								return nil
 							}
 							ext := filepath.Ext(path)
-							if (ext == ".go" || ext == ".cue") && !w.isLibraryFile(path) {
+							if (ext == ".go" || ext == ".cue") && w.isDashboardFile(path) {
 								w.changedFiles[path] = true
 								fmt.Fprintf(w.writer, "   Found new dashboard: %s\n", path)
 							}
@@ -191,7 +191,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 				// If it's a CREATE or RENAME, rebuild dependency map to discover new files
 				if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
 					w.buildDependencyMap()
-				} else if !w.isLibraryFile(event.Name) {
+				} else if w.isDashboardFile(event.Name) {
 					// For WRITE on existing dashboards, rebuild dependency map to catch new imports
 					w.buildDependencyMap()
 				}
@@ -238,9 +238,9 @@ func (w *watcher) rebuildAffectedFiles() {
 	// Check if any changed files are library/shared files (not buildable as main packages)
 	hasLibraryFiles := false
 	for _, file := range filesToBuild {
-		isLib := w.isLibraryFile(file)
-		fmt.Fprintf(w.writer, "   - %s (library: %v)\n", file, isLib)
-		if isLib {
+		isDash := w.isDashboardFile(file)
+		fmt.Fprintf(w.writer, "   - %s (library: %v)\n", file, !isDash)
+		if !isDash {
 			hasLibraryFiles = true
 		}
 	}
@@ -332,8 +332,8 @@ func (w *watcher) findDashboardFiles() []string {
 
 		ext := filepath.Ext(path)
 		if ext == ".go" || ext == ".cue" {
-			// Check if it's NOT a library file
-			if !w.isLibraryFile(path) {
+			// Check if it's a dashboard file
+			if w.isDashboardFile(path) {
 				dashboards = append(dashboards, path)
 			}
 		}
@@ -375,56 +375,56 @@ func (w *watcher) buildAllDashboards() {
 	}
 }
 
-// isLibraryFile checks if a file is a library/shared file that shouldn't be built directly
-func (w *watcher) isLibraryFile(file string) bool {
+// isDashboardFile checks if a file is a dashboard file that should be built directly
+func (w *watcher) isDashboardFile(file string) bool {
 	ext := filepath.Ext(file)
 
 	if ext == ".go" {
-		return w.isGoLibraryFile(file)
+		return w.isGoDashboardFile(file)
 	} else if ext == ".cue" {
-		return w.isCueLibraryFile(file)
+		return w.isCueDashboardFile(file)
 	}
 
-	return true // Unknown files are libraries by default
+	return false // Unknown files are not dashboards by default
 }
 
-// isGoLibraryFile checks if a Go file is a library (not a main package)
-func (w *watcher) isGoLibraryFile(file string) bool {
+// isGoDashboardFile checks if a Go file is a dashboard (main package)
+func (w *watcher) isGoDashboardFile(file string) bool {
 	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, file, nil, parser.PackageClauseOnly)
 	if err != nil {
-		return true // Can't parse = treat as library
+		return false // Can't parse = not a dashboard
 	}
 
 	// Go dashboards MUST be "package main"
-	return node.Name.Name != "main"
+	return node.Name.Name == "main"
 }
 
-// isCueLibraryFile checks if a CUE file is a library based on import patterns and filename
-func (w *watcher) isCueLibraryFile(file string) bool {
+// isCueDashboardFile checks if a CUE file is a dashboard based on import patterns and filename
+func (w *watcher) isCueDashboardFile(file string) bool {
 	content, err := os.ReadFile(file)
 	if err != nil {
-		return true
+		return false
 	}
 
 	parsed, err := cueparser.ParseFile(file, content)
 	if err != nil {
-		return true
+		return false
 	}
 
 	// Strategy 1: Check for named import "dashboardBuilder"
 	for imp := range parsed.ImportSpecs() {
 		if imp.Name != nil && imp.Name.String() == "dashboardBuilder" {
-			return false // This is a dashboard file!
+			return true
 		}
 	}
 
 	// Strategy 2: Check if filename contains "dashboard"
 	if strings.Contains(strings.ToLower(filepath.Base(file)), "dashboard") {
-		return false // This is a dashboard file!
+		return true
 	}
 
-	return true // It's a library file
+	return false
 }
 
 // findAllDependencies recursively finds all dependencies (direct + transitive) for a file
@@ -591,7 +591,7 @@ func (w *watcher) resolveImportToFiles(importPath string) []string {
 				}
 				filePath := filepath.Join(path, entry.Name())
 				ext := filepath.Ext(filePath)
-				if (ext == ".go" || ext == ".cue") && w.isLibraryFile(filePath) {
+				if (ext == ".go" || ext == ".cue") && !w.isDashboardFile(filePath) {
 					files = append(files, filePath)
 				}
 			}
@@ -608,7 +608,7 @@ func (w *watcher) findAffectedDashboards(changedFiles []string) []string {
 	dashboardSet := make(map[string]bool)
 
 	for _, changedFile := range changedFiles {
-		if !w.isLibraryFile(changedFile) {
+		if w.isDashboardFile(changedFile) {
 			continue
 		}
 

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -16,12 +16,15 @@ package watch
 import (
 	"context"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	cueparser "cuelang.org/go/cue/parser"
 	"github.com/fsnotify/fsnotify"
 	"github.com/perses/common/async"
 	"github.com/perses/perses/internal/cli/cmd/dac/build"
@@ -37,7 +40,8 @@ type watcher struct {
 	errWriter     io.Writer
 	buildChan     chan struct{}
 	buildOption   *build.Option
-	changedFiles  map[string]bool // Track files changed during debounce period
+	changedFiles  map[string]bool     // Track files changed during debounce period
+	dependencyMap map[string][]string // Maps library files to dashboard files that import them
 }
 
 // newWatcher creates a new file watcher that monitors DaC files and triggers rebuilds
@@ -51,7 +55,7 @@ func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, de
 	buildOpt.SetWriter(writer)
 	buildOpt.SetErrWriter(errWriter)
 
-	return &watcher{
+	w := &watcher{
 		sourceDir:     sourceDir,
 		buildDir:      buildDir,
 		debounceDelay: debounceDelay,
@@ -60,7 +64,11 @@ func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, de
 		buildChan:     make(chan struct{}, 1),
 		buildOption:   buildOpt,
 		changedFiles:  make(map[string]bool),
+		dependencyMap: make(map[string][]string),
 	}
+	// Build initial dependency map
+	w.buildDependencyMap()
+	return w
 }
 
 // Execute runs the main watch loop, monitoring files and triggering rebuilds on changes
@@ -81,6 +89,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 	// Initial build - build all dashboard files
 	fmt.Fprintf(w.writer, "🔨 Running initial build...\n")
 	w.buildAllDashboards()
+	fmt.Fprintf(w.writer, "📊 Dependency tracking enabled (%d library -> dashboard mappings)\n", len(w.dependencyMap))
 
 	var debounceTimer *time.Timer
 	var debouncePending bool
@@ -111,6 +120,12 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
 				// Track the changed file
 				w.changedFiles[event.Name] = true
+
+				// If a dashboard file changed, rebuild dependency map to catch new imports
+				if !w.isLibraryFile(event.Name) {
+					w.buildDependencyMap()
+				}
+
 				if debounceTimer == nil {
 					debounceTimer = time.NewTimer(w.debounceDelay)
 				} else if !debouncePending {
@@ -160,11 +175,34 @@ func (w *watcher) rebuildAffectedFiles() {
 		}
 	}
 
-	// If library files changed, do full rebuild
-	// TODO: Phase 2 - Parse imports and rebuild only affected dashboards
+	// If library files changed, find and rebuild affected dashboards
 	if hasLibraryFiles {
-		fmt.Fprintf(w.writer, "Library file(s) changed, rebuilding all dashboards...\n")
-		w.buildAllDashboards()
+		affectedDashboards := w.findAffectedDashboards(filesToBuild)
+		if len(affectedDashboards) == 0 {
+			// Fallback: if we can't determine dependencies, rebuild all
+			fmt.Fprintf(w.writer, "Library file(s) changed (dependencies unknown), rebuilding all dashboards...\n")
+			w.buildAllDashboards()
+			return
+		}
+		fmt.Fprintf(w.writer, "Library file(s) changed, rebuilding %d affected dashboard(s)...\n", len(affectedDashboards))
+		for _, dashboard := range affectedDashboards {
+			relPath, _ := filepath.Rel(w.sourceDir, dashboard)
+			fmt.Fprintf(w.writer, "   → %s\n", relPath)
+		}
+		hasErrors := false
+		for _, dashboard := range affectedDashboards {
+			if err := w.buildFile(dashboard); err != nil {
+				fmt.Fprintf(w.errWriter, "❌ Build failed for %s: %v\n", dashboard, err)
+				hasErrors = true
+			}
+		}
+		if !hasErrors {
+			fmt.Fprintf(w.writer, "✅ Build successful!\n")
+			select {
+			case w.buildChan <- struct{}{}:
+			default:
+			}
+		}
 		return
 	} else if len(filesToBuild) > 10 {
 		// Too many files changed, do full rebuild
@@ -290,6 +328,172 @@ func (w *watcher) isLibraryFile(file string) bool {
 
 	// Otherwise, it's likely a library file
 	return true
+}
+
+// buildDependencyMap builds a map of library files to dashboards that import them
+func (w *watcher) buildDependencyMap() {
+	w.dependencyMap = make(map[string][]string)
+	dashboards := w.findDashboardFiles()
+
+	fmt.Fprintf(w.writer, "🔍 Building dependency graph...\n")
+
+	for _, dashboard := range dashboards {
+		imports := w.parseImports(dashboard)
+		for _, importPath := range imports {
+			// Try to resolve import path to actual file
+			libraryFiles := w.resolveImportToFiles(importPath)
+			for _, libFile := range libraryFiles {
+				w.dependencyMap[libFile] = append(w.dependencyMap[libFile], dashboard)
+			}
+		}
+	}
+
+	// Log dependency map summary
+	if len(w.dependencyMap) > 0 {
+		fmt.Fprintf(w.writer, "   Found %d library file(s) with dependencies\n", len(w.dependencyMap))
+		for libFile, dashboards := range w.dependencyMap {
+			relLib, _ := filepath.Rel(w.sourceDir, libFile)
+			fmt.Fprintf(w.writer, "   - %s → %d dashboard(s)\n", relLib, len(dashboards))
+		}
+	} else {
+		fmt.Fprintf(w.writer, "   No library dependencies found\n")
+	}
+}
+
+// parseImports extracts import paths from a Go or CUE file
+func (w *watcher) parseImports(filePath string) []string {
+	ext := filepath.Ext(filePath)
+	if ext == ".go" {
+		return w.parseGoImports(filePath)
+	} else if ext == ".cue" {
+		return w.parseCueImports(filePath)
+	}
+	return nil
+}
+
+// parseGoImports parses import statements from a Go file
+func (w *watcher) parseGoImports(filePath string) []string {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filePath, nil, parser.ImportsOnly)
+	if err != nil {
+		return nil
+	}
+
+	var imports []string
+	for _, imp := range node.Imports {
+		importPath := strings.Trim(imp.Path.Value, `"`)
+		imports = append(imports, importPath)
+	}
+	return imports
+}
+
+// parseCueImports parses import statements from a CUE file using the official parser
+func (w *watcher) parseCueImports(filePath string) []string {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+
+	// Parse the CUE file using the official parser
+	file, err := cueparser.ParseFile(filePath, content)
+	if err != nil {
+		return nil
+	}
+
+	var imports []string
+	for imp := range file.ImportSpecs() {
+		if imp.Path != nil {
+			// Import path includes quotes, so we need to trim them
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			imports = append(imports, importPath)
+		}
+	}
+	return imports
+}
+
+// resolveImportToFiles attempts to resolve an import path to actual library files
+func (w *watcher) resolveImportToFiles(importPath string) []string {
+	var files []string
+
+	// For local imports, we need to find the directory that matches the import path
+	// Import examples:
+	//   "dac-example.com/m/mylibrary/variables" -> should match mylibrary/variables/
+	//   "dac-example.com/m/mylibrary/panels" -> should match mylibrary/panels/
+
+	// Look for directories matching the import in the source tree
+	filepath.Walk(w.sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			return nil
+		}
+
+		// Skip ignored directories
+		name := info.Name()
+		if name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir {
+			return filepath.SkipDir
+		}
+
+		// Get relative path from source directory
+		relPath, err := filepath.Rel(w.sourceDir, path)
+		if err != nil {
+			return nil
+		}
+
+		// Normalize path separators for comparison
+		relPathNormalized := filepath.ToSlash(relPath)
+
+		// Check if the import path ends with this relative path
+		// This ensures we match the exact directory structure
+		if strings.HasSuffix(importPath, relPathNormalized) ||
+			strings.HasSuffix(importPath, "/"+relPathNormalized) {
+			// Add all .go and .cue files from this directory (non-recursive)
+			entries, err := os.ReadDir(path)
+			if err != nil {
+				return nil
+			}
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				filePath := filepath.Join(path, entry.Name())
+				ext := filepath.Ext(filePath)
+				if (ext == ".go" || ext == ".cue") && w.isLibraryFile(filePath) {
+					files = append(files, filePath)
+				}
+			}
+			return filepath.SkipDir
+		}
+		return nil
+	})
+
+	return files
+}
+
+// findAffectedDashboards returns dashboard files that depend on the given changed files
+func (w *watcher) findAffectedDashboards(changedFiles []string) []string {
+	dashboardSet := make(map[string]bool)
+
+	for _, changedFile := range changedFiles {
+		if !w.isLibraryFile(changedFile) {
+			continue
+		}
+
+		// Look up dashboards that depend on this library file
+		if dashboards, exists := w.dependencyMap[changedFile]; exists {
+			for _, dashboard := range dashboards {
+				dashboardSet[dashboard] = true
+			}
+		}
+	}
+
+	// Convert set to slice
+	result := make([]string, 0, len(dashboardSet))
+	for dashboard := range dashboardSet {
+		result = append(result, dashboard)
+	}
+	return result
 }
 
 // shouldRebuild determines if a file change event should trigger a rebuild (.go or .cue files)

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -31,6 +31,12 @@ import (
 	"github.com/perses/perses/internal/cli/opt"
 )
 
+// fileExists checks if a file or directory exists
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 type watcher struct {
 	async.SimpleTask
 	sourceDir     string
@@ -42,6 +48,7 @@ type watcher struct {
 	buildOption   *build.Option
 	changedFiles  map[string]bool     // Track files changed during debounce period
 	dependencyMap map[string][]string // Maps library files to dashboard files that import them
+	allDashboards map[string]bool     // Track all known dashboard files for deletion detection
 }
 
 // newWatcher creates a new file watcher that monitors DaC files and triggers rebuilds
@@ -101,28 +108,91 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			return ctx.Err()
 
 		case event := <-fsWatcher.Events:
+			// Handle deletions (REMOVE or RENAME where file no longer exists)
+			if event.Op&fsnotify.Remove != 0 || (event.Op&fsnotify.Rename != 0 && !fileExists(event.Name)) {
+				// Could be a file or directory deletion - rebuild dependency map
+				fmt.Fprintf(w.writer, "📝 File/directory removed: %s\n", event.Name)
+				
+				// Get list of all dashboards we knew about BEFORE the deletion
+				// Must use cached state, not filesystem scan (folder already deleted!)
+				dashboardsBefore := make(map[string]bool)
+				for dash := range w.allDashboards {
+					dashboardsBefore[dash] = true
+				}
+				
+				fmt.Fprintf(w.writer, "   Rebuilding dependency map...\n")
+				w.buildDependencyMap()
+				
+				// Find removed dashboards by comparing before/after
+				for dashboard := range dashboardsBefore {
+					if !w.allDashboards[dashboard] {
+						relPath, _ := filepath.Rel(w.sourceDir, dashboard)
+						fmt.Fprintf(w.writer, "   ❌ Dashboard removed: %s\n", relPath)
+					}
+				}
+				
+				continue
+			}
+
+			// Handle new directories BEFORE checking file extensions
+			// (directories don't have .go/.cue extensions but still need to be tracked)
+			if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
+				info, err := os.Stat(event.Name)
+				if err == nil && info.IsDir() {
+					if err := w.addWatchRecursive(fsWatcher, event.Name); err != nil {
+						fmt.Fprintf(w.errWriter, "Failed to watch new directory %s: %v\n", event.Name, err)
+					} else {
+						// Directory created or renamed - scan for existing files and rebuild dependency map
+						fmt.Fprintf(w.writer, "   New directory detected: %s\n", event.Name)
+
+						// Scan for dashboard files in the new directory
+						// (copying a folder means files are already there, not created individually)
+						filepath.Walk(event.Name, func(path string, info os.FileInfo, err error) error {
+							if err != nil || info.IsDir() {
+								return nil
+							}
+							ext := filepath.Ext(path)
+							if (ext == ".go" || ext == ".cue") && !w.isLibraryFile(path) {
+								w.changedFiles[path] = true
+								fmt.Fprintf(w.writer, "   Found new dashboard: %s\n", path)
+							}
+							return nil
+						})
+
+						// Rebuild dependency map to include new files
+						w.buildDependencyMap()
+
+						// Trigger build if we found dashboard files
+						if len(w.changedFiles) > 0 {
+							if debounceTimer == nil {
+								debounceTimer = time.NewTimer(w.debounceDelay)
+							} else if !debouncePending {
+								debounceTimer.Reset(w.debounceDelay)
+							}
+							debouncePending = true
+						}
+					}
+					continue
+				}
+			}
+
+			// Now check if it's a file we care about (.go or .cue)
 			if !w.shouldRebuild(event) {
 				continue
 			}
 
 			fmt.Fprintf(w.writer, "📝 File event: %s (%s)\n", event.Name, event.Op)
 
-			// Handle new directories
-			if event.Op&fsnotify.Create == fsnotify.Create {
-				info, err := os.Stat(event.Name)
-				if err == nil && info.IsDir() {
-					if err := w.addWatchRecursive(fsWatcher, event.Name); err != nil {
-						fmt.Fprintf(w.errWriter, "Failed to watch new directory %s: %v\n", event.Name, err)
-					}
-				}
-			}
-
-			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+			// Handle file operations: CREATE, WRITE, RENAME (move)
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) != 0 {
 				// Track the changed file
 				w.changedFiles[event.Name] = true
 
-				// If a dashboard file changed, rebuild dependency map to catch new imports
-				if !w.isLibraryFile(event.Name) {
+				// If it's a CREATE or RENAME, rebuild dependency map to discover new files
+				if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
+					w.buildDependencyMap()
+				} else if !w.isLibraryFile(event.Name) {
+					// For WRITE on existing dashboards, rebuild dependency map to catch new imports
 					w.buildDependencyMap()
 				}
 
@@ -335,6 +405,12 @@ func (w *watcher) buildDependencyMap() {
 	w.dependencyMap = make(map[string][]string)
 	dashboards := w.findDashboardFiles()
 
+	// Track all dashboards for deletion detection
+	w.allDashboards = make(map[string]bool)
+	for _, dash := range dashboards {
+		w.allDashboards[dash] = true
+	}
+
 	fmt.Fprintf(w.writer, "🔍 Building dependency graph...\n")
 
 	for _, dashboard := range dashboards {
@@ -483,7 +559,10 @@ func (w *watcher) findAffectedDashboards(changedFiles []string) []string {
 		// Look up dashboards that depend on this library file
 		if dashboards, exists := w.dependencyMap[changedFile]; exists {
 			for _, dashboard := range dashboards {
-				dashboardSet[dashboard] = true
+				// Check if the dashboard file still exists
+				if _, err := os.Stat(dashboard); err == nil {
+					dashboardSet[dashboard] = true
+				}
 			}
 		}
 	}

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -25,12 +25,14 @@ import (
 	"time"
 
 	cueparser "cuelang.org/go/cue/parser"
+	cuemodfile "cuelang.org/go/mod/modfile"
 	"github.com/fsnotify/fsnotify"
 	"github.com/perses/common/async"
 	"github.com/perses/perses/internal/cli/cmd/dac/build"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/opt"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/mod/modfile"
 )
 
 // fileExists checks if a file or directory exists
@@ -44,6 +46,47 @@ func (w *watcher) shouldSkipDirectory(name string) bool {
 	return name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir
 }
 
+// detectModulePaths finds module paths for both Go and CUE projects.
+// This information is used to determine if an import is local (part of the project).
+func detectModulePaths(sourceDir string) []string {
+	var paths []string
+
+	// Check for go.mod
+	goModPath := filepath.Join(sourceDir, "go.mod")
+	if data, err := os.ReadFile(goModPath); err == nil {
+		if parsed, err := modfile.Parse(goModPath, data, nil); err == nil && parsed.Module != nil {
+			paths = append(paths, parsed.Module.Mod.Path)
+		}
+	}
+
+	// Check for cue.mod/module.cue
+	cueModPath := filepath.Join(sourceDir, "cue.mod", "module.cue")
+	if data, err := os.ReadFile(cueModPath); err == nil {
+		if parsed, err := cuemodfile.Parse(data, cueModPath); err == nil {
+			paths = append(paths, parsed.Module)
+		}
+	}
+
+	return paths
+}
+
+// isLocalImport checks if an import path belongs to this project (not a remote dependency)
+func (w *watcher) isLocalImport(importPath string) bool {
+	// If no module paths detected, fall back to checking all imports (legacy behavior)
+	if len(w.modulePaths) == 0 {
+		return true
+	}
+
+	// Check if the import starts with any of our module paths
+	for _, modulePath := range w.modulePaths {
+		if strings.HasPrefix(importPath, modulePath+"/") || importPath == modulePath {
+			return true
+		}
+	}
+
+	return false
+}
+
 type watcher struct {
 	async.SimpleTask
 	sourceDir     string
@@ -52,6 +95,7 @@ type watcher struct {
 	writer        io.Writer
 	errWriter     io.Writer
 	buildOption   *build.Option
+	modulePaths   []string            // Module paths from go.mod and cue.mod for identifying local imports
 	changedFiles  map[string]bool     // Track files changed during debounce period
 	dependencyMap map[string][]string // Maps library files to dashboard files that import them
 	allDashboards map[string]bool     // Track all known dashboard files for deletion detection
@@ -75,6 +119,7 @@ func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, de
 		writer:        writer,
 		errWriter:     errWriter,
 		buildOption:   buildOpt,
+		modulePaths:   detectModulePaths(sourceDir),
 		changedFiles:  make(map[string]bool),
 		dependencyMap: make(map[string][]string),
 	}
@@ -550,6 +595,11 @@ func (w *watcher) parseCueImports(filePath string) []string {
 
 // resolveImportToFiles attempts to resolve an import path to actual library files
 func (w *watcher) resolveImportToFiles(importPath string) []string {
+	// Skip remote/external imports - we only track local project files
+	if !w.isLocalImport(importPath) {
+		return nil
+	}
+
 	var files []string
 
 	// For local imports, we need to find the directory that matches the import path

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -28,7 +28,9 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/perses/common/async"
 	"github.com/perses/perses/internal/cli/cmd/dac/build"
+	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/opt"
+	"github.com/sirupsen/logrus"
 )
 
 // fileExists checks if a file or directory exists
@@ -91,12 +93,10 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 		return err
 	}
 
-	fmt.Fprintf(w.writer, "👀 Watching %s for changes...\n", w.sourceDir)
-
 	// Initial build - build all dashboard files
-	fmt.Fprintf(w.writer, "🔨 Running initial build...\n")
+	logrus.Debug("🔨 Running initial build...")
 	w.buildAllDashboards()
-	fmt.Fprintf(w.writer, "📊 Dependency tracking enabled (%d library -> dashboard mappings)\n", len(w.dependencyMap))
+	logrus.Debugf("📊 Dependency tracking enabled (%d library -> dashboard mappings)", len(w.dependencyMap))
 
 	var debounceTimer *time.Timer
 	var debouncePending bool
@@ -111,7 +111,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			// Handle deletions (REMOVE or RENAME where file no longer exists)
 			if event.Op&fsnotify.Remove != 0 || (event.Op&fsnotify.Rename != 0 && !fileExists(event.Name)) {
 				// Could be a file or directory deletion - rebuild dependency map
-				fmt.Fprintf(w.writer, "📝 File/directory removed: %s\n", event.Name)
+				logrus.Debugf("📝 File/directory removed: %s", event.Name)
 
 				// Get list of all dashboards we knew about BEFORE the deletion
 				// Must use cached state, not filesystem scan (folder already deleted!)
@@ -120,14 +120,14 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 					dashboardsBefore[dash] = true
 				}
 
-				fmt.Fprintf(w.writer, "   Rebuilding dependency map...\n")
+				logrus.Debug("   Rebuilding dependency map...")
 				w.buildDependencyMap()
 
 				// Find removed dashboards by comparing before/after
 				for dashboard := range dashboardsBefore {
 					if !w.allDashboards[dashboard] {
 						relPath, _ := filepath.Rel(w.sourceDir, dashboard)
-						fmt.Fprintf(w.writer, "   ❌ Dashboard removed: %s\n", relPath)
+						logrus.Debugf("   ❌ Dashboard removed: %s", relPath)
 					}
 				}
 
@@ -140,10 +140,10 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 				info, err := os.Stat(event.Name)
 				if err == nil && info.IsDir() {
 					if err := w.addWatchRecursive(fsWatcher, event.Name); err != nil {
-						fmt.Fprintf(w.errWriter, "Failed to watch new directory %s: %v\n", event.Name, err)
+						logrus.Errorf("Failed to watch new directory %s: %v", event.Name, err)
 					} else {
 						// Directory created or renamed - scan for existing files and rebuild dependency map
-						fmt.Fprintf(w.writer, "   New directory detected: %s\n", event.Name)
+						logrus.Debugf("   New directory detected: %s", event.Name)
 
 						// Scan for dashboard files in the new directory
 						// (copying a folder means files are already there, not created individually)
@@ -154,7 +154,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 							ext := filepath.Ext(path)
 							if (ext == ".go" || ext == ".cue") && w.isDashboardFile(path) {
 								w.changedFiles[path] = true
-								fmt.Fprintf(w.writer, "   Found new dashboard: %s\n", path)
+								logrus.Debugf("   Found new dashboard: %s", path)
 							}
 							return nil
 						})
@@ -181,7 +181,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 				continue
 			}
 
-			fmt.Fprintf(w.writer, "📝 File event: %s (%s)\n", event.Name, event.Op)
+			logrus.Debugf("📝 File event: %s (%s)", event.Name, event.Op)
 
 			// Handle file operations: CREATE, WRITE, RENAME (move)
 			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) != 0 {
@@ -214,7 +214,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			w.rebuildAffectedFiles()
 
 		case err := <-fsWatcher.Errors:
-			fmt.Fprintf(w.errWriter, "⚠️ Watcher error: %v\n", err)
+			logrus.Warnf("⚠️ Watcher error: %v", err)
 		}
 	}
 }
@@ -233,13 +233,13 @@ func (w *watcher) rebuildAffectedFiles() {
 	// Clear the changed files map
 	w.changedFiles = make(map[string]bool)
 
-	fmt.Fprintf(w.writer, "🔄 Changes detected in %d file(s), rebuilding...\n", len(filesToBuild))
+	logrus.Debugf("🔄 Changes detected in %d file(s), rebuilding...", len(filesToBuild))
 
 	// Check if any changed files are library/shared files (not buildable as main packages)
 	hasLibraryFiles := false
 	for _, file := range filesToBuild {
 		isDash := w.isDashboardFile(file)
-		fmt.Fprintf(w.writer, "   - %s (library: %v)\n", file, !isDash)
+		logrus.Debugf("   - %s (library: %v)", file, !isDash)
 		if !isDash {
 			hasLibraryFiles = true
 		}
@@ -250,24 +250,29 @@ func (w *watcher) rebuildAffectedFiles() {
 		affectedDashboards := w.findAffectedDashboards(filesToBuild)
 		if len(affectedDashboards) == 0 {
 			// Fallback: if we can't determine dependencies, rebuild all
-			fmt.Fprintf(w.writer, "Library file(s) changed (dependencies unknown), rebuilding all dashboards...\n")
+			logrus.Debug("Library file(s) changed (dependencies unknown), rebuilding all dashboards...")
 			w.buildAllDashboards()
 			return
 		}
-		fmt.Fprintf(w.writer, "Library file(s) changed, rebuilding %d affected dashboard(s)...\n", len(affectedDashboards))
-		for _, dashboard := range affectedDashboards {
-			relPath, _ := filepath.Rel(w.sourceDir, dashboard)
-			fmt.Fprintf(w.writer, "   → %s\n", relPath)
+		logrus.Debugf("Library file(s) changed, rebuilding %d affected dashboard(s)...", len(affectedDashboards))
+		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+			for _, dashboard := range affectedDashboards {
+				relPath, _ := filepath.Rel(w.sourceDir, dashboard)
+				logrus.Debugf("   → %s", relPath)
+			}
 		}
 		hasErrors := false
 		for _, dashboard := range affectedDashboards {
-			if err := w.buildFile(dashboard); err != nil {
-				fmt.Fprintf(w.errWriter, "❌ Build failed for %s: %v\n", dashboard, err)
+			outputPath, err := w.buildFile(dashboard)
+			if err != nil {
+				logrus.Errorf("❌ Build failed for %s: %v", dashboard, err)
 				hasErrors = true
+			} else {
+				logrus.Debugf("Successfully built %s at %s", dashboard, outputPath)
 			}
 		}
 		if !hasErrors {
-			fmt.Fprintf(w.writer, "✅ Build successful!\n")
+			logrus.Debug("✅ Build successful!")
 			select {
 			case w.buildChan <- struct{}{}:
 			default:
@@ -276,16 +281,19 @@ func (w *watcher) rebuildAffectedFiles() {
 		return
 	} else if len(filesToBuild) > 10 {
 		// Too many files changed, do full rebuild
-		fmt.Fprintf(w.writer, "Multiple files changed, rebuilding all dashboards...\n")
+		logrus.Debug("Multiple files changed, rebuilding all dashboards...")
 		w.buildAllDashboards()
 		return
 	} else {
 		// Build each changed file individually
 		hasErrors := false
 		for _, file := range filesToBuild {
-			if err := w.buildFile(file); err != nil {
-				fmt.Fprintf(w.errWriter, "❌ Build failed for %s: %v\n", file, err)
+			outputPath, err := w.buildFile(file)
+			if err != nil {
+				logrus.Errorf("❌ Build failed for %s: %v", file, err)
 				hasErrors = true
+			} else {
+				logrus.Debugf("Successfully built %s at %s", file, outputPath)
 			}
 		}
 		if hasErrors {
@@ -293,7 +301,7 @@ func (w *watcher) rebuildAffectedFiles() {
 		}
 	}
 
-	fmt.Fprintf(w.writer, "✅ Build successful!\n")
+	logrus.Debug("✅ Build successful!")
 	// Notify build completion (non-blocking)
 	select {
 	case w.buildChan <- struct{}{}:
@@ -301,17 +309,28 @@ func (w *watcher) rebuildAffectedFiles() {
 	}
 }
 
-// buildFile builds a single file using the build option
-func (w *watcher) buildFile(file string) error {
+// buildFile builds a single file using the build option and returns the output path
+func (w *watcher) buildFile(file string) (string, error) {
 	// Create a temporary build option for this specific file
 	fileOpt := &build.Option{
 		FileOption:   opt.FileOption{File: file},
 		OutputOption: w.buildOption.OutputOption,
 		Mode:         "file",
 	}
-	fileOpt.SetWriter(w.writer)
+	// Suppress build option's own output - we'll log via logrus instead
+	fileOpt.SetWriter(io.Discard)
 	fileOpt.SetErrWriter(w.errWriter)
-	return fileOpt.Run()
+
+	err := fileOpt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	// Compute output path (same logic as build.Option.buildOutputFilePath)
+	baseName := strings.TrimSuffix(file, filepath.Ext(file))
+	outputPath := filepath.Join(config.Global.Dac.OutputFolder, fmt.Sprintf("%s_output.%s", baseName, w.buildOption.Output))
+
+	return outputPath, nil
 }
 
 // findDashboardFiles finds all dashboard files (main packages) in the source directory
@@ -346,27 +365,32 @@ func (w *watcher) findDashboardFiles() []string {
 func (w *watcher) buildAllDashboards() {
 	dashboards := w.findDashboardFiles()
 	if len(dashboards) == 0 {
-		fmt.Fprintf(w.writer, "⚠️  No dashboard files found\n")
+		logrus.Warn("⚠️  No dashboard files found")
 		return
 	}
 
-	fmt.Fprintf(w.writer, "Building %d dashboard(s)...\n", len(dashboards))
+	logrus.Debugf("Building %d dashboard(s)...", len(dashboards))
 	hasErrors := false
 	successCount := 0
 
 	for _, file := range dashboards {
-		if err := w.buildFile(file); err != nil {
-			fmt.Fprintf(w.errWriter, "❌ Build failed for %s: %v\n", file, err)
+		outputPath, err := w.buildFile(file)
+		if err != nil {
+			logrus.Errorf("❌ Build failed for %s: %v", file, err)
 			hasErrors = true
 		} else {
+			logrus.Debugf("Successfully built %s at %s", file, outputPath)
 			successCount++
 		}
 	}
 
 	if hasErrors {
-		fmt.Fprintf(w.writer, "⚠️  Build completed with errors (%d/%d succeeded)\n", successCount, len(dashboards))
+		logrus.Warnf("⚠️  Build completed with errors (%d/%d succeeded)", successCount, len(dashboards))
 	} else {
-		fmt.Fprintf(w.writer, "✅ Build successful! (%d dashboard(s))\n", len(dashboards))
+		logrus.Debugf("✅ Build successful! (%d dashboard(s))", len(dashboards))
+	}
+
+	if !hasErrors {
 		// Notify build completion (non-blocking)
 		select {
 		case w.buildChan <- struct{}{}:
@@ -469,7 +493,7 @@ func (w *watcher) buildDependencyMap() {
 		w.allDashboards[dash] = true
 	}
 
-	fmt.Fprintf(w.writer, "🔍 Building dependency graph (including transitive dependencies)...\n")
+	logrus.Debug("🔍 Building dependency graph (including transitive dependencies)...")
 
 	for _, dashboard := range dashboards {
 		// Recursively find ALL dependencies (direct + transitive)
@@ -481,14 +505,16 @@ func (w *watcher) buildDependencyMap() {
 	}
 
 	// Log dependency map summary
-	if len(w.dependencyMap) > 0 {
-		fmt.Fprintf(w.writer, "   Found %d library file(s) with dependencies\n", len(w.dependencyMap))
-		for libFile, dashboards := range w.dependencyMap {
-			relLib, _ := filepath.Rel(w.sourceDir, libFile)
-			fmt.Fprintf(w.writer, "   - %s → %d dashboard(s)\n", relLib, len(dashboards))
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		if len(w.dependencyMap) > 0 {
+			logrus.Debugf("   Found %d library file(s) with dependencies", len(w.dependencyMap))
+			for libFile, dashboards := range w.dependencyMap {
+				relLib, _ := filepath.Rel(w.sourceDir, libFile)
+				logrus.Debugf("   - %s → %d dashboard(s)", relLib, len(dashboards))
+			}
+		} else {
+			logrus.Debug("   No library dependencies found")
 		}
-	} else {
-		fmt.Fprintf(w.writer, "   No library dependencies found\n")
 	}
 }
 

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -36,6 +37,7 @@ type watcher struct {
 	errWriter     io.Writer
 	buildChan     chan struct{}
 	buildOption   *build.Option
+	changedFiles  map[string]bool // Track files changed during debounce period
 }
 
 // newWatcher creates a new file watcher that monitors DaC files and triggers rebuilds
@@ -57,6 +59,7 @@ func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, de
 		errWriter:     errWriter,
 		buildChan:     make(chan struct{}, 1),
 		buildOption:   buildOpt,
+		changedFiles:  make(map[string]bool),
 	}
 }
 
@@ -75,10 +78,9 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 
 	fmt.Fprintf(w.writer, "👀 Watching %s for changes...\n", w.sourceDir)
 
-	// Initial build using build command logic
-	if err := w.buildOption.Run(); err != nil {
-		fmt.Fprintf(w.errWriter, "❌ Initial build failed: %v\n", err)
-	}
+	// Initial build - build all dashboard files
+	fmt.Fprintf(w.writer, "🔨 Running initial build...\n")
+	w.buildAllDashboards()
 
 	var debounceTimer *time.Timer
 	var debouncePending bool
@@ -94,6 +96,8 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 				continue
 			}
 
+			fmt.Fprintf(w.writer, "📝 File event: %s (%s)\n", event.Name, event.Op)
+
 			// Handle new directories
 			if event.Op&fsnotify.Create == fsnotify.Create {
 				info, err := os.Stat(event.Name)
@@ -105,6 +109,8 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			}
 
 			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+				// Track the changed file
+				w.changedFiles[event.Name] = true
 				if debounceTimer == nil {
 					debounceTimer = time.NewTimer(w.debounceDelay)
 				} else if !debouncePending {
@@ -120,22 +126,170 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			return nil
 		}():
 			debouncePending = false
-			fmt.Fprintf(w.writer, "🔄 Changes detected, rebuilding...\n")
-			if err := w.buildOption.Run(); err != nil {
-				fmt.Fprintf(w.errWriter, "❌ Build failed: %v\n", err)
-			} else {
-				fmt.Fprintf(w.writer, "✅ Build successful!\n")
-				// Notify build completion (non-blocking)
-				select {
-				case w.buildChan <- struct{}{}:
-				default:
-				}
-			}
+			w.rebuildAffectedFiles()
 
 		case err := <-fsWatcher.Errors:
 			fmt.Fprintf(w.errWriter, "⚠️ Watcher error: %v\n", err)
 		}
 	}
+}
+
+// rebuildAffectedFiles rebuilds only the files that changed, with fallback to full rebuild
+func (w *watcher) rebuildAffectedFiles() {
+	if len(w.changedFiles) == 0 {
+		return
+	}
+
+	// Get list of changed files
+	filesToBuild := make([]string, 0, len(w.changedFiles))
+	for file := range w.changedFiles {
+		filesToBuild = append(filesToBuild, file)
+	}
+	// Clear the changed files map
+	w.changedFiles = make(map[string]bool)
+
+	fmt.Fprintf(w.writer, "🔄 Changes detected in %d file(s), rebuilding...\n", len(filesToBuild))
+
+	// Check if any changed files are library/shared files (not buildable as main packages)
+	hasLibraryFiles := false
+	for _, file := range filesToBuild {
+		isLib := w.isLibraryFile(file)
+		fmt.Fprintf(w.writer, "   - %s (library: %v)\n", file, isLib)
+		if isLib {
+			hasLibraryFiles = true
+		}
+	}
+
+	// If library files changed, do full rebuild
+	// TODO: Phase 2 - Parse imports and rebuild only affected dashboards
+	if hasLibraryFiles {
+		fmt.Fprintf(w.writer, "Library file(s) changed, rebuilding all dashboards...\n")
+		w.buildAllDashboards()
+		return
+	} else if len(filesToBuild) > 10 {
+		// Too many files changed, do full rebuild
+		fmt.Fprintf(w.writer, "Multiple files changed, rebuilding all dashboards...\n")
+		w.buildAllDashboards()
+		return
+	} else {
+		// Build each changed file individually
+		hasErrors := false
+		for _, file := range filesToBuild {
+			if err := w.buildFile(file); err != nil {
+				fmt.Fprintf(w.errWriter, "❌ Build failed for %s: %v\n", file, err)
+				hasErrors = true
+			}
+		}
+		if hasErrors {
+			return
+		}
+	}
+
+	fmt.Fprintf(w.writer, "✅ Build successful!\n")
+	// Notify build completion (non-blocking)
+	select {
+	case w.buildChan <- struct{}{}:
+	default:
+	}
+}
+
+// buildFile builds a single file using the build option
+func (w *watcher) buildFile(file string) error {
+	// Create a temporary build option for this specific file
+	fileOpt := &build.Option{
+		FileOption:   opt.FileOption{File: file},
+		OutputOption: w.buildOption.OutputOption,
+		Mode:         "file",
+	}
+	fileOpt.SetWriter(w.writer)
+	fileOpt.SetErrWriter(w.errWriter)
+	return fileOpt.Run()
+}
+
+// findDashboardFiles finds all dashboard files (main packages) in the source directory
+func (w *watcher) findDashboardFiles() []string {
+	var dashboards []string
+	filepath.Walk(w.sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			// Skip ignored directories
+			name := info.Name()
+			if name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext == ".go" || ext == ".cue" {
+			// Check if it's NOT a library file
+			if !w.isLibraryFile(path) {
+				dashboards = append(dashboards, path)
+			}
+		}
+		return nil
+	})
+	return dashboards
+}
+
+// buildAllDashboards builds all dashboard files in the source directory
+func (w *watcher) buildAllDashboards() {
+	dashboards := w.findDashboardFiles()
+	if len(dashboards) == 0 {
+		fmt.Fprintf(w.writer, "⚠️  No dashboard files found\n")
+		return
+	}
+
+	fmt.Fprintf(w.writer, "Building %d dashboard(s)...\n", len(dashboards))
+	hasErrors := false
+	successCount := 0
+
+	for _, file := range dashboards {
+		if err := w.buildFile(file); err != nil {
+			fmt.Fprintf(w.errWriter, "❌ Build failed for %s: %v\n", file, err)
+			hasErrors = true
+		} else {
+			successCount++
+		}
+	}
+
+	if hasErrors {
+		fmt.Fprintf(w.writer, "⚠️  Build completed with errors (%d/%d succeeded)\n", successCount, len(dashboards))
+	} else {
+		fmt.Fprintf(w.writer, "✅ Build successful! (%d dashboard(s))\n", len(dashboards))
+		// Notify build completion (non-blocking)
+		select {
+		case w.buildChan <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// isLibraryFile checks if a file is a library/shared file that shouldn't be built directly
+func (w *watcher) isLibraryFile(file string) bool {
+	// Library files are typically in directories like: library/, lib/, pkg/, shared/, etc.
+	// Dashboard files are typically in: dashboards/, or are direct main.go files
+	relPath, err := filepath.Rel(w.sourceDir, file)
+	if err != nil {
+		return false
+	}
+
+	// Check if file is NOT in a dashboards directory
+	// Common patterns: dashboards/, dashboard/, or files directly in root with main package
+	dir := filepath.Dir(relPath)
+	if dir == "." {
+		return false // Files in root are likely main dashboards
+	}
+
+	// Check if path contains "dashboard" - likely a dashboard file
+	if strings.Contains(strings.ToLower(relPath), "dashboard") {
+		return false
+	}
+
+	// Otherwise, it's likely a library file
+	return true
 }
 
 // shouldRebuild determines if a file change event should trigger a rebuild (.go or .cue files)

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -105,7 +105,8 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 		select {
 		case <-ctx.Done():
 			close(w.buildChan)
-			return ctx.Err()
+			logrus.Info("Watch stopped")
+			return nil
 
 		case event := <-fsWatcher.Events:
 			// Handle deletions (REMOVE or RENAME where file no longer exists)

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -401,7 +401,38 @@ func (w *watcher) isLibraryFile(file string) bool {
 	return true
 }
 
-// buildDependencyMap builds a map of library files to dashboards that import them
+// findAllDependencies recursively finds all dependencies (direct + transitive) for a file
+func (w *watcher) findAllDependencies(file string, visited map[string]bool) map[string]bool {
+	deps := make(map[string]bool)
+
+	// Prevent infinite loops from circular imports
+	if visited[file] {
+		return deps
+	}
+	visited[file] = true
+
+	// Get direct imports
+	imports := w.parseImports(file)
+
+	for _, importPath := range imports {
+		libraryFiles := w.resolveImportToFiles(importPath)
+
+		for _, libFile := range libraryFiles {
+			// Add this library file
+			deps[libFile] = true
+
+			// Recursively get its dependencies (transitive)
+			transitiveDeps := w.findAllDependencies(libFile, visited)
+			for transFile := range transitiveDeps {
+				deps[transFile] = true
+			}
+		}
+	}
+
+	return deps
+}
+
+// buildDependencyMap builds a map of library files to dashboards that import them (including transitive dependencies)
 func (w *watcher) buildDependencyMap() {
 	w.dependencyMap = make(map[string][]string)
 	dashboards := w.findDashboardFiles()
@@ -412,16 +443,14 @@ func (w *watcher) buildDependencyMap() {
 		w.allDashboards[dash] = true
 	}
 
-	fmt.Fprintf(w.writer, "🔍 Building dependency graph...\n")
+	fmt.Fprintf(w.writer, "🔍 Building dependency graph (including transitive dependencies)...\n")
 
 	for _, dashboard := range dashboards {
-		imports := w.parseImports(dashboard)
-		for _, importPath := range imports {
-			// Try to resolve import path to actual file
-			libraryFiles := w.resolveImportToFiles(importPath)
-			for _, libFile := range libraryFiles {
-				w.dependencyMap[libFile] = append(w.dependencyMap[libFile], dashboard)
-			}
+		// Recursively find ALL dependencies (direct + transitive)
+		allDeps := w.findAllDependencies(dashboard, make(map[string]bool))
+
+		for libFile := range allDeps {
+			w.dependencyMap[libFile] = append(w.dependencyMap[libFile], dashboard)
 		}
 	}
 

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -35,6 +35,11 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
+const (
+	goFileExt  = ".go"
+	cueFileExt = ".cue"
+)
+
 // fileExists checks if a file or directory exists
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
@@ -53,7 +58,7 @@ func detectModulePaths(sourceDir string) []string {
 
 	// Check for go.mod
 	goModPath := filepath.Join(sourceDir, "go.mod")
-	if data, err := os.ReadFile(goModPath); err == nil {
+	if data, err := os.ReadFile(goModPath); err == nil { //nolint: gosec
 		if parsed, err := modfile.Parse(goModPath, data, nil); err == nil && parsed.Module != nil {
 			paths = append(paths, parsed.Module.Mod.Path)
 		}
@@ -61,7 +66,7 @@ func detectModulePaths(sourceDir string) []string {
 
 	// Check for cue.mod/module.cue
 	cueModPath := filepath.Join(sourceDir, "cue.mod", "module.cue")
-	if data, err := os.ReadFile(cueModPath); err == nil {
+	if data, err := os.ReadFile(cueModPath); err == nil { //nolint: gosec
 		if parsed, err := cuemodfile.Parse(data, cueModPath); err == nil {
 			paths = append(paths, parsed.Module)
 		}
@@ -102,7 +107,7 @@ type watcher struct {
 }
 
 // newWatcher creates a new file watcher that monitors DaC files and triggers rebuilds
-func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, debounceDelay time.Duration, writer, errWriter io.Writer) *watcher {
+func newWatcher(sourceDir, buildDir, outputFormat string, debounceDelay time.Duration, writer, errWriter io.Writer) *watcher {
 	// Create build option to reuse build logic
 	buildOpt := &build.Option{
 		DirectoryOption: opt.DirectoryOption{Directory: sourceDir},
@@ -134,7 +139,11 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 	if err != nil {
 		return err
 	}
-	defer fsWatcher.Close()
+	defer func() {
+		if err := fsWatcher.Close(); err != nil {
+			logrus.Warnf("Failed to close file watcher: %v", err)
+		}
+	}()
 
 	// Watch source directory recursively
 	if err := w.addWatchRecursive(fsWatcher, w.sourceDir); err != nil {
@@ -156,97 +165,20 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 
 		case event := <-fsWatcher.Events:
 			// Handle deletions (REMOVE or RENAME where file no longer exists)
-			// In such cases, the dependency map should be rebuilt
 			if event.Op&fsnotify.Remove != 0 || (event.Op&fsnotify.Rename != 0 && !fileExists(event.Name)) {
-				logrus.Debugf("📝 File/directory removed: %s", event.Name)
-
-				// Get list of all dashboards we knew about BEFORE the deletion
-				// Must use cached state, not filesystem scan (folder already deleted!)
-				dashboardsBefore := make(map[string]bool)
-				for dash := range w.allDashboards {
-					dashboardsBefore[dash] = true
-				}
-
-				logrus.Debug("   Rebuilding dependency map...")
-				w.buildDependencyMap()
-
-				// Find removed dashboards by comparing before/after
-				for dashboard := range dashboardsBefore {
-					if !w.allDashboards[dashboard] {
-						relPath, _ := filepath.Rel(w.sourceDir, dashboard)
-						logrus.Debugf("   ❌ Dashboard removed: %s", relPath)
-					}
-				}
-
+				w.handleDeletion(event.Name)
 				continue
 			}
 
-			// Handle new directories BEFORE checking file extensions
-			// (directories don't have .go/.cue extensions but still need to be tracked)
+			// Handle new directories
 			if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
-				info, err := os.Stat(event.Name)
-				if err == nil && info.IsDir() {
-					if err := w.addWatchRecursive(fsWatcher, event.Name); err != nil {
-						logrus.Errorf("Failed to watch new directory %s: %v", event.Name, err)
-					} else {
-						// Directory created or renamed - scan for existing files and rebuild dependency map
-						logrus.Debugf("   New directory detected: %s", event.Name)
-
-						// Scan for dashboard files in the new directory
-						// (copying a folder means files are already there, not created individually)
-						filepath.Walk(event.Name, func(path string, info os.FileInfo, err error) error {
-							if err != nil || info.IsDir() {
-								return nil
-							}
-							ext := filepath.Ext(path)
-							if (ext == ".go" || ext == ".cue") && w.isDashboardFile(path) {
-								w.changedFiles[path] = true
-								logrus.Debugf("   Found new dashboard: %s", path)
-							}
-							return nil
-						})
-
-						// Rebuild dependency map to include new files
-						w.buildDependencyMap()
-
-						// Trigger build if we found dashboard files
-						if len(w.changedFiles) > 0 {
-							if debounceTimer == nil {
-								debounceTimer = time.NewTimer(w.debounceDelay)
-							} else if !debouncePending {
-								debounceTimer.Reset(w.debounceDelay)
-							}
-							debouncePending = true
-						}
-					}
+				if w.handleNewDirectory(fsWatcher, event.Name, &debounceTimer, &debouncePending) {
 					continue
 				}
 			}
 
-			// Now check if it's a file we care about
-			ext := filepath.Ext(event.Name)
-			if ext != ".go" && ext != ".cue" {
-				continue
-			}
-			logrus.Debugf("📝 File event: %s (%s)", event.Name, event.Op)
-
-			// Handle file operations: CREATE, WRITE, RENAME (move)
-			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) != 0 {
-				// Track the changed file
-				w.changedFiles[event.Name] = true
-
-				// Rebuild dependency map to discover new files or catch new imports in dashboards
-				if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 || w.isDashboardFile(event.Name) {
-					w.buildDependencyMap()
-				}
-
-				if debounceTimer == nil {
-					debounceTimer = time.NewTimer(w.debounceDelay)
-				} else if !debouncePending {
-					debounceTimer.Reset(w.debounceDelay)
-				}
-				debouncePending = true
-			}
+			// Handle file events
+			w.handleFileEvent(event, &debounceTimer, &debouncePending)
 
 		// Debounce: waits for a pause in file changes before triggering rebuild
 		case <-func() <-chan time.Time {
@@ -262,6 +194,107 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			logrus.Warnf("⚠️ Watcher error: %v", err)
 		}
 	}
+}
+
+// handleDeletion handles file/directory deletion events
+func (w *watcher) handleDeletion(name string) {
+	logrus.Debugf("📝 File/directory removed: %s", name)
+
+	// Get list of all dashboards we knew about BEFORE the deletion
+	// Must use cached state, not filesystem scan (folder already deleted!)
+	dashboardsBefore := make(map[string]bool)
+	for dash := range w.allDashboards {
+		dashboardsBefore[dash] = true
+	}
+
+	logrus.Debug("   Rebuilding dependency map...")
+	w.buildDependencyMap()
+
+	// Find removed dashboards by comparing before/after
+	for dashboard := range dashboardsBefore {
+		if !w.allDashboards[dashboard] {
+			relPath, _ := filepath.Rel(w.sourceDir, dashboard)
+			logrus.Debugf("   ❌ Dashboard removed: %s", relPath)
+		}
+	}
+}
+
+// handleNewDirectory handles new directory creation events
+// Returns true if the event was a directory creation and was handled
+func (w *watcher) handleNewDirectory(fsWatcher *fsnotify.Watcher, name string, debounceTimer **time.Timer, debouncePending *bool) bool {
+	info, err := os.Stat(name)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+
+	if err := w.addWatchRecursive(fsWatcher, name); err != nil {
+		logrus.Errorf("Failed to watch new directory %s: %v", name, err)
+		return true
+	}
+
+	// Directory created or renamed - scan for existing files and rebuild dependency map
+	logrus.Debugf("   New directory detected: %s", name)
+
+	// Scan for dashboard files in the new directory
+	// (copying a folder means files are already there, not created individually)
+	if err := filepath.Walk(name, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if (ext == goFileExt || ext == cueFileExt) && w.isDashboardFile(path) {
+			w.changedFiles[path] = true
+			logrus.Debugf("   Found new dashboard: %s", path)
+		}
+		return nil
+	}); err != nil {
+		logrus.Warnf("Failed to scan directory %s: %v", name, err)
+	}
+
+	// Rebuild dependency map to include new files
+	w.buildDependencyMap()
+
+	// Trigger build if we found dashboard files
+	if len(w.changedFiles) > 0 {
+		w.triggerDebounce(debounceTimer, debouncePending)
+	}
+	return true
+}
+
+// handleFileEvent handles file modification events
+func (w *watcher) handleFileEvent(event fsnotify.Event, debounceTimer **time.Timer, debouncePending *bool) {
+	// Check if it's a file we care about
+	ext := filepath.Ext(event.Name)
+	if ext != goFileExt && ext != cueFileExt {
+		return
+	}
+
+	// Only handle write, create, and rename operations
+	if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+		return
+	}
+
+	logrus.Debugf("📝 File event: %s (%s)", event.Name, event.Op)
+
+	// Track the changed file
+	w.changedFiles[event.Name] = true
+
+	// Rebuild dependency map to discover new files or catch new imports in dashboards
+	if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 || w.isDashboardFile(event.Name) {
+		w.buildDependencyMap()
+	}
+
+	w.triggerDebounce(debounceTimer, debouncePending)
+}
+
+// triggerDebounce starts or resets the debounce timer
+func (w *watcher) triggerDebounce(debounceTimer **time.Timer, debouncePending *bool) {
+	if *debounceTimer == nil {
+		*debounceTimer = time.NewTimer(w.debounceDelay)
+	} else if !*debouncePending {
+		(*debounceTimer).Reset(w.debounceDelay)
+	}
+	*debouncePending = true
 }
 
 // rebuildAffectedFiles rebuilds only the files that changed, with fallback to full rebuild
@@ -367,7 +400,7 @@ func (w *watcher) buildFile(file string) (string, error) {
 // findDashboardFiles finds all dashboard files in the source directory
 func (w *watcher) findDashboardFiles() []string {
 	var dashboards []string
-	filepath.Walk(w.sourceDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(w.sourceDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -379,14 +412,16 @@ func (w *watcher) findDashboardFiles() []string {
 		}
 
 		ext := filepath.Ext(path)
-		if ext == ".go" || ext == ".cue" {
+		if ext == goFileExt || ext == cueFileExt {
 			// Check if it's a dashboard file
 			if w.isDashboardFile(path) {
 				dashboards = append(dashboards, path)
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		logrus.Warnf("Failed to walk source directory %s: %v", w.sourceDir, err)
+	}
 	return dashboards
 }
 
@@ -425,9 +460,9 @@ func (w *watcher) isDashboardFile(file string) bool {
 	ext := filepath.Ext(file)
 
 	switch ext {
-	case ".go":
+	case goFileExt:
 		return w.isGoDashboardFile(file)
-	case ".cue":
+	case cueFileExt:
 		return w.isCueDashboardFile(file)
 	}
 
@@ -450,7 +485,7 @@ func (w *watcher) isGoDashboardFile(file string) bool {
 // isCueDashboardFile checks if a CUE file is to be considered a dashboard
 // No 100% reliable way here, thus we take a heuristic approach based on import patterns and filename
 func (w *watcher) isCueDashboardFile(file string) bool {
-	content, err := os.ReadFile(file)
+	content, err := os.ReadFile(file) //nolint: gosec
 	if err != nil {
 		return false
 	}
@@ -545,9 +580,10 @@ func (w *watcher) buildDependencyMap() {
 // parseImports extracts import paths from a Go or CUE file
 func (w *watcher) parseImports(filePath string) []string {
 	ext := filepath.Ext(filePath)
-	if ext == ".go" {
+	switch ext {
+	case goFileExt:
 		return w.parseGoImports(filePath)
-	} else if ext == ".cue" {
+	case cueFileExt:
 		return w.parseCueImports(filePath)
 	}
 	return nil
@@ -571,7 +607,7 @@ func (w *watcher) parseGoImports(filePath string) []string {
 
 // parseCueImports parses import statements from a CUE file
 func (w *watcher) parseCueImports(filePath string) []string {
-	content, err := os.ReadFile(filePath)
+	content, err := os.ReadFile(filePath) //nolint: gosec
 	if err != nil {
 		return nil
 	}
@@ -608,7 +644,7 @@ func (w *watcher) resolveImportToFiles(importPath string) []string {
 	//   "dac-example.com/m/mylibrary/panels" -> should match mylibrary/panels/
 
 	// Look for directories matching the import in the source tree
-	filepath.Walk(w.sourceDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(w.sourceDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -644,14 +680,16 @@ func (w *watcher) resolveImportToFiles(importPath string) []string {
 				}
 				filePath := filepath.Join(path, entry.Name())
 				ext := filepath.Ext(filePath)
-				if (ext == ".go" || ext == ".cue") && !w.isDashboardFile(filePath) {
+				if (ext == goFileExt || ext == cueFileExt) && !w.isDashboardFile(filePath) {
 					files = append(files, filePath)
 				}
 			}
 			return filepath.SkipDir
 		}
 		return nil
-	})
+	}); err != nil {
+		logrus.Warnf("Failed to resolve import %s: %v", importPath, err)
+	}
 
 	return files
 }

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -376,29 +376,55 @@ func (w *watcher) buildAllDashboards() {
 }
 
 // isLibraryFile checks if a file is a library/shared file that shouldn't be built directly
-// TODO too simplist, "root files are dashboards" assumption is wrong
 func (w *watcher) isLibraryFile(file string) bool {
-	// Library files are typically in directories like: library/, lib/, pkg/, shared/, etc.
-	// Dashboard files are typically in: dashboards/, or are direct main.go files
-	relPath, err := filepath.Rel(w.sourceDir, file)
+	ext := filepath.Ext(file)
+
+	if ext == ".go" {
+		return w.isGoLibraryFile(file)
+	} else if ext == ".cue" {
+		return w.isCueLibraryFile(file)
+	}
+
+	return true // Unknown files are libraries by default
+}
+
+// isGoLibraryFile checks if a Go file is a library (not a main package)
+func (w *watcher) isGoLibraryFile(file string) bool {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, file, nil, parser.PackageClauseOnly)
 	if err != nil {
-		return false
+		return true // Can't parse = treat as library
 	}
 
-	// Check if file is NOT in a dashboards directory
-	// Common patterns: dashboards/, dashboard/, or files directly in root with main package
-	dir := filepath.Dir(relPath)
-	if dir == "." {
-		return false // Files in root are likely main dashboards
+	// Go dashboards MUST be "package main"
+	return node.Name.Name != "main"
+}
+
+// isCueLibraryFile checks if a CUE file is a library based on import patterns and filename
+func (w *watcher) isCueLibraryFile(file string) bool {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return true
 	}
 
-	// Check if path contains "dashboard" - likely a dashboard file
-	if strings.Contains(strings.ToLower(relPath), "dashboard") {
-		return false
+	parsed, err := cueparser.ParseFile(file, content)
+	if err != nil {
+		return true
 	}
 
-	// Otherwise, it's likely a library file
-	return true
+	// Strategy 1: Check for named import "dashboardBuilder"
+	for imp := range parsed.ImportSpecs() {
+		if imp.Name != nil && imp.Name.String() == "dashboardBuilder" {
+			return false // This is a dashboard file!
+		}
+	}
+
+	// Strategy 2: Check if filename contains "dashboard"
+	if strings.Contains(strings.ToLower(filepath.Base(file)), "dashboard") {
+		return false // This is a dashboard file!
+	}
+
+	return true // It's a library file
 }
 
 // findAllDependencies recursively finds all dependencies (direct + transitive) for a file

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -1,0 +1,174 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/perses/common/async"
+	"github.com/perses/perses/internal/cli/cmd/dac/build"
+	"github.com/perses/perses/internal/cli/opt"
+)
+
+type watcher struct {
+	async.SimpleTask
+	sourceDir     string
+	buildDir      string
+	debounceDelay time.Duration
+	writer        io.Writer
+	errWriter     io.Writer
+	buildChan     chan struct{}
+	buildOption   *build.Option
+}
+
+// newWatcher creates a new file watcher that monitors DaC files and triggers rebuilds
+func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, debounceDelay time.Duration, writer, errWriter io.Writer) *watcher {
+	// Create build option to reuse build logic
+	buildOpt := &build.Option{
+		DirectoryOption: opt.DirectoryOption{Directory: sourceDir},
+		OutputOption:    opt.OutputOption{Output: outputFormat},
+		Mode:            "file",
+	}
+	buildOpt.SetWriter(writer)
+	buildOpt.SetErrWriter(errWriter)
+
+	return &watcher{
+		sourceDir:     sourceDir,
+		buildDir:      buildDir,
+		debounceDelay: debounceDelay,
+		writer:        writer,
+		errWriter:     errWriter,
+		buildChan:     make(chan struct{}, 1),
+		buildOption:   buildOpt,
+	}
+}
+
+// Execute runs the main watch loop, monitoring files and triggering rebuilds on changes
+func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer fsWatcher.Close()
+
+	// Watch source directory recursively
+	if err := w.addWatchRecursive(fsWatcher, w.sourceDir); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w.writer, "👀 Watching %s for changes...\n", w.sourceDir)
+
+	// Initial build using build command logic
+	if err := w.buildOption.Run(); err != nil {
+		fmt.Fprintf(w.errWriter, "❌ Initial build failed: %v\n", err)
+	}
+
+	var debounceTimer *time.Timer
+	var debouncePending bool
+
+	for {
+		select {
+		case <-ctx.Done():
+			close(w.buildChan)
+			return ctx.Err()
+
+		case event := <-fsWatcher.Events:
+			if !w.shouldRebuild(event) {
+				continue
+			}
+
+			// Handle new directories
+			if event.Op&fsnotify.Create == fsnotify.Create {
+				info, err := os.Stat(event.Name)
+				if err == nil && info.IsDir() {
+					if err := w.addWatchRecursive(fsWatcher, event.Name); err != nil {
+						fmt.Fprintf(w.errWriter, "Failed to watch new directory %s: %v\n", event.Name, err)
+					}
+				}
+			}
+
+			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+				if debounceTimer == nil {
+					debounceTimer = time.NewTimer(w.debounceDelay)
+				} else if !debouncePending {
+					debounceTimer.Reset(w.debounceDelay)
+				}
+				debouncePending = true
+			}
+
+		case <-func() <-chan time.Time {
+			if debounceTimer != nil {
+				return debounceTimer.C
+			}
+			return nil
+		}():
+			debouncePending = false
+			fmt.Fprintf(w.writer, "🔄 Changes detected, rebuilding...\n")
+			if err := w.buildOption.Run(); err != nil {
+				fmt.Fprintf(w.errWriter, "❌ Build failed: %v\n", err)
+			} else {
+				fmt.Fprintf(w.writer, "✅ Build successful!\n")
+				// Notify build completion (non-blocking)
+				select {
+				case w.buildChan <- struct{}{}:
+				default:
+				}
+			}
+
+		case err := <-fsWatcher.Errors:
+			fmt.Fprintf(w.errWriter, "⚠️ Watcher error: %v\n", err)
+		}
+	}
+}
+
+// shouldRebuild determines if a file change event should trigger a rebuild (.go or .cue files)
+func (w *watcher) shouldRebuild(event fsnotify.Event) bool {
+	// Watch .go and .cue files
+	ext := filepath.Ext(event.Name)
+	return ext == ".go" || ext == ".cue"
+}
+
+// addWatchRecursive recursively adds directories to the file watcher, skipping ignored folders
+func (w *watcher) addWatchRecursive(watcher *fsnotify.Watcher, root string) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// Skip vendor, node_modules, .git, build output folder
+			name := info.Name()
+			if name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir {
+				return filepath.SkipDir
+			}
+			return watcher.Add(path)
+		}
+		return nil
+	})
+}
+
+// GetBuildNotifications returns a channel that signals when a build completes
+func (w *watcher) GetBuildNotifications() <-chan struct{} {
+	return w.buildChan
+}
+
+// String returns a human-readable description of the watcher task
+func (w *watcher) String() string {
+	return "DaC file watcher"
+}

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -112,17 +112,17 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 			if event.Op&fsnotify.Remove != 0 || (event.Op&fsnotify.Rename != 0 && !fileExists(event.Name)) {
 				// Could be a file or directory deletion - rebuild dependency map
 				fmt.Fprintf(w.writer, "📝 File/directory removed: %s\n", event.Name)
-				
+
 				// Get list of all dashboards we knew about BEFORE the deletion
 				// Must use cached state, not filesystem scan (folder already deleted!)
 				dashboardsBefore := make(map[string]bool)
 				for dash := range w.allDashboards {
 					dashboardsBefore[dash] = true
 				}
-				
+
 				fmt.Fprintf(w.writer, "   Rebuilding dependency map...\n")
 				w.buildDependencyMap()
-				
+
 				// Find removed dashboards by comparing before/after
 				for dashboard := range dashboardsBefore {
 					if !w.allDashboards[dashboard] {
@@ -130,7 +130,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 						fmt.Fprintf(w.writer, "   ❌ Dashboard removed: %s\n", relPath)
 					}
 				}
-				
+
 				continue
 			}
 
@@ -376,6 +376,7 @@ func (w *watcher) buildAllDashboards() {
 }
 
 // isLibraryFile checks if a file is a library/shared file that shouldn't be built directly
+// TODO too simplist, "root files are dashboards" assumption is wrong
 func (w *watcher) isLibraryFile(file string) bool {
 	// Library files are typically in directories like: library/, lib/, pkg/, shared/, etc.
 	// Dashboard files are typically in: dashboards/, or are direct main.go files

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -39,6 +39,11 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
+// shouldSkipDirectory checks if a directory should be skipped during file walks
+func (w *watcher) shouldSkipDirectory(name string) bool {
+	return name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir
+}
+
 type watcher struct {
 	async.SimpleTask
 	sourceDir     string
@@ -46,7 +51,6 @@ type watcher struct {
 	debounceDelay time.Duration
 	writer        io.Writer
 	errWriter     io.Writer
-	buildChan     chan struct{}
 	buildOption   *build.Option
 	changedFiles  map[string]bool     // Track files changed during debounce period
 	dependencyMap map[string][]string // Maps library files to dashboard files that import them
@@ -70,7 +74,6 @@ func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, de
 		debounceDelay: debounceDelay,
 		writer:        writer,
 		errWriter:     errWriter,
-		buildChan:     make(chan struct{}, 1),
 		buildOption:   buildOpt,
 		changedFiles:  make(map[string]bool),
 		dependencyMap: make(map[string][]string),
@@ -96,7 +99,6 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 	// Initial build - build all dashboard files
 	logrus.Debug("🔨 Running initial build...")
 	w.buildAllDashboards()
-	logrus.Debugf("📊 Dependency tracking enabled (%d library -> dashboard mappings)", len(w.dependencyMap))
 
 	var debounceTimer *time.Timer
 	var debouncePending bool
@@ -104,14 +106,13 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 	for {
 		select {
 		case <-ctx.Done():
-			close(w.buildChan)
 			logrus.Info("Watch stopped")
 			return nil
 
 		case event := <-fsWatcher.Events:
 			// Handle deletions (REMOVE or RENAME where file no longer exists)
+			// In such cases, the dependency map should be rebuilt
 			if event.Op&fsnotify.Remove != 0 || (event.Op&fsnotify.Rename != 0 && !fileExists(event.Name)) {
-				// Could be a file or directory deletion - rebuild dependency map
 				logrus.Debugf("📝 File/directory removed: %s", event.Name)
 
 				// Get list of all dashboards we knew about BEFORE the deletion
@@ -177,11 +178,11 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 				}
 			}
 
-			// Now check if it's a file we care about (.go or .cue)
-			if !w.shouldRebuild(event) {
+			// Now check if it's a file we care about
+			ext := filepath.Ext(event.Name)
+			if ext != ".go" && ext != ".cue" {
 				continue
 			}
-
 			logrus.Debugf("📝 File event: %s (%s)", event.Name, event.Op)
 
 			// Handle file operations: CREATE, WRITE, RENAME (move)
@@ -189,11 +190,8 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 				// Track the changed file
 				w.changedFiles[event.Name] = true
 
-				// If it's a CREATE or RENAME, rebuild dependency map to discover new files
-				if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
-					w.buildDependencyMap()
-				} else if w.isDashboardFile(event.Name) {
-					// For WRITE on existing dashboards, rebuild dependency map to catch new imports
+				// Rebuild dependency map to discover new files or catch new imports in dashboards
+				if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 || w.isDashboardFile(event.Name) {
 					w.buildDependencyMap()
 				}
 
@@ -205,6 +203,7 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 				debouncePending = true
 			}
 
+		// Debounce: waits for a pause in file changes before triggering rebuild
 		case <-func() <-chan time.Time {
 			if debounceTimer != nil {
 				return debounceTimer.C
@@ -274,40 +273,26 @@ func (w *watcher) rebuildAffectedFiles() {
 		}
 		if !hasErrors {
 			logrus.Debug("✅ Build successful!")
-			select {
-			case w.buildChan <- struct{}{}:
-			default:
-			}
 		}
 		return
-	} else if len(filesToBuild) > 10 {
-		// Too many files changed, do full rebuild
-		logrus.Debug("Multiple files changed, rebuilding all dashboards...")
-		w.buildAllDashboards()
+	}
+
+	// Build each changed dashboard file individually
+	hasErrors := false
+	for _, file := range filesToBuild {
+		outputPath, err := w.buildFile(file)
+		if err != nil {
+			logrus.Errorf("❌ Build failed for %s: %v", file, err)
+			hasErrors = true
+		} else {
+			logrus.Debugf("Successfully built %s at %s", file, outputPath)
+		}
+	}
+	if hasErrors {
 		return
-	} else {
-		// Build each changed file individually
-		hasErrors := false
-		for _, file := range filesToBuild {
-			outputPath, err := w.buildFile(file)
-			if err != nil {
-				logrus.Errorf("❌ Build failed for %s: %v", file, err)
-				hasErrors = true
-			} else {
-				logrus.Debugf("Successfully built %s at %s", file, outputPath)
-			}
-		}
-		if hasErrors {
-			return
-		}
 	}
 
 	logrus.Debug("✅ Build successful!")
-	// Notify build completion (non-blocking)
-	select {
-	case w.buildChan <- struct{}{}:
-	default:
-	}
 }
 
 // buildFile builds a single file using the build option and returns the output path
@@ -334,7 +319,7 @@ func (w *watcher) buildFile(file string) (string, error) {
 	return outputPath, nil
 }
 
-// findDashboardFiles finds all dashboard files (main packages) in the source directory
+// findDashboardFiles finds all dashboard files in the source directory
 func (w *watcher) findDashboardFiles() []string {
 	var dashboards []string
 	filepath.Walk(w.sourceDir, func(path string, info os.FileInfo, err error) error {
@@ -342,9 +327,7 @@ func (w *watcher) findDashboardFiles() []string {
 			return nil
 		}
 		if info.IsDir() {
-			// Skip ignored directories
-			name := info.Name()
-			if name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir {
+			if w.shouldSkipDirectory(info.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -386,17 +369,9 @@ func (w *watcher) buildAllDashboards() {
 	}
 
 	if hasErrors {
-		logrus.Warnf("⚠️  Build completed with errors (%d/%d succeeded)", successCount, len(dashboards))
+		logrus.Warnf("⚠️ Build completed with errors (%d/%d succeeded)", successCount, len(dashboards))
 	} else {
 		logrus.Debugf("✅ Build successful! (%d dashboard(s))", len(dashboards))
-	}
-
-	if !hasErrors {
-		// Notify build completion (non-blocking)
-		select {
-		case w.buildChan <- struct{}{}:
-		default:
-		}
 	}
 }
 
@@ -404,16 +379,18 @@ func (w *watcher) buildAllDashboards() {
 func (w *watcher) isDashboardFile(file string) bool {
 	ext := filepath.Ext(file)
 
-	if ext == ".go" {
+	switch ext {
+	case ".go":
 		return w.isGoDashboardFile(file)
-	} else if ext == ".cue" {
+	case ".cue":
 		return w.isCueDashboardFile(file)
 	}
 
 	return false // Unknown files are not dashboards by default
 }
 
-// isGoDashboardFile checks if a Go file is a dashboard (main package)
+// isGoDashboardFile checks if a Go file is to be considered a dashboard.
+// It simply checks if the package is "main"
 func (w *watcher) isGoDashboardFile(file string) bool {
 	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, file, nil, parser.PackageClauseOnly)
@@ -425,7 +402,8 @@ func (w *watcher) isGoDashboardFile(file string) bool {
 	return node.Name.Name == "main"
 }
 
-// isCueDashboardFile checks if a CUE file is a dashboard based on import patterns and filename
+// isCueDashboardFile checks if a CUE file is to be considered a dashboard
+// No 100% reliable way here, thus we take a heuristic approach based on import patterns and filename
 func (w *watcher) isCueDashboardFile(file string) bool {
 	content, err := os.ReadFile(file)
 	if err != nil {
@@ -546,7 +524,7 @@ func (w *watcher) parseGoImports(filePath string) []string {
 	return imports
 }
 
-// parseCueImports parses import statements from a CUE file using the official parser
+// parseCueImports parses import statements from a CUE file
 func (w *watcher) parseCueImports(filePath string) []string {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
@@ -588,9 +566,7 @@ func (w *watcher) resolveImportToFiles(importPath string) []string {
 			return nil
 		}
 
-		// Skip ignored directories
-		name := info.Name()
-		if name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir {
+		if w.shouldSkipDirectory(info.Name()) {
 			return filepath.SkipDir
 		}
 
@@ -658,13 +634,6 @@ func (w *watcher) findAffectedDashboards(changedFiles []string) []string {
 	return result
 }
 
-// shouldRebuild determines if a file change event should trigger a rebuild (.go or .cue files)
-func (w *watcher) shouldRebuild(event fsnotify.Event) bool {
-	// Watch .go and .cue files
-	ext := filepath.Ext(event.Name)
-	return ext == ".go" || ext == ".cue"
-}
-
 // addWatchRecursive recursively adds directories to the file watcher, skipping ignored folders
 func (w *watcher) addWatchRecursive(watcher *fsnotify.Watcher, root string) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -672,20 +641,13 @@ func (w *watcher) addWatchRecursive(watcher *fsnotify.Watcher, root string) erro
 			return err
 		}
 		if info.IsDir() {
-			// Skip vendor, node_modules, .git, build output folder
-			name := info.Name()
-			if name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir {
+			if w.shouldSkipDirectory(info.Name()) {
 				return filepath.SkipDir
 			}
 			return watcher.Add(path)
 		}
 		return nil
 	})
-}
-
-// GetBuildNotifications returns a channel that signals when a build completes
-func (w *watcher) GetBuildNotifications() <-chan struct{} {
-	return w.buildChan
 }
 
 // String returns a human-readable description of the watcher task

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/perses/perses/internal/cli/cmd/dac/build"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/opt"
+	"github.com/perses/spec/go/common"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/mod/modfile"
 )
@@ -46,9 +47,29 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-// shouldSkipDirectory checks if a directory should be skipped during file walks
-func (w *watcher) shouldSkipDirectory(name string) bool {
-	return name == "vendor" || name == "node_modules" || name == ".git" || name == w.buildDir
+// shouldSkipDirectory checks if a directory should be skipped during file walks.
+// It expects the full directory path (not just the base name) so that the build
+// directory can be matched precisely by its absolute path.
+func (w *watcher) shouldSkipDirectory(path string) bool {
+	// Well-known directories are matched by base name since they can appear
+	// anywhere in the source tree.
+	switch filepath.Base(path) {
+	case "vendor", "node_modules", ".git":
+		return true
+	}
+
+	// Match the build directory by absolute path so that unrelated directories
+	// that merely share its base name (e.g. another "dashboards" folder) are not
+	// skipped by mistake. The build directory's absolute path is precomputed once
+	// at watcher creation time.
+	if w.absoluteBuildDir == "" {
+		return false
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	return absPath == w.absoluteBuildDir
 }
 
 // detectModulePaths finds module paths for both Go and CUE projects.
@@ -94,21 +115,21 @@ func (w *watcher) isLocalImport(importPath string) bool {
 
 type watcher struct {
 	async.SimpleTask
-	sourceDir     string
-	buildDir      string
-	buildArgs     []string
-	debounceDelay time.Duration
-	writer        io.Writer
-	errWriter     io.Writer
-	buildOption   *build.Option
-	modulePaths   []string            // Module paths from go.mod and cue.mod for identifying local imports
-	changedFiles  map[string]bool     // Track files changed during debounce period
-	dependencyMap map[string][]string // Maps library files to dashboard files that import them
-	allDashboards map[string]bool     // Track all known dashboard files for deletion detection
+	sourceDir        string
+	absoluteBuildDir string
+	buildArgs        []string
+	debounceDelay    time.Duration
+	writer           io.Writer
+	errWriter        io.Writer
+	buildOption      *build.Option
+	modulePaths      []string            // Module paths from go.mod and cue.mod for identifying local imports
+	changedFiles     map[string]bool     // Track files changed during debounce period
+	dependencyMap    map[string][]string // Maps library files to dashboard files that import them
+	allDashboards    map[string]bool     // Track all known dashboard files for deletion detection
 }
 
 // newWatcher creates a new file watcher that monitors DaC files and triggers rebuilds
-func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, debounceDelay time.Duration, writer, errWriter io.Writer) *watcher {
+func newWatcher(sourceDir, absoluteBuildDir, outputFormat string, buildArgs []string, debounceDelay common.Duration, writer, errWriter io.Writer) *watcher {
 	// Create build option to reuse build logic
 	buildOpt := &build.Option{
 		DirectoryOption: opt.DirectoryOption{Directory: sourceDir},
@@ -119,16 +140,16 @@ func newWatcher(sourceDir, buildDir, outputFormat string, buildArgs []string, de
 	buildOpt.SetErrWriter(errWriter)
 
 	w := &watcher{
-		sourceDir:     sourceDir,
-		buildDir:      buildDir,
-		buildArgs:     buildArgs,
-		debounceDelay: debounceDelay,
-		writer:        writer,
-		errWriter:     errWriter,
-		buildOption:   buildOpt,
-		modulePaths:   detectModulePaths(sourceDir),
-		changedFiles:  make(map[string]bool),
-		dependencyMap: make(map[string][]string),
+		sourceDir:        sourceDir,
+		absoluteBuildDir: absoluteBuildDir,
+		buildArgs:        buildArgs,
+		debounceDelay:    time.Duration(debounceDelay),
+		writer:           writer,
+		errWriter:        errWriter,
+		buildOption:      buildOpt,
+		modulePaths:      detectModulePaths(sourceDir),
+		changedFiles:     make(map[string]bool),
+		dependencyMap:    make(map[string][]string),
 	}
 	// Build initial dependency map
 	w.buildDependencyMap()
@@ -412,7 +433,7 @@ func (w *watcher) findDashboardFiles() []string {
 			return nil
 		}
 		if info.IsDir() {
-			if w.shouldSkipDirectory(info.Name()) {
+			if w.shouldSkipDirectory(path) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -659,7 +680,7 @@ func (w *watcher) resolveImportToFiles(importPath string) []string {
 			return nil
 		}
 
-		if w.shouldSkipDirectory(info.Name()) {
+		if w.shouldSkipDirectory(path) {
 			return filepath.SkipDir
 		}
 
@@ -736,7 +757,7 @@ func (w *watcher) addWatchRecursive(watcher *fsnotify.Watcher, root string) erro
 			return err
 		}
 		if info.IsDir() {
-			if w.shouldSkipDirectory(info.Name()) {
+			if w.shouldSkipDirectory(path) {
 				return filepath.SkipDir
 			}
 			return watcher.Add(path)

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -175,7 +175,8 @@ func (w *watcher) Execute(ctx context.Context, _ context.CancelFunc) error {
 
 	// Initial build - build all dashboard files
 	logrus.Debug("🔨 Running initial build...")
-	w.buildAllDashboards()
+	dashboards := w.findDashboardFiles()
+	w.buildDashboards(dashboards)
 
 	var debounceTimer *time.Timer
 	var debouncePending bool
@@ -336,18 +337,24 @@ func (w *watcher) rebuildAffectedFiles() {
 
 	logrus.Infof("🔄 Changes detected in %d file(s), rebuilding...", len(filesToBuild))
 
+	// Prepare a set of dashboard files to be built
+	dashboardFiles := make(map[string]bool)
+
 	// Check if any changed files are library/shared files (not buildable as main packages)
-	hasLibraryFiles := false
+	// If this is directly dashboards, add them directly into the set of dashboards
+	libraryFiles := make(map[string]bool)
 	for _, file := range filesToBuild {
 		isDash := w.isDashboardFile(file)
 		logrus.Debugf("   - %s (library: %v)", file, !isDash)
-		if !isDash {
-			hasLibraryFiles = true
+		if isDash {
+			dashboardFiles[file] = true
+		} else {
+			libraryFiles[file] = true
 		}
 	}
 
-	// If library files changed, find and rebuild affected dashboards
-	if hasLibraryFiles {
+	// If library files changed, find the affected dashboards and add them to the set of dashboards
+	if len(libraryFiles) > 0 {
 		affectedDashboards := w.findAffectedDashboards(filesToBuild)
 		if len(affectedDashboards) == 0 {
 			// Fallback: if we can't determine dependencies, rebuild all
@@ -355,45 +362,24 @@ func (w *watcher) rebuildAffectedFiles() {
 			w.buildAllDashboards()
 			return
 		}
-		logrus.Debugf("Library file(s) changed, rebuilding %d affected dashboard(s)...", len(affectedDashboards))
+		logrus.Debugf("Library file(s) changed, will rebuild %d affected dashboard(s)...", len(affectedDashboards))
 		if logrus.IsLevelEnabled(logrus.DebugLevel) {
 			for _, dashboard := range affectedDashboards {
 				relPath, _ := filepath.Rel(w.sourceDir, dashboard)
 				logrus.Debugf("   → %s", relPath)
 			}
 		}
-		hasErrors := false
 		for _, dashboard := range affectedDashboards {
-			outputPath, err := w.buildFile(dashboard)
-			if err != nil {
-				logrus.Errorf("❌ Build failed for %s: %v", dashboard, err)
-				hasErrors = true
-			} else {
-				logrus.Debugf("Successfully built %s at %s", dashboard, outputPath)
-			}
+			dashboardFiles[dashboard] = true
 		}
-		if !hasErrors {
-			logrus.Info("✅ Build successful!")
-		}
-		return
 	}
 
-	// Build each changed dashboard file individually
-	hasErrors := false
-	for _, file := range filesToBuild {
-		outputPath, err := w.buildFile(file)
-		if err != nil {
-			logrus.Errorf("❌ Build failed for %s: %v", file, err)
-			hasErrors = true
-		} else {
-			logrus.Debugf("Successfully built %s at %s", file, outputPath)
-		}
+	// Turn back the set into a slice and build all the dashboards
+	dashboardFilesSlice := make([]string, 0, len(dashboardFiles))
+	for dashboard := range dashboardFiles {
+		dashboardFilesSlice = append(dashboardFilesSlice, dashboard)
 	}
-	if hasErrors {
-		return
-	}
-
-	logrus.Info("✅ Build successful!")
+	w.buildDashboards(dashboardFilesSlice)
 }
 
 // buildFile builds a single file using the build option and returns the output path
@@ -456,6 +442,11 @@ func (w *watcher) findDashboardFiles() []string {
 // buildAllDashboards builds all dashboard files in the source directory
 func (w *watcher) buildAllDashboards() {
 	dashboards := w.findDashboardFiles()
+	w.buildDashboards(dashboards)
+}
+
+// buildDashboards builds given dashboard files in the source directory
+func (w *watcher) buildDashboards(dashboards []string) {
 	if len(dashboards) == 0 {
 		logrus.Warn("⚠️  No dashboard files found")
 		return

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -334,7 +334,7 @@ func (w *watcher) rebuildAffectedFiles() {
 	// Clear the changed files map
 	w.changedFiles = make(map[string]bool)
 
-	logrus.Debugf("🔄 Changes detected in %d file(s), rebuilding...", len(filesToBuild))
+	logrus.Infof("🔄 Changes detected in %d file(s), rebuilding...", len(filesToBuild))
 
 	// Check if any changed files are library/shared files (not buildable as main packages)
 	hasLibraryFiles := false
@@ -373,7 +373,7 @@ func (w *watcher) rebuildAffectedFiles() {
 			}
 		}
 		if !hasErrors {
-			logrus.Debug("✅ Build successful!")
+			logrus.Info("✅ Build successful!")
 		}
 		return
 	}
@@ -393,7 +393,7 @@ func (w *watcher) rebuildAffectedFiles() {
 		return
 	}
 
-	logrus.Debug("✅ Build successful!")
+	logrus.Info("✅ Build successful!")
 }
 
 // buildFile builds a single file using the build option and returns the output path
@@ -461,7 +461,7 @@ func (w *watcher) buildAllDashboards() {
 		return
 	}
 
-	logrus.Debugf("Building %d dashboard(s)...", len(dashboards))
+	logrus.Infof("Building %d dashboard(s)...", len(dashboards))
 	hasErrors := false
 	successCount := 0
 
@@ -479,7 +479,7 @@ func (w *watcher) buildAllDashboards() {
 	if hasErrors {
 		logrus.Warnf("⚠️ Build completed with errors (%d/%d succeeded)", successCount, len(dashboards))
 	} else {
-		logrus.Debugf("✅ Build successful! (%d dashboard(s))", len(dashboards))
+		logrus.Infof("✅ Build successful! (%d dashboard(s))", len(dashboards))
 	}
 }
 

--- a/internal/cli/cmd/dac/watch/watcher.go
+++ b/internal/cli/cmd/dac/watch/watcher.go
@@ -15,7 +15,6 @@ package watch
 
 import (
 	"context"
-	"fmt"
 	"go/parser"
 	"go/token"
 	"io"
@@ -29,7 +28,6 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/perses/common/async"
 	"github.com/perses/perses/internal/cli/cmd/dac/build"
-	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/opt"
 	"github.com/perses/spec/go/common"
 	"github.com/sirupsen/logrus"
@@ -227,20 +225,42 @@ func (w *watcher) handleDeletion(name string) {
 	// Get list of all dashboards we knew about BEFORE the deletion
 	// Must use cached state, not filesystem scan (folder already deleted!)
 	dashboardsBefore := make(map[string]bool)
+	libsBefore := make(map[string]bool)
 	for dash := range w.allDashboards {
 		dashboardsBefore[dash] = true
+	}
+
+	for lib := range w.dependencyMap {
+		libsBefore[lib] = true
 	}
 
 	logrus.Debug("   Rebuilding dependency map...")
 	w.buildDependencyMap()
 
-	// Find removed dashboards by comparing before/after
+	// Remove generated outputs for dashboards that were deleted.
 	for dashboard := range dashboardsBefore {
 		if !w.allDashboards[dashboard] {
-			relPath, _ := filepath.Rel(w.sourceDir, dashboard)
-			logrus.Debugf("   ❌ Dashboard removed: %s", relPath)
+			inputPath, _ := filepath.Rel(w.sourceDir, dashboard)
+			logrus.Debugf("   ❌ Dashboard removed: %s", inputPath)
+			outputPath := w.buildOption.BuildOutputFilePath(inputPath)
+			if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
+				logrus.Warnf("   ⚠️  Failed to remove Dashboard output file %s: %v", outputPath, err)
+			} else {
+				logrus.Infof("   🗑️  Removed Dashboard output file: %s", outputPath)
+			}
 		}
 	}
+
+	// Display the libs removed
+	for lib := range libsBefore {
+		if len(w.dependencyMap[lib]) == 0 {
+			inputPath, _ := filepath.Rel(w.sourceDir, lib)
+			logrus.Debugf("   ❌ Library removed: %s", inputPath)
+		}
+	}
+
+	// A deletion (especially of a library file) can invalidate dependent dashboards; rebuild to refresh outputs.
+	w.buildAllDashboards()
 }
 
 // handleNewDirectory handles new directory creation events
@@ -404,11 +424,8 @@ func (w *watcher) buildFile(file string) (string, error) {
 		return "", err
 	}
 
-	// Compute output path (same logic as build.Option.buildOutputFilePath)
-	baseName := strings.TrimSuffix(file, filepath.Ext(file))
-	outputPath := filepath.Join(config.Global.Dac.OutputFolder, fmt.Sprintf("%s_output.%s", baseName, w.buildOption.Output))
-
-	return outputPath, nil
+	// Compute the output path reusing the same logic as in build command.
+	return w.buildOption.BuildOutputFilePath(file), nil
 }
 
 // findDashboardFiles finds all dashboard files in the source directory


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Relates to #3899.

Add a new `percli dac watch` command to watch Dashboard-as-Code files and auto-rebuild on changes. This command provides a development workflow similar to frontend hot-reload, where changes to DaC files are immediately compiled and made available for provisioning.

Sample outputs:

- basic run:
```
$ percli dac watch                         
INFO[2026-02-23T18:19:14+01:00] 📦 Dashboard-as-Code Watcher                  
INFO[2026-02-23T18:19:14+01:00]    Source: .                                 
INFO[2026-02-23T18:19:14+01:00]    Output: built                             
INFO[2026-02-23T18:19:14+01:00]    Format: yaml                              
INFO[2026-02-23T18:19:14+01:00]                                              
INFO[2026-02-23T18:19:14+01:00] 👀 Watching for changes... (Ctrl+C to stop)   
INFO[2026-02-23T18:19:14+01:00]                                              
```

- with debug logs with a Go repo:
```
$ percli dac watch --log.level debug                                             
INFO[2026-02-23T18:21:01+01:00] 📦 Dashboard-as-Code Watcher                  
INFO[2026-02-23T18:21:01+01:00]    Source: .                                 
INFO[2026-02-23T18:21:01+01:00]    Output: built                             
INFO[2026-02-23T18:21:01+01:00]    Format: yaml                              
INFO[2026-02-23T18:21:01+01:00]                                              
INFO[2026-02-23T18:21:01+01:00] 👀 Watching for changes... (Ctrl+C to stop)   
INFO[2026-02-23T18:21:01+01:00]                                              
DEBU[2026-02-23T18:21:01+01:00] 🔍 Building dependency graph (including transitive dependencies)... 
DEBU[2026-02-23T18:21:01+01:00]    Found 3 library file(s) with dependencies 
DEBU[2026-02-23T18:21:01+01:00]    - mylibrary/panels/mypanel.go → 3 dashboard(s) 
DEBU[2026-02-23T18:21:01+01:00]    - mylibrary/shared/visual.go → 3 dashboard(s) 
DEBU[2026-02-23T18:21:01+01:00]    - mylibrary/variables/myvariable.go → 1 dashboard(s) 
DEBU[2026-02-23T18:21:01+01:00] 🔨 Running initial build...                   
DEBU[2026-02-23T18:21:01+01:00] Building 3 dashboard(s)...                   
DEBU[2026-02-23T18:21:01+01:00] Successfully built dashboards/ContainerMonitoring/main.go at built/dashboards/ContainerMonitoring/main_output.yaml 
DEBU[2026-02-23T18:21:01+01:00] Successfully built dashboards/withoutVariable/main.go at built/dashboards/withoutVariable/main_output.yaml 
DEBU[2026-02-23T18:21:01+01:00] Successfully built dashboards/withoutVariable3/main.go at built/dashboards/withoutVariable3/main_output.yaml 
DEBU[2026-02-23T18:21:01+01:00] ✅ Build successful! (3 dashboard(s))
```

- with debug logs with a CUE repo:
```
$ percli dac watch --log.level debug
INFO[2026-02-23T18:20:02+01:00] 📦 Dashboard-as-Code Watcher                  
INFO[2026-02-23T18:20:02+01:00]    Source: .                                 
INFO[2026-02-23T18:20:02+01:00]    Output: built                             
INFO[2026-02-23T18:20:02+01:00]    Format: yaml                              
INFO[2026-02-23T18:20:02+01:00]                                              
INFO[2026-02-23T18:20:02+01:00] 👀 Watching for changes... (Ctrl+C to stop)   
INFO[2026-02-23T18:20:02+01:00]                                              
DEBU[2026-02-23T18:20:02+01:00] 🔍 Building dependency graph (including transitive dependencies)... 
DEBU[2026-02-23T18:20:02+01:00]    Found 12 library file(s) with dependencies 
DEBU[2026-02-23T18:20:02+01:00]    - panels/gaugeSysLoad.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/statRAMTotal.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/timeseriesNetworkTrafficBasic.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/gaugeRootFS.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/statCPUCores.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/timeseriesDiskSpaceUsedBasic.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/gaugeRAMUsed.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/helpers.cue → 3 dashboard(s)     
DEBU[2026-02-23T18:20:02+01:00]    - panels/statRootFSTotal.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/statUptime.cue → 3 dashboard(s)  
DEBU[2026-02-23T18:20:02+01:00]    - panels/timeseriesCPUBasic.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00]    - panels/timeseriesMemoryBasic.cue → 3 dashboard(s) 
DEBU[2026-02-23T18:20:02+01:00] 🔨 Running initial build...                   
DEBU[2026-02-23T18:20:02+01:00] Building 4 dashboard(s)...                   
DEBU[2026-02-23T18:20:02+01:00] Successfully built dashboards/baredash/simple-dashboard.cue at built/dashboards/baredash/simple-dashboard_output.yaml 
DEBU[2026-02-23T18:20:02+01:00] Successfully built dashboards/node/node-exporter-partial.cue at built/dashboards/node/node-exporter-partial_output.yaml 
DEBU[2026-02-23T18:20:02+01:00] Successfully built dashboards/node/node-exporter-simple copy.cue at built/dashboards/node/node-exporter-simple copy_output.yaml 
DEBU[2026-02-23T18:20:03+01:00] Successfully built dashboards/node/node-exporter-simple.cue at built/dashboards/node/node-exporter-simple_output.yaml 
DEBU[2026-02-23T18:20:03+01:00] ✅ Build successful! (4 dashboard(s))         
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).