### PR TITLE
[IGNORE] fix e2e tests and docs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,12 +44,7 @@ jobs:
       - name: Run Playwright tests
         working-directory: ./ui
         timeout-minutes: 15
-        run: npm run e2e:ci
-        env:
-          # Outputs information from webservers started in the background by
-          # Playwright. Useful for understanding if something failing there
-          # breaks the tests.
-          DEBUG: pw:webserver
+        run: npm run e2e:ci:stream
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -55,3 +55,6 @@ validators:
     type: 'ignore'
   - regex: 'medium\.com'
     type: 'ignore'
+  # localhost URLs are used in documentation examples
+  - regex: 'localhost'
+    type: 'ignore'

--- a/scripts/api_backend_dev.sh
+++ b/scripts/api_backend_dev.sh
@@ -7,16 +7,25 @@
 echo ">> build the api server"
 make build-api
 
-if [[ $1 == "--e2e" ]]; then
-  # deactivate the permission because e2e tests doesn't support yet the JWT cookies
-  previous_file="./dev/config.previous.yaml"
-  config_file="./dev/config.yaml"
-  cp ${config_file} ${previous_file}
-  sed 's/enable_auth: true/enable_auth: false/g' ${previous_file} >${config_file}
-  rm ${previous_file}
-fi
+log_level="debug"
+
+for arg in "$@"; do
+  case $arg in
+    --e2e)
+      # deactivate the permission because e2e tests doesn't support yet the JWT cookies
+      previous_file="./dev/config.previous.yaml"
+      config_file="./dev/config.yaml"
+      cp ${config_file} ${previous_file}
+      sed 's/enable_auth: true/enable_auth: false/g' ${previous_file} >${config_file}
+      rm ${previous_file}
+      ;;
+    --ci)
+      log_level="error"
+      ;;
+  esac
+done
 
 # Run backend server
 echo ">> start the api server"
 echo '>> Log in with user: `admin` and password: `password`'
-./bin/perses --config ./dev/config.yaml --log.level=debug
+./bin/perses --config ./dev/config.yaml --log.level=${log_level}

