### PR TITLE
[IGNORE] update vulnerable dependencies

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -57,7 +57,7 @@
     },
     "app": {
       "name": "@perses-dev/app",
-      "version": "0.54.0-beta.0",
+      "version": "0.54.0-beta.1",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
@@ -67,7 +67,7 @@
         "@mui/x-data-grid": "^7.25.0",
         "@nexucis/kvsearch": "^0.9.1",
         "@perses-dev/components": "^0.54.0-beta.3",
-        "@perses-dev/core": "0.54.0-beta.0",
+        "@perses-dev/core": "0.54.0-beta.1",
         "@perses-dev/dashboards": "^0.54.0-beta.3",
         "@perses-dev/explore": "^0.54.0-beta.3",
         "@perses-dev/plugin-system": "^0.54.0-beta.3",
@@ -198,7 +198,7 @@
     },
     "core": {
       "name": "@perses-dev/core",
-      "version": "0.54.0-beta.0",
+      "version": "0.54.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@perses-dev/spec": "0.2.0-beta.0",
@@ -214,14 +214,14 @@
     },
     "e2e": {
       "name": "@perses-dev/e2e",
-      "version": "0.54.0-beta.0",
+      "version": "0.54.0-beta.1",
       "dependencies": {
-        "@perses-dev/core": "0.54.0-beta.0",
+        "@perses-dev/core": "0.54.0-beta.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0"
       },
       "devDependencies": {
-        "@perses-dev/internal-utils": "0.54.0-beta.0",
+        "@perses-dev/internal-utils": "0.54.0-beta.1",
         "@playwright/test": "^1.54.2",
         "chokidar-cli": "^3.0.0",
         "eslint-plugin-playwright": "^0.11.2"
@@ -229,7 +229,7 @@
     },
     "internal-utils": {
       "name": "@perses-dev/internal-utils",
-      "version": "0.54.0-beta.0"
+      "version": "0.54.0-beta.1"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.2",
@@ -2679,12 +2679,12 @@
       "license": "MIT"
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.5.0.tgz",
-      "integrity": "sha512-Ux9XVW//K6K+KHKPdc0Jnc7RtTpZaEXgbVhp5yovtFkCJVt8hEClcTeuI18MvvLiV/q2hUpCU5Wsf9zNaIYStQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.5.1.tgz",
+      "integrity": "sha512-bMRKo1ac6dYUhvPWH6ElFRfR+yWjbCse2mwu9fEzjemeaAqqse0K7XBIrW+4HcU7k/A6fu4Dk8o137ol6ZFXvw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.5.0",
+        "@module-federation/sdk": "2.5.1",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
@@ -2702,13 +2702,13 @@
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.5.0.tgz",
-      "integrity": "sha512-+czXA6yoiiF9W6+YEOCpQE6zpGZpA89X0oCEz3EaWPTkL4chEbxurjpME8CMnJk9iuFxl167+cBQiQlVBiHGGg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.5.1.tgz",
+      "integrity": "sha512-Y5dQrcPoph91KAzg6XXQ40faqFQ4iPwq3JuvFbsawyKwhQ/+aHkaH7cfclNbNr9pHGiiozkdxb22zK3oJRI3rw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.5.0",
-        "@module-federation/sdk": "2.5.0",
+        "@module-federation/dts-plugin": "2.5.1",
+        "@module-federation/sdk": "2.5.1",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -2720,21 +2720,21 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.5.0.tgz",
-      "integrity": "sha512-q7KDhJ5tn2HrUV7uMuh/L3TaaztUosE+4LAb90sxx0pPPqWRwlpBpxu1REubv5BWXmU1K/Ozn14u6jRbjLVaGA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.5.1.tgz",
+      "integrity": "sha512-XylIL02As+VXk4DzFb8qYQs1YYoY0MZOpIqhf06LMkZBjPdOE0wJ1GOBvhFP9kM/cfuK7QV//mNdrWlZgvEkRA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/managers": "2.5.0",
-        "@module-federation/sdk": "2.5.0",
-        "@module-federation/third-party-dts-extractor": "2.5.0",
+        "@module-federation/error-codes": "2.5.1",
+        "@module-federation/managers": "2.5.1",
+        "@module-federation/sdk": "2.5.1",
+        "@module-federation/third-party-dts-extractor": "2.5.1",
         "adm-zip": "0.5.10",
         "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
         "node-schedule": "2.1.1",
         "undici": "7.24.7",
-        "ws": "8.18.0"
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": "^4.9.0 || ^5.0.0",
@@ -2746,44 +2746,23 @@
         }
       }
     },
