### PR TITLE
[ENHANCEMENT] add timezone validator to the gosdk

### DIFF
--- a/pkg/model/api/v1/common/validate.go
+++ b/pkg/model/api/v1/common/validate.go
@@ -14,6 +14,9 @@
 package common
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/perses/spec/go/common"
 )
 
@@ -27,4 +30,17 @@ func ValidateID(name string) error {
 // DEPRECATED: this is replaced by the struct github.com/perses/spec/go/common.ValidateDescription
 func ValidateDescription(description string) error {
 	return common.ValidateDescription(description)
+}
+
+// ValidateTimezone checks for the forbidden timezone
+func ValidateTimezone(timezone string) error {
+	if timezone == "" || timezone == "local" {
+		return nil
+	}
+
+	_, err := time.LoadLocation(timezone)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid timezone: %w", timezone, err)
+	}
+	return nil
 }

--- a/pkg/model/api/v1/common/validate_test.go
+++ b/pkg/model/api/v1/common/validate_test.go
@@ -1,0 +1,47 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTimezone(t *testing.T) {
+	tests := []struct {
+		name     string
+		timezone string
+		wantErr  bool
+	}{
+		{"empty string is valid", "", false},
+		{"valid timezone America/New_York", "America/New_York", false},
+		{"valid timezone Europe/London", "Europe/London", false},
+		{"valid timezone Asia/Tokyo", "Asia/Tokyo", false},
+		{"invalid timezone name", "Invalid/Zone", true},
+		{"random string", "mars-timezone", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTimezone(tt.timezone)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.timezone)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION


# Description
This change adds time zone validator to the `pkg/model/api/v1/common/validate.go`

The new validate function is necessary for https://github.com/perses/perses/pull/3957

<img width="664" height="233" alt="image" src="https://github.com/user-attachments/assets/670964ea-7728-4b2d-bcb4-7a99821ba6fb" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
