### PR TITLE
[FEATURE] Implement NoItems representation in DashboardTreeList and r…

### DIFF
--- a/ui/app/src/components/DashboardList/DashboardTreeList.tsx
+++ b/ui/app/src/components/DashboardList/DashboardTreeList.tsx
@@ -12,15 +12,11 @@
 // limitations under the License.
 
 import { FolderResource } from '@perses-dev/core';
-import { Box, CircularProgress, IconButton, Link, Stack } from '@mui/material';
+import { Box, CircularProgress, Stack } from '@mui/material';
 import { Table, TableColumnConfig } from '@perses-dev/components';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import ContentCopyIcon from 'mdi-material-ui/ContentCopy';
-import ChevronDownIcon from 'mdi-material-ui/ChevronDown';
-import ChevronRightIcon from 'mdi-material-ui/ChevronRight';
-import FolderOutlineIcon from 'mdi-material-ui/FolderOutline';
-import ViewDashboardOutlineIcon from 'mdi-material-ui/ViewDashboardOutline';
 import AddFolderOutlineIcon from 'mdi-material-ui/FolderPlusOutline';
 import { ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { CRUDIconButton } from '../CRUDButton/CRUDIconButton';
@@ -32,10 +28,11 @@ import {
   sortDashboardTableStringColumn,
 } from '../../utils/dashboardTableUtils';
 import { useIsMobileSize } from '../../utils/browser-size';
+import { NameCell } from './NameCell';
 import { DashboardListRow } from './DashboardList';
 
 export interface DashboardTreeTableRow {
-  kind: 'Folder' | 'Dashboard';
+  kind: 'Folder' | 'Dashboard' | 'NoItems';
   name: string;
   displayName: string;
   project: string;
@@ -125,44 +122,17 @@ function DashboardTreeList({
         width: 300,
         cellDescription: (): string => '',
         sortingFn: sortStringColumn('displayName'),
-        cell: ({ row, getValue }): ReactElement => {
-          const value = getValue() as string;
-          const kind = row.original.kind;
-          const paddingLeft = kind === 'Folder' ? row.depth * 24 : (row.depth + 1) * 24;
-          return (
-            <Box sx={{ paddingLeft: paddingLeft + 'px', display: 'flex', alignItems: 'center', gap: '4px' }}>
-              {kind === 'Folder' ? (
-                <>
-                  <IconButton
-                    onClick={row.getToggleExpandedHandler()}
-                    aria-expanded={row.getIsExpanded()}
-                    aria-label={row.getIsExpanded() ? 'collapse folder' : 'expand folder'}
-                    sx={{ padding: 0 }}
-                  >
-                    {row.getIsExpanded() || !row.getCanExpand() ? (
-                      <ChevronDownIcon fontSize="small" />
-                    ) : (
-                      <ChevronRightIcon fontSize="small" />
-                    )}
-                  </IconButton>
-                  <FolderOutlineIcon fontSize="small" />
-                  {value}
-                </>
-              ) : (
-                <>
-                  <ViewDashboardOutlineIcon fontSize="small" />
-                  <Link
-                    href={`/projects/${row.original.project}/dashboards/${row.original.name}`}
-                    color="inherit"
-                    underline="hover"
-                  >
-                    {value}
-                  </Link>
-                </>
-              )}
-            </Box>
-          );
-        },
+        cell: ({ row, getValue }): ReactElement => (
+          <NameCell
+            kind={row.original.kind}
+            depth={row.depth}
+            displayName={getValue() as string}
+            project={row.original.project}
+            name={row.original.name}
+            isOpen={row.getIsExpanded() || !row.getCanExpand()}
+            onToggleExpanded={row.getToggleExpandedHandler()}
+          />
+        ),
       },
       {
         id: 'tags',
@@ -219,6 +189,9 @@ function DashboardTreeList({
         width: 90,
         cellDescription: (): string => '',
         cell: ({ row }): ReactElement | undefined => {
+          if (row.original.kind === 'NoItems') {
+            return undefined;
+          }
           if (row.original.kind === 'Dashboard') {
             return (
               <Stack direction="row" gap={1} alignItems="center" justifyContent="center">

--- a/ui/app/src/components/DashboardList/NameCell.test.tsx
+++ b/ui/app/src/components/DashboardList/NameCell.test.tsx
@@ -1,0 +1,161 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { NameCell, NameCellProps } from './NameCell';
+
+const theme = createTheme();
+
+function renderCell(props: NameCellProps): ReturnType<typeof render> {
+  return render(
+    <ThemeProvider theme={theme}>
+      <NameCell {...props} />
+    </ThemeProvider>
+  );
+}
+
+const noop = (): void => {};
+
+describe('NameCell – Folder', () => {
+  it('renders the display name', () => {
+    renderCell({
+      kind: 'Folder',
+      depth: 0,
+      displayName: 'My Folder',
+      project: 'p',
+      name: 'my-folder',
+      isOpen: false,
+      onToggleExpanded: noop,
+    });
+    expect(screen.getByText('My Folder')).toBeInTheDocument();
+  });
+
+  it('shows expand button with aria-expanded=false when closed', () => {
+    renderCell({
+      kind: 'Folder',
+      depth: 0,
+      displayName: 'F',
+      project: 'p',
+      name: 'f',
+      isOpen: false,
+      onToggleExpanded: noop,
+    });
+    const button = screen.getByRole('button', { name: 'expand folder' });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('shows collapse button with aria-expanded=true when open', () => {
+    renderCell({
+      kind: 'Folder',
+      depth: 0,
+      displayName: 'F',
+      project: 'p',
+      name: 'f',
+      isOpen: true,
+      onToggleExpanded: noop,
+    });
+    const button = screen.getByRole('button', { name: 'collapse folder' });
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('calls onToggleExpanded when the button is clicked', () => {
+    const onToggle = jest.fn();
+    renderCell({
+      kind: 'Folder',
+      depth: 0,
+      displayName: 'F',
+      project: 'p',
+      name: 'f',
+      isOpen: false,
+      onToggleExpanded: onToggle,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'expand folder' }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies left padding based on depth', () => {
+    const { container } = renderCell({
+      kind: 'Folder',
+      depth: 2,
+      displayName: 'F',
+      project: 'p',
+      name: 'f',
+      isOpen: false,
+      onToggleExpanded: noop,
+    });
+    const box = container.firstChild as HTMLElement;
+    expect(box).toHaveStyle({ paddingLeft: '48px' });
+  });
+});
+
+describe('NameCell – Dashboard', () => {
+  it('renders the display name as a link', () => {
+    renderCell({
+      kind: 'Dashboard',
+      depth: 0,
+      displayName: 'My Dashboard',
+      project: 'myproj',
+      name: 'my-dash',
+      isOpen: false,
+      onToggleExpanded: noop,
+    });
+    const link = screen.getByRole('link', { name: 'My Dashboard' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/projects/myproj/dashboards/my-dash');
+  });
+
+  it('applies left padding with one extra depth level for the chevron offset', () => {
+    const { container } = renderCell({
+      kind: 'Dashboard',
+      depth: 1,
+      displayName: 'D',
+      project: 'p',
+      name: 'd',
+      isOpen: false,
+      onToggleExpanded: noop,
+    });
+    const box = container.firstChild as HTMLElement;
+    expect(box).toHaveStyle({ paddingLeft: '48px' });
+  });
+});
+
+describe('NameCell – NoItems', () => {
+  it('renders "No Items" text', () => {
+    renderCell({
+      kind: 'NoItems',
+      depth: 0,
+      displayName: '',
+      project: 'p',
+      name: '__no_items__',
+      isOpen: false,
+      onToggleExpanded: noop,
+    });
+    expect(screen.getByText('No Items')).toBeInTheDocument();
+  });
+
+  it('applies left padding based on depth', () => {
+    const { container } = renderCell({
+      kind: 'NoItems',
+      depth: 2,
+      displayName: '',
+      project: 'p',
+      name: '__no_items__',
+      isOpen: false,
+      onToggleExpanded: noop,
+    });
+    const box = container.firstChild as HTMLElement;
+    expect(box).toHaveStyle({ paddingLeft: '72px' });
+  });
+});

--- a/ui/app/src/components/DashboardList/NameCell.tsx
+++ b/ui/app/src/components/DashboardList/NameCell.tsx
@@ -1,0 +1,77 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box, IconButton, Link } from '@mui/material';
+import ChevronDownIcon from 'mdi-material-ui/ChevronDown';
+import ChevronRightIcon from 'mdi-material-ui/ChevronRight';
+import FolderOutlineIcon from 'mdi-material-ui/FolderOutline';
+import FolderOpenOutlineIcon from 'mdi-material-ui/FolderOpenOutline';
+import ViewDashboardOutlineIcon from 'mdi-material-ui/ViewDashboardOutline';
+import { ReactElement } from 'react';
+import { DashboardTreeTableRow } from './DashboardTreeList';
+
+export interface NameCellProps {
+  kind: DashboardTreeTableRow['kind'];
+  depth: number;
+  displayName: string;
+  project: string;
+  name: string;
+  isOpen: boolean;
+  onToggleExpanded: () => void;
+}
+
+export function NameCell({
+  kind,
+  depth,
+  displayName,
+  project,
+  name,
+  isOpen,
+  onToggleExpanded,
+}: NameCellProps): ReactElement {
+  // folder padding is based on depth, with dashboards having an extra 24px to account for the chevron icon
+  const paddingLeft = kind === 'Folder' ? depth * 24 : (depth + 1) * 24;
+
+  switch (kind) {
+    case 'Folder':
+      return (
+        <Box sx={{ paddingLeft: `${paddingLeft}px`, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <IconButton
+            onClick={onToggleExpanded}
+            aria-expanded={isOpen}
+            aria-label={isOpen ? 'collapse folder' : 'expand folder'}
+            sx={{ padding: 0 }}
+          >
+            {isOpen ? <ChevronDownIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+          </IconButton>
+          {isOpen ? <FolderOpenOutlineIcon fontSize="small" /> : <FolderOutlineIcon fontSize="small" />}
+          {displayName}
+        </Box>
+      );
+    case 'NoItems':
+      return (
+        <Box component="span" sx={{ paddingLeft: `${paddingLeft}px`, color: 'text.secondary', fontStyle: 'italic' }}>
+          No Items
+        </Box>
+      );
+    case 'Dashboard':
+      return (
+        <Box sx={{ paddingLeft: `${paddingLeft}px`, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <ViewDashboardOutlineIcon fontSize="small" />
+          <Link href={`/projects/${project}/dashboards/${name}`} color="inherit" underline="hover">
+            {displayName}
+          </Link>
+        </Box>
+      );
+  }
+}

--- a/ui/app/src/utils/dashboardTableUtils.test.ts
+++ b/ui/app/src/utils/dashboardTableUtils.test.ts
@@ -377,10 +377,11 @@ describe('buildTableRows – flat folders', () => {
 
     const rows = buildTableRows([folder], new Map());
 
-    expect(rows[0]!.children).toHaveLength(0);
+    expect(rows[0]!.children).toHaveLength(1);
+    expect(rows[0]!.children![0]!.kind).toBe('NoItems');
   });
 
-  it('a folder referencing no dashboards produces an empty children array', () => {
+  it('a folder referencing no dashboards produces a NoItems child', () => {
     const folder: FolderResource = {
       kind: 'Folder',
       metadata: { name: 'empty-folder', project: 'p', version: 1 },
@@ -389,7 +390,8 @@ describe('buildTableRows – flat folders', () => {
 
     const rows = buildTableRows([folder], new Map());
 
-    expect(rows[0]!.children).toHaveLength(0);
+    expect(rows[0]!.children).toHaveLength(1);
+    expect(rows[0]!.children![0]!.kind).toBe('NoItems');
   });
 
   it('carries folder version from metadata', () => {
@@ -486,7 +488,7 @@ describe('buildTableRows – nested folders', () => {
     expect(dashRow.path).toEqual(['top', 'mid', 'deep']);
   });
 
-  it('a nested folder with no items produces undefined children', () => {
+  it('a nested folder with no items produces a NoItems child', () => {
     const outer: FolderResource = {
       kind: 'Folder',
       metadata: { name: 'outer', project: 'p', version: 1 },
@@ -495,7 +497,8 @@ describe('buildTableRows – nested folders', () => {
 
     const rows = buildTableRows([outer], new Map());
 
-    expect(rows[0]!.children![0]!.children).toBeUndefined();
+    expect(rows[0]!.children![0]!.children).toHaveLength(1);
+    expect(rows[0]!.children![0]!.children![0]!.kind).toBe('NoItems');
   });
 
   it('throws on an unknown kind in folder items', () => {
@@ -595,7 +598,7 @@ describe('buildTableRows – multiple projects', () => {
     expect(looseRow.project).toBe('proj-b');
   });
 
-  it('emits an empty children list for a folder whose project has no dashboards in the map', () => {
+  it('emits a NoItems child for a folder whose project has no dashboards in the map', () => {
     const folder: FolderResource = {
       kind: 'Folder',
       metadata: { name: 'f', project: 'ghost-project', version: 1 },
@@ -604,7 +607,8 @@ describe('buildTableRows – multiple projects', () => {
 
     const rows = buildTableRows([folder], new Map());
 
-    expect(rows[0]!.children).toHaveLength(0);
+    expect(rows[0]!.children).toHaveLength(1);
+    expect(rows[0]!.children![0]!.kind).toBe('NoItems');
   });
 });
 

--- a/ui/app/src/utils/dashboardTableUtils.ts
+++ b/ui/app/src/utils/dashboardTableUtils.ts
@@ -135,8 +135,8 @@ const mapFolderItemsToTableRow = (
   dashboardMap: Map<string, DashboardListRow & { inFolder?: boolean }>,
   project: string,
   parentPath: string[]
-): DashboardTreeTableRow[] | undefined => {
-  return folderItems
+): DashboardTreeTableRow[] => {
+  const rows = folderItems
     ?.map((item) => {
       switch (item.kind) {
         case 'Dashboard': {
@@ -156,7 +156,7 @@ const mapFolderItemsToTableRow = (
             displayName: item.name,
             children: item.items
               ? mapFolderItemsToTableRow(item.items, dashboardMap, project, buildPath(parentPath, item.name))
-              : undefined,
+              : [noItemsRow(project, parentPath)],
           };
         default:
           throw new Error(`Unknown kind: ${item.kind}`);
@@ -164,11 +164,24 @@ const mapFolderItemsToTableRow = (
     })
     .filter((row): row is DashboardTreeTableRow => row !== undefined)
     .sort((a, b) => compareFolderFirst(a.kind, b.kind));
+
+  if (!rows || rows.length === 0) {
+    return [noItemsRow(project, parentPath)];
+  }
+  return rows;
 };
 
 const buildPath = (parentPath: string[], name: string): string[] => {
   return [...parentPath, name];
 };
+
+const noItemsRow = (project: string, path: string[]): DashboardTreeTableRow => ({
+  kind: 'NoItems',
+  name: '__no_items__',
+  displayName: '',
+  project: project,
+  path: path,
+});
 
 function compareFolderFirst(kindA: string, kindB: string, isDesc = false): number {
   if (kindA === kindB) return 0;


### PR DESCRIPTION
…elated components


# Description

Related to: https://github.com/perses/perses/issues/4110

Shows 'No Items' when user expands empty folder. 
Changes Icon for expanded folder.

# Screenshots

<img width="1466" height="830" alt="Screenshot 2026-06-09 at 08 28 08" src="https://github.com/user-attachments/assets/23bf4722-be9d-4f43-a2d4-23bb9a145218" />

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
