### PR TITLE
[ENHANCEMENT] Allow decrypt secret in DB with "authenticated" mode AEAD for future backward compatibility

### DIFF
--- a/internal/api/crypto/crypto.go
+++ b/internal/api/crypto/crypto.go
@@ -25,13 +25,31 @@ import (
 
 	"github.com/perses/perses/pkg/model/api/config"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
 )
 
-// based on https://www.golinuxcloud.com/golang-encrypt-decrypt/
+// TODO(celian-garcia): follow the plan described in the following issue to migrate old encryption to new encryption,
+//  maximizing backward compatibility: https://github.com/perses/perses/issues/2901
+//  ==========================================================
+// 	s0 (based on https://www.golinuxcloud.com/golang-encrypt-decrypt/)
+// 	- encrypt in BAD
+// 	- decrypt in BAD
+// 	*s1 (*current situation)
+// 	- encrypt in BAD
+// 	- decrypt in GOOD or BAD
+// 	s2
+// 	- encrypt in GOOD
+//  - decrypt in GOOD or BAD (+reencrypt script on start)
+// 	s3
+// 	- encrypt in GOOD
+//  - decrypt in GOOD
+//  ==========================================================
 
 type Crypto interface {
 	Encrypt(spec *modelV1.SecretSpec) error
-	Decrypt(spec *modelV1.SecretSpec) error
+	// Decrypt decrypts the spec fields in place.
+	// Returns true if the data was encrypted with the old format and needs re-encryption.
+	Decrypt(spec *modelV1.SecretSpec) (bool, error)
 }
 
 func New(security config.Security) (Crypto, JWT, error) {
@@ -45,8 +63,9 @@ func New(security config.Security) (Crypto, JWT, error) {
 		return nil, nil, err
 	}
 	return &crypto{
-			key:   key,
-			block: aesBlock,
+			usingAuthenticatedEncryption: false,
+			key:                          key,
+			block:                        aesBlock,
 		},
 		&jwtImpl{
 			accessKey:       key,
@@ -57,9 +76,17 @@ func New(security config.Security) (Crypto, JWT, error) {
 		}, nil
 }
 
+// crypto is an implementation of the encrypt / decrypt interface that allows the user to decide which algorithm to be
+// used for encryption. For decryption, it will use both for compatibility.
 type crypto struct {
-	key   []byte
-	block cipher.Block
+	// usingAuthenticatedEncryption allow you to choose between:
+	// - authenticated algorithm (AEAD): we use here GCM (Galois/Counter Mode)
+	// - unauthenticated algorithm: we use here CFB (Cipher Feedback)
+	// === /!\ Beware to not play too much with that to avoid backward incompatibility. /!\ ===
+	// === /!\ This is mainly used internally in a migration process of several months. /!\ ===
+	usingAuthenticatedEncryption bool
+	key                          []byte
+	block                        cipher.Block
 }
 
 func (c *crypto) Encrypt(spec *modelV1.SecretSpec) error {
@@ -106,55 +133,71 @@ func (c *crypto) Encrypt(spec *modelV1.SecretSpec) error {
 	return nil
 }
 
-func (c *crypto) Decrypt(spec *modelV1.SecretSpec) error {
-	basicAuth := spec.BasicAuth
-	if basicAuth != nil {
-		decryptedPassword, err := c.decrypt(basicAuth.Password)
+func (c *crypto) Decrypt(spec *modelV1.SecretSpec) (bool, error) {
+	needsReEncryption := false
+
+	if spec.BasicAuth != nil {
+		decrypted, legacy, err := c.decrypt(spec.BasicAuth.Password)
 		if err != nil {
-			return err
+			return false, err
 		}
-		basicAuth.Password = decryptedPassword
+		spec.BasicAuth.Password = decrypted
+		needsReEncryption = needsReEncryption || legacy
 	}
 
-	authorization := spec.Authorization
-	if authorization != nil {
-		decryptedCredentials, err := c.decrypt(authorization.Credentials)
+	if spec.Authorization != nil {
+		decrypted, legacy, err := c.decrypt(spec.Authorization.Credentials)
 		if err != nil {
-			return err
+			return false, err
 		}
-		authorization.Credentials = decryptedCredentials
+		spec.Authorization.Credentials = decrypted
+		needsReEncryption = needsReEncryption || legacy
 	}
 
-	oauth := spec.OAuth
-	if oauth != nil {
-		decryptedClientID, err := c.decrypt(oauth.ClientID)
+	if spec.OAuth != nil {
+		decrypted, legacy, err := c.decrypt(spec.OAuth.ClientID)
 		if err != nil {
-			return err
+			return false, err
 		}
-		oauth.ClientID = decryptedClientID
+		spec.OAuth.ClientID = decrypted
+		needsReEncryption = needsReEncryption || legacy
 
-		decryptedClientSecret, err := c.decrypt(oauth.ClientSecret)
+		decrypted, legacy, err = c.decrypt(spec.OAuth.ClientSecret)
 		if err != nil {
-			return err
+			return false, err
 		}
-		oauth.ClientSecret = decryptedClientSecret
+		spec.OAuth.ClientSecret = decrypted
+		needsReEncryption = needsReEncryption || legacy
 	}
 
-	tlsConfig := spec.TLSConfig
-	if tlsConfig != nil {
-		decryptedKey, err := c.decrypt(tlsConfig.Key)
+	if spec.TLSConfig != nil {
+		decrypted, legacy, err := c.decrypt(spec.TLSConfig.Key)
 		if err != nil {
-			return err
+			return false, err
 		}
-		tlsConfig.Key = decryptedKey
+		spec.TLSConfig.Key = decrypted
+		needsReEncryption = needsReEncryption || legacy
 	}
-	return nil
+
+	return needsReEncryption, nil
 }
 
-func (c *crypto) encrypt(stringToEncrypt string) (string, error) {
-	if len(stringToEncrypt) == 0 {
-		return "", nil
+func (c *crypto) encryptGCM(stringToEncrypt string) (string, error) {
+	gcm, err := cipher.NewGCM(c.block)
+	if err != nil {
+		return "", err
 	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	cipherText := gcm.Seal(nonce, nonce, []byte(stringToEncrypt), nil)
+	return base64.URLEncoding.EncodeToString(cipherText), nil
+}
+
+func (c *crypto) encryptCFB(stringToEncrypt string) (string, error) {
 	plainText := []byte(stringToEncrypt)
 	cipherText := make([]byte, aes.BlockSize+len(plainText))
 	iv := cipherText[:aes.BlockSize]
@@ -162,32 +205,83 @@ func (c *crypto) encrypt(stringToEncrypt string) (string, error) {
 		return "", err
 	}
 
-	// TODO use AEAD instead of CFB as recommended by Go
 	stream := cipher.NewCFBEncrypter(c.block, iv) //nolint: staticcheck
 	stream.XORKeyStream(cipherText[aes.BlockSize:], plainText)
 
 	return base64.URLEncoding.EncodeToString(cipherText), nil
 }
 
-func (c *crypto) decrypt(stringToDecrypt string) (string, error) {
-	if len(stringToDecrypt) == 0 {
+// encrypt uses AES-GCM (AEAD) or old CFB format to encrypt the string.
+// The returned string is base64 encoded and contains the nonce as prefix.
+func (c *crypto) encrypt(stringToEncrypt string) (string, error) {
+	if len(stringToEncrypt) == 0 {
 		return "", nil
 	}
-	cipherText, err := base64.URLEncoding.DecodeString(stringToDecrypt)
+
+	if c.usingAuthenticatedEncryption {
+		return c.encryptGCM(stringToEncrypt)
+	}
+	return c.encryptCFB(stringToEncrypt)
+}
+
+func (c *crypto) decryptGCM(cipherText []byte) (string, error) {
+	gcm, err := cipher.NewGCM(c.block)
 	if err != nil {
 		return "", err
 	}
+
+	if len(cipherText) >= gcm.NonceSize() {
+		nonce := cipherText[:gcm.NonceSize()]
+		plainText, err := gcm.Open(nil, nonce, cipherText[gcm.NonceSize():], nil)
+		if err == nil {
+			return string(plainText), nil
+		}
+	}
+	return "", nil
+}
+
+func (c *crypto) decryptCFB(cipherText []byte) (string, error) {
 	if len(cipherText) < aes.BlockSize {
 		return "", fmt.Errorf("ciphertext too short")
 	}
 	iv := cipherText[:aes.BlockSize]
 	cipherText = cipherText[aes.BlockSize:]
 
-	// TODO use AEAD instead of CFB as recommended by Go
 	stream := cipher.NewCFBDecrypter(c.block, iv) //nolint: staticcheck
 
 	// XORKeyStream can work in-place if the two arguments are the same.
 	stream.XORKeyStream(cipherText, cipherText)
 
 	return string(cipherText), nil
+}
+
+// decrypt tries AES-GCM (AEAD) first. If it fails, it falls back to the old CFB format.
+// Returns (plaintext, needsReEncryption, error).
+func (c *crypto) decrypt(stringToDecrypt string) (string, bool, error) {
+	if len(stringToDecrypt) == 0 {
+		return "", false, nil
+	}
+
+	cipherText, decodeErr := base64.URLEncoding.DecodeString(stringToDecrypt)
+	if decodeErr != nil {
+		return "", false, decodeErr
+	}
+
+	// Try GCM first
+	plaintext, err := c.decryptGCM(cipherText)
+	if err != nil {
+		return plaintext, false, err
+	}
+	if len(plaintext) > 0 {
+		return plaintext, false, nil
+	}
+
+	logrus.Debugf("Failed to decrypt with GCM (old format), falling back to CFB (new authenticated format)")
+
+	// Fallback to old CFB format
+	plaintext, err = c.decryptCFB(cipherText)
+	// If decryption is successful with the old format, we need to re-encrypt it with the new format.
+	// But only if the encryption with new format is enabled.
+	needsReEncryption := c.usingAuthenticatedEncryption && err == nil
+	return plaintext, needsReEncryption, err
 }

--- a/internal/api/crypto/crypto_test.go
+++ b/internal/api/crypto/crypto_test.go
@@ -1,0 +1,216 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/secret"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func authLabel(authenticated bool) string {
+	if authenticated {
+		return "authenticated"
+	}
+	return "unauthenticated"
+}
+
+func generateTestKey() []byte {
+	keyHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func createTestCrypto(t *testing.T, authenticated bool) *crypto {
+	key := generateTestKey()
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	return &crypto{
+		usingAuthenticatedEncryption: authenticated,
+		key:                          key,
+		block:                        block,
+	}
+}
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	testCases := []string{
+		"",
+		"a",
+		"mysecretpassword",
+		"complex!@#$%^&*()password",
+		"multiline\npassword",
+		"unicode_パスワード",
+	}
+
+	for _, authenticated := range []bool{true, false} {
+		t.Run(authLabel(authenticated), func(t *testing.T) {
+			c := createTestCrypto(t, authenticated)
+			for _, plaintext := range testCases {
+				t.Run(plaintext, func(t *testing.T) {
+					encrypted, err := c.encrypt(plaintext)
+					require.NoError(t, err)
+
+					decrypted, needsReEncryption, err := c.decrypt(encrypted)
+					require.NoError(t, err)
+					assert.Equal(t, plaintext, decrypted)
+					assert.False(t, needsReEncryption)
+				})
+			}
+		})
+	}
+}
+
+func TestEncryptDecrypt_DifferentEncryptions(t *testing.T) {
+	for _, authenticated := range []bool{true, false} {
+		t.Run(authLabel(authenticated), func(t *testing.T) {
+			c := createTestCrypto(t, authenticated)
+			plaintext := "samepassword"
+
+			encrypted1, err := c.encrypt(plaintext)
+			require.NoError(t, err)
+
+			encrypted2, err := c.encrypt(plaintext)
+			require.NoError(t, err)
+
+			// Due to random nonce, two encryptions of the same plaintext should differ
+			assert.NotEqual(t, encrypted1, encrypted2)
+
+			decrypted1, _, err := c.decrypt(encrypted1)
+			require.NoError(t, err)
+			decrypted2, _, err := c.decrypt(encrypted2)
+			require.NoError(t, err)
+			assert.Equal(t, plaintext, decrypted1)
+			assert.Equal(t, plaintext, decrypted2)
+		})
+	}
+}
+
+func TestEncryptDecryptSpec(t *testing.T) {
+	for _, authenticated := range []bool{true, false} {
+		t.Run(authLabel(authenticated), func(t *testing.T) {
+			c := createTestCrypto(t, authenticated)
+			spec := &modelV1.SecretSpec{
+				BasicAuth: &secret.BasicAuth{
+					Username: "user",
+					Password: "pass123",
+				},
+				Authorization: &secret.Authorization{
+					Credentials: "Bearer token",
+				},
+				OAuth: &secret.OAuth{
+					ClientID:     "client123",
+					ClientSecret: "secret123",
+				},
+			}
+
+			originalPassword := spec.BasicAuth.Password
+			originalCredentials := spec.Authorization.Credentials
+			originalClientID := spec.OAuth.ClientID
+			originalClientSecret := spec.OAuth.ClientSecret
+
+			err := c.Encrypt(spec)
+			require.NoError(t, err)
+			assert.NotEqual(t, originalPassword, spec.BasicAuth.Password)
+			assert.NotEqual(t, originalCredentials, spec.Authorization.Credentials)
+			assert.NotEqual(t, originalClientID, spec.OAuth.ClientID)
+			assert.NotEqual(t, originalClientSecret, spec.OAuth.ClientSecret)
+
+			needsReEncryption, err := c.Decrypt(spec)
+			require.NoError(t, err)
+			assert.False(t, needsReEncryption)
+			assert.Equal(t, originalPassword, spec.BasicAuth.Password)
+			assert.Equal(t, originalCredentials, spec.Authorization.Credentials)
+			assert.Equal(t, originalClientID, spec.OAuth.ClientID)
+			assert.Equal(t, originalClientSecret, spec.OAuth.ClientSecret)
+		})
+	}
+}
+
+func TestEncryptDecryptSpec_NilFields(t *testing.T) {
+	for _, authenticated := range []bool{true, false} {
+		t.Run(authLabel(authenticated), func(t *testing.T) {
+			c := createTestCrypto(t, authenticated)
+			spec := &modelV1.SecretSpec{}
+
+			err := c.Encrypt(spec)
+			require.NoError(t, err)
+
+			needsReEncryption, err := c.Decrypt(spec)
+			require.NoError(t, err)
+			assert.False(t, needsReEncryption)
+		})
+	}
+}
+
+func TestDecrypt_InvalidInputs(t *testing.T) {
+	for _, authenticated := range []bool{true, false} {
+		t.Run(authLabel(authenticated), func(t *testing.T) {
+			c := createTestCrypto(t, authenticated)
+
+			_, _, err := c.decrypt("!!!invalid base64!!!")
+			assert.Error(t, err)
+
+			_, _, err = c.decrypt("YQ==") // too short
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestBackwardCompatibility_CFBToGCM(t *testing.T) {
+	c := createTestCrypto(t, true)
+	plaintext := "mysecretpassword"
+
+	// Encrypt with old CFB format
+	cfbCiphertext := encryptCFB(c, plaintext)
+
+	// Decrypt should work and flag for re-encryption
+	decrypted, needsReEncryption, err := c.decrypt(cfbCiphertext)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+	assert.True(t, needsReEncryption)
+
+	// Now encrypt with new GCM format
+	gcmCiphertext, err := c.encrypt(plaintext)
+	require.NoError(t, err)
+
+	// Should not need re-encryption
+	decrypted, needsReEncryption, err = c.decrypt(gcmCiphertext)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+	assert.False(t, needsReEncryption)
+}
+
+// encryptCFB simulates the old CFB encryption for backward compatibility tests.
+func encryptCFB(c *crypto, plaintext string) string {
+	plainTextBytes := []byte(plaintext)
+	cipherText := make([]byte, aes.BlockSize+len(plainTextBytes))
+	iv := cipherText[:aes.BlockSize]
+	_, _ = rand.Reader.Read(iv)
+
+	stream := cipher.NewCFBEncrypter(c.block, iv) //nolint: staticcheck
+	stream.XORKeyStream(cipherText[aes.BlockSize:], plainTextBytes)
+
+	return base64.URLEncoding.EncodeToString(cipherText)
+}

--- a/internal/api/impl/proxy/proxy.go
+++ b/internal/api/impl/proxy/proxy.go
@@ -217,7 +217,7 @@ func newProxy(datasourceName, projectName string, spec datasourceSpec.Spec, path
 			if err != nil {
 				return nil, err
 			}
-			if decryptErr := crypto.Decrypt(scrt); decryptErr != nil {
+			if _, decryptErr := crypto.Decrypt(scrt); decryptErr != nil {
 				logrus.WithError(decryptErr).WithFields(map[string]interface{}{
 					datasourceFieldLog: datasourceName,
 					projectFieldLog:    projectForLog(projectName),
@@ -238,7 +238,7 @@ func newProxy(datasourceName, projectName string, spec datasourceSpec.Spec, path
 			if err != nil {
 				return nil, err
 			}
-			if decryptErr := crypto.Decrypt(scrt); decryptErr != nil {
+			if _, decryptErr := crypto.Decrypt(scrt); decryptErr != nil {
 				logrus.WithError(decryptErr).WithFields(map[string]interface{}{
 					datasourceFieldLog: datasourceName,
 					projectFieldLog:    projectForLog(projectName),


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Objective of this PR is to migrate the Perses encryption from CFB (deprecated, unauthenticated) to GCM (AEAD, authenticated) while maintaining full backward compatibility with old data.

Ref: https://go.dev/doc/go1.24#cryptocipherpkgcryptocipher

- [x] Encrypt method can encrypt in both GCM and CFB formats ~
- [x] Decrypt method use first GCM then CFB as fallback for backward compatibility
- [x] Decrypt method returns a boolean to tells user that the data has been encrypted with old model, and needs to be encrypted again
- [ ] ~Everywhere we use Decrypt after fetching a DB object, we need to reencrypt and save with new encryption.~
-> Not yet for backward compatibility. Will be done differently with a script on start.


relates #2901 

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A
