### PR TITLE
[FEATURE] By configuration, enable or disable plugins

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -840,6 +840,18 @@ archive_paths:
 # Allow use of plugins in dev mode.
 enable_dev: <bool> | default = false # Optional
 
+# The list of plugin or module activated. Leave empty if you want to activate all plugins found in the `path` directory.
+# If not empty, only the plugins whose name is in this list will be activated.
+# The name can be the name of the plugin or the name of the module. For example, you can put `Prometheus` to enable the Prometheus module that contains query, variables and datasource plugin.
+# Use either Enabled or Disabled. Both can not be used at the same time.
+enabled:
+    - <string> # Optional
+# The list of plugin or module deactivated. Leave empty if you want to activate all plugins found in the `path` directory.
+# If not empty, the plugins whose name is in this list will be deactivated.
+# The name can be the name of the plugin or the name of the module. For example, you can put `Prometheus` to disable the Prometheus module that contains query, variables and datasource plugin.
+# Use either Enabled or Disabled. Both can not be used at the same time.
+disabled:
+  - <string> # Optional
 ```
 
 ### Dashboard config

--- a/internal/api/plugin/plugin.go
+++ b/internal/api/plugin/plugin.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -83,6 +84,8 @@ func New(cfg config.Plugin) Plugin {
 			folders:      cfg.ArchivePaths,
 			targetFolder: cfg.Path,
 		},
+		enabled:   cfg.Enabled,
+		disabled:  cfg.Disabled,
 		sch:       schema.New(),
 		mig:       migrate.New(),
 		loaded:    make(tree.Tree[*Loaded]),
@@ -97,6 +100,10 @@ type pluginFile struct {
 	loaded tree.Tree[*Loaded]
 	// devLoaded is a map that contains all the loaded plugin modules in development mode.
 	devLoaded tree.Tree[*Loaded]
+	// enabled is the list of plugin or module that will be kept when loading them from the file system. If empty, all plugins/modules will be loaded.
+	enabled []string
+	// disabled is the list of plugin or module that will be dropped when loading them from the file system. If empty, all plugins/modules will be loaded.
+	disabled []string
 	// archibal is the archive service used only to extract the plugin files from the archive.
 	archibal *arch
 	// sch is the service used to load and provide the schema of the plugin.
@@ -220,6 +227,11 @@ func (p *pluginFile) loadSinglePlugin(file os.DirEntry, pluginPath string) *v1.P
 	}
 	pluginModule.Spec = npmPackageData.Perses
 
+	if p.filter(pluginModule) {
+		logrus.Debugf("plugin module %q has been filtered", manifest.Name)
+		return nil
+	}
+
 	if IsSchemaRequired(pluginModule.Spec) {
 		if pluginSchemaLoadErr := p.sch.Load(pluginPath, *pluginModule); pluginSchemaLoadErr != nil {
 			pluginStatus.IsLoaded = false
@@ -259,4 +271,39 @@ func (p *pluginFile) storeLoadedList() error {
 		return marshalErr
 	}
 	return os.WriteFile(filepath.Join(p.path, pluginFileName), marshalData, 0644) // nolint: gosec
+}
+
+// filter is filtering the module and/or the plugins based on the configuration.
+// The boolean returned is true if the complete module is filtered, false if only some plugins are filtered or if no filtering is applied.
+func (p *pluginFile) filter(pluginModule *v1.PluginModule) bool {
+	if len(p.enabled) > 0 {
+		// if the module or the plugin is in the activated list, we keep it, otherwise we filter it out
+		if slices.Contains(p.enabled, strings.ToLower(pluginModule.Metadata.Name)) {
+			return false
+		}
+		var newSpec []plugin.Plugin
+		for _, plg := range pluginModule.Spec.Plugins {
+			if slices.Contains(p.enabled, strings.ToLower(plg.Spec.Name)) {
+				newSpec = append(newSpec, plg)
+			}
+		}
+		pluginModule.Spec.Plugins = newSpec
+		// if the length of the new spec is 0, it means that all the plugins of the module are filtered out, so we can filter out the complete module
+		return len(newSpec) == 0
+	}
+	if len(p.disabled) > 0 {
+		// we can then check if the module or plugins are dropped. Logic is the opposite of the activation, if the module or the plugin is in the deactivated list, we filter it out, otherwise we keep it.
+		if slices.Contains(p.disabled, strings.ToLower(pluginModule.Metadata.Name)) {
+			return true
+		}
+		var newSpec []plugin.Plugin
+		for _, plg := range pluginModule.Spec.Plugins {
+			if !slices.Contains(p.disabled, strings.ToLower(plg.Spec.Name)) {
+				newSpec = append(newSpec, plg)
+			}
+		}
+		pluginModule.Spec.Plugins = newSpec
+		return len(newSpec) == 0
+	}
+	return false
 }

--- a/internal/api/plugin/plugin_test.go
+++ b/internal/api/plugin/plugin_test.go
@@ -1,0 +1,348 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilter(t *testing.T) {
+	tests := []struct {
+		title          string
+		enabled        []string
+		disabled       []string
+		module         *v1.PluginModule
+		isFiltered     bool
+		expectedModule *v1.PluginModule
+	}{
+		{
+			title: "no filter",
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "foo",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: false,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "activated",
+			enabled: []string{
+				"foo",
+			},
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "foo",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: false,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "not activated",
+			enabled: []string{
+				"bar",
+			},
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "foo",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: true,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{},
+			},
+		},
+		{
+			title: "activated but with less plugins",
+			enabled: []string{
+				"bar",
+			},
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "tartampion",
+							},
+						},
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: false,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "deactivated",
+			disabled: []string{
+				"foo",
+			},
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: true,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "deactivated with no plugins",
+			disabled: []string{
+				"bar",
+			},
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: true,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{},
+			},
+		},
+		{
+			title: "deactivated with less plugins",
+			disabled: []string{
+				"bar",
+			},
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "tartampion",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: false,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "tartampion",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "not deactivated",
+			disabled: []string{
+				"tartampion",
+			},
+			module: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+			isFiltered: false,
+			expectedModule: &v1.PluginModule{
+				Kind: v1.PluginModuleKind,
+				Metadata: plugin.ModuleMetadata{
+					Name: "foo",
+				},
+				Spec: plugin.ModuleSpec{
+					Plugins: []plugin.Plugin{
+						{
+							Kind: plugin.KindPanel,
+							Spec: plugin.Spec{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			p := &pluginFile{
+				enabled:  test.enabled,
+				disabled: test.disabled,
+			}
+			result := p.filter(test.module)
+			assert.Equal(t, test.expectedModule, test.module)
+			assert.Equal(t, test.isFiltered, result)
+		})
+	}
+}

--- a/pkg/model/api/config/plugin.go
+++ b/pkg/model/api/config/plugin.go
@@ -14,7 +14,9 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -46,6 +48,16 @@ type Plugin struct {
 	ArchivePaths []string `json:"archive_paths,omitempty" yaml:"archive_paths,omitempty"`
 	// DevEnvironment is the configuration to use when developing a plugin
 	EnableDev bool `json:"enable_dev" yaml:"enable_dev"`
+	// Enabled is a list of plugin activated. Leave empty if you want to activate all plugins found in the `path` directory.
+	// If not empty, only the plugins whose name is in this list will be activated.
+	// The name can be the name of the plugin or the name of the module. For example, you can put `Prometheus` to enable the Prometheus module that contains query, variables and datasource plugin.
+	// Use either Enabled or Disabled. Both can not be used at the same time.
+	Enabled []string `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// Disabled is a list of plugin deactivated. Leave empty if you want to activate all plugins found in the `path` directory.
+	// If not empty, the plugins whose name is in this list will be deactivated.
+	// The name can be the name of the plugin or the name of the module. For example, you can put `Prometheus` to disable the Prometheus module that contains query, variables and datasource plugin.
+	// Use either Enabled or Disabled. Both can not be used at the same time.
+	Disabled []string `json:"disabled,omitempty" yaml:"disabled,omitempty"`
 }
 
 func (p *Plugin) Verify() error {
@@ -72,6 +84,23 @@ func (p *Plugin) Verify() error {
 		} else {
 			p.ArchivePaths = append(p.ArchivePaths, DefaultArchivePluginPath)
 		}
+	}
+	if len(p.Enabled) > 0 && len(p.Disabled) > 0 {
+		return fmt.Errorf("the 'activated' and 'deactivated' attributes can not be used at the same time. Please use either one of them")
+	}
+	if len(p.Enabled) > 0 {
+		newEnabled := make([]string, len(p.Enabled))
+		for _, s := range p.Enabled {
+			newEnabled = append(newEnabled, strings.ToLower(s))
+		}
+		p.Enabled = newEnabled
+	}
+	if len(p.Disabled) > 0 {
+		newDisabled := make([]string, len(p.Disabled))
+		for _, s := range p.Disabled {
+			newDisabled = append(newDisabled, strings.ToLower(s))
+		}
+		p.Disabled = newDisabled
 	}
 	return nil
 }


### PR DESCRIPTION
This PR is proposing a way to disable or enable the various plugin available in the folder `plugins`. 

It fix #4075

Now, with the following config

```yaml
plugin:
  disabled:
    - "pyroscope"
    - "victoriaLogs"
    - "clickHouse"
    - "tempo"
```

I have now only one datasource activated and only the prometheus explorer available
<img width="792" height="613" alt="Screenshot 2026-05-26 at 12 33 55" src="https://github.com/user-attachments/assets/10dce62f-51f4-43dd-8163-02b5d5b73288" />