### PR TITLE
[ignore] ignore sbom generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ dev/kubernetes/local
 /prometheus
 
 !.gitkeep
+
+ui-sbom.cdx.json
+/**/*.sbom.spdx.json


### PR DESCRIPTION
these files are generated and not ignored and as such git is in a dirty state and goreleaser is blocking the release because of that: https://github.com/perses/perses/actions/runs/26890613065/job/79315862335