### PR TITLE
[ENHANCEMENT] simplify breadcrumbs and restore page header hierarchy

### DIFF
--- a/ui/app/src/components/breadcrumbs/AppBreadcrumbs.tsx
+++ b/ui/app/src/components/breadcrumbs/AppBreadcrumbs.tsx
@@ -13,34 +13,35 @@
 
 import { ReactElement, ReactNode } from 'react';
 import { useIsMobileSize } from '../../utils/browser-size';
-import { Breadcrumbs, HomeLinkCrumb, StackCrumb, TitleCrumb } from './breadcrumbs';
+import { BreadcrumbVariant, Breadcrumbs, HomeLinkCrumb, StackCrumb, TitleCrumb } from './breadcrumbs';
 
 interface AppBreadcrumbsProps {
   rootPageName: string;
   icon: ReactNode;
+  variant?: BreadcrumbVariant;
 }
 
 function AppBreadcrumbs(props: AppBreadcrumbsProps): ReactElement {
-  const { rootPageName, icon } = props;
+  const { rootPageName, icon, variant } = props;
 
   const isMobileSize = useIsMobileSize();
   if (isMobileSize) {
     return (
-      <Breadcrumbs>
-        <StackCrumb>
+      <Breadcrumbs variant={variant}>
+        <StackCrumb variant={variant}>
           {icon}
-          <TitleCrumb>{rootPageName}</TitleCrumb>
+          <TitleCrumb variant={variant}>{rootPageName}</TitleCrumb>
         </StackCrumb>
       </Breadcrumbs>
     );
   }
 
   return (
-    <Breadcrumbs>
-      <HomeLinkCrumb />
-      <StackCrumb>
+    <Breadcrumbs variant={variant}>
+      <HomeLinkCrumb variant={variant} />
+      <StackCrumb variant={variant}>
         {icon}
-        <TitleCrumb>{rootPageName}</TitleCrumb>
+        <TitleCrumb variant={variant}>{rootPageName}</TitleCrumb>
       </StackCrumb>
     </Breadcrumbs>
   );

--- a/ui/app/src/components/breadcrumbs/ProjectBreadcrumbs.tsx
+++ b/ui/app/src/components/breadcrumbs/ProjectBreadcrumbs.tsx
@@ -11,70 +11,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Typography } from '@mui/material';
 import Archive from 'mdi-material-ui/Archive';
 import ViewDashboardIcon from 'mdi-material-ui/ViewDashboard';
 import { getResourceDisplayName, ProjectResource } from '@perses-dev/core';
 import { ReactElement } from 'react';
