### PR TITLE
[BUGFIX] set correct ContentLength for request body

### DIFF
--- a/internal/api/impl/proxy/proxy.go
+++ b/internal/api/impl/proxy/proxy.go
@@ -105,11 +105,11 @@ func (u *unsavedProxyBody) setRequestParams(ctx echo.Context) {
 
 	if len(u.Body) > 0 {
 		req.Body = io.NopCloser(strings.NewReader(string(u.Body)))
-		req.ContentLength = int64(len(u.Body))
 	} else {
 		req.Body = nil
-		req.ContentLength = 0
 	}
+
+	req.ContentLength = int64(len(u.Body))
 
 	ctx.SetRequest(req)
 }

--- a/internal/api/impl/proxy/proxy.go
+++ b/internal/api/impl/proxy/proxy.go
@@ -105,8 +105,10 @@ func (u *unsavedProxyBody) setRequestParams(ctx echo.Context) {
 
 	if len(u.Body) > 0 {
 		req.Body = io.NopCloser(strings.NewReader(string(u.Body)))
+		req.ContentLength = int64(len(u.Body))
 	} else {
 		req.Body = nil
+		req.ContentLength = 0
 	}
 
 	ctx.SetRequest(req)


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
Related pull requests (in order): 
1. https://github.com/perses/perses/pull/4006
2. **[This one](https://github.com/perses/perses/pull/4007)** 
3. https://github.com/perses/shared/pull/99
4. https://github.com/perses/perses/pull/4008
5. https://github.com/perses/plugins/pull/620)

Related issue: 
https://github.com/perses/perses/issues/1542

# Description
When calling unsaved datasource api the call is made to POST endpoint and then translated to different call based on config in the request body. Body of the first request is replaced with body that is send in "body" attribute in json but content length header is not updated to reflect new body. This results in "error proxying, remote unreachable: err=http: Request.ContentLength=599 with nil Body  datasource=unsaved-datasource error="http: Request.ContentLength=599 with nil Body" target="http://localhost:9090"" when calling this endpoint with config for GET. This change aligns content length header with actual body send.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
