### PR TITLE
Move FolderResource from core to ui/app

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -21,6 +21,7 @@
     "@mui/material": "^6.1.10",
     "@mui/x-data-grid": "^7.25.0",
     "@nexucis/kvsearch": "^0.9.1",
+    "@perses-dev/client": "^0.54.0-beta.3",
     "@perses-dev/components": "^0.54.0-beta.3",
     "@perses-dev/core": "0.54.0-beta.1",
     "@perses-dev/dashboards": "^0.54.0-beta.3",

--- a/ui/app/src/components/DashboardList/DashboardList.tsx
+++ b/ui/app/src/components/DashboardList/DashboardList.tsx
@@ -15,7 +15,6 @@ import {
   DashboardResource,
   DashboardSelector,
   EphemeralDashboardInfo,
-  FolderResource,
   getResourceDisplayName,
   getResourceExtendedDisplayName,
 } from '@perses-dev/core';
@@ -24,6 +23,7 @@ import { ReactElement, useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSnackbar } from '@perses-dev/components';
 import { useDeleteDashboardMutation } from '../../model/dashboard-client';
+import { FolderResource } from '../../model/folder';
 import {
   AddFolderDialog,
   CreateDashboardDialog,

--- a/ui/app/src/components/DashboardList/DashboardTreeList.tsx
+++ b/ui/app/src/components/DashboardList/DashboardTreeList.tsx
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FolderResource } from '@perses-dev/core';
 import { Box, CircularProgress, IconButton, Link, Stack } from '@mui/material';
 import { Table, TableColumnConfig } from '@perses-dev/components';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
@@ -23,6 +22,7 @@ import FolderOutlineIcon from 'mdi-material-ui/FolderOutline';
 import ViewDashboardOutlineIcon from 'mdi-material-ui/ViewDashboardOutline';
 import AddFolderOutlineIcon from 'mdi-material-ui/FolderPlusOutline';
 import { ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { FolderResource } from '../../model/folder';
 import { CRUDIconButton } from '../CRUDButton/CRUDIconButton';
 import {
   buildTableRows,

--- a/ui/app/src/components/dialogs/AddFolderDialog.tsx
+++ b/ui/app/src/components/dialogs/AddFolderDialog.tsx
@@ -14,9 +14,10 @@
 import { Dispatch, DispatchWithoutAction, ReactElement, useMemo } from 'react';
 import { Autocomplete, Button, Chip, Stack, TextField } from '@mui/material';
 import { Dialog, useSnackbar } from '@perses-dev/components';
-import { FolderItem, FolderResource, getResourceExtendedDisplayName } from '@perses-dev/core';
+import { getResourceExtendedDisplayName } from '@perses-dev/core';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { FolderItem, FolderResource } from '../../model/folder';
 import { EditFolderValidationType, useAddFolderValidationSchema } from '../../validation';
 import { useUpdateFolderMutation } from '../../model/folder-client';
 import { collectDashboards, insertSubFolder } from '../../utils/folderUtils';

--- a/ui/app/src/components/dialogs/CreateFolderDialog.tsx
+++ b/ui/app/src/components/dialogs/CreateFolderDialog.tsx
@@ -14,9 +14,10 @@
 import { Dispatch, DispatchWithoutAction, ReactElement, useMemo } from 'react';
 import { Autocomplete, Button, Chip, CircularProgress, Stack, TextField } from '@mui/material';
 import { Dialog, useSnackbar } from '@perses-dev/components';
-import { FolderItem, FolderResource, getResourceDisplayName, getResourceExtendedDisplayName } from '@perses-dev/core';
+import { getResourceDisplayName, getResourceExtendedDisplayName } from '@perses-dev/core';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { FolderItem, FolderResource } from '../../model/folder';
 import { CreateFolderValidationType, useFolderValidationSchema } from '../../validation';
 import { useDashboardList } from '../../model/dashboard-client';
 import { useCreateFolderMutation } from '../../model/folder-client';

--- a/ui/app/src/components/dialogs/DeleteFolderDialog.tsx
+++ b/ui/app/src/components/dialogs/DeleteFolderDialog.tsx
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FolderResource, getResourceExtendedDisplayName } from '@perses-dev/core';
+import { getResourceExtendedDisplayName } from '@perses-dev/core';
 import { DispatchWithoutAction, ReactElement, useCallback, useMemo } from 'react';
 import { useSnackbar } from '@perses-dev/components';
+import { FolderResource } from '../../model/folder';
 import { withoutSubFolder, getSubFolderRef } from '../../utils/folderUtils';
 import { useDeleteFolderMutation, useUpdateFolderMutation } from '../../model/folder-client';
 import { DeleteDialog } from './DeleteDialog';

--- a/ui/app/src/components/dialogs/EditFolderDialog.tsx
+++ b/ui/app/src/components/dialogs/EditFolderDialog.tsx
@@ -14,9 +14,10 @@
 import { Dispatch, DispatchWithoutAction, ReactElement, useMemo } from 'react';
 import { Autocomplete, Button, Chip, Stack, TextField } from '@mui/material';
 import { Dialog, useSnackbar } from '@perses-dev/components';
-import { FolderItem, FolderResource, getResourceDisplayName, getResourceExtendedDisplayName } from '@perses-dev/core';
+import { getResourceDisplayName, getResourceExtendedDisplayName } from '@perses-dev/core';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { FolderItem, FolderResource } from '../../model/folder';
 import { editFolderDialogValidationSchema, EditFolderValidationType } from '../../validation';
 import { useUpdateFolderMutation } from '../../model/folder-client';
 import { collectDashboards, getSubFolderDeepCopy, replaceSubFolder } from '../../utils/folderUtils';

--- a/ui/app/src/model/folder-client.ts
+++ b/ui/app/src/model/folder-client.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { fetch, fetchJson, FolderResource, StatusError } from '@perses-dev/core';
 import {
   useMutation,
   UseMutationResult,
@@ -20,6 +19,8 @@ import {
   UseQueryOptions,
   UseQueryResult,
 } from '@tanstack/react-query';
+import { fetch, fetchJson, StatusError } from '@perses-dev/client';
+import { FolderResource } from './folder';
 import buildURL from './url-builder';
 import { HTTPHeader, HTTPMethodDELETE, HTTPMethodGET, HTTPMethodPOST, HTTPMethodPUT } from './http';
 

--- a/ui/app/src/model/folder.ts
+++ b/ui/app/src/model/folder.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ProjectMetadata } from './resource';
+import { ProjectMetadata } from '@perses-dev/client';
 
 export interface FolderDisplay {
   name?: string;

--- a/ui/app/src/utils/dashboardTableUtils.test.ts
+++ b/ui/app/src/utils/dashboardTableUtils.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FolderResource } from '@perses-dev/core';
+import { FolderResource } from '../model/folder';
 import { DashboardTreeTableRow } from '../components/DashboardList/DashboardTreeList';
 import { DashboardListRow } from '../components/DashboardList/DashboardList';
 import { buildTableRows, sortDashboardTableStringColumn } from './dashboardTableUtils';

--- a/ui/app/src/utils/dashboardTableUtils.ts
+++ b/ui/app/src/utils/dashboardTableUtils.ts
@@ -11,8 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FolderItem, FolderResource, getResourceDisplayName } from '@perses-dev/core';
+import { getResourceDisplayName } from '@perses-dev/core';
 import { intlFormatDistance } from 'date-fns';
