### PR TITLE
[FEATURE] Add tags display with chips in DashboardTreeList

### DIFF
--- a/ui/app/src/components/DashboardList/DashboardTreeList.tsx
+++ b/ui/app/src/components/DashboardList/DashboardTreeList.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { FolderResource } from '@perses-dev/core';
-import { Box, CircularProgress, Stack } from '@mui/material';
+import { Box, Chip, CircularProgress, Stack } from '@mui/material';
 import { Table, TableColumnConfig } from '@perses-dev/components';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import PencilIcon from 'mdi-material-ui/Pencil';
@@ -140,6 +140,26 @@ function DashboardTreeList({
         header: 'Tags',
         align: 'left',
         enableSorting: true,
+        cellDescription: (): string => '',
+        cell: ({ getValue }): ReactNode => {
+          const tags: string[] | undefined = getValue();
+          return tags ? (
+            <Box
+              sx={{
+                pt: 0.75,
+                mt: -1,
+                overflow: 'inherit',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {tags.map((tag, index) => (
+                <Chip key={`${tag}-${index}`} label={tag} size="small" sx={{ mr: index < tags.length - 1 ? 0.5 : 0 }} />
+              ))}
+            </Box>
+          ) : (
+            ''
+          );
+        },
       },
       {
         id: 'version',


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->
Related to: https://github.com/perses/perses/issues/4110
# Description

Wraps each tag in Chip.

# Screenshots

<img width="1465" height="732" alt="Screenshot 2026-06-08 at 15 35 14" src="https://github.com/user-attachments/assets/a2eeacf4-bacb-4dc3-ba7e-b296fd307e3e" />

<img width="1460" height="744" alt="Screenshot 2026-06-08 at 15 35 58" src="https://github.com/user-attachments/assets/edbc03db-9fb5-44c8-b7ec-d2f76ebe6668" />



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