-    "node_modules/@module-federation/dts-plugin/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@module-federation/enhanced": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.5.0.tgz",
-      "integrity": "sha512-P91tzwyKSCQ6AwirqvAvTqWqmTY79ndpH0uenejFw+bbLpWrjuY0q+iZUXCV/7CSNmqwH2bkA/ssuyZljmcMVQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.5.1.tgz",
+      "integrity": "sha512-uddrS58NxOW2lsLfXLHenzfX37QMuZ0g03nG9SVhqfo3tMdP9877SLaMKRpoOvy7YQRfrXVAGF//9U9QtEWr7A==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.5.0",
-        "@module-federation/cli": "2.5.0",
-        "@module-federation/dts-plugin": "2.5.0",
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.5.0",
-        "@module-federation/managers": "2.5.0",
-        "@module-federation/manifest": "2.5.0",
-        "@module-federation/rspack": "2.5.0",
-        "@module-federation/runtime-tools": "2.5.0",
-        "@module-federation/sdk": "2.5.0",
-        "@module-federation/webpack-bundler-runtime": "2.5.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.5.1",
+        "@module-federation/cli": "2.5.1",
+        "@module-federation/dts-plugin": "2.5.1",
+        "@module-federation/error-codes": "2.5.1",
+        "@module-federation/inject-external-runtime-core-plugin": "2.5.1",
+        "@module-federation/managers": "2.5.1",
+        "@module-federation/manifest": "2.5.1",
+        "@module-federation/rspack": "2.5.1",
+        "@module-federation/runtime-tools": "2.5.1",
+        "@module-federation/sdk": "2.5.1",
+        "@module-federation/webpack-bundler-runtime": "2.5.1",
         "schema-utils": "4.3.0",
         "tapable": "2.3.0",
         "upath": "2.0.1"