+import { FolderItem, FolderResource } from '../model/folder';
 import type { DashboardTreeTableRow } from '../components/DashboardList/DashboardTreeList';
 import { DashboardListRow } from '../components/DashboardList/DashboardList';
 

--- a/ui/app/src/utils/folderUtils.test.ts
+++ b/ui/app/src/utils/folderUtils.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FolderItem } from '@perses-dev/core';
+import { FolderItem } from '../model/folder';
 import {
   collectDashboards,
   getSubFolderDeepCopy,

--- a/ui/app/src/utils/folderUtils.ts
+++ b/ui/app/src/utils/folderUtils.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FolderItem } from '@perses-dev/core';
+import { FolderItem } from '../model/folder';
 
 /**
  * Returns a new items array without the `FolderItem` node identified by `path`.

--- a/ui/app/src/validation/folder.ts
+++ b/ui/app/src/validation/folder.ts
@@ -13,7 +13,7 @@
 
 import { z } from 'zod';
 import { useMemo } from 'react';
-import { FolderItem } from '@perses-dev/core';
+import { FolderItem } from '../model/folder';
 import { useFolderList } from '../model/folder-client';
 import { getSubFolderRef } from '../utils/folderUtils';
 import { generateMetadataName } from '../utils/metadata';

--- a/ui/core/src/model/index.ts
+++ b/ui/core/src/model/index.ts
@@ -19,7 +19,6 @@ export * from './definitions';
 export * from './display';
 export * from './ephemeraldashboard';
 export * from './external-variable';
-export * from './folder';
 export * from './http';
 export * from './http-proxy';
 export * from './kind';

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -57,7 +57,7 @@
     },
     "app": {
       "name": "@perses-dev/app",
-      "version": "0.54.0-beta.0",
+      "version": "0.54.0-beta.1",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
@@ -66,8 +66,9 @@
         "@mui/material": "^6.1.10",
         "@mui/x-data-grid": "^7.25.0",
         "@nexucis/kvsearch": "^0.9.1",
+        "@perses-dev/client": "^0.54.0-beta.3",
         "@perses-dev/components": "^0.54.0-beta.3",
-        "@perses-dev/core": "0.54.0-beta.0",
+        "@perses-dev/core": "0.54.0-beta.1",
         "@perses-dev/dashboards": "^0.54.0-beta.3",
         "@perses-dev/explore": "^0.54.0-beta.3",
         "@perses-dev/plugin-system": "^0.54.0-beta.3",


### PR DESCRIPTION
## Summary
- Move `FolderResource` from `@perses-dev/core` to `ui/app/src/model/folder.ts`, since it is only used by the app
- Update all `ui/app` imports to use the local type instead of `@perses-dev/core`
- Remove `FolderResource` from `ui/core/src/model/folder.ts` to avoid adding new types to core as it is phased out

Fixes #4076

## Test plan
- [x] `npm run type-check --workspace=@perses-dev/core --workspace=@perses-dev/app`
- [ ] `npm test -- --testPathPatterns="dashboardTableUtils|folderUtils"` in `ui/app`