### PR TITLE
[ignore] replace usage of github.com/redbo/gohsv in favor of github.com/crazy3lf/colorconv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.2-0.20240726212847-3a740cf7976f
 	github.com/brunoga/deep v1.3.1
 	github.com/charmbracelet/huh v1.0.0
+	github.com/crazy3lf/colorconv v1.2.0
 	github.com/efficientgo/core v1.0.0-rc.3
 	github.com/fatih/color v1.19.0
 	github.com/fsnotify/fsnotify v1.10.1
@@ -34,7 +35,6 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/common/assets v0.2.0
 	github.com/prometheus/promu v0.18.1
-	github.com/redbo/gohsv v0.0.0-20191210185714-eac2cca0cae9
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03V
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/crazy3lf/colorconv v1.2.0 h1:UM7kSZWnwFMGiC+PpYrjxQSOd6sEyWb+dRKKTd3KslA=
+github.com/crazy3lf/colorconv v1.2.0/go.mod h1:2jTJ7QCWCj2sSLOhF4Gzi0J5/hoX8/VY8VzNvXAlD1I=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
@@ -496,8 +498,6 @@ github.com/prometheus/promu v0.18.1 h1:XHW7QooowPkJRsrULFfiIhdtfPYeXN0gQAZ9yzHQP
 github.com/prometheus/promu v0.18.1/go.mod h1:K7oXFdmDNWtT/z2R6VUcp+CzH8di44jzn3e0KL4zawk=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20260217160748-a481f6a22f94 h1:2PC6Ql3jipz1KvBlqUHjjk6v4aMwE86mfDu1XMH0LR8=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20260217160748-a481f6a22f94/go.mod h1:JSbkp0BviKovYYt9XunS95M3mLPibE9bGg+Y95DsEEY=
-github.com/redbo/gohsv v0.0.0-20191210185714-eac2cca0cae9 h1:sLkcyZjpHheUmUGTvlTyBGavi32krtUjVzxEnrgspCg=
-github.com/redbo/gohsv v0.0.0-20191210185714-eac2cca0cae9/go.mod h1:nCp2JIf5URL6ISQMiNR5fApUfK5jfC+nbPjNVsbtWE4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/internal/cli/cmd/plugin/start/color.go
+++ b/internal/cli/cmd/plugin/start/color.go
@@ -17,8 +17,8 @@ import (
 	"math"
 	"math/rand/v2"
 
+	"github.com/crazy3lf/colorconv"
 	"github.com/fatih/color"
-	"github.com/redbo/gohsv"
 )
 
 const goldenRatioConjugate = 0.618033988749895
@@ -32,7 +32,7 @@ func generateColors(n int) []*color.Color {
 	for range n {
 		h := rand.Float64() + goldenRatioConjugate // nolint: gosec // We don't need a secure random number here.
 		h = math.Mod(h, 1.0)                       // Normalize the value to keep only the decimal value.
-		r, g, b := gohsv.HSVtoRGB(h*360, 0.5, 0.95)
+		r, g, b, _ := colorconv.HSVToRGB(h*360, 0.5, 0.95)
 		result = append(result, color.RGB(int(r), int(g), int(b)))
 	}
 	return result


### PR DESCRIPTION
The previous library did not contain any license and because of that we were not allowed to use this library. ([github documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#choosing-the-right-license) for more information)

I have found another implementation to transform HSV to RGB which is under the MIT license.

close https://github.com/perses/perses/discussions/4073