### PR TITLE
[IGNORE] fix e2e flakiness

### DIFF
--- a/ui/e2e/src/tests/timeSeriesChartLegends.spec.ts
+++ b/ui/e2e/src/tests/timeSeriesChartLegends.spec.ts
@@ -82,7 +82,7 @@ test.describe('Dashboard: Time Series Chart Legends', () => {
         const legendItemRole = panelName.includes('table') ? 'row' : 'listitem';
 
         const legendItems = timeSeriesPanel.container.getByRole(legendItemRole);
-        await legendItems.nth(2).hover();
+        await legendItems.first().hover();
       });
     });
   });


### PR DESCRIPTION
# Description

Fix e2e flakiness when hovering timeseries legends which use a virtualized table

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
