### PR TITLE
[BUGFIX] read formatters from the cache

### DIFF
--- a/ui/core/src/model/units/bits.test.ts
+++ b/ui/core/src/model/units/bits.test.ts
@@ -13,6 +13,7 @@
 
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
+import { getFormatterStats } from './formatterCache';
 
 const BITS_TESTS: UnitTestCase[] = [
   {
@@ -132,5 +133,16 @@ const BITS_TESTS: UnitTestCase[] = [
 describe('formatBits', () => {
   it.each(BITS_TESTS)('formats $value with $format as $expected', ({ value, format, expected }) => {
     expect(formatValue(value, format)).toBe(expected);
+  });
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('bits')).toBe(5);
+    expect(getKeys('bits')).toStrictEqual([
+      'decimal|true|false|decbits|en-US',
+      'decimal|true|4|false|decbits|en-US',
+      'decimal|true|3|bits|en-US',
+      'decimal|true|3|decbits|en-US',
+      'decimal|true|false|bits|en-US',
+    ]);
   });
 });

--- a/ui/core/src/model/units/bits.ts
+++ b/ui/core/src/model/units/bits.ts
@@ -16,6 +16,7 @@ import numbro from 'numbro';
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces, shouldShortenValues } from './utils';
+import { getFormatterFromCache } from './formatterCache';
 
 /**
  * We support both SI (decimal) and IEC (binary) units for bits:
@@ -78,8 +79,17 @@ export function formatBits(bits: number, { unit = 'bits', shortValues, decimalPl
         formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
       }
     }
-    const formatter = Intl.NumberFormat('en-US', formatterOptions);
-    return formatter.format(bits) + ' bits';
+
+    const key = [
+      formatterOptions.style,
+      formatterOptions.useGrouping,
+      formatterOptions.maximumSignificantDigits,
+      decimalPlaces,
+      shortValues,
+      unit,
+    ];
+
+    return `${getFormatterFromCache(key, 'bits', formatterOptions, 'en-US')(bits)} bits`;
   }
 
   // If we're showing the shorten value, we use numbro.

--- a/ui/core/src/model/units/bytes.test.ts
+++ b/ui/core/src/model/units/bytes.test.ts
@@ -13,6 +13,7 @@
 
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
+import { getFormatterStats } from './formatterCache';
 
 const BYTES_TESTS: UnitTestCase[] = [
   {
@@ -356,5 +357,18 @@ describe('formatValue', () => {
   it.each(BYTES_TESTS)('returns $expected when $value formatted as $unit', (args: UnitTestCase) => {
     const { value, format: format, expected } = args;
     expect(formatValue(value, format)).toEqual(expected);
+  });
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('bytes')).toBe(7);
+    expect(getKeys('bytes')).toStrictEqual([
+      'unit|byte|long|true|false|decbytes|en-US',
+      'unit|byte|long|true|4|false|decbytes|en-US',
+      'unit|byte|long|true|3|bytes|en-US',
+      'unit|byte|long|true|3|decbytes|en-US',
+      'unit|byte|long|true|3|true|decbytes|en-US',
+      'unit|byte|long|true|4|true|decbytes|en-US',
+      'unit|byte|long|true|false|bytes|en-US',
+    ]);
   });
 });

--- a/ui/core/src/model/units/bytes.ts
+++ b/ui/core/src/model/units/bytes.ts
@@ -16,6 +16,7 @@ import numbro from 'numbro';
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces, shouldShortenValues } from './utils';
+import { getFormatterFromCache } from './formatterCache';
 
 /**
  * We support both SI (decimal) and IEC (binary) units for bytes:
@@ -78,8 +79,19 @@ export function formatBytes(bytes: number, { unit = 'bytes', shortValues, decima
         formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
       }
     }
-    const formatter = Intl.NumberFormat('en-US', formatterOptions);
-    return formatter.format(bytes);
+
+    const key = [
+      formatterOptions.style,
+      formatterOptions.unit,
+      formatterOptions.unitDisplay,
+      formatterOptions.useGrouping,
+      formatterOptions.maximumSignificantDigits,
+      decimalPlaces,
+      shortValues,
+      unit,
+    ];
+
+    return getFormatterFromCache(key, 'bytes', formatterOptions, 'en-US')(bytes);
   }
 
   // If we're showing the shorten value, we use numbro.

--- a/ui/core/src/model/units/currency.test.ts
+++ b/ui/core/src/model/units/currency.test.ts
@@ -13,12 +13,18 @@
 
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
+import { getFormatterStats } from './formatterCache';
 
 const CURRENCY_TESTS: UnitTestCase[] = [
   {
     value: 1.23,
     format: { unit: 'eur' },
     expected: '€1.23',
+  },
+  {
+    value: 0.99,
+    format: { unit: 'eur' },
+    expected: '€0.99',
   },
   {
     value: 1.23,
@@ -46,5 +52,17 @@ describe('formatValue', () => {
   it.each(CURRENCY_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
     const { value, format: format, expected } = args;
     expect(formatValue(value, format)).toEqual(expected);
+  });
+
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('currency')).toBe(5);
+    expect(getKeys('currency')).toStrictEqual([
+      'currency|EUR|symbol|3|eur|en-US',
+      'currency|AUD|symbol|3|aud|en-US',
+      'currency|GBP|symbol|3|gbp|en-US',
+      'currency|JPY|symbol|3|jpy|en-US',
+      'currency|USD|symbol|3|usd|en-US',
+    ]);
   });
 });

--- a/ui/core/src/model/units/currency.ts
+++ b/ui/core/src/model/units/currency.ts
@@ -15,6 +15,7 @@ import { toUpper } from 'lodash';
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitConfig, UnitGroupConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
+import { getFormatterFromCache } from './formatterCache';
 
 // See Intl.supportedValuesOf("currency") for valid options, key names will
 // be converted to uppercase to match the expectation of Intl.NumberFormat
@@ -121,6 +122,14 @@ export function formatCurrency(value: number, { unit, decimalPlaces }: CurrencyF
     formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
   }
 
-  const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(value);
+  const key = [
+    formatterOptions.style,
+    formatterOptions.currency,
+    formatterOptions.currencyDisplay,
+    formatterOptions.maximumSignificantDigits,
+    decimalPlaces,
+    unit,
+  ];
+
+  return getFormatterFromCache(key, 'currency', formatterOptions, 'en-US')(value);
 }

--- a/ui/core/src/model/units/decimal.test.ts
+++ b/ui/core/src/model/units/decimal.test.ts
@@ -13,6 +13,7 @@
 
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
+import { getFormatterStats } from './formatterCache';
 
 const DECIMAL_TESTS: UnitTestCase[] = [
   {
@@ -338,5 +339,16 @@ describe('formatValue', () => {
   it.each(DECIMAL_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
     const { value, format: format, expected } = args;
     expect(formatValue(value, format)).toEqual(expected);
+  });
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('decimal')).toBe(5);
+    expect(getKeys('decimal')).toStrictEqual([
+      'decimal|true|compact|3|en-US',
+      'decimal|true|en-US',
+      'decimal|true|4|en-US',
+      'decimal|true|compact|4|en-US',
+      'decimal|true|compact|2|en-US',
+    ]);
   });
 });

--- a/ui/core/src/model/units/decimal.ts
+++ b/ui/core/src/model/units/decimal.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
+import { getFormatterFromCache } from './formatterCache';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces, shouldShortenValues } from './utils';
 
@@ -52,6 +53,13 @@ export function formatDecimal(value: number, { shortValues, decimalPlaces }: Dec
     }
   }
 
-  const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(value);
+  const key = [
+    formatterOptions.style,
+    formatterOptions.useGrouping,
+    formatterOptions.notation,
+    formatterOptions.maximumSignificantDigits,
+    decimalPlaces,
+  ];
+
+  return getFormatterFromCache(key, 'decimal', formatterOptions, 'en-US')(value);
 }

--- a/ui/core/src/model/units/formatterCache.ts
+++ b/ui/core/src/model/units/formatterCache.ts
@@ -1,0 +1,94 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+type FormatFn = (value: number | bigint) => string;
+type InputType = 'time' | 'temperature' | 'bytes' | 'bits' | 'decimal' | 'currency' | 'percent' | 'throughput';
+type Locals = 'en-US' | 'en-GB';
+
+/**
+ * REASONING FOR CLUSTERING (Map-of-Maps):
+ *
+ * 1. PERSISTENCE & REUSE: Intl.NumberFormat instantiation is CPU-heavy due to
+ *    locale/data lookups. Clustering allows 100x faster reuse via caching.
+ *
+ *
+ * 2. LOOKUP PERFORMANCE: Smaller, specialized Maps reduce the risk of hash
+ *    collisions, ensuring O(1) retrieval time remains consistent even as
+ *    the total number of formatters across the app grows.
+ *
+ * 3. GARBAGE COLLECTION & STATS: Categorization allows for targeted memory
+ *    monitoring and easier debugging of which specific data types are
+ *    consuming the most resources.
+ */
+const TIME_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+const DECIMAL_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+const BITS_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+const BYTES_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+const CURRENCY_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+const PERCENT_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+const TEMPERATURE_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+const THROUGHPUT_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+
+const ALL_FORMATTERS: Map<InputType, Map<string, Intl.NumberFormat>> = new Map([
+  ['time', TIME_FORMATTER_CACHE],
+  ['decimal', DECIMAL_FORMATTER_CACHE],
+  ['bits', BITS_FORMATTER_CACHE],
+  ['bytes', BYTES_FORMATTER_CACHE],
+  ['currency', CURRENCY_FORMATTER_CACHE],
+  ['percent', PERCENT_FORMATTER_CACHE],
+  ['temperature', TEMPERATURE_FORMATTER_CACHE],
+  ['throughput', THROUGHPUT_FORMATTER_CACHE],
+]);
+
+export function getFormatterFromCache(
+  key: Array<string | number | boolean | undefined>,
+  inputType: InputType,
+  formatterOptions: Intl.NumberFormatOptions,
+  locals: Locals = 'en-US'
+): FormatFn {
+  const compoundKey = `${key.filter((k) => !([undefined, null, '', NaN] as unknown[]).includes(k)).join('|')}|${locals}`;
+  const inputTypeFormatters = ALL_FORMATTERS.get(inputType);
+  if (!inputTypeFormatters) throw new Error('No formatter found for the input type');
+
+  const formatter = inputTypeFormatters.get(compoundKey);
+  if (formatter) {
+    return formatter.format;
+  }
+
+  const newFormatter = Intl.NumberFormat(locals, formatterOptions);
+  inputTypeFormatters?.set(`${compoundKey}`, newFormatter);
+
+  return newFormatter.format;
+}
+
+/* This is a small utility for unit tests */
+export interface IFormatterStats {
+  countCacheItems: (inputType: InputType | 'all') => number;
+  getKeys: (inputType: InputType) => string[];
+}
+
+export const getFormatterStats = (): IFormatterStats => {
+  const countCacheItems = (inputType: InputType | 'all'): number => {
+    if (inputType !== 'all') {
+      return ALL_FORMATTERS.get(inputType)?.size ?? 0;
+    }
+
+    return Array.from(ALL_FORMATTERS.values()).reduce((acc, map) => acc + (map?.size ?? 0), 0);
+  };
+
+  const getKeys = (inputType: InputType): string[] => {
+    return [...(ALL_FORMATTERS.get(inputType)?.keys() || [])];
+  };
+
+  return { countCacheItems, getKeys };
+};

