### PR TITLE
[ignore] Make sure the cookies are not interfering on e2e tests

### DIFF
--- a/internal/api/e2e/api/rbac_test.go
+++ b/internal/api/e2e/api/rbac_test.go
@@ -125,11 +125,9 @@ func TestUnauthorizedEndpoints(t *testing.T) {
 		glRole := e2eframework.NewGlobalRole("test")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathGlobalRole)).WithJSON(glRole).WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).Expect().Status(http.StatusForbidden)
 
-		// This test only works if the auth cookies are not present from a request to another one.
-		// During the execution of the e2e tests, cookies are persisted from a request to another one.
-		// The only way to avoid keeping the auth cookie is to set the cookie param 'secure' at true.
-		// As the connection is not secured, the cookies cannot be kept (secure means it works only with https).
-		// This is what is done in e2eframework.DefaultAuthConfig
+		// This test assumes requests are stateless.
+		// e2eframework.CreateServer configures httpexpect with a client that has no cookie jar,
+		// so auth cookies from previous requests are never persisted.
 		project2Entity := e2eframework.NewProject("mysuperproject2")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathProject)).WithJSON(project2Entity).WithHeader("Authorization", "Bearer <bad token>").Expect().Status(http.StatusUnauthorized)
 

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -191,6 +191,9 @@ func CreateServer(t *testing.T, conf apiConfig.Config) (*httptest.Server, *httpe
 	return server, httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  server.URL,
 		Reporter: httpexpect.NewAssertReporter(t),
+		// Keep e2e requests stateless: do not persist cookies between requests.
+		// This is explicit and avoids Go runtime cookiejar behavior changes (e.g. localhost Secure cookies).
+		Client: &http.Client{Jar: nil},
 	}), dependencyManager
 }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