@@ -2862,55 +2841,55 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.0.tgz",
-      "integrity": "sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.1.tgz",
+      "integrity": "sha512-3KIR8XbEW0Y+Fn8IAnxzDWMvXQWiS40Z1TE/Fft9aTeXP9dDAM7AiVhjTh5yF2csAwHSt/1LJVZbiCmS13mE8A==",
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.5.0.tgz",
-      "integrity": "sha512-e2KyTHpesBrPXGHMh4d4+s2xBiNoxbiFJkPRYHMCl81a/Gu+byrMkriZcV4VM/TFvBIlrgOJisVc1nnBI5UDRQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.5.1.tgz",
+      "integrity": "sha512-cCFCQ0j0xObXwVwBq/ZiU+MMdJrE2OVwdPUR7l6NHKKwKAOmkagM+AE5wNEkzVht6m+Dh6x6/5UTqqa/vbDrjQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "2.5.0"
+        "@module-federation/runtime-tools": "2.5.1"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.5.0.tgz",
-      "integrity": "sha512-9b5mU/7OYbKrYUJmhZ1kkfeJCZqR7qX6/FWp+oOfZMzUynN7Rb41dwoUs3TdnOKzbZ3CCwtZ2WsR4pF9ZNvuJA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.5.1.tgz",
+      "integrity": "sha512-AWbkH/U76FJDbdwBOodQ1An40WOdrDGAgqUMc8RD62+Ec/ocPfda0NhFcJbPxlUIvSFPTvBv6DwTnygmNC7GPA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.5.0",
+        "@module-federation/sdk": "2.5.1",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/manifest": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.5.0.tgz",
-      "integrity": "sha512-pmwQCGWjM2oKY7CkR7nEDOfMK0bNFJUifuDxuOB5iOWhU+Rp92UyyBI9IbJAtiISTSFGtuKRy40peJGvQq2VcQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.5.1.tgz",
+      "integrity": "sha512-z44Fita44rpLufoEW71tWw+eWGMVLVQzT2OjrzOHH8JLPOX3czT0INPwVbRp9v8puzWiU6Kz5W6PqelqutpJKA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.5.0",
-        "@module-federation/managers": "2.5.0",
-        "@module-federation/sdk": "2.5.0",
+        "@module-federation/dts-plugin": "2.5.1",
+        "@module-federation/managers": "2.5.1",
+        "@module-federation/sdk": "2.5.1",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/rspack": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.5.0.tgz",
-      "integrity": "sha512-OAFMpMXuLEQFmWBuC1I7LNDQ8N3CDANXe0YGPWkIPNxKq5Tj/KNfDidmutoYgvXlZKOM4yKBKBsL6Xt/UvtOIw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.5.1.tgz",
+      "integrity": "sha512-9Qu4Q7P4VHUhMQLHKA95x3L85WKPtk2Lz0VPpUprIwlKhKgZbuy5ou2PjlWiaPIffWo1JsVfoBi+P9dtpOeEsw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.5.0",
-        "@module-federation/dts-plugin": "2.5.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.5.0",
-        "@module-federation/managers": "2.5.0",
-        "@module-federation/manifest": "2.5.0",
-        "@module-federation/runtime-tools": "2.5.0",
-        "@module-federation/sdk": "2.5.0"
+        "@module-federation/bridge-react-webpack-plugin": "2.5.1",
+        "@module-federation/dts-plugin": "2.5.1",
+        "@module-federation/inject-external-runtime-core-plugin": "2.5.1",
+        "@module-federation/managers": "2.5.1",
+        "@module-federation/manifest": "2.5.1",
+        "@module-federation/runtime-tools": "2.5.1",
+        "@module-federation/sdk": "2.5.1"
       },
       "peerDependencies": {
         "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
@@ -2927,40 +2906,40 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.0.tgz",
-      "integrity": "sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.1.tgz",
+      "integrity": "sha512-Tf33FIpnQMn8FjIUAQMtSTYQgGibfh5vEvJihFO3q/hG9LiWwLMErZvOz/+wcPsE81gzHjYPxQgMKGSP3BuG8g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/runtime-core": "2.5.0",
-        "@module-federation/sdk": "2.5.0"
+        "@module-federation/error-codes": "2.5.1",
+        "@module-federation/runtime-core": "2.5.1",
+        "@module-federation/sdk": "2.5.1"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.0.tgz",
-      "integrity": "sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.1.tgz",
+      "integrity": "sha512-UMuMsWHXeMrm8Isl8YD6/s1jmTVau3SQhp9RO4Ln+eD2lrjM4hQSwOX2xPtfT1C1I4/E6hgyZQV1K1Q/3Zpr0Q==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/sdk": "2.5.0"
+        "@module-federation/error-codes": "2.5.1",
+        "@module-federation/sdk": "2.5.1"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.5.0.tgz",
-      "integrity": "sha512-fR3Na6V78ov3/O17Mev+1vydfmqlYWP4ZNxD/bBkmqKhCO7jMdthNTT02yDljlCyhYl6+X90UJlFhwFle6rIsw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.5.1.tgz",
+      "integrity": "sha512-pYUNvaQQBEwP66TLrjmmfkDIrTmPnX0kK86HgClkWLQKkX/oCgnqDxEgNbjeCc75dwUvZP6fW2d0pZ5++XILTw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "2.5.0",
-        "@module-federation/webpack-bundler-runtime": "2.5.0"
+        "@module-federation/runtime": "2.5.1",
+        "@module-federation/webpack-bundler-runtime": "2.5.1"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
-      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.1.tgz",
+      "integrity": "sha512-FDhCx81ZCxX1oT/fyt/bW+gpPt287GR156E/Thv1yhb9XyNHGNkqe8zqJOipOMfb07E22OMzSzOulCBvAOgn3g==",
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "^2.7.0 || ^3.3.2"
@@ -2972,9 +2951,9 @@
       }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.5.0.tgz",
