### PR TITLE
[BUGFIX] Go SDK: fail on invalid dashboard name

### DIFF
--- a/go-sdk/dashboard/dashboard.go
+++ b/go-sdk/dashboard/dashboard.go
@@ -14,9 +14,11 @@
 package dashboard
 
 import (
+	"fmt"
 	"time"
 
 	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/common"
 )
 
 type Option func(dashboard *Builder) error
@@ -27,9 +29,9 @@ func New(name string, options ...Option) (Builder, error) {
 			Kind: v1.KindDashboard,
 		},
 	}
+	builder.Dashboard.Metadata.Name = name
 
 	defaults := []Option{
-		Name(name),
 		Duration(time.Hour),
 	}
 
@@ -37,6 +39,10 @@ func New(name string, options ...Option) (Builder, error) {
 		if err := opt(builder); err != nil {
 			return *builder, err
 		}
+	}
+
+	if err := common.ValidateID(builder.Dashboard.Metadata.Name); err != nil {
+		return *builder, fmt.Errorf("invalid dashboard metadata name %q: %w", builder.Dashboard.Metadata.Name, err)
 	}
 
 	return *builder, nil

--- a/go-sdk/test/dashboard_test.go
+++ b/go-sdk/test/dashboard_test.go
@@ -247,3 +247,14 @@ func TestDashboardBuilderWithGroupedVariables(t *testing.T) {
 		require.JSONEq(t, string(expectedOutput), string(builderOutput))
 	})
 }
+
+func TestDashboardNewWithInvalidMetadataName(t *testing.T) {
+	inputName := "Space in title"
+
+	builder, err := dashboard.New(inputName,
+		dashboard.ProjectName("MyProject"),
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, inputName, builder.Dashboard.Metadata.Name)
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

currently with such Go SDK payload:

```go
	builder, buildErr := dashboard.New("Showcase of the different panels",
		[...]
```
- it produces this wrong output with empty name:
  ```yaml
  metadata:
    name: ""
  spec:
    display:
        name: Showcase of the different panels
  ```
- `percli dac build` doesn't complain:
  ```sh
  $ ../perses/bin/percli dac build -f dac/SingleGauge/main.go
  Successfully built dac/SingleGauge/main.go at built/dac/SingleGauge/main_output.yaml
  ```
So you notice the issue only at validate or deploy time.

This PR fixes that by:
- properly passing the (invalid) string to the final json/yaml:
  ```yaml
  metadata:
    name: Showcase of the different panels
  spec:
    display:
        name: Showcase of the different panels
  ```
- failing at build time:
  ```sh
  $ ../perses/bin/percli dac build -f dac/SingleGauge/main.go
  Error: failed to build dac/SingleGauge/main.go: invalid dashboard metadata name "Showcase of the different panels": "Showcase of the different panels" is not a correct name. It should match the regexp: ^[a-zA-Z0-9_.-]+$exit status 255
  ```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).