### PR TITLE
[BUGFIX] Fix `percli get user` panic when users exist

### DIFF
--- a/internal/cli/service/user.go
+++ b/internal/cli/service/user.go
@@ -48,7 +48,7 @@ func (u *user) DeleteResource(name string) error {
 func (u *user) BuildMatrix(hits []modelAPI.Entity) [][]string {
 	var data [][]string
 	for _, hit := range hits {
-		entity := hit.(*modelV1.User)
+		entity := hit.(*modelV1.PublicUser)
 		line := []string{
 			entity.Metadata.Name,
 			output.FormatAge(entity.Metadata.UpdatedAt),


### PR DESCRIPTION
# Description

Small change to fix a panic when running `percli get user` if one or more user exist. Discussion here: https://github.com/perses/perses/discussions/4091

Steps to reproduce the issue:
```bash
$ percli get user
 NAME │ AGE

$ percli apply -f user.yml
object "User" "daniel" has been applied

$ percli get user
panic: interface conversion: api.Entity is *v1.PublicUser, not *v1.User

[...]
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).