### PR TITLE
[ignore] trigger workflow to cleanup old docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,17 @@
+name: docker
+on:
+  schedule:
+    - cron: '0 0 1 * *' # Run on the first day of every month at midnight'
+jobs:
+  cleanup:
+    name: "cleanup old docker images"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - uses: perses/github-actions@v0.12.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+      - name: cleanup old images
+        run: go run ./scripts/docker-cleanup/docker-cleanup.go --username="${{ secrets.DOCKER_USERNAME }}" --password="${{ secrets.DOCKER_PASSWORD }}" --dry-run=false

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We are providing an online demo available at **https://demo.perses.dev**, where 
    * The data model reached a stable point, and we are providing multiple panel types that should cover most of the monitoring & tracing use cases.
    * Authentication and authorization are available.
 2. On the GitOps aspect:
-   * We provide a CLI that helps interacting with the API. A short doc is available [here](./docs/cli.md)
+   * We provide a CLI that helps to interact with the API. A short doc is available [here](./docs/cli.md)
    * Two SDKs (in Golang and in Cuelang) are available for coding dashboards. See [Dashboard-as-Code](./docs/dac/getting-started.md) guide.
      These SDKs will likely evolve based on the feedback we receive. However, changes are expected to focus on adding utility functions rather than introducing breaking changes.
 3. A plugin architecture:
@@ -93,7 +93,7 @@ We have [a Homebrew tap](https://github.com/perses/homebrew-tap) so macOS and Li
 
 To build Perses from source code, You need:
 
-- Go [version 1.23 or greater](https://golang.org/doc/install).
+- Go [version 1.26 or greater](https://golang.org/doc/install).
 - NodeJS [version 22 or greater](https://nodejs.org/).
 - npm [version 10 or greater](https://www.npmjs.com/).
 

--- a/scripts/docker-cleanup/docker-cleanup.go
+++ b/scripts/docker-cleanup/docker-cleanup.go
@@ -1,0 +1,185 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultRepository = "perses"
+	defaultNamespace  = "persesdev"
+)
+
+type loginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type loginResponse struct {
+	Token string `json:"token"`
+}
+
+type tagsResponse struct {
+	Next    string `json:"next"`
+	Results []struct {
+		Name        string    `json:"name"`
+		LastUpdated time.Time `json:"last_updated"`
+	} `json:"results"`
+}
+
+type dockerHubClient struct {
+	client *http.Client
+	token  string
+}
+
+func (d *dockerHubClient) login(username, password string) error {
+	body, _ := json.Marshal(loginRequest{Username: username, Password: password}) // nolint:gosec
+	req, err := http.NewRequest(http.MethodPost, "https://hub.docker.com/v2/users/login/", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		b, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("login failed: %s: %s", res.Status, string(b))
+	}
+
+	var lr loginResponse
+	if err := json.NewDecoder(res.Body).Decode(&lr); err != nil {
+		return err
+	}
+	if lr.Token == "" {
+		return fmt.Errorf("empty token in login response")
+	}
+	d.token = lr.Token
+	logrus.Info("login succeeded")
+	return nil
+}
+
+func (d *dockerHubClient) listTags(endpoint string) (*tagsResponse, error) {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+d.token)
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		b, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("list tags failed: %s: %s", res.Status, string(b))
+	}
+
+	var tr tagsResponse
+	if err := json.NewDecoder(res.Body).Decode(&tr); err != nil {
+		return nil, err
+	}
+	return &tr, nil
+}
+
+func (d *dockerHubClient) deleteTag(tag string) error {
+	logrus.Infof("deleting tag: %s", tag)
+	endpoint := fmt.Sprintf("https://hub.docker.com/v2/repositories/%s/%s/tags/%s/", defaultNamespace, defaultRepository, url.PathEscape(tag))
+	req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+d.token)
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		b, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("delete tag %q failed: %s: %s", tag, res.Status, string(b))
+	}
+	return nil
+}
+
+// This script is removing docker image from dockerhub older than one month. It only removes images starting with 'main-'.
+// So only the images created for each commit.
+func main() {
+	var (
+		username = flag.String("username", os.Getenv("DOCKERHUB_USER"), "Docker Hub username")
+		password = flag.String("password", os.Getenv("DOCKERHUB_PAT"), "Docker Hub PAT/password")
+		dryRun   = flag.Bool("dry-run", true, "Only print tags that would be deleted")
+		pageSize = flag.Int("page-size", 100, "Tags page size")
+	)
+	flag.Parse()
+
+	if *username == "" || *password == "" {
+		fmt.Fprintln(os.Stderr, "missing required params: username, password")
+		os.Exit(1)
+	}
+	client := &dockerHubClient{client: &http.Client{Timeout: 30 * time.Second}}
+
+	must(client.login(*username, *password))
+
+	cutoff := time.Now().UTC().AddDate(0, -1, 0) // 1 month ago
+	nextURL := fmt.Sprintf("https://hub.docker.com/v2/namespaces/%s/repositories/%s/tags?page_size=%d", defaultNamespace, defaultRepository, *pageSize)
+
+	for nextURL != "" {
+		resp, err := client.listTags(nextURL)
+		must(err)
+
+		for _, t := range resp.Results {
+			if !strings.HasPrefix(t.Name, "main-") {
+				continue
+			}
+			if t.LastUpdated.Before(cutoff) {
+				if *dryRun {
+					fmt.Printf("Would delete: %s (last_updated=%s)\n", t.Name, t.LastUpdated.Format(time.RFC3339))
+				} else {
+					fmt.Printf("Deleting: %s\n", t.Name)
+					must(client.deleteTag(t.Name))
+				}
+			}
+		}
+
+		nextURL = resp.Next
+	}
+}
+
+func must(err error) {
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
I would like to add a script to cleanup the docker images we are building for the main branch older than one month.

Today we have created around 8000 tags just with the commit. It's a bit too much and I think a cleanup would help.

Perhaps we could do the same on quay.io if it is possible