-import { HomeLinkCrumb, Breadcrumbs, LinkCrumb, StackCrumb, TitleCrumb } from './breadcrumbs';
+import { BreadcrumbVariant, HomeLinkCrumb, Breadcrumbs, LinkCrumb, StackCrumb, TitleCrumb } from './breadcrumbs';
 
 interface ProjectBreadcrumbsProps {
   project: ProjectResource;
   dashboardName?: string;
+  variant?: BreadcrumbVariant;
 }
 
 function ProjectBreadcrumbs(props: ProjectBreadcrumbsProps): ReactElement {
-  const { project, dashboardName } = props;
+  const { project, dashboardName, variant } = props;
 
   if (dashboardName) {
     return (
-      <Breadcrumbs
-        id="breadcrumbs"
-        sx={{
-          overflowX: 'scroll',
-          scrollbarWidth: 'none' /* Firefox */,
-          '& .MuiBreadcrumbs-ol': {
-            flexWrap: 'nowrap',
-            whiteSpace: 'nowrap',
-          },
-          '&::-webkit-scrollbar': {
-            display: 'none' /* Safari and Chrome */,
-          },
-        }}
-      >
-        <HomeLinkCrumb />
-        <LinkCrumb to={`/projects/${project.metadata.name}`}>
-          <StackCrumb>
-            <Archive fontSize="small" /> {getResourceDisplayName(project)}
+      <Breadcrumbs id="breadcrumbs" variant={variant}>
+        <HomeLinkCrumb variant={variant} />
+        <LinkCrumb to={`/projects/${project.metadata.name}`} variant={variant}>
+          <StackCrumb variant={variant}>
+            <Archive />
+            <TitleCrumb variant={variant} inheritTypography={true}>
+              {getResourceDisplayName(project)}
+            </TitleCrumb>
           </StackCrumb>
         </LinkCrumb>
-        <StackCrumb>
-          <ViewDashboardIcon fontSize="small" />
-          <Typography variant="h3">{dashboardName}</Typography>
+        <StackCrumb variant={variant}>
+          <ViewDashboardIcon />
+          <TitleCrumb variant={variant}>{dashboardName}</TitleCrumb>
         </StackCrumb>
       </Breadcrumbs>
     );
   }
 
   return (
-    <Breadcrumbs
-      id="breadcrumbs"
-      sx={{
-        overflowX: 'scroll',
-        scrollbarWidth: 'none' /* Firefox */,
-        '& .MuiBreadcrumbs-ol': {
-          flexWrap: 'nowrap',
-          whiteSpace: 'nowrap',
-        },
-        '&::-webkit-scrollbar': {
-          display: 'none' /* Safari and Chrome */,
-        },
-      }}
-    >
-      <HomeLinkCrumb />
-      <StackCrumb>
-        <Archive fontSize="large" />
-        <TitleCrumb>{getResourceDisplayName(project)}</TitleCrumb>
+    <Breadcrumbs id="breadcrumbs" variant={variant}>
+      <HomeLinkCrumb variant={variant} />
+      <StackCrumb variant={variant}>
+        <Archive />
+        <TitleCrumb variant={variant}>{getResourceDisplayName(project)}</TitleCrumb>
       </StackCrumb>
     </Breadcrumbs>
   );

--- a/ui/app/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/ui/app/src/components/breadcrumbs/breadcrumbs.tsx
@@ -11,32 +11,126 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Breadcrumbs as MUIBreadcrumbs, Link, styled, Stack, Typography } from '@mui/material';
+import {
+  Breadcrumbs as MUIBreadcrumbs,
+  BreadcrumbsProps as MUIBreadcrumbsProps,
+  Link,
+  styled,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { SxProps, SystemStyleObject, Theme } from '@mui/system';
+import ChevronRight from 'mdi-material-ui/ChevronRight';
 import { Link as RouterLink } from 'react-router-dom';
 import { ReactElement } from 'react';
 
-const BREADCRUMB_HEIGHT = '35px';
+export type BreadcrumbVariant = 'default' | 'workspace';
 
-export const Breadcrumbs = styled(MUIBreadcrumbs)({
-  fontSize: 'large',
-  paddingLeft: 0.5,
-  height: BREADCRUMB_HEIGHT,
-  lineHeight: BREADCRUMB_HEIGHT,
-});
+function getBreadcrumbSx(variant: BreadcrumbVariant): SystemStyleObject<Theme> {
+  if (variant === 'workspace') {
+    return {
+      color: 'primary.contrastText',
+      minHeight: 42,
+      px: 1,
+      display: 'flex',
+      alignItems: 'center',
+      '& .MuiBreadcrumbs-separator': {
+        marginInline: 0.75,
+        color: 'rgba(255, 255, 255, 0.54)',
+      },
+      '& .MuiSvgIcon-root': {
+        color: 'primary.contrastText',
+      },
+    };
+  }
 
-export function HomeLinkCrumb(): ReactElement {
-  return <LinkCrumb to="/">Home</LinkCrumb>;
+  return {
+    color: 'text.secondary',
+    minHeight: 32,
+    px: 0.5,
+    display: 'flex',
+    alignItems: 'center',
+    '& .MuiBreadcrumbs-separator': {
+      marginInline: 0.75,
+      color: 'text.disabled',
+    },
+    '& .MuiSvgIcon-root': {
+      color: 'text.secondary',
+    },
+  };
+}
+
+const StyledBreadcrumbs = styled(MUIBreadcrumbs)(({ theme }) => ({
+  paddingLeft: theme.spacing(0.5),
+  overflowX: 'auto',
+  scrollbarWidth: 'none',
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
+  '& .MuiBreadcrumbs-ol': {
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    whiteSpace: 'nowrap',
+  },
+}));
+
+export interface BreadcrumbsProps extends Omit<MUIBreadcrumbsProps, 'color'> {
+  variant?: BreadcrumbVariant;
+}
+
+type BreadcrumbSxEntry = Exclude<SxProps<Theme>, readonly unknown[]>;
+
+export function Breadcrumbs(props: BreadcrumbsProps): ReactElement {
+  const { sx, variant = 'default', ...rest } = props;
+  const breadcrumbSx = getBreadcrumbSx(variant);
+  let mergedSx: SxProps<Theme> = breadcrumbSx;
+
+  if (Array.isArray(sx)) {
+    mergedSx = [breadcrumbSx, ...(sx as BreadcrumbSxEntry[])];
+  } else if (sx !== undefined) {
+    mergedSx = [breadcrumbSx, sx as BreadcrumbSxEntry];
+  }
+
+  return (
+    <StyledBreadcrumbs
+      aria-label="breadcrumb"
+      separator={<ChevronRight sx={{ fontSize: 14 }} />}
+      sx={mergedSx}
+      {...rest}
+    />
+  );
+}
+
+export function HomeLinkCrumb({ variant }: { variant?: BreadcrumbVariant }): ReactElement {
+  return (
+    <LinkCrumb to="/" variant={variant}>
+      Home
+    </LinkCrumb>
+  );
 }
 
 export interface StackCrumbProps {
   children?: React.ReactNode;
+  variant?: BreadcrumbVariant;
 }
 
 export function StackCrumb(props: StackCrumbProps): ReactElement {
-  const { children } = props;
+  const { children, variant = 'default' } = props;
+  const iconColor = variant === 'workspace' ? 'primary.contrastText' : 'text.secondary';
 
   return (
-    <Stack direction="row" alignItems="center" gap={0.5}>
+    <Stack
+      direction="row"
+      alignItems="center"
+      gap={0.75}
+      sx={{
+        minWidth: 0,
+        '& .MuiSvgIcon-root': {
+          fontSize: 18,
+          color: iconColor,
+        },
+      }}
+    >
       {children}
     </Stack>
   );
@@ -45,13 +139,48 @@ export function StackCrumb(props: StackCrumbProps): ReactElement {
 export interface LinkCrumbProps {
   children?: React.ReactNode;
   to: string;
+  variant?: BreadcrumbVariant;
 }
 
 export function LinkCrumb(props: LinkCrumbProps): ReactElement {
-  const { children, to } = props;
+  const { children, to, variant = 'default' } = props;
+  const isWorkspace = variant === 'workspace';
 
   return (
-    <Link underline="hover" variant="h3" component={RouterLink} to={to}>
+    <Link
+      underline="none"
+      component={RouterLink}
+      to={to}
+      color="inherit"
+      sx={(theme) => ({
+        display: 'inline-flex',
+        alignItems: 'center',
+        minWidth: 0,
+        fontSize: isWorkspace ? 15 : 14,
+        fontWeight: 500,
+        lineHeight: 1.25,
+        letterSpacing: 0,
+        color: isWorkspace ? theme.palette.primary.contrastText : theme.palette.text.secondary,
+        borderRadius: theme.shape.borderRadius,
+        paddingBlock: 2 / 8,
+        transition: theme.transitions.create('color', {
+          duration: theme.transitions.duration.shorter,
+        }),
+        '&:hover': {
+          color: isWorkspace ? theme.palette.primary.contrastText : theme.palette.text.primary,
+          opacity: 1,
+        },
+        '&:focus-visible': {
+          outlineOffset: 3,
+          borderRadius: theme.shape.borderRadius,
+        },
+        ...(isWorkspace
+          ? {
+              opacity: 0.88,
+            }
+          : null),
+      })}
+    >
       {children}
     </Link>
   );
@@ -59,10 +188,34 @@ export function LinkCrumb(props: LinkCrumbProps): ReactElement {
 
 export interface TitleCrumbProps {
   children?: React.ReactNode;
+  variant?: BreadcrumbVariant;
+  inheritTypography?: boolean;
 }
 
 export function TitleCrumb(props: TitleCrumbProps): ReactElement {
-  const { children } = props;
+  const { children, variant = 'default', inheritTypography = false } = props;
+  const isWorkspace = variant === 'workspace';
+  let fontSize: 'inherit' | number = 'inherit';
 
-  return <Typography variant="h1">{children}</Typography>;
+  if (!inheritTypography) {
+    fontSize = isWorkspace ? 15 : 14;
+  }
+
+  const fontWeight = inheritTypography ? 'inherit' : 700;
+  const lineHeight = inheritTypography ? 'inherit' : 1.25;
+  const letterSpacing = inheritTypography ? 'inherit' : 0;
+
+  return (
+    <Typography
+      component="span"
+      color={isWorkspace ? 'primary.contrastText' : 'text.primary'}
+      fontSize={fontSize}
+      fontWeight={fontWeight}
+      lineHeight={lineHeight}
+      letterSpacing={letterSpacing}
+      sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+    >
+      {children}
+    </Typography>
+  );
 }

--- a/ui/app/src/components/page-header/PageHeader.tsx
+++ b/ui/app/src/components/page-header/PageHeader.tsx
@@ -1,0 +1,79 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box, Stack, SxProps, Theme, Typography } from '@mui/material';
+import { ReactElement, ReactNode } from 'react';
+
+export interface PageHeaderProps {
+  breadcrumb: ReactNode;
+  title: ReactNode;
+  icon?: ReactNode;
+  actions?: ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+function PageHeader(props: PageHeaderProps): ReactElement {
+  const { breadcrumb, title, icon, actions, sx } = props;
+
+  return (
+    <Stack gap={1} sx={sx}>
+      {breadcrumb}
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        alignItems={{ xs: 'flex-start', md: 'center' }}
+        justifyContent="space-between"
+        gap={1.5}
+      >
+        <Stack direction="row" alignItems="center" gap={1.25} sx={{ minWidth: 0 }}>
+          {icon !== undefined && (
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'text.primary',
+                '& .MuiSvgIcon-root': {
+                  fontSize: { xs: 24, sm: 28 },
+                },
+              }}
+            >
+              {icon}
+            </Box>
+          )}
+          <Typography
+            variant="h1"
+            sx={{
+              minWidth: 0,
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {title}
+          </Typography>
+        </Stack>
+        {actions !== undefined && (
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            gap={1}
+            sx={{ alignSelf: { xs: 'stretch', md: 'center' }, width: { xs: '100%', md: 'auto' } }}
+          >
+            {actions}
+          </Stack>
+        )}
+      </Stack>
+    </Stack>
+  );
+}
+
+export default PageHeader;

--- a/ui/app/src/views/admin/AdminView.tsx
+++ b/ui/app/src/views/admin/AdminView.tsx
@@ -16,6 +16,7 @@ import ShieldStar from 'mdi-material-ui/ShieldStar';
 import { useParams } from 'react-router-dom';
 import { ReactElement } from 'react';
 import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
+import PageHeader from '../../components/page-header/PageHeader';
 import { useIsMobileSize } from '../../utils/browser-size';
 import { AdminTabs } from './AdminTabs';
 
@@ -24,8 +25,11 @@ function AdminView(): ReactElement {
   const isMobileSize = useIsMobileSize();
 
   return (
-    <Stack sx={{ width: '100%', overflowX: 'hidden' }} m={isMobileSize ? 1 : 2} mt={1.5} gap={1}>
-      <AppBreadcrumbs rootPageName="Administration" icon={<ShieldStar fontSize="large" />} />
+    <Stack sx={{ width: '100%', overflowX: 'hidden' }} m={isMobileSize ? 1 : 2} mt={1.5} gap={1.5}>
+      <PageHeader
+        breadcrumb={<AppBreadcrumbs rootPageName="Administration" icon={<ShieldStar />} />}
+        title="Administration"
+      />
       <AdminTabs initialTab={tab} />
     </Stack>
   );

--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -19,6 +19,7 @@ import { JSONEditor } from '@perses-dev/components';
 import { MenuTab, MenuTabs } from '../../components/tabs';
 
 import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
+import PageHeader from '../../components/page-header/PageHeader';
 import { useConfigContext } from '../../context/Config';
 import { useIsMobileSize } from '../../utils/browser-size';
 import { PluginsList } from './PluginsList';
@@ -48,8 +49,8 @@ function ConfigView(): ReactElement {
   };
 
   return (
-    <Stack sx={{ width: '100%', overflowX: 'hidden' }} m={isMobileSize ? 1 : 2} mt={1.5} gap={1}>
-      <AppBreadcrumbs rootPageName="Configuration" icon={<Cog fontSize="large" />} />
+    <Stack sx={{ width: '100%', overflowX: 'hidden' }} m={isMobileSize ? 1 : 2} mt={1.5} gap={1.5}>
+      <PageHeader breadcrumb={<AppBreadcrumbs rootPageName="Configuration" icon={<Cog />} />} title="Configuration" />
       <Stack>
         <Stack
           direction="row"

--- a/ui/app/src/views/explore/ExploreView.tsx
+++ b/ui/app/src/views/explore/ExploreView.tsx
@@ -25,11 +25,7 @@ import { useGlobalVariableList } from '../../model/global-variable-client';
 import { buildGlobalVariableDefinition } from '../../utils/variables';
 
 function ExploreView(): ReactElement {
-  return (
-    <HelperExploreView
-      exploreTitleComponent={<AppBreadcrumbs rootPageName="Explore" icon={<Compass fontSize="large" />} />}
-    />
-  );
+  return <HelperExploreView exploreTitleComponent={<AppBreadcrumbs rootPageName="Explore" icon={<Compass />} />} />;
 }
 
 export interface HelperExploreViewProps {

--- a/ui/app/src/views/projects/ProjectView.tsx
+++ b/ui/app/src/views/projects/ProjectView.tsx
@@ -16,11 +16,12 @@ import { Box, Stack, CircularProgress } from '@mui/material';
 import React, { ReactElement, useState } from 'react';
 import DeleteOutline from 'mdi-material-ui/DeleteOutline';
 import PencilIcon from 'mdi-material-ui/Pencil';
-import { ProjectResource } from '@perses-dev/core';
+import { getResourceDisplayName, ProjectResource } from '@perses-dev/core';
 import { useSnackbar } from '@perses-dev/components';
 import { DeleteResourceDialog, RenameResourceDialog } from '../../components/dialogs';
 import ProjectBreadcrumbs from '../../components/breadcrumbs/ProjectBreadcrumbs';
 import { CRUDButton } from '../../components/CRUDButton/CRUDButton';
+import PageHeader from '../../components/page-header/PageHeader';
 import { useIsMobileSize } from '../../utils/browser-size';
 import { useDeleteProjectMutation, useProject, useUpdateProjectMutation } from '../../model/project-client';
 import { ProjectTabs } from './ProjectTabs';
@@ -85,34 +86,33 @@ function ProjectView(): ReactElement {
 
   return (
     <Stack sx={{ width: '100%', overflowX: 'hidden' }} m={isMobileSize ? 1 : 2} mt={1.5} gap={2.5}>
-      <Stack gap={1.5}>
-        <ProjectBreadcrumbs project={project} />
-        <Stack
-          direction={{ xs: 'column', sm: 'row' }}
-          gap={1}
-          sx={{ alignSelf: { xs: 'stretch', sm: 'flex-end' }, width: { xs: '100%', sm: 'auto' } }}
-        >
-          <CRUDButton
-            action="update"
-            scope="Project"
-            project={projectName}
-            variant="contained"
-            onClick={() => setIsRenameProjectDialogOpen(true)}
-          >
-            {isMobileSize ? <PencilIcon /> : 'Rename project'}
-          </CRUDButton>
-          <CRUDButton
-            action="delete"
-            scope="Project"
-            project={projectName}
-            variant="outlined"
-            color="error"
-            onClick={() => setIsDeleteProjectDialogOpen(true)}
-          >
-            {isMobileSize ? <DeleteOutline /> : 'Delete project'}
-          </CRUDButton>
-        </Stack>
-      </Stack>
+      <PageHeader
+        breadcrumb={<ProjectBreadcrumbs project={project} />}
+        title={getResourceDisplayName(project)}
+        actions={
+          <>
+            <CRUDButton
+              action="update"
+              scope="Project"
+              project={projectName}
+              variant="contained"
+              onClick={() => setIsRenameProjectDialogOpen(true)}
+            >
+              {isMobileSize ? <PencilIcon /> : 'Rename project'}
+            </CRUDButton>
+            <CRUDButton
+              action="delete"
+              scope="Project"
+              project={projectName}
+              variant="outlined"
+              color="error"
+              onClick={() => setIsDeleteProjectDialogOpen(true)}
+            >
+              {isMobileSize ? <DeleteOutline /> : 'Delete project'}
+            </CRUDButton>
+          </>
+        }
+      />
       <Box
         sx={{
           display: 'grid',

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -55,6 +55,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
     isCreating,
     isLeavingConfirmDialogEnabled = true,
   } = props;
+  const breadcrumbVariant = isEditing || isCreating ? 'workspace' : 'default';
 
   const isLocalDatasourceEnabled = useIsLocalDatasourceEnabled();
   const isLocalVariableEnabled = useIsLocalVariableEnabled();
@@ -114,7 +115,11 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
                   datasourceApi={datasourceApi}
                   externalVariableDefinitions={externalVariableDefinitions}
                   dashboardTitleComponent={
-                    <ProjectBreadcrumbs dashboardName={getResourceDisplayName(dashboardResource)} project={project} />
+                    <ProjectBreadcrumbs
+                      dashboardName={getResourceDisplayName(dashboardResource)}
+                      project={project}
+                      variant={breadcrumbVariant}
+                    />
                   }
                   onSave={onSave}
                   onDiscard={onDiscard}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

- Refine breadcrumb styling to improve hierarchy, readability, and workspace-mode presentation.
- Add lightweight page headers to Admin, Config, and Project root views so compact breadcrumbs remain navigational instead of acting as page titles.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

**Before**

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/bbbe7203-6c54-409f-87ed-23321a7117d9" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/e865ef43-6a60-4a77-a9e2-f4a5b98752f5" />


**After**

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/8896fb30-5ded-4005-83c1-f2710ca41718" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/b040cd90-b977-4988-89f1-0f5bf0d9c72a" />


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
