### PR TITLE
[FEATURE] core: add optional 'name' field to query spec

### DIFF
--- a/cue/model/api/v1/dashboard_go_gen.cue
+++ b/cue/model/api/v1/dashboard_go_gen.cue
@@ -37,6 +37,7 @@ import "github.com/perses/perses/cue/model/api/v1/common"
 }
 
 #QuerySpec: {
+	name?:  string         @go(Name)
 	plugin: common.#Plugin @go(Plugin)
 }
 

--- a/pkg/model/api/v1/dashboard.go
+++ b/pkg/model/api/v1/dashboard.go
@@ -54,6 +54,7 @@ type Query struct {
 }
 
 type QuerySpec struct {
+	Name   string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Plugin common.Plugin `json:"plugin" yaml:"plugin"`
 }
 

--- a/ui/core/src/model/query.ts
+++ b/ui/core/src/model/query.ts
@@ -18,6 +18,7 @@ import { ProfileData } from './profile-data';
 import { LogData } from './log-data';
 
 interface QuerySpec<PluginSpec> {
+  name?: string;
   plugin: Definition<PluginSpec>;
 }
 /**

--- a/ui/core/src/schema/panel.ts
+++ b/ui/core/src/schema/panel.ts
@@ -23,6 +23,7 @@ export const panelDisplaySpec: z.ZodSchema<PanelDisplay> = z.object({
 export const querySpecSchema: z.ZodSchema<QueryDefinition> = z.object({
   kind: z.string().min(1),
   spec: z.object({
+    name: z.string().optional(),
     plugin: pluginSchema,
   }),
 });


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Relates to https://github.com/perses/perses/issues/2469.
Add a new optional field to query spec. It will be used to allow user to name their query as they want. This PR is part of multiples PR:

- https://github.com/perses/shared/pull/69
- https://github.com/perses/plugins/pull/585

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
