### PR TITLE
[ENHANCEMENT] aligning configuration page layout with admin and projects

### DIFF
--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -34,7 +34,7 @@ function TabPanel(props: TabPanelProps): ReactElement | null {
   const { children, value, index, ...other } = props;
   return (
     <div role="tabpanel" hidden={value !== index} id={`tabpanel-${index}`} aria-labelledby={`tab-${index}`} {...other}>
-      {value === index && <Box sx={{ pt: 2 }}>{children}</Box>}
+      {value === index && children}
     </div>
   );
 }
@@ -51,12 +51,18 @@ function ConfigView(): ReactElement {
   return (
     <Stack sx={{ width: '100%', overflowX: 'hidden' }} m={isMobileSize ? 1 : 2} mt={1.5} gap={1.5}>
       <PageHeader breadcrumb={<AppBreadcrumbs rootPageName="Configuration" icon={<Cog />} />} title="Configuration" />
-      <Stack>
+      <Stack gap={0}>
         <Stack
           direction="row"
           alignItems="center"
-          justifyContent="space-between"
-          sx={{ borderBottom: 1, borderColor: 'divider' }}
+          sx={{
+            bgcolor: 'background.paper',
+            borderRadius: '8px 8px 0 0',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderBottom: 'none',
+            px: 1,
+          }}
         >
           <MenuTabs value={tabIndex} onChange={handleTabChange} aria-label="configuration tabs">
             <MenuTab
@@ -76,10 +82,34 @@ function ConfigView(): ReactElement {
           </MenuTabs>
         </Stack>
         <TabPanel value={tabIndex} index={0}>
-          <JSONEditor value={config} readOnly />
+          <Box
+            sx={{
+              overflow: 'hidden',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderTop: 'none',
+              borderRadius: '0 0 8px 8px',
+              bgcolor: 'background.default',
+              boxShadow: (theme) => theme.shadows[1],
+            }}
+          >
+            <JSONEditor value={config} readOnly />
+          </Box>
         </TabPanel>
         <TabPanel value={tabIndex} index={1}>
-          <PluginsList />
+          <Box
+            sx={{
+              overflow: 'hidden',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderTop: 'none',
+              borderRadius: '0 0 8px 8px',
+              bgcolor: 'background.paper',
+              boxShadow: (theme) => theme.shadows[1],
+            }}
+          >
+            <PluginsList />
+          </Box>
         </TabPanel>
       </Stack>
     </Stack>

--- a/ui/app/src/views/config/PluginDetailsDialog.tsx
+++ b/ui/app/src/views/config/PluginDetailsDialog.tsx
@@ -11,10 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PluginModuleResource } from '@perses-dev/plugin-system';
-import { DialogContent, DialogTitle, Divider, List, ListItem, ListItemText, Stack, Typography } from '@mui/material';
+import type { PluginModuleResource } from '@perses-dev/plugin-system';
+import {
+  Chip,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material';
 import { Dialog } from '@perses-dev/components';
-import { Fragment, ReactElement } from 'react';
+import { Fragment } from 'react';
+import type { ReactElement } from 'react';
 
 interface PluginDetailsDialogProps {
   selectedPluginModule: PluginModuleResource | null;
@@ -28,7 +39,18 @@ export function PluginDetailsDialog({ selectedPluginModule, onClose }: PluginDet
 
   return (
     <Dialog open={!!selectedPluginModule} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Plugins for {selectedPluginModule.metadata.name} Module</DialogTitle>
+      <DialogTitle>
+        <Stack spacing={1}>
+          <Typography variant="h2">{selectedPluginModule.metadata.name}</Typography>
+          <Stack direction="row" alignItems="center" gap={1} sx={{ flexWrap: 'wrap' }}>
+            <Chip label={`Version ${selectedPluginModule.metadata.version}`} size="small" variant="outlined" />
+            <Typography variant="body2" color="text.secondary">
+              {selectedPluginModule.spec.plugins.length} plugin
+              {selectedPluginModule.spec.plugins.length !== 1 ? 's' : ''}
+            </Typography>
+          </Stack>
+        </Stack>
+      </DialogTitle>
       <DialogContent dividers sx={{ maxHeight: 400 }}>
         <List>
           <Stack divider={<Divider flexItem orientation="horizontal" />}>
@@ -36,11 +58,7 @@ export function PluginDetailsDialog({ selectedPluginModule, onClose }: PluginDet
               <Fragment key={index}>
                 <ListItem>
                   <ListItemText
-                    primary={
-                      <Typography>
-                        <strong>{pluginItem.spec.name}</strong>
-                      </Typography>
-                    }
+                    primary={<Typography sx={{ fontWeight: 600 }}>{pluginItem.spec.name}</Typography>}
                     secondary={<Typography color="text.secondary">Kind: {pluginItem.kind}</Typography>}
                   />
                 </ListItem>

--- a/ui/app/src/views/config/PluginsList.tsx
+++ b/ui/app/src/views/config/PluginsList.tsx
@@ -11,14 +11,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Card, CardContent, Typography, Divider, Button } from '@mui/material';
-import Grid from '@mui/material/Grid2';
-import { ReactElement, useMemo, useState } from 'react';
-import { PluginModuleResource } from '@perses-dev/plugin-system';
-import { useSnackbar } from '@perses-dev/components';
-import { usePlugins } from '../../model/plugin-client';
+import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import { NoDataOverlay, useSnackbar } from '@perses-dev/components';
+import { useMemo, useState } from 'react';
+import type { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+import type { PluginModuleResource } from '@perses-dev/plugin-system';
+import type { ReactElement } from 'react';
+import { DATA_GRID_SLOT_PROPS, DATA_GRID_STYLES, GridToolbar, PAGE_SIZE_OPTIONS } from '../../components/datagrid';
 import { PersesLoader } from '../../components/PersesLoader';
+import { usePlugins } from '../../model/plugin-client';
 import { PluginDetailsDialog } from './PluginDetailsDialog';
+
+interface PluginRow {
+  id: string;
+  name: string;
+  version: string;
+  pluginCount: number;
+  kinds: string[];
+  pluginModule: PluginModuleResource;
+}
+
+function NoPluginRowOverlay(): ReactElement {
+  return <NoDataOverlay resource="plugins" />;
+}
 
 export function PluginsList(): ReactElement {
   const [selectedPluginModule, setSelectedPluginModule] = useState<PluginModuleResource | null>(null);
@@ -26,9 +42,89 @@ export function PluginsList(): ReactElement {
 
   const { data: pluginModules, isLoading, error } = usePlugins();
 
-  const sortedPluginModules = useMemo(() => {
-    return (pluginModules ?? []).toSorted((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+  const rows = useMemo<PluginRow[]>(() => {
+    return (pluginModules ?? [])
+      .toSorted((a, b) => a.metadata.name.localeCompare(b.metadata.name))
+      .map((pluginModule) => ({
+        id: `${pluginModule.metadata.name}-${pluginModule.metadata.version}`,
+        name: pluginModule.metadata.name,
+        version: pluginModule.metadata.version,
+        pluginCount: pluginModule.spec.plugins.length,
+        kinds: [...new Set(pluginModule.spec.plugins.map((plugin) => plugin.kind))],
+        pluginModule,
+      }));
   }, [pluginModules]);
+
+  const columns = useMemo<Array<GridColDef<PluginRow>>>(
+    () => [
+      {
+        field: 'name',
+        headerName: 'Module',
+        flex: 1.2,
+        minWidth: 220,
+        renderCell: ({ row }: GridRenderCellParams<PluginRow, string>): ReactElement => (
+          <Stack spacing={0.5} sx={{ justifyContent: 'center', height: '100%', py: 1 }}>
+            <Typography variant="body1" sx={{ fontWeight: 600 }}>
+              {row.name}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Version {row.version}
+            </Typography>
+          </Stack>
+        ),
+      },
+      {
+        field: 'pluginCount',
+        headerName: 'Plugins',
+        width: 120,
+        align: 'center',
+        headerAlign: 'center',
+      },
+      {
+        field: 'kinds',
+        headerName: 'Kinds',
+        flex: 1,
+        minWidth: 220,
+        sortable: false,
+        renderCell: ({ row }: GridRenderCellParams<PluginRow, string[]>): ReactElement => (
+          <Stack direction="row" gap={0.75} sx={{ alignItems: 'center', flexWrap: 'wrap', height: '100%', py: 1 }}>
+            {row.kinds.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                None
+              </Typography>
+            ) : (
+              row.kinds.map((kind) => <Chip key={kind} label={kind} size="small" variant="outlined" />)
+            )}
+          </Stack>
+        ),
+      },
+      {
+        field: 'actions',
+        headerName: 'Details',
+        width: 140,
+        sortable: false,
+        filterable: false,
+        align: 'right',
+        headerAlign: 'right',
+        renderCell: ({ row }: GridRenderCellParams<PluginRow>): ReactElement => (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              height: '100%',
+              width: '100%',
+            }}
+          >
+            <Button size="small" onClick={() => setSelectedPluginModule(row.pluginModule)}>
+              Inspect
+            </Button>
+          </Box>
+        ),
+      },
+    ],
+    []
+  );
 
   if (isLoading || pluginModules === undefined) {
     return <PersesLoader />;
@@ -38,60 +134,30 @@ export function PluginsList(): ReactElement {
     exceptionSnackbar(error);
   }
 
-  const handleOpenPluginDetails = (pluginModule: PluginModuleResource): void => {
-    setSelectedPluginModule(pluginModule);
-  };
-
-  const handleClosePluginDetails = (): void => {
-    setSelectedPluginModule(null);
-  };
-
   return (
-    <Box sx={{ p: 2 }}>
-      <Grid container spacing={3}>
-        {sortedPluginModules.map((pluginModule) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }} key={pluginModule.metadata.name}>
-            <Card elevation={2} sx={{ height: '100%' }}>
-              <CardContent>
-                <Typography variant="h3" gutterBottom>
-                  {pluginModule?.metadata?.name}
-                </Typography>
-                <Typography>Version {pluginModule.metadata.version}</Typography>
-                <Divider sx={{ my: 1.5 }} />
-                <Box>
-                  {
-                    // Case 1: No plugins available
-                    (!pluginModule?.spec?.plugins || pluginModule?.spec?.plugins.length === 0) && (
-                      <Typography variant="body2">No plugins available 😢</Typography>
-                    )
-                  }
-                  {
-                    // Case 2: Single plugin
-                    pluginModule?.spec?.plugins.length === 1 && (
-                      <Box sx={{ mt: 2 }}>
-                        <Typography variant="body1" color="text.secondary">
-                          <strong>Kind:</strong> {pluginModule?.spec?.plugins[0]?.kind}
-                        </Typography>
-                      </Box>
-                    )
-                  }
-                  {
-                    // Case 3: Multiple plugins
-                    pluginModule?.spec?.plugins.length > 1 && (
-                      <Box>
-                        <Button color="info" size="small" onClick={() => handleOpenPluginDetails(pluginModule)}>
-                          View {pluginModule.spec.plugins.length} Plugins
-                        </Button>
-                      </Box>
-                    )
-                  }
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
-      <PluginDetailsDialog selectedPluginModule={selectedPluginModule} onClose={handleClosePluginDetails} />
+    <Box sx={{ overflow: 'hidden' }}>
+      <DataGrid
+        autoHeight
+        disableRowSelectionOnClick
+        getRowHeight={() => 'auto'}
+        rows={rows}
+        columns={columns}
+        slots={{ toolbar: GridToolbar, noRowsOverlay: NoPluginRowOverlay }}
+        pageSizeOptions={PAGE_SIZE_OPTIONS}
+        initialState={{ pagination: { paginationModel: { pageSize: 10, page: 0 } } }}
+        slotProps={DATA_GRID_SLOT_PROPS}
+        sx={{
+          ...DATA_GRID_STYLES,
+          '& .MuiDataGrid-cell': {
+            display: 'flex',
+            alignItems: 'center',
+          },
+          '& .MuiDataGrid-cell--withRenderer': {
+            py: 0.5,
+          },
+        }}
+      />
+      <PluginDetailsDialog selectedPluginModule={selectedPluginModule} onClose={() => setSelectedPluginModule(null)} />
     </Box>
   );
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

- Align the Configuration page with the app’s existing section-page structure by using the same page header and tabbed content rhythm as Administration.
- Simplify the Config shell so the active tab content attaches directly to the tab header, reducing extra wrapper chrome and improving visual consistency.
- Replace the Installed Plugins card wall with a denser inventory table and clean up the plugin details dialog for a more product-grade management experience.

Depends on #4010 

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->
Before:
<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/2088f3e0-b3a1-4016-a439-6ffe7c502bda" />

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/be689d1b-e265-4fb5-a1c2-70e84caf37d4" />


After:

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/92a7874c-90ad-4d36-a298-61e1078835ac" />

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/ab433feb-d43b-47fb-87c4-27d122ecabee" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
