### PR TITLE
[FEATURE] integrate test datasource connection button into DatasourceDrawer

### DIFF
--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -12,12 +12,18 @@
 // limitations under the License.
 
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { Datasource, DatasourceDefinition } from '@perses-dev/core';
-import { DatasourceEditorForm, PluginRegistry, ValidationProvider } from '@perses-dev/plugin-system';
+import { Datasource, DatasourceDefinition, getMetadataProject } from '@perses-dev/core';
+import {
+  DatasourceEditorForm,
+  PluginRegistry,
+  ValidationProvider,
+  UnsavedDatasourceProvider,
+} from '@perses-dev/plugin-system';
 import { ReactElement, useState } from 'react';
 import { DeleteResourceDialog } from '../dialogs';
 import { DrawerProps } from '../form-drawers';
 import { useRemotePluginLoader } from '../../model/remote-plugin-loader';
+import { useDatasourceApi } from '../../model/datasource-api';
 
 interface DatasourceDrawerProps<T extends Datasource> extends DrawerProps<T> {
   datasource: T;
@@ -35,6 +41,7 @@ export function DatasourceDrawer<T extends Datasource>({
 }: DatasourceDrawerProps<T>): ReactElement {
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
   const pluginLoader = useRemotePluginLoader();
+  const datasourceApi = useDatasourceApi();
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
   // -> TODO find a way to enable closing by clicking-out in edit view, with a discard confirmation modal popping up
@@ -55,18 +62,20 @@ export function DatasourceDrawer<T extends Datasource>({
       <ErrorBoundary FallbackComponent={ErrorAlert}>
         <PluginRegistry pluginLoader={pluginLoader}>
           <ValidationProvider>
-            {isOpen && (
-              <DatasourceEditorForm
-                initialDatasourceDefinition={{ name: datasource.metadata.name, spec: datasource.spec }}
-                action={action}
-                isDraft={false}
-                isReadonly={isReadonly}
-                onActionChange={onActionChange}
-                onSave={handleSave}
-                onClose={onClose}
-                onDelete={onDelete ? (): void => setDeleteDatasourceDialogStateOpened(true) : undefined}
-              />
-            )}
+            <UnsavedDatasourceProvider datasourceApi={datasourceApi} project={getMetadataProject(datasource.metadata)}>
+              {isOpen && (
+                <DatasourceEditorForm
+                  initialDatasourceDefinition={{ name: datasource.metadata.name, spec: datasource.spec }}
+                  action={action}
+                  isDraft={false}
+                  isReadonly={isReadonly}
+                  onActionChange={onActionChange}
+                  onSave={handleSave}
+                  onClose={onClose}
+                  onDelete={onDelete ? (): void => setDeleteDatasourceDialogStateOpened(true) : undefined}
+                />
+              )}
+            </UnsavedDatasourceProvider>
           </ValidationProvider>
         </PluginRegistry>
         {onDelete && (

--- a/ui/app/src/components/datasource/DatasourceDrawer.tsx
+++ b/ui/app/src/components/datasource/DatasourceDrawer.tsx
@@ -13,8 +13,8 @@
 
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { DatasourceEditorForm, PluginRegistry, ValidationProvider } from '@perses-dev/plugin-system';
-import { ReactElement, useState } from 'react';
-import { Datasource, DatasourceDefinition } from '@perses-dev/client';
+import { ReactElement, useMemo, useState } from 'react';
+import { createTestDatasourceConnection, Datasource, DatasourceDefinition } from '@perses-dev/client';
 import { DeleteResourceDialog } from '../dialogs';
 import { DrawerProps } from '../form-drawers';
 import { useRemotePluginLoader } from '../../model/remote-plugin-loader';
@@ -35,6 +35,9 @@ export function DatasourceDrawer<T extends Datasource>({
 }: DatasourceDrawerProps<T>): ReactElement {
   const [isDeleteDatasourceDialogStateOpened, setDeleteDatasourceDialogStateOpened] = useState<boolean>(false);
   const pluginLoader = useRemotePluginLoader();
+
+  const project = datasource.kind === 'Datasource' ? datasource.metadata.project : undefined;
+  const testConnection = useMemo(() => createTestDatasourceConnection({ project }), [project]);
 
   // Disables closing on click out. This is a quick-win solution to avoid losing draft changes.
   // -> TODO find a way to enable closing by clicking-out in edit view, with a discard confirmation modal popping up
@@ -65,6 +68,7 @@ export function DatasourceDrawer<T extends Datasource>({
                 onSave={handleSave}
                 onClose={onClose}
                 onDelete={onDelete ? (): void => setDeleteDatasourceDialogStateOpened(true) : undefined}
+                testConnection={testConnection}
               />
             )}
           </ValidationProvider>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
Related pull requests (in order): 
1. https://github.com/perses/perses/pull/4007
2. https://github.com/perses/shared/pull/99
3. **[This one](https://github.com/perses/perses/pull/4008)**
4. https://github.com/perses/perses/pull/4302
5. https://github.com/perses/plugins/pull/620

Related issue: 
https://github.com/perses/perses/issues/1542

# Description
Passes needed props to have test connection button available in plugins that support it.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
