### PR TITLE
[BUGFIX] Fix some error message when password/credentials files config missing

### DIFF
--- a/pkg/model/api/v1/secret/authorization.go
+++ b/pkg/model/api/v1/secret/authorization.go
@@ -92,7 +92,7 @@ func (a *Authorization) GetCredentials() (string, error) {
 
 func (a *Authorization) validate() error {
 	if len(a.Credentials) > 0 && len(a.CredentialsFile) > 0 {
-		return fmt.Errorf("at most one of authorization credentials & credentials_file must be configured")
+		return fmt.Errorf("at most one of authorization credentials & credentialsFile must be configured")
 	}
 	a.Type = strings.TrimSpace(a.Type)
 	if len(a.Type) == 0 {

--- a/pkg/model/api/v1/secret/basic_auth.go
+++ b/pkg/model/api/v1/secret/basic_auth.go
@@ -84,10 +84,10 @@ func (b *BasicAuth) GetPassword() (string, error) {
 
 func (b *BasicAuth) validate() error {
 	if len(b.Username) == 0 || (len(b.Password) == 0 && len(b.PasswordFile) == 0) {
-		return fmt.Errorf("when using basicAuth, username and password/password_file cannot be empty")
+		return fmt.Errorf("when using basicAuth, username and password/passwordFile cannot be empty")
 	}
 	if len(b.Password) > 0 && len(b.PasswordFile) > 0 {
-		return fmt.Errorf("at most one of basicAuth password & password_file must be configured")
+		return fmt.Errorf("at most one of basicAuth password & passwordFile must be configured")
 	}
 	return nil
 }


### PR DESCRIPTION
…

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This is confusing when you put 
```yaml
basicAuth:
  username: "johndoe"
  password_file: "/etc/secret.txt"
```

And the error message is "when using basicAuth, username and password/password_file cannot be empty"

I think there is still some discrepancies in the config. But I don't want to make breaking changes 
<img width="1401" height="568" alt="image" src="https://github.com/user-attachments/assets/e2733eee-ed95-42b4-b07d-f797d7aca2b1" />

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A
