### PR TITLE
fix(api): set specific Content-Type for static resources

### DIFF
--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"mime"
 	"net/http"
 	"net/http/httputil"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -174,6 +176,10 @@ func (f *frontend) assetHandler() echo.HandlerFunc {
 		if strings.Contains(fileName, ".js") {
 			data = bytes.ReplaceAll(data, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
 		}
+		if ct := mime.TypeByExtension(filepath.Ext(fileName)); ct != "" {
+			c.Response().Header().Set(echo.HeaderContentType, ct)
+		}
+		c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 		_, err = c.Response().Write(data)
 		return apiinterface.HandleError(err)
 	}


### PR DESCRIPTION
## Summary

Static resources served by the frontend now get their correct Content-Type based on file extension (e.g. `text/css` for `.css`, `application/javascript` for `.js`). Also adds `X-Content-Type-Options: nosniff` to prevent MIME confusion attacks.

## Why this matters

The `assetHandler()` in `ui/endpoint.go` writes response bytes directly via `c.Response().Write(data)` without setting Content-Type. Browsers had to sniff the MIME type. Setting explicit types + nosniff follows OWASP security best practices.

## Changes

- `ui/endpoint.go`: Added `mime.TypeByExtension` lookup and `X-Content-Type-Options: nosniff` header in `assetHandler()`.

## Testing

- `go build ./ui/...` passes (note: `embedFS` undefined is pre-existing, only resolved when UI assets are built)

Fixes #3979

This contribution was developed with AI assistance (Claude Code).