--- a/ui/core/src/model/units/percent.test.ts
+++ b/ui/core/src/model/units/percent.test.ts
@@ -13,6 +13,7 @@
 
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
+import { getFormatterStats } from './formatterCache';
 
 const PERCENT_TESTS: UnitTestCase[] = [
   // percent
@@ -99,5 +100,18 @@ describe('formatValue', () => {
   it.each(PERCENT_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
     const { value, format: unit, expected } = args;
     expect(formatValue(value, unit)).toEqual(expected);
+  });
+
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('percent')).toBe(6);
+    expect(getKeys('percent')).toStrictEqual([
+      'percent|true|3|percent|en-US',
+      'percent|true|4|percent|en-US',
+      'percent|true|0|percent|en-US',
+      'percent|true|3|percent-decimal|en-US',
+      'percent|true|4|percent-decimal|en-US',
+      'percent|true|0|percent-decimal|en-US',
+    ]);
   });
 });

--- a/ui/core/src/model/units/percent.ts
+++ b/ui/core/src/model/units/percent.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
+import { getFormatterFromCache } from './formatterCache';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
 
@@ -61,6 +62,13 @@ export function formatPercent(value: number, { unit, decimalPlaces }: PercentFor
     value = value / 100;
   }
 
-  const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(value);
+  const key = [
+    formatterOptions.style,
+    formatterOptions.useGrouping,
+    formatterOptions.maximumSignificantDigits,
+    decimalPlaces,
+    unit,
+  ];
+
+  return getFormatterFromCache(key, 'percent', formatterOptions, 'en-US')(value);
 }

