### PR TITLE
[FEATURE] Add project scope selector to Explore view

### DIFF
--- a/ui/app/src/views/explore/ExploreView.tsx
+++ b/ui/app/src/views/explore/ExploreView.tsx
@@ -12,17 +12,20 @@
 // limitations under the License.
 
 import Compass from 'mdi-material-ui/Compass';
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import { PluginRegistry } from '@perses-dev/plugin-system';
-import { ExternalVariableDefinition } from '@perses-dev/core';
-import { CircularProgress, Stack } from '@mui/material';
+import { ExternalVariableDefinition, getResourceDisplayName, ProjectResource } from '@perses-dev/core';
+import { Autocomplete, CircularProgress, Stack, TextField } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { ViewExplore } from '@perses-dev/explore';
+import { useQueryClient } from '@tanstack/react-query';
 import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
 import { useDatasourceApi } from '../../model/datasource-api';
 import { useRemotePluginLoader } from '../../model/remote-plugin-loader';
 import { useGlobalVariableList } from '../../model/global-variable-client';
+import { useProjectList } from '../../model/project-client';
 import { buildGlobalVariableDefinition } from '../../utils/variables';
+import { useIsProjectDatasourceEnabled } from '../../context/Config';
 
 function ExploreView(): ReactElement {
   return <HelperExploreView exploreTitleComponent={<AppBreadcrumbs rootPageName="Explore" icon={<Compass />} />} />;
@@ -35,10 +38,24 @@ export interface HelperExploreViewProps {
 function HelperExploreView(props: HelperExploreViewProps): ReactElement {
   const { exploreTitleComponent } = props;
 
+  const [selectedProject, setSelectedProject] = useState<ProjectResource | null>(null);
+  const projectName = selectedProject?.metadata.name;
+
   const datasourceApi = useDatasourceApi();
   const pluginLoader = useRemotePluginLoader();
+  const isProjectDatasourceEnabled = useIsProjectDatasourceEnabled();
+  const queryClient = useQueryClient();
 
-  // Collect the Project variables and setup external variables from it
+  // Invalidate datasource select item cache when project changes so
+  // DatasourceStoreProvider re-fetches with the new project scope
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ['listDatasourceSelectItems'] });
+  }, [projectName, queryClient]);
+
+  // Fetch the list of projects the user has access to
+  const { data: projects } = useProjectList({ enabled: isProjectDatasourceEnabled });
+
+  // Collect global variables
   const { data: globalVars, isLoading: isLoadingGlobalVars } = useGlobalVariableList();
   const externalVariableDefinitions: ExternalVariableDefinition[] | undefined = useMemo(
     () => [buildGlobalVariableDefinition(globalVars ?? [])],
@@ -59,8 +76,24 @@ function HelperExploreView(props: HelperExploreViewProps): ReactElement {
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <ViewExplore
             datasourceApi={datasourceApi}
+            projectName={projectName}
             externalVariableDefinitions={externalVariableDefinitions}
-            exploreTitleComponent={exploreTitleComponent}
+            exploreTitleComponent={
+              <Stack direction="row" alignItems="center" gap={2}>
+                {exploreTitleComponent}
+                {isProjectDatasourceEnabled && (
+                  <Autocomplete<ProjectResource>
+                    size="small"
+                    options={projects ?? []}
+                    getOptionLabel={(option) => getResourceDisplayName(option)}
+                    value={selectedProject}
+                    onChange={(_, value) => setSelectedProject(value)}
+                    renderInput={(params) => <TextField {...params} label="Project" placeholder="Global" />}
+                    sx={{ minWidth: 200 }}
+                  />
+                )}
+              </Stack>
+            }
           />
         </ErrorBoundary>
       </PluginRegistry>

--- a/ui/app/src/views/explore/ExploreView.tsx
+++ b/ui/app/src/views/explore/ExploreView.tsx
@@ -22,12 +22,7 @@ import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { ViewExplore } from '@perses-dev/explore';
 import { useQueryClient } from '@tanstack/react-query';
 import { StringParam, useQueryParam } from 'use-query-params';
-import {
-  Breadcrumbs,
-  HomeLinkCrumb,
-  StackCrumb,
-  TitleCrumb,
-} from '../../components/breadcrumbs/breadcrumbs';
+import { Breadcrumbs, HomeLinkCrumb, StackCrumb, TitleCrumb } from '../../components/breadcrumbs/breadcrumbs';
 import { useDatasourceApi } from '../../model/datasource-api';
 import { useRemotePluginLoader } from '../../model/remote-plugin-loader';
 import { useGlobalVariableList } from '../../model/global-variable-client';
@@ -69,9 +64,7 @@ function ProjectScopeCrumb(props: ProjectScopeCrumbProps): ReactElement {
     <>
       <StackCrumb>
         <Archive />
-        <TitleCrumb
-          inheritTypography={true}
-        >
+        <TitleCrumb inheritTypography={true}>
           <Stack
             direction="row"
             alignItems="center"
@@ -105,10 +98,7 @@ function ProjectScopeCrumb(props: ProjectScopeCrumbProps): ReactElement {
         onClose={handleClose}
         slotProps={{ paper: { sx: { maxHeight: 300 } } }}
       >
-        <MenuItem
-          selected={!projectName}
-          onClick={() => handleSelect(undefined)}
-        >
+        <MenuItem selected={!projectName} onClick={() => handleSelect(undefined)}>
           <ListItemText>Global only</ListItemText>
         </MenuItem>
         {projects.map((project) => (

--- a/ui/app/src/views/explore/ExploreView.tsx
+++ b/ui/app/src/views/explore/ExploreView.tsx
@@ -12,39 +12,131 @@
 // limitations under the License.
 
 import Compass from 'mdi-material-ui/Compass';
-import React, { ReactElement, useEffect, useMemo, useState } from 'react';
+import Archive from 'mdi-material-ui/Archive';
+import ChevronDown from 'mdi-material-ui/ChevronDown';
+import React, { ReactElement, useEffect, useMemo, MouseEvent, useState } from 'react';
 import { PluginRegistry } from '@perses-dev/plugin-system';
 import { ExternalVariableDefinition, getResourceDisplayName, ProjectResource } from '@perses-dev/core';
-import { Autocomplete, CircularProgress, Stack, TextField } from '@mui/material';
+import { CircularProgress, Menu, MenuItem, Stack, ListItemIcon, ListItemText } from '@mui/material';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { ViewExplore } from '@perses-dev/explore';
 import { useQueryClient } from '@tanstack/react-query';
-import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
+import { StringParam, useQueryParam } from 'use-query-params';
+import {
+  Breadcrumbs,
+  HomeLinkCrumb,
+  StackCrumb,
+  TitleCrumb,
+} from '../../components/breadcrumbs/breadcrumbs';
 import { useDatasourceApi } from '../../model/datasource-api';
 import { useRemotePluginLoader } from '../../model/remote-plugin-loader';
 import { useGlobalVariableList } from '../../model/global-variable-client';
 import { useProjectList } from '../../model/project-client';
 import { buildGlobalVariableDefinition } from '../../utils/variables';
 import { useIsProjectDatasourceEnabled } from '../../context/Config';
+import { useIsMobileSize } from '../../utils/browser-size';
 
 function ExploreView(): ReactElement {
-  return <HelperExploreView exploreTitleComponent={<AppBreadcrumbs rootPageName="Explore" icon={<Compass />} />} />;
+  return <HelperExploreView />;
 }
 
-export interface HelperExploreViewProps {
-  exploreTitleComponent?: React.ReactNode;
+interface ProjectScopeCrumbProps {
+  projectName: string | undefined;
+  projects: ProjectResource[];
+  onSelect: (projectName: string | undefined) => void;
 }
 
-function HelperExploreView(props: HelperExploreViewProps): ReactElement {
-  const { exploreTitleComponent } = props;
+function ProjectScopeCrumb(props: ProjectScopeCrumbProps): ReactElement {
+  const { projectName, projects, onSelect } = props;
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-  const [selectedProject, setSelectedProject] = useState<ProjectResource | null>(null);
-  const projectName = selectedProject?.metadata.name;
+  const handleOpen = (event: MouseEvent<HTMLElement>): void => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (): void => {
+    setAnchorEl(null);
+  };
+
+  const handleSelect = (name: string | undefined): void => {
+    onSelect(name);
+    handleClose();
+  };
+
+  const selectedProject = projects.find((p) => p.metadata.name === projectName);
+
+  return (
+    <>
+      <StackCrumb>
+        <Archive />
+        <TitleCrumb
+          inheritTypography={true}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            gap={0.25}
+            onClick={handleOpen}
+            sx={(theme) => ({
+              cursor: 'pointer',
+              borderRadius: 1,
+              px: 0.75,
+              py: 0.25,
+              backgroundColor: theme.palette.action.hover,
+              border: '1px solid',
+              borderColor: theme.palette.divider,
+              transition: theme.transitions.create(['background-color', 'border-color'], {
+                duration: theme.transitions.duration.shorter,
+              }),
+              '&:hover': {
+                backgroundColor: theme.palette.action.selected,
+                borderColor: theme.palette.action.disabled,
+              },
+            })}
+          >
+            {selectedProject ? getResourceDisplayName(selectedProject) : 'Global'}
+            <ChevronDown sx={{ fontSize: 16 }} />
+          </Stack>
+        </TitleCrumb>
+      </StackCrumb>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        slotProps={{ paper: { sx: { maxHeight: 300 } } }}
+      >
+        <MenuItem
+          selected={!projectName}
+          onClick={() => handleSelect(undefined)}
+        >
+          <ListItemText>Global only</ListItemText>
+        </MenuItem>
+        {projects.map((project) => (
+          <MenuItem
+            key={project.metadata.name}
+            selected={project.metadata.name === projectName}
+            onClick={() => handleSelect(project.metadata.name)}
+          >
+            <ListItemIcon>
+              <Archive fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>{getResourceDisplayName(project)}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}
+
+function HelperExploreView(): ReactElement {
+  const [projectParam, setProjectParam] = useQueryParam('project', StringParam);
+  const projectName = projectParam ?? undefined;
 
   const datasourceApi = useDatasourceApi();
   const pluginLoader = useRemotePluginLoader();
   const isProjectDatasourceEnabled = useIsProjectDatasourceEnabled();
   const queryClient = useQueryClient();
+  const isMobileSize = useIsMobileSize();
 
   // Invalidate datasource select item cache when project changes so
   // DatasourceStoreProvider re-fetches with the new project scope
@@ -62,6 +154,33 @@ function HelperExploreView(props: HelperExploreViewProps): ReactElement {
     [globalVars]
   );
 
+  const exploreTitleComponent = useMemo(() => {
+    const breadcrumbContent = isMobileSize ? (
+      <Breadcrumbs>
+        <StackCrumb>
+          <Compass />
+          <TitleCrumb>Explore</TitleCrumb>
+        </StackCrumb>
+      </Breadcrumbs>
+    ) : (
+      <Breadcrumbs>
+        <HomeLinkCrumb />
+        {isProjectDatasourceEnabled && (
+          <ProjectScopeCrumb
+            projectName={projectName}
+            projects={projects ?? []}
+            onSelect={(name) => setProjectParam(name ?? undefined)}
+          />
+        )}
+        <StackCrumb>
+          <Compass />
+          <TitleCrumb>Explore</TitleCrumb>
+        </StackCrumb>
+      </Breadcrumbs>
+    );
+    return breadcrumbContent;
+  }, [isMobileSize, isProjectDatasourceEnabled, projectName, projects, setProjectParam]);
+
   if (isLoadingGlobalVars) {
     return (
       <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
@@ -78,22 +197,7 @@ function HelperExploreView(props: HelperExploreViewProps): ReactElement {
             datasourceApi={datasourceApi}
             projectName={projectName}
             externalVariableDefinitions={externalVariableDefinitions}
-            exploreTitleComponent={
-              <Stack direction="row" alignItems="center" gap={2}>
-                {exploreTitleComponent}
-                {isProjectDatasourceEnabled && (
-                  <Autocomplete<ProjectResource>
-                    size="small"
-                    options={projects ?? []}
-                    getOptionLabel={(option) => getResourceDisplayName(option)}
-                    value={selectedProject}
-                    onChange={(_, value) => setSelectedProject(value)}
-                    renderInput={(params) => <TextField {...params} label="Project" placeholder="Global" />}
-                    sx={{ minWidth: 200 }}
-                  />
-                )}
-              </Stack>
-            }
+            exploreTitleComponent={exploreTitleComponent}
           />
         </ErrorBoundary>
       </PluginRegistry>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
# Description

Add a project scope selector to the Explore view, allowing users to explore project-scoped datasources alongside global ones. Addresses https://github.com/perses/perses/issues/3005.

The selector is integrated into the breadcrumb trail as a dropdown menu (`Home > [Global ▾] > Explore`). Selecting a project scopes the datasource dropdown to that project's datasources plus global datasources, using `DatasourceStoreProvider`'s existing precedence logic. The selected project is persisted as a `?project=` URL query parameter for shareable links.

All changes are in the app layer (`ui/app/`). Depends on https://github.com/perses/shared/pull/104/changes which threads the existing `projectName` prop through `ViewExplore`.

Implementation details:
- React Query cache for `listDatasourceSelectItems` is invalidated on project change, since `DatasourceStoreProvider` uses `useEvent` for stable function references that React Query can't detect have changed behavior.
- Project list is fetched via the existing `useProjectList` hook, gated by `useIsProjectDatasourceEnabled`.

# Screenshots
<img width="2672" height="1391" alt="Screenshot 2026-04-13 at 23 45 40" src="https://github.com/user-attachments/assets/d6d5edb4-90ef-4dec-a5c8-0069fe1aeb89" />
<img width="2672" height="1391" alt="Screenshot 2026-04-13 at 23 45 47" src="https://github.com/user-attachments/assets/4a9aaba4-b92d-41ca-bbcc-94296a9d7550" />
<img width="2672" height="1391" alt="Screenshot 2026-04-13 at 23 45 57" src="https://github.com/user-attachments/assets/e8e46527-e6bf-4658-84fd-e615276198cd" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
