### PR TITLE
Set specific Content-Type for static resources

### DIFF
--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"mime"
 	"net/http"
 	"net/http/httputil"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -174,6 +176,10 @@ func (f *frontend) assetHandler() echo.HandlerFunc {
 		if strings.Contains(fileName, ".js") {
 			data = bytes.ReplaceAll(data, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
 		}
+		if ct := mime.TypeByExtension(filepath.Ext(fileName)); ct != "" {
+			c.Response().Header().Set("Content-Type", ct)
+		}
+		c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 		_, err = c.Response().Write(data)
 		return apiinterface.HandleError(err)
 	}
@@ -231,6 +237,8 @@ func (f *frontend) serveASTFiles(c echo.Context) error {
 		return apiinterface.HandleError(err)
 	}
 	idx = bytes.ReplaceAll(idx, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
+	c.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
+	c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 	_, err = c.Response().Write(idx)
 	return apiinterface.HandleError(err)
 }


### PR DESCRIPTION
Static assets were served with a generic `Content-Type`, forcing browsers to MIME-sniff the correct type. This adds `mime.TypeByExtension()` to set the correct `Content-Type` based on file extension (e.g. `text/css` for `.css`, `text/javascript` for `.js`), and sets `X-Content-Type-Options: nosniff` to prevent MIME confusion attacks.

Changes in `ui/endpoint.go`:
- `assetHandler()`: determine Content-Type from file extension via `mime.TypeByExtension()`
- `serveASTFiles()`: explicitly set `text/html; charset=utf-8` for `index.html`
- Both handlers now include `X-Content-Type-Options: nosniff`

Fixes #3979

Signed-off-by: Trevin Chow <trevin@tmchow.com>

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)