--- a/ui/app/src/components/ShortcutHelpModal.tsx
+++ b/ui/app/src/components/ShortcutHelpModal.tsx
@@ -26,7 +26,6 @@ import {
 /** Modal displaying all registered keyboard shortcuts, grouped by category. */
 export function ShortcutHelpModal(): ReactElement {
   const [open, setOpen] = useState(false);
-  const { hotkeys, sequences } = useHotkeyRegistrations();
 
   const handleShowShortcuts = useCallback(() => {
     setOpen(true);
@@ -42,6 +41,22 @@ export function ShortcutHelpModal(): ReactElement {
   const handleClose = useCallback(() => {
     setOpen(false);
   }, []);
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle component="h3" sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        Keyboard Shortcuts
+        <IconButton onClick={handleClose} size="small">
+          <Close />
+        </IconButton>
+      </DialogTitle>
+      {open && <ShortcutHelpContent />}
+    </Dialog>
+  );
+}
+/** This wrapper component is required as a workaround till https://github.com/TanStack/hotkeys/issues/113 upstream issue is fixed */
+function ShortcutHelpContent(): ReactElement {
+  const { hotkeys, sequences } = useHotkeyRegistrations();
 
   const groupedShortcuts = useMemo(() => {
     const groups: Record<ShortcutCategory, Array<{ name: string; description: string; displayParts: string[] }>> = {
@@ -85,64 +100,56 @@ export function ShortcutHelpModal(): ReactElement {
   }, [hotkeys, sequences]);
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Typography variant="h6">Keyboard Shortcuts</Typography>
-        <IconButton onClick={handleClose} size="small">
-          <Close />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent>
-        {SHORTCUT_CATEGORY_ORDER.map((category) => {
-          const shortcuts = groupedShortcuts[category];
-          if (!shortcuts?.length) return null;
+    <DialogContent>
+      {SHORTCUT_CATEGORY_ORDER.map((category) => {
+        const shortcuts = groupedShortcuts[category];
+        if (!shortcuts?.length) return null;
 
-          return (
-            <Box key={category} sx={{ mb: 2 }}>
-              <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 'bold', textTransform: 'uppercase' }}>
-                {SHORTCUT_CATEGORY_LABELS[category]}
-              </Typography>
-              {shortcuts.map((shortcut) => (
-                <Box
-                  key={shortcut.name}
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    py: 0.5,
-                  }}
-                >
-                  <Typography variant="body2">{shortcut.description || shortcut.name}</Typography>
-                  <Box sx={{ display: 'flex', gap: 0.5 }}>
-                    {shortcut.displayParts.map((part, i) => (
-                      <Box key={i} sx={{ display: 'flex', gap: 0.25 }}>
-                        <Typography
-                          component="kbd"
-                          variant="caption"
-                          sx={{
-                            px: 0.75,
-                            py: 0.25,
-                            borderRadius: 0.5,
-                            border: 1,
-                            borderColor: 'divider',
-                            backgroundColor: 'action.hover',
-                            fontFamily: 'monospace',
-                            fontSize: '0.75rem',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          {part}
-                        </Typography>
-                      </Box>
-                    ))}
-                  </Box>
+        return (
+          <Box key={category} sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 'bold', textTransform: 'uppercase' }}>
+              {SHORTCUT_CATEGORY_LABELS[category]}
+            </Typography>
+            {shortcuts.map((shortcut) => (
+              <Box
+                key={shortcut.name}
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  py: 0.5,
+                }}
+              >
+                <Typography variant="body2">{shortcut.description || shortcut.name}</Typography>
+                <Box sx={{ display: 'flex', gap: 0.5 }}>
+                  {shortcut.displayParts.map((part, i) => (
+                    <Box key={i} sx={{ display: 'flex', gap: 0.25 }}>
+                      <Typography
+                        component="kbd"
+                        variant="caption"
+                        sx={{
+                          px: 0.75,
+                          py: 0.25,
+                          borderRadius: 0.5,
+                          border: 1,
+                          borderColor: 'divider',
+                          backgroundColor: 'action.hover',
+                          fontFamily: 'monospace',
+                          fontSize: '0.75rem',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {part}
+                      </Typography>
+                    </Box>
+                  ))}
                 </Box>
-              ))}
-              <Divider sx={{ mt: 1 }} />
-            </Box>
-          );
-        })}
-      </DialogContent>
-    </Dialog>
+              </Box>
+            ))}
+            <Divider sx={{ mt: 1 }} />
+          </Box>
+        );
+      })}
+    </DialogContent>
   );
 }

--- a/ui/app/src/components/users/UserEditorForm.tsx
+++ b/ui/app/src/components/users/UserEditorForm.tsx
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Action, UserEditorSchemaType, UserResource, userSchema } from '@perses-dev/core';
-import { getSubmitText, getTitleAction } from '@perses-dev/plugin-system';
-import React, { Fragment, ReactElement, useMemo, useState } from 'react';
-import { Control, Controller, FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Alert, Box, Divider, FormControl, IconButton, Stack, TextField, Typography } from '@mui/material';
 import { DiscardChangesConfirmationDialog, FormActions } from '@perses-dev/components';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { Action, UserEditorSchemaType, UserResource, userSchema } from '@perses-dev/core';
+import { getSubmitText, getTitleAction } from '@perses-dev/plugin-system';
+import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import MinusIcon from 'mdi-material-ui/Minus';
 import PlusIcon from 'mdi-material-ui/Plus';
