### PR TITLE
DOC Fix documentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ monitoring needs. And it will help us to grow the community and make Perses even
 - [BUGFIX] PluginEditor - Fix createInitialOptions for plugins (#3613)
 - [BUGFIX] PanelEditor + VariableEditor: queries changes are not saved (#3590)
 - [BUGFIX] Fix embedding markdown panels in tables (#3588)
-- [BUGFIX] Add bits/sec convertion to human-readable sizes, add bits units(#3441) (#3583)
+- [BUGFIX] Add bits/sec conversion to human-readable sizes, add bits units(#3441) (#3583)
 - [BUGFIX] Fix navigation after creating a new ephemeral dashboard (#3584)
 - [BUGFIX] CLI/PLUGIN: Avoid re-building dev server tasks to shut down correctly the start plugin command (#3579)
 - [BUGFIX] Add back piechart removed by mistake (#3552)
@@ -362,7 +362,7 @@ usability improvements, and upgraded CLI commands to streamline plugin developme
 - [BREAKINGCHANGE] Watch the changes of the unknown specs in all Editor Plugins (#3203)
 - [BUGFIX] fix merge indexed columns regex (#3341)
 - [BUGFIX] Simplify the panels management (#3332)
-- [BUGFIX] Readd ReactRouterProvider (#3327)
+- [BUGFIX] Re-add ReactRouterProvider (#3327)
 - [BUGFIX] Grafana migration: fix invisible group generated for orphan panels (#3271)
 - [BUGFIX] Remove Variable Preview refresh button (#3298)
 - [BUGFIX] Force a refresh time range when the Run Query Button is clicked every time (#3287)
@@ -497,7 +497,7 @@ We have also improved the documentation, highlighting features that were impleme
 - [BREAKINGCHANGE] Rename field in the service discovery config and add a concept doc about SD (#2665)
 - [DOC] Update embedding panels guide with the latest recommendations (#2899)
 - [DOC] Document some of the not-resource-related API endpoints (#2874)
-- [DOC] Add kubecon pres to the list of materials (#2872)
+- [DOC] Add kubecon presentation to the list of materials (#2872)
 - [DOC] Remove duplicated section (#2837)
 - [DOC] Add top key 'security' required for the oidc/oauth2 config (#2815)
 - [DOC] Fix the markdown syntax in docs/configuration/configuration.md (#2847)
@@ -750,7 +750,7 @@ and includes a breaking change to OAuth & OIDC to better respect the industry st
 - [FEATURE] Instant query table view (#1982)
 - [FEATURE] Explorer: Add tracing support and introduce Graph tab (#1974)
 - [ENHANCEMENT] DaC SDKs: showcase custom configurable grouping capabilities in example files (#2042)
-- [ENHANCEMENT] Add formating to series name in explorer and use MUI Table (#2013)
+- [ENHANCEMENT] Add formatting to series name in explorer and use MUI Table (#2013)
 - [ENHANCEMENT] Make gauge chart background color close to theme color (#2018)
 - [ENHANCEMENT] Add `bytes/sec` format (#2009)
 - [ENHANCEMENT] Keep data when switching explorer tabs (#2008)
@@ -803,7 +803,7 @@ and includes a breaking change to OAuth & OIDC to better respect the industry st
 - [BUGFIX] Grafana migration: best-effort solution to not migrate irrelevant regexps (#1929)
 - [BUGFIX] Fix grafana migration failing for "custom" template variables (#1927)
 - [BUGFIX] Fix dashboard list with empty project on home page (#1928)
-- [BUGFIX] Fix no project permssion after creating project (#1926)
+- [BUGFIX] Fix no project permission after creating project (#1926)
 - [BUGFIX] Fix `percli dac setup` failing for CUE (#1918)
 - [BUGFIX] Fix how we get a list of resources based on the permission (#1912) (#1932)
 - [BUGFIX] Fix HTTP error returned when access permission is missing (#1913)
@@ -1005,7 +1005,7 @@ It only contains a fix in the CI to release Perses.
 - [BUGFIX] Align camelCase json value in secret (#1422)
 - [BUGFIX] Fix panel preview unresponsive after query error (#1418)
 - [BUGFIX] Fix saved changes to refresh interval not preserved (#1407)
-- [BUGFIX] Fix BE/FE misalignement on threshold datamodel #1389 (#1404)
+- [BUGFIX] Fix BE/FE misalignment on threshold datamodel #1389 (#1404)
 - [BUGFIX] Fix dashboard save button staying disabled after failing to save dashboard #1357 (#1398)
 - [BUGFIX] Fix reloading /admin route in react (#1386)
 - [BUGFIX] datasource form: make name readonly after creation + fix wrong titles/names in readonly mode (#1374)
@@ -1559,7 +1559,7 @@ It only contains a fix in the CI to release Perses.
 - [ENHANCEMENT] QueryStringProvider allows apps to pass their own utils to update the URL #530
 - [ENHANCEMENT] DashboardProvider improvements #540
 - [ENHANCEMENT] Governance process changes #431 #522 #523
-- [ENHANCEMENT] Use React 18 for development, allow React 17 backward compatability #533
+- [ENHANCEMENT] Use React 18 for development, allow React 17 backward compatibility #533
 - [ENHANCEMENT] upgrade go to 1.19 #543
 - [ENHANCEMENT] build process improvements #489, #490, #491 #515
 - [ENHANCEMENT] add datasource documentation #404

--- a/docs/concepts/authorization.md
+++ b/docs/concepts/authorization.md
@@ -99,7 +99,7 @@ This restriction is in place for the following reasons:
 
 - If you are unable to update the role in a binding's spec, then you will not grant by accident a user more permissions
   than they should have.
-- We consider that a binding to a different role is fundamentally differen
+- We consider that a binding to a different role is fundamentally different
 
 ## Referring to resources
 

--- a/docs/concepts/datasource.md
+++ b/docs/concepts/datasource.md
@@ -1,6 +1,6 @@
 # Datasource
 
-A **datasource** in Perses represents a connection configuration to an external system that provides observability data, such as metrics or traces. Datasources are there to allow retrieving data from different backends without hardcoding connection details everytime. They are thus reusable configuration objects that encapsulate how to query a specific data provider.
+A **datasource** in Perses represents a connection configuration to an external system that provides observability data, such as metrics or traces. Datasources are there to allow retrieving data from different backends without hardcoding connection details every time. They are thus reusable configuration objects that encapsulate how to query a specific data provider.
 
 Datasources are implemented as [plugins](./plugin.md).
 

--- a/docs/concepts/open-specification.md
+++ b/docs/concepts/open-specification.md
@@ -22,7 +22,7 @@ This open specification is currently implemented in the following languages:
 This section is here to explain what means for a software or a tool to be compatible with Perses.
 
 !!! warning
-    This documentation can change over the time. Therefor a software that said it is compatible with Perses today may not be compatible anymore in the future if Perses changes its specifications or APIs. 
+    This documentation can change over the time. Therefore a software that said it is compatible with Perses today may not be compatible anymore in the future if Perses changes its specifications or APIs. 
     Always check the latest documentation to ensure compatibility.
 
 ### What does "compatible with Perses" mean?

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -215,7 +215,7 @@ oidc:
 oauth:
   - <OAuth provider> # Optional
 # Kubernetes authentication provider
-kubernetes: <Kubernetes provider> # Optionall
+kubernetes: <Kubernetes provider> # Optional
 ```
 
 ##### OIDC provider
@@ -472,7 +472,7 @@ allow_credentials: <boolean> | default = false # Optional
 expose_headers: <string[]> | default = [] # Optional
 
 # Configure how long (in seconds) the results of a preflight request can be cached.
-max_age: <intger> | default = 0 # Optional
+max_age: <integer> | default = 0 # Optional
 ```
 
 ### Database config

--- a/docs/dac/getting-started.md
+++ b/docs/dac/getting-started.md
@@ -36,7 +36,7 @@ Check the helper of that command to see the different flags available (e.g to de
 
 ### Develop dashboards
 
-You are now fully ready to start developping dashboards as code with CUE!
+You are now fully ready to start developing dashboards as code with CUE!
 
 It's first strongly recommended to ramp up on CUE if you are not familiar with this technology. For this have a look at:
 

--- a/docs/dac/go/variable.md
+++ b/docs/dac/go/variable.md
@@ -9,7 +9,7 @@ var options []variable.Option
 variable.New("My Super Variable", options...)
 ```
 
-Need to provide the name of the varaible and a list of options.
+Need to provide the name of the variable and a list of options.
 
 ## Default options
 

--- a/docs/installation/in-a-container.md
+++ b/docs/installation/in-a-container.md
@@ -20,7 +20,7 @@ $ podman run --name perses --rm -p 127.0.0.1:8080:8080 persesdev/perses
 $ docker run --name perses --rm -p 127.0.0.1:8080:8080 persesdev/perses
 ```
 
-The details in this command are that we give the container a referencable name (--name perses), automatically remove
+The details in this command are that we give the container a referenceable name (--name perses), automatically remove
 the container when it stops (--rm), map the local machine port 8080 to the container port 8080 (-p 127.0.0.1:8080:8080),
 and use the image version supported in these instructions (latest). Note: you can use any local port you have available,
 but you need to map to container port 8080.

--- a/docs/plugins/creation.md
+++ b/docs/plugins/creation.md
@@ -77,7 +77,7 @@ Perses CLI (`percli`) has a plugin option that helps you create and manage your 
 
 - `percli plugin generate --module.org=<plugin module org> --module.name=<plugin module name> --plugin.type=<plugin type> --plugin.name=<plugin name> [<plugin module directory>]`: Creates a new plugin module if does not exist and generates a plugin inside it. This command can be used several times to add more plugins to the same module. A single plugin can be generated at a time.
   - `--module.name`: The plugin module name, required only when the module does not exist, ignored otherwise.
-  - `--module.org`: The organization name on which the plugin module will be created, useful for publising the plugin. This is required only when the module does not exist, ignored otherwise.
+  - `--module.org`: The organization name on which the plugin module will be created, useful for publishing the plugin. This is required only when the module does not exist, ignored otherwise.
   - `--plugin.name`: The plugin name. A pascal case and kebab case variants will be generated inside the templates. If a plugin with the same name already exists, it will be overwritten.
   - `--plugin.type`: The plugin type can be one of
     `Datasource`, `TimeSeriesQuery` , `TraceQuery`, `ProfileQuery`, `LogQuery`, `Variable`, `Panel`, or `Explore`.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

I am currently implementing/experimenting with Perses and I noticed a type-o in the documentation and thought why not run codespel on the docs. This is the result.

# Screenshots

N/A
# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
