### PR TITLE
Set specific Content-Type for static resources

### DIFF
--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"mime"
 	"net/http"
 	"net/http/httputil"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -174,6 +176,10 @@ func (f *frontend) assetHandler() echo.HandlerFunc {
 		if strings.Contains(fileName, ".js") {
 			data = bytes.ReplaceAll(data, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
 		}
+		if ct := mime.TypeByExtension(filepath.Ext(fileName)); ct != "" {
+			c.Response().Header().Set("Content-Type", ct)
+		}
+		c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 		_, err = c.Response().Write(data)
 		return apiinterface.HandleError(err)
 	}


### PR DESCRIPTION
The asset handler in `ui/endpoint.go` serves static files (CSS, JS, SVG, etc.) without setting a `Content-Type` header, forcing the browser to sniff the correct MIME type. This adds `mime.TypeByExtension` to detect the type from the file extension and sets `X-Content-Type-Options: nosniff` to prevent MIME confusion attacks.

Changed `assetHandler()` in `ui/endpoint.go` to call `mime.TypeByExtension(filepath.Ext(fileName))` before writing the response body, and set the `nosniff` header on every static response.

This contribution was developed with AI assistance (Claude Code).

Fixes #3979