### PR TITLE
fix(ui): fallback to metadata.name when project spec or display name …

### DIFF
--- a/ui/app/src/views/projects/ProjectView.tsx
+++ b/ui/app/src/views/projects/ProjectView.tsx
@@ -47,7 +47,7 @@ function ProjectView(): ReactElement {
 
   function handleProjectRename(project: ProjectResource, projectName: string): void {
     updateProjectMutation.mutate(
-      { ...project, spec: { display: { ...project.spec.display, name: projectName } } },
+      { ...project, spec: { display: { ...project.spec?.display, name: projectName } } },
       {
         onSuccess: (updatedProject: ProjectResource) => {
           successSnackbar(`Project ${updatedProject.metadata.name} has been successfully updated`);

--- a/ui/core/src/model/project.ts
+++ b/ui/core/src/model/project.ts
@@ -17,7 +17,7 @@ import { Display } from './display';
 export interface ProjectResource {
   kind: 'Project';
   metadata: Metadata;
-  spec: ProjectSpec;
+  spec?: ProjectSpec;
 }
 
 export interface ProjectSpec {

--- a/ui/core/src/model/resource.ts
+++ b/ui/core/src/model/resource.ts
@@ -33,7 +33,7 @@ export interface Resource {
   kind: Kind;
   metadata: Metadata | ProjectMetadata;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  spec: any;
+  spec?: any;
 }
 
 export function getMetadataProject(metadata: ProjectMetadata | Metadata): string | undefined {

--- a/ui/core/src/utils/text.test.ts
+++ b/ui/core/src/utils/text.test.ts
@@ -1,0 +1,60 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ProjectResource } from '../model';
+import { getResourceDisplayName, getResourceExtendedDisplayName } from './text';
+
+const projectWithDisplayName: ProjectResource = {
+  kind: 'Project',
+  metadata: { name: 'my-project' },
+  spec: { display: { name: 'My Project' } },
+};
+
+const projectWithoutDisplayName: ProjectResource = {
+  kind: 'Project',
+  metadata: { name: 'my-project' },
+  spec: {},
+};
+
+const projectWithoutSpec = {
+  kind: 'Project',
+  metadata: { name: 'my-project' },
+} as unknown as ProjectResource;
+
+describe('getResourceDisplayName', () => {
+  test('returns spec.display.name when present', () => {
+    expect(getResourceDisplayName(projectWithDisplayName)).toBe('My Project');
+  });
+
+  test('falls back to metadata.name when spec.display.name is absent', () => {
+    expect(getResourceDisplayName(projectWithoutDisplayName)).toBe('my-project');
+  });
+
+  test('falls back to metadata.name when spec is absent', () => {
+    expect(getResourceDisplayName(projectWithoutSpec)).toBe('my-project');
+  });
+});
+
+describe('getResourceExtendedDisplayName', () => {
+  test('returns display name with metadata.name in parentheses when display name present', () => {
+    expect(getResourceExtendedDisplayName(projectWithDisplayName)).toBe('My Project (ID: my-project)');
+  });
+
+  test('falls back to metadata.name when spec.display.name is absent', () => {
+    expect(getResourceExtendedDisplayName(projectWithoutDisplayName)).toBe('my-project');
+  });
+
+  test('falls back to metadata.name when spec is absent', () => {
+    expect(getResourceExtendedDisplayName(projectWithoutSpec)).toBe('my-project');
+  });
+});

--- a/ui/core/src/utils/text.ts
+++ b/ui/core/src/utils/text.ts
@@ -19,12 +19,12 @@ import { Resource } from '../model';
  */
 export function getResourceDisplayName<T extends Resource>(resource: T): string {
   // Variables
-  if (resource.spec.spec?.display?.name) {
+  if (resource.spec?.spec?.display?.name) {
     return resource.spec.spec.display.name;
   }
 
   // Other resources with display
-  if (resource.spec.display?.name) {
+  if (resource.spec?.display?.name) {
     return resource.spec.display.name;
   }
 
@@ -37,12 +37,12 @@ export function getResourceDisplayName<T extends Resource>(resource: T): string 
  */
 export function getResourceExtendedDisplayName<T extends Resource>(resource: T): string {
   // Variables
-  if (resource.spec.spec?.display?.name) {
+  if (resource.spec?.spec?.display?.name) {
     return `${resource.spec.spec.display.name} (ID: ${resource.metadata.name})`;
   }
 
   // Other resources with display
-  if (resource.spec.display?.name) {
+  if (resource.spec?.display?.name) {
     return `${resource.spec.display.name} (ID: ${resource.metadata.name})`;
   }
 


### PR DESCRIPTION
…is missing

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

When spec.display.name is missing UI is now fall backing to metadata.name.
Closes: #3991 

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
