### PR TITLE
[ENHANCEMENT] support unsaved url generation for datasource api

### DIFF
--- a/ui/app/src/model/datasource-api.test.ts
+++ b/ui/app/src/model/datasource-api.test.ts
@@ -17,7 +17,7 @@ interface TestData {
   input: {
     project?: string;
     dashboard?: string;
-    name: string;
+    name?: string;
   };
   expected: string;
 }
@@ -30,14 +30,29 @@ describe('buildProxyUrl', () => {
       expected: '/proxy/globaldatasources/datasourceA',
     },
     {
+      title: 'should build unsaved global datasource proxy url',
+      input: {},
+      expected: '/proxy/unsaved/globaldatasources',
+    },
+    {
       title: 'should build project datasource proxy url',
       input: { project: 'projectA', name: 'datasourceA' },
       expected: '/proxy/projects/projectA/datasources/datasourceA',
     },
     {
+      title: 'should build unsaved project datasource proxy url',
+      input: { project: 'projectA' },
+      expected: '/proxy/unsaved/projects/projectA/datasources',
+    },
+    {
       title: 'should build dashboard datasource proxy url',
       input: { project: 'projectA', dashboard: 'dashboardA', name: 'datasourceA' },
       expected: '/proxy/projects/projectA/dashboards/dashboardA/datasources/datasourceA',
+    },
+    {
+      title: 'should build unsaved dashboard datasource proxy url',
+      input: { project: 'projectA', dashboard: 'dashboardA' },
+      expected: '/proxy/unsaved/projects/projectA/dashboards/dashboardA/datasources',
     },
   ])('$title', (data: TestData) => {
     expect(buildProxyUrl(data.input)).toEqual(data.expected);

--- a/ui/app/src/model/datasource-api.ts
+++ b/ui/app/src/model/datasource-api.ts
@@ -24,16 +24,17 @@ export function buildProxyUrl({
 }: {
   project?: string;
   dashboard?: string;
-  name: string;
+  name?: string;
 }): string {
   const basePath = PERSES_APP_CONFIG.api_prefix;
-  let url = `${!project && !dashboard ? 'globaldatasources' : 'datasources'}/${encodeURIComponent(name)}`;
+  let url = `${!project && !dashboard ? 'globaldatasources' : 'datasources'}`;
   if (dashboard) {
     url = `dashboards/${encodeURIComponent(dashboard)}/${url}`;
   }
   if (project) {
     url = `projects/${encodeURIComponent(project)}/${url}`;
   }
+  url = name === undefined ? `unsaved/${url}` : `${url}/${encodeURIComponent(name)}`;
   return `${basePath}/proxy/${url}`;
 }
 

--- a/ui/core/src/model/datasource-api.ts
+++ b/ui/core/src/model/datasource-api.ts
@@ -19,7 +19,7 @@ import { DatasourceResource, DatasourceSelector, GlobalDatasourceResource } from
 export interface BuildDatasourceProxyUrlParams {
   project?: string;
   dashboard?: string;
-  name: string;
+  name?: string;
 }
 
 /**


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
Related pull requests (in order): 
1. **[This one](https://github.com/perses/perses/pull/4006)** 
2. https://github.com/perses/perses/pull/4007
3. https://github.com/perses/shared/pull/99 
4. https://github.com/perses/perses/pull/4008
5. https://github.com/perses/plugins/pull/620)

Related issue: 
https://github.com/perses/perses/issues/1542

# Description
Allows to create proxy url for unsaved datasources.


# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