-      "integrity": "sha512-5di43LGk2ies86Cj8QyzYr540Ijc+nyPqYziyFotL6Pparnu+uf3b3ERfEyQfBmEcyGk1MpitQIO2J3bd9BcNw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.5.1.tgz",
+      "integrity": "sha512-/jD/o2IivDgg6jGUgdb9NZtlJWeoz1uKcblGL2BxYVzzlKT+1YS7Y2idTl1tqp4hNdFnDlPpQv6WLdKiLoOPNw==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -2999,14 +2978,14 @@
       }
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.5.0.tgz",
-      "integrity": "sha512-UxVad+tNZYkBnZzqJQsZa0pB5gO5cJoCjMumOo3bhzXBJVqHsFupfeHa8Nk7WrRVbJE6zRT9ZHK0s0NDWBMyJw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.5.1.tgz",
+      "integrity": "sha512-0pUsP9aaWIUcfWUXqax/iSwozngORwf4RK0R1qTOYYC13qx+p4p1Ck28Rz6Tzj/6zpzJgcMQXR7nW4sL+ztaww==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/runtime": "2.5.0",
-        "@module-federation/sdk": "2.5.0"
+        "@module-federation/error-codes": "2.5.1",
+        "@module-federation/runtime": "2.5.1",
+        "@module-federation/sdk": "2.5.1"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -4289,9 +4268,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -5192,6 +5171,90 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.17.tgz",
+      "integrity": "sha512-io5jn5RDeU+9YV78rWhwG++HD/OZ/Lxg1sg93+jDGKQNP3UDxY6RX2dmarbCILhNxNuAM8FH3WgGMY9E96Mf8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.17.tgz",
+      "integrity": "sha512-83YZTYmN2sxFWf2LTMOwqbOvR3qZMa/TSFwnB6BHVBbIWyoPPe+TAdSTd8KevEx8ml8KkycJ/9A70DFVReyUww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.17.tgz",
+      "integrity": "sha512-teKfwJg0zSC+C2ZSOsX3VnAJGVgcN+pgKNmnGWzcpXQ9eIkAQtYP+getrQ2f1Tw/ePudnreQhq8tVP8S73Vy6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.17.tgz",
+      "integrity": "sha512-mqO36x2CNtJ9CCbEf5xOqH662tVSc1wB0mxh7dopBpgXg0fEifdzwX0IEAUW1WUAaNH986L7iEUUgw3HNqUWgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.17.tgz",
+      "integrity": "sha512-jbyoNePufyMoSSrvVr+/mglcjmya/MOgoIrSHPr67iZ1VFgrlMQXHXtptR2lR48gi+86b1XBvsviJZ9A7zrydg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.17.tgz",
+      "integrity": "sha512-+ql0wYc99Y2AMvyHCcC/P+xtyV4nz522L+C9HDnyi7ryHXBGM+ZjBP28M7SLBGMDImgpN8sk2szpgbvreMeXVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -9897,9 +9960,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -14315,9 +14378,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -14569,12 +14632,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14584,13 +14647,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14886,9 +14949,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15277,9 +15340,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16406,106 +16469,22 @@
       "peer": true
     },
     "node_modules/turbo": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.4.4.tgz",
-      "integrity": "sha512-N9FDOVaY3yz0YCOhYIgOGYad7+m2ptvinXygw27WPLQvcZDl3+0Sa77KGVlLSiuPDChOUEnTKE9VJwLSi9BPGQ==",
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.17.tgz",
+      "integrity": "sha512-91Q3KxfHJn7esFu2Ic6j9pkvQqWjncQCOp7r1gCKChRSb/+T/yIjsavAmbGLmFRKAzSjmWW/FMrcknmJ4hEOPA==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.4.4",
-        "turbo-darwin-arm64": "2.4.4",
-        "turbo-linux-64": "2.4.4",
-        "turbo-linux-arm64": "2.4.4",
-        "turbo-windows-64": "2.4.4",
-        "turbo-windows-arm64": "2.4.4"
+        "@turbo/darwin-64": "2.9.17",
+        "@turbo/darwin-arm64": "2.9.17",
+        "@turbo/linux-64": "2.9.17",
+        "@turbo/linux-arm64": "2.9.17",
+        "@turbo/windows-64": "2.9.17",
+        "@turbo/windows-arm64": "2.9.17"
       }
