### PR TITLE
[ENHANCEMENT] Log incorrectly sized encryption key size

### DIFF
--- a/pkg/model/api/config/security.go
+++ b/pkg/model/api/config/security.go
@@ -180,7 +180,7 @@ func (s *Security) Verify() error {
 		s.EncryptionKey = secret.Hidden(data)
 	}
 	if len(s.EncryptionKey) != 32 {
-		return fmt.Errorf("encryption_key size must be 32 bytes")
+		return fmt.Errorf("encryption_key size must be 32 bytes, got %d bytes", len(s.EncryptionKey))
 	}
 	s.EncryptionKey = secret.Hidden(hex.EncodeToString([]byte(s.EncryptionKey)))
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

I figured it might be neat to get a bit more information when an incorrect encryption key is passed to perses, since it's one of the first things people might do when installing the software.

I stumbled over this, when i did not account for the character increase from base64 encoding in e.g.


```bash
# this leads to an incorrect number of base64 characters
openssl rand -base64 32
```


### Before

```bash
make build-api

PERSES_SECURITY_ENCRYPTION_KEY=$(openssl rand -base64 32) ./bin/perses
```

```
FATA[0000] error reading configuration from file "" or from environment  error="encryption_key size must be 32 bytes"
```


### After

```bash
make build-api

PERSES_SECURITY_ENCRYPTION_KEY=$(openssl rand -base64 32) ./bin/perses
```

```
FATA[0000] error reading configuration from file "" or from environment  error="encryption_key size must be 32 bytes, got 44 bytes"
```

# Screenshots

None

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

None