--- a/ui/core/src/model/units/temperature.test.ts
+++ b/ui/core/src/model/units/temperature.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { getFormatterStats } from './formatterCache';
 import { UnitTestCase } from './types';
 import { formatValue } from './units';
 
@@ -35,11 +36,43 @@ const TEMPERATURE_TESTS: UnitTestCase[] = [
     format: { unit: 'fahrenheit', decimalPlaces: 0 },
     expected: '0°F',
   },
+  {
+    value: 0.005,
+    format: { unit: 'celsius', decimalPlaces: 2 },
+    expected: '0.01°C',
+  },
+  {
+    value: 10.5,
+    format: { unit: 'celsius', decimalPlaces: 0 },
+    expected: '11°C',
+  },
+  {
+    value: 10.3,
+    format: { unit: 'celsius', decimalPlaces: 0 },
+    expected: '10°C',
+  },
+  {
+    value: 1234567,
+    format: { unit: 'celsius', decimalPlaces: 0 },
+    expected: '1,234,567°C',
+  },
 ];
 
 describe('temperature formatValue', () => {
   it.each(TEMPERATURE_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
     const { value, format: format, expected } = args;
     expect(formatValue(value, format)).toEqual(expected);
+  });
+
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('temperature')).toBe(5);
+    expect(getKeys('temperature')).toStrictEqual([
+      'unit|celsius|1|en-GB|en-GB',
+      'unit|celsius|2|en-GB|en-GB',
+      'unit|fahrenheit|1|en-US|en-US',
+      'unit|fahrenheit|0|en-US|en-US',
+      'unit|celsius|0|en-GB|en-GB',
+    ]);
   });
 });

