### PR TITLE
[BUGFIX] Set specific Content-Type for static UI resources

### DIFF
--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"mime"
 	"net/http"
 	"net/http/httputil"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -103,6 +105,11 @@ func (f *frontend) servePluginFiles(c echo.Context) error {
 		// The First thing to do is to replace the URL path with the local path of the plugin.
 		localPath := strings.Replace(req.URL.Path, fmt.Sprintf("%s/plugins/%s", f.apiPrefix, pluginName), loaded.LocalPath, 1)
 		// Then we just need to rely on the echo router to serve the file.
+
+		// X-Content-Type-Options: nosniff is an HTTP response header that tells browsers: "Do not try to guess the content type — trust the Content-Type header I sent you."
+		// Without it, browsers perform "MIME sniffing". For example, a file served as text/plain could be sniffed as text/html and executed as HTML, which could open the door to XSS attacks.
+		// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
+		c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 		return c.File(localPath)
 	}
 	// Otherwise, it means we are in a dev environment, and we need to proxy the request to the dev server.
@@ -174,6 +181,12 @@ func (f *frontend) assetHandler() echo.HandlerFunc {
 		if strings.Contains(fileName, ".js") {
 			data = bytes.ReplaceAll(data, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
 		}
+		contentType := mime.TypeByExtension(filepath.Ext(fileName))
+		if contentType == "" {
+			contentType = http.DetectContentType(data)
+		}
+		c.Response().Header().Set("Content-Type", contentType)
+		c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 		_, err = c.Response().Write(data)
 		return apiinterface.HandleError(err)
 	}
@@ -231,6 +244,8 @@ func (f *frontend) serveASTFiles(c echo.Context) error {
 		return apiinterface.HandleError(err)
 	}
 	idx = bytes.ReplaceAll(idx, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
+	c.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
+	c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 	_, err = c.Response().Write(idx)
 	return apiinterface.HandleError(err)
 }

--- a/ui/endpoint_test.go
+++ b/ui/endpoint_test.go
@@ -1,0 +1,101 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetHandlerContentType(t *testing.T) {
+	// Override the package-level embedded filesystem with test data.
+	originalAsts := asts
+	t.Cleanup(func() { asts = originalAsts })
+
+	testFS := fstest.MapFS{
+		"app/dist/main.abc123.css": &fstest.MapFile{Data: []byte("body { color: red; }")},
+		"app/dist/main.abc123.js":  &fstest.MapFile{Data: []byte("console.log('hello')")},
+		"app/dist/image.png":       &fstest.MapFile{Data: []byte("fake-png-data")},
+		"app/dist/index.html":      &fstest.MapFile{Data: []byte("<html></html>")},
+	}
+	asts = http.FS(testFS)
+
+	f := &frontend{apiPrefix: ""}
+
+	tests := []struct {
+		name                 string
+		path                 string
+		expectedContentTypes []string
+	}{
+		{
+			name:                 "CSS file",
+			path:                 "/app/dist/main.abc123.css",
+			expectedContentTypes: []string{"text/css; charset=utf-8"},
+		},
+		{
+			name: "JavaScript file",
+			path: "/app/dist/main.abc123.js",
+			// Windows registers the obsolete application/javascript MIME type.
+			expectedContentTypes: []string{"text/javascript; charset=utf-8", "application/javascript"},
+		},
+		{
+			name:                 "HTML file",
+			path:                 "/app/dist/index.html",
+			expectedContentTypes: []string{"text/html; charset=utf-8"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+
+			handler := f.assetHandler()
+			err := handler(ctx)
+			require.NoError(t, err)
+			assert.Contains(t, tt.expectedContentTypes, rec.Header().Get("Content-Type"))
+			assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+		})
+	}
+}
+
+func TestServeASTFilesContentType(t *testing.T) {
+	// Override the package-level embedded filesystem with test data.
+	originalAsts := asts
+	t.Cleanup(func() { asts = originalAsts })
+
+	testFS := fstest.MapFS{
+		"app/dist/index.html": &fstest.MapFile{Data: []byte("<html><head></head><body></body></html>")},
+	}
+	asts = http.FS(testFS)
+
+	f := &frontend{apiPrefix: ""}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := f.serveASTFiles(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "text/html; charset=utf-8", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+}


### PR DESCRIPTION
# Description

As per
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options `Content-Type` is required to avoid potential browser blocking

+ `X-Content-Type-Options: nosniff` to avoid MIME confusion attack

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).