### PR TITLE
[DOC] Describe generation of encryption keys

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -160,6 +160,8 @@ enable_auth: <boolean> | default = false # Optional
 # Note that if it is not provided, it will use a default value.
 # On a production instance, you should set this key.
 # Also note the key size must be exactly 32 bytes long as we are using AES-256 to encrypt the data.
+# One way to generate a valid key could be the following command (using only visible characters):
+# LC_ALL=C tr -dc '[:graph:]' < /dev/urandom | head -c 32
 encryption_key: <secret> # Optional
 
 # The path to the file containing the secret key.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This adds a command for generating encryption keys to the docs,  so that users don't have to reach for their own documentation on generating decent passwords, unless they want to, hopefully improving the onboarding experience a bit.

# Screenshots

None

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

None