-    },
-    "node_modules/turbo-darwin-64": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.4.4.tgz",
-      "integrity": "sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-darwin-arm64": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.4.4.tgz",
-      "integrity": "sha512-/gtHPqbGQXDFhrmy+Q/MFW2HUTUlThJ97WLLSe4bxkDrKHecDYhAjbZ4rN3MM93RV9STQb3Tqy4pZBtsd4DfCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-linux-64": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.4.4.tgz",
-      "integrity": "sha512-SR0gri4k0bda56hw5u9VgDXLKb1Q+jrw4lM7WAhnNdXvVoep4d6LmnzgMHQQR12Wxl3KyWPbkz9d1whL6NTm2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-linux-arm64": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.4.4.tgz",
-      "integrity": "sha512-COXXwzRd3vslQIfJhXUklgEqlwq35uFUZ7hnN+AUyXx7hUOLIiD5NblL+ETrHnhY4TzWszrbwUMfe2BYWtaPQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-windows-64": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.4.4.tgz",
-      "integrity": "sha512-PV9rYNouGz4Ff3fd6sIfQy5L7HT9a4fcZoEv8PKRavU9O75G7PoDtm8scpHU10QnK0QQNLbE9qNxOAeRvF0fJg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/turbo-windows-arm64": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.4.4.tgz",
-      "integrity": "sha512-403sqp9t5sx6YGEC32IfZTVWkRAixOQomGYB8kEc6ZD+//LirSxzeCHCnM8EmSXw7l57U1G+Fb0kxgTcKPU/Lg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -17387,9 +17366,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
# Description

Upgrade vulnerable dependencies:

```
brace-expansion  5.0.2 - 5.0.5
Severity: moderate
brace-expansion: Large numeric range defeats documented `max` DoS protection - https://github.com/advisories/GHSA-jxxr-4gwj-5jf2
fix available via `npm audit fix`
node_modules/rimraf/node_modules/brace-expansion

fast-uri  <=3.1.1
Severity: high
fast-uri vulnerable to path traversal via percent-encoded dot segments - https://github.com/advisories/GHSA-q3j6-qgpj-74h6
fast-uri vulnerable to host confusion via percent-encoded authority delimiters - https://github.com/advisories/GHSA-v39h-62p7-jpjc
fix available via `npm audit fix`
node_modules/fast-uri

qs  6.11.1 - 6.15.1
Severity: moderate
qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set - https://github.com/advisories/GHSA-q8mj-m7cp-5q26
fix available via `npm audit fix`
node_modules/qs

react-router  6.7.0 - 6.30.3
Severity: moderate
React Router's same-origin redirect with path starting // causes open redirect via protocol-relative URL reinterpretation - https://github.com/advisories/GHSA-2j2x-hqr9-3h42
fix available via `npm audit fix`
node_modules/react-router
  react-router-dom  6.6.3-pre.0 - 6.30.3
  Depends on vulnerable versions of react-router
  node_modules/react-router-dom

shell-quote  1.1.0 - 1.8.3
Severity: critical
shell-quote quote() does not escape newlines in object .op values - https://github.com/advisories/GHSA-w7jw-789q-3m8p
fix available via `npm audit fix`
node_modules/shell-quote

turbo  <=2.9.13-canary.1
Severity: moderate
Trubo: Login callback CSRF/session fixation - https://github.com/advisories/GHSA-hcf7-66rw-9f5r
Turbo: Unexpected local code execution during Yarn Berry detection - https://github.com/advisories/GHSA-3qcw-2rhx-2726
fix available via `npm audit fix`
node_modules/turbo

ws  8.0.0 - 8.20.0
Severity: moderate
ws: Uninitialized memory disclosure - https://github.com/advisories/GHSA-58qx-3vcg-4xpx
fix available via `npm audit fix`
node_modules/@module-federation/dts-plugin/node_modules/ws
node_modules/ws
  @module-federation/dts-plugin  <=2.5.0
  Depends on vulnerable versions of ws
  node_modules/@module-federation/dts-plugin
    @module-federation/cli  <=2.5.0
    Depends on vulnerable versions of @module-federation/dts-plugin
    node_modules/@module-federation/cli
      @module-federation/enhanced  <=0.0.1-rc.0 || 0.1.2 - 2.5.0
      Depends on vulnerable versions of @module-federation/cli
      Depends on vulnerable versions of @module-federation/dts-plugin
      Depends on vulnerable versions of @module-federation/manifest
      Depends on vulnerable versions of @module-federation/rspack
      node_modules/@module-federation/enhanced
    @module-federation/manifest  <=0.0.0-research-issue-4085-20251016232757 || 0.1.3 - 2.5.0
    Depends on vulnerable versions of @module-federation/dts-plugin
    node_modules/@module-federation/manifest
      @module-federation/rspack  <=2.5.0
      Depends on vulnerable versions of @module-federation/dts-plugin
      Depends on vulnerable versions of @module-federation/manifest
      node_modules/@module-federation/rspack

13 vulnerabilities (11 moderate, 1 high, 1 critical)
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