--- a/ui/core/src/model/units/temperature.ts
+++ b/ui/core/src/model/units/temperature.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
+import { getFormatterFromCache } from './formatterCache';
 import { UnitConfig, UnitGroupConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
 
@@ -54,5 +55,14 @@ export const formatTemperature = (value: number, { unit, decimalPlaces }: Temper
   }
 
   const locals = unit === 'celsius' ? 'en-GB' : 'en-US';
-  return Intl.NumberFormat(locals, formatterOptions).format(value);
+
+  const key = [
+    formatterOptions.style,
+    formatterOptions.unit,
+    formatterOptions.maximumSignificantDigits,
+    decimalPlaces,
+    locals,
+  ];
+
+  return getFormatterFromCache(key, 'temperature', formatterOptions, locals)(value);
 };

--- a/ui/core/src/model/units/throughput.test.ts
+++ b/ui/core/src/model/units/throughput.test.ts
@@ -13,6 +13,7 @@
 
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
+import { getFormatterStats } from './formatterCache';
 
 const THROUGHPUT_TESTS: UnitTestCase[] = [
   {
@@ -88,5 +89,22 @@ describe('formatValue', () => {
   it.each(THROUGHPUT_TESTS)('returns $expected when $value formatted as $format', (args: UnitTestCase) => {
     const { value, format: format, expected } = args;
     expect(formatValue(value, format)).toEqual(expected);
+  });
+
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('throughput')).toBe(10);
+    expect(getKeys('throughput')).toStrictEqual([
+      'decimal|true|compact|3|counts/sec|en-US',
+      'decimal|true|false|ops/sec|en-US',
+      'decimal|true|4|false|requests/sec|en-US',
+      'decimal|true|compact|3|true|reads/sec|en-US',
+      'decimal|true|compact|4|true|writes/sec|en-US',
+      'decimal|true|compact|3|events/sec|en-US',
+      'decimal|true|false|messages/sec|en-US',
+      'decimal|true|4|false|records/sec|en-US',
+      'decimal|true|compact|3|true|rows/sec|en-US',
+      'decimal|true|compact|3|ops/sec|en-US',
+    ]);
   });
 });

--- a/ui/core/src/model/units/throughput.ts
+++ b/ui/core/src/model/units/throughput.ts
@@ -16,6 +16,7 @@ import { formatBits } from './bits';
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces, shouldShortenValues } from './utils';
+import { getFormatterFromCache } from './formatterCache';
 
 type ThroughputUnit =
   | 'bits/sec'
@@ -142,6 +143,15 @@ export function formatThroughput(value: number, { unit, shortValues, decimalPlac
     }
   }
 
-  const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(value) + ' ' + unit;
+  const key = [
+    formatterOptions.style,
+    formatterOptions.useGrouping,
+    formatterOptions.notation,
+    formatterOptions.maximumSignificantDigits,
+    decimalPlaces,
+    shortValues,
+    unit,
+  ];
+
+  return `${getFormatterFromCache(key, 'throughput', formatterOptions, 'en-US')(value)} ${unit}`;
 }

