### PR TITLE
[BUGFIX] Fix scrollbar not following theme mode

### DIFF
--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -35,6 +35,7 @@ function App(): ReactElement {
         flexDirection: 'column',
         minHeight: '100vh',
         backgroundColor: ({ palette }) => palette.background.default,
+        colorScheme: ({ palette }) => palette.mode,
       }}
     >
       {location.pathname !== SignInRoute &&
@@ -45,7 +46,6 @@ function App(): ReactElement {
         sx={{
           flex: 1,
           display: 'flex',
-          backgroundColor: ({ palette }) => palette.background.default,
           '--perses-colors-gray-100': (theme) => theme.palette.grey[100],
           '--perses-colors-gray-300': (theme) => theme.palette.grey[300],
           '--perses-colors-primary': (theme) => theme.palette.primary.main,


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Quick fix for Perses App, enforce the scrollbar to use the theme selected and not use browser theme.

# Screenshots

<!-- If there are UI changes -->
Before:
<img width="1264" height="914" alt="image" src="https://github.com/user-attachments/assets/0558f627-8d62-4856-8371-be37eb183d21" />


After:
<img width="1266" height="911" alt="image" src="https://github.com/user-attachments/assets/433bf283-21a2-41da-ac9b-eb2c7b9a619b" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