-import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import { Fragment, ReactElement, useMemo, useState } from 'react';
+import { Control, Controller, FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { useIsExternalAuthnProviderEnabled, useIsNativeAuthnProviderEnabled } from '../../context/Config';
 import { FormEditorProps } from '../form-drawers';
 

--- a/ui/e2e/src/config/ci.playwright.config.ts
+++ b/ui/e2e/src/config/ci.playwright.config.ts
@@ -22,6 +22,8 @@ import baseConfig from './base.playwright.config';
 const config: PlaywrightTestConfig = {
   ...baseConfig,
 
+  reporter: [['html'], ['list', { printSteps: true }], ['github']],
+
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: true,
 
@@ -35,7 +37,7 @@ const config: PlaywrightTestConfig = {
   webServer: [
     // Start the binary
     {
-      command: './scripts/api_backend_dev.sh --e2e',
+      command: './scripts/api_backend_dev.sh --e2e --ci',
       port: 8080,
       cwd: path.resolve(__dirname, '../../../..'),
       reuseExistingServer: true,

--- a/ui/e2e/src/tests/keyboardShortcuts.spec.ts
+++ b/ui/e2e/src/tests/keyboardShortcuts.spec.ts
@@ -37,7 +37,7 @@ test.describe('Keyboard Shortcuts', () => {
     await expect(dashboardPage.toolbar).toBeVisible();
 
     // Press Shift+? to open the shortcuts help modal
-    await page.keyboard.press('Shift+/');
+    await page.keyboard.press('Shift+?');
 
     // The help modal should appear with the title "Keyboard Shortcuts"
     const dialog = page.getByRole('dialog');
@@ -45,10 +45,10 @@ test.describe('Keyboard Shortcuts', () => {
     await expect(dialog).toContainText('Keyboard Shortcuts');
 
     // Verify some expected category headings are present
-    await expect(dialog).toContainText('GLOBAL');
-    await expect(dialog).toContainText('TIME RANGE');
-    await expect(dialog).toContainText('DASHBOARD');
-    await expect(dialog).toContainText('FOCUSED PANEL');
+    await expect(dialog).toContainText('Global');
+    await expect(dialog).toContainText('Time Range');
+    await expect(dialog).toContainText('Dashboard');
+    await expect(dialog).toContainText('Focused Panel');
   });
 
   test('d then m toggles dashboard edit mode', async ({ dashboardPage, page }) => {
@@ -101,7 +101,9 @@ test.describe('Keyboard Shortcuts', () => {
 
     // The search dialog/bar should open
     // Look for the search input or dialog
-    const searchInput = page.getByRole('combobox', { name: /search/i }).or(page.getByPlaceholder(/search/i));
+    const searchInput = page
+      .getByRole('combobox', { name: /search/i })
+      .or(page.getByPlaceholder(/What are you looking for\?/i));
     await expect(searchInput).toBeVisible({ timeout: 5000 });
   });
 

--- a/ui/e2e/src/tests/saveDefaults.spec.ts
+++ b/ui/e2e/src/tests/saveDefaults.spec.ts
@@ -41,8 +41,7 @@ test.describe('Dashboard: Defaults', () => {
 
     // Change text variable
     const textVariableInput = await page.getByRole('textbox', { name: 'Text variable' });
-    await textVariableInput.clear();
-    await textVariableInput.type(TEXT_VARIABLE_UPDATED_VALUE, { delay: 100 });
+    await textVariableInput.fill(TEXT_VARIABLE_UPDATED_VALUE);
 
     // Switch to edit mode and click save
     await dashboardPage.startEditing();

--- a/ui/endpoint.go
+++ b/ui/endpoint.go
@@ -178,7 +178,7 @@ func (f *frontend) assetHandler() echo.HandlerFunc {
 			logrus.WithError(err).Error("Error reading React index.html")
 			return apiinterface.HandleError(err)
 		}
-		if strings.Contains(fileName, ".js") {
+		if strings.Contains(fileName, ".js") || strings.Contains(fileName, ".css") {
 			data = bytes.ReplaceAll(data, []byte(prefixPathPlaceholder), []byte(f.apiPrefix))
 		}
 		contentType := mime.TypeByExtension(filepath.Ext(fileName))

--- a/ui/endpoint_test.go
+++ b/ui/endpoint_test.go
@@ -30,30 +30,33 @@ func TestAssetHandlerContentType(t *testing.T) {
 	t.Cleanup(func() { asts = originalAsts })
 
 	testFS := fstest.MapFS{
-		"app/dist/main.abc123.css": &fstest.MapFile{Data: []byte("body { color: red; }")},
-		"app/dist/main.abc123.js":  &fstest.MapFile{Data: []byte("console.log('hello')")},
+		"app/dist/main.abc123.css": &fstest.MapFile{Data: []byte("body { background: url(PREFIX_PATH_PLACEHOLDER/font.woff2); }")},
+		"app/dist/main.abc123.js":  &fstest.MapFile{Data: []byte("console.log('PREFIX_PATH_PLACEHOLDER')")},
 		"app/dist/image.png":       &fstest.MapFile{Data: []byte("fake-png-data")},
 		"app/dist/index.html":      &fstest.MapFile{Data: []byte("<html></html>")},
 	}
 	asts = http.FS(testFS)
 
-	f := &frontend{apiPrefix: ""}
+	f := &frontend{apiPrefix: "/custom"}
 
 	tests := []struct {
 		name                 string
 		path                 string
 		expectedContentTypes []string
+		expectedBody         string
 	}{
 		{
-			name:                 "CSS file",
+			name:                 "CSS file with placeholder substitution",
 			path:                 "/app/dist/main.abc123.css",
 			expectedContentTypes: []string{"text/css; charset=utf-8"},
+			expectedBody:         "body { background: url(/custom/font.woff2); }",
 		},
 		{
-			name: "JavaScript file",
+			name: "JavaScript file with placeholder substitution",
 			path: "/app/dist/main.abc123.js",
 			// Windows registers the obsolete application/javascript MIME type.
 			expectedContentTypes: []string{"text/javascript; charset=utf-8", "application/javascript"},
+			expectedBody:         "console.log('/custom')",
 		},
 		{
 			name:                 "HTML file",
@@ -73,6 +76,10 @@ func TestAssetHandlerContentType(t *testing.T) {
 			require.NoError(t, err)
 			assert.Contains(t, tt.expectedContentTypes, rec.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+			if tt.expectedBody != "" {
+				assert.Equal(t, tt.expectedBody, rec.Body.String())
+				assert.NotContains(t, rec.Body.String(), prefixPathPlaceholder)
+			}
 		})
 	}
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6897,6 +6897,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -10298,12 +10299,14 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -14713,6 +14716,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14818,12 +14822,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
-      "license": "MIT"
-    },
-    "node_modules/rambda": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
-      "integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
       "license": "MIT"
     },
     "node_modules/range-parser": {
@@ -15548,7 +15546,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15653,6 +15651,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "e2e": "turbo run e2e:local",
     "e2e:debug": "turbo run e2e -- --debug",
     "e2e:ci": "turbo run e2e:ci",
+    "e2e:ci:stream": "npm run e2e:ci --workspace=@perses-dev/e2e",
     "typedoc": "typedoc"
   },
   "workspaces": [


### PR DESCRIPTION
# Description

This PR aims to reduce the CI errors to spot actual errors

- Fix keyboard shortcuts e2e tests and missing functions related to 0.54.0-beta update
- Fix save defaults e2e test
- Remove warning caused by `useHotkeyRegistrations` hook by moving hook initialization only when the modal is open
- Ignores localhost urls from documentation check
- bypasses the turbo command for e2e tests in the ci to be able to properly log e2e errors

> [!WARNING]
> Other e2e tests might still fail due to a duplicated key issue in the table plugin. Will fix from the plugins side

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).