### PR TITLE
[ignore] update cue to v0.16.1

### DIFF
--- a/.github/workflows/cue.yaml
+++ b/.github/workflows/cue.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.15.1"
+          cue_version: "v0.16.1"
       - name: check cue schema
         run: make cue-eval
 
@@ -43,7 +43,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.15.1"
+          cue_version: "v0.16.1"
       - name: Login to Central Registry # to allow publishing the module
         run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: Publish the module

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.15.1"
+          cue_version: "v0.16.1"
       - name: check format
         run: make checkformat
       - name: check go.mod
@@ -97,7 +97,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
-          cue_version: "v0.15.1"
+          cue_version: "v0.16.1"
       - name: Download plugin archive
         uses: actions/download-artifact@v8
         with:
@@ -117,7 +117,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
-          cue_version: "v0.15.1"
+          cue_version: "v0.16.1"
       - name: Download plugin archive
         uses: actions/download-artifact@v8
         with:
@@ -169,7 +169,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true # needed for DaC CLI commands unit tests
-          cue_version: "v0.15.1"
+          cue_version: "v0.16.1"
       - name: Download plugin archive
         uses: actions/download-artifact@v8
         with:
@@ -227,7 +227,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
-          cue_version: "v0.15.1"
+          cue_version: "v0.16.1"
       - name: generate .cue model files
         run: make cue-gen
       - name: check for changes

--- a/cue/cue.mod/module.cue
+++ b/cue/cue.mod/module.cue
@@ -1,6 +1,6 @@
 module: "github.com/perses/perses/cue@v0"
 language: {
-	version: "v0.15.1"
+	version: "v0.16.1"
 }
 source: {
 	kind: "git"


### PR DESCRIPTION
the cue version used previously is below the one used from the spec. As a consequence, the publication of the cuelang module failed in the release.

This PR is updating the cue version to be able to publish the cue module