### PR TITLE
[FEATURE] save dashboard timezone after change and confirmation

### DIFF
--- a/ui/.prettierrc.json
+++ b/ui/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "printWidth": 120,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "endOfLine": "auto"
 }

--- a/ui/app/src/views/projects/dashboards/DashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/DashboardView.tsx
@@ -21,6 +21,7 @@ import { useIsReadonly } from '../../../context/Config';
 import { useNavHistoryDispatch } from '../../../context/DashboardNavHistory';
 import { HelperDashboardView } from './HelperDashboardView';
 
+/* START */
 /**
  * The View for displaying an existing Dashboard.
  */


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/1382

# Description
This PR gives users the opportunity to persist a selected time zone for the dashboard. 

## How it works 
Users can change the time zone of dashboards. The confirmation modal asks them if the new time zone should be persisted. If approved the selected time zone is persisted into the dashboard specification. The time zone field has already been added into the dashboard specification.  

## What comes next?
Please note that a simultaneous feature is in progress by which the users could set their preferred time zone through the user preferences form. When finished, the dashboard will be equipped with a time zone determination logic. The logic determines which time zone should be taken into account. 

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