--- a/ui/core/src/model/units/time.test.ts
+++ b/ui/core/src/model/units/time.test.ts
@@ -21,6 +21,7 @@ import {
 import { Duration } from 'date-fns';
 import { formatValue } from './units';
 import { UnitTestCase } from './types';
+import { getFormatterStats } from './formatterCache';
 
 const TIME_TESTS: UnitTestCase[] = [
   {
@@ -376,4 +377,36 @@ describe('formatDuration', () => {
       expect(formatDuration(duration)).toEqual(expected);
     }
   );
+
+  it('should get identical formatters from cache', () => {
+    const { countCacheItems, getKeys } = getFormatterStats();
+    expect(countCacheItems('time')).toBe(25);
+    expect(getKeys('time')).toStrictEqual([
+      'unit|nanosecond|narrow|3|nanoseconds|en-US',
+      'unit|nanosecond|narrow|3|microseconds|en-US',
+      'unit|microsecond|narrow|3|milliseconds|en-US',
+      'unit|millisecond|narrow|3|seconds|en-US',
+      'unit|millisecond|narrow|3|minutes|en-US',
+      'unit|second|narrow|3|hours|en-US',
+      'unit|minute|narrow|3|days|en-US',
+      'unit|minute|narrow|3|weeks|en-US',
+      'unit|minute|narrow|3|months|en-US',
+      'unit|hour|narrow|3|years|en-US',
+      'unit|microsecond|narrow|3|microseconds|en-US',
+      'unit|millisecond|narrow|3|milliseconds|en-US',
+      'unit|second|narrow|3|seconds|en-US',
+      'unit|minute|narrow|3|minutes|en-US',
+      'unit|hour|narrow|3|hours|en-US',
+      'unit|day|narrow|3|days|en-US',
+      'unit|week|narrow|3|weeks|en-US',
+      'unit|month|long|3|months|en-US',
+      'unit|year|long|3|years|en-US',
+      'unit|minute|narrow|3|seconds|en-US',
+      'unit|hour|narrow|3|minutes|en-US',
+      'unit|day|narrow|3|hours|en-US',
+      'unit|month|long|3|days|en-US',
+      'unit|year|long|3|weeks|en-US',
+      'unit|year|long|3|months|en-US',
+    ]);
+  });
 });

--- a/ui/core/src/model/units/time.ts
+++ b/ui/core/src/model/units/time.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { MAX_SIGNIFICANT_DIGITS } from './constants';
+import { getFormatterFromCache } from './formatterCache';
 import { UnitGroupConfig, UnitConfig } from './types';
 import { hasDecimalPlaces, limitDecimalPlaces } from './utils';
 
@@ -169,6 +170,14 @@ export function formatTime(value: number, { unit, decimalPlaces }: TimeFormatOpt
     formatterOptions.maximumSignificantDigits = MAX_SIGNIFICANT_DIGITS;
   }
 
-  const formatter = Intl.NumberFormat('en-US', formatterOptions);
-  return formatter.format(results.value);
+  const key = [
+    formatterOptions.style,
+    formatterOptions.unit,
+    formatterOptions.unitDisplay,
+    formatterOptions.maximumSignificantDigits,
+    decimalPlaces,
+    unit ?? 'seconds',
+  ];
+
+  return getFormatterFromCache(key, 'time', formatterOptions, 'en-US')(results.value);
 }


### PR DESCRIPTION


Relates to https://github.com/perses/perses/issues/3448

# Description
Creating the formatter object is an expensive task. **This was pointed out by the browser profiler** that the main thread is spending some considerable amount of time for creating formatters. This can significantly affect huge dashboards.

The suggested fix utilizes a JS map and a short key to quickly pickup the proper formatter. So, the formatter is created once and used whenever it is needed. The following screenshots demonstrate that the max INP drops using the cache.

# Screenshots

## Before change

<img width="2131" height="925" alt="p1" src="https://github.com/user-attachments/assets/137352f4-6cd8-401a-a07f-1738751045bc" />

## After using cache

<img width="2110" height="1227" alt="image" src="https://github.com/user-attachments/assets/3e29934c-86fc-421a-b848-eb0b9b106f75" />

<img width="944" height="319" alt="image" src="https://github.com/user-attachments/assets/b33e5e9e-56e9-4b7a-93dc-9e7ee158b3c8" />




<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
