### PR TITLE
[ENHANCEMENT] Add new ``api/v1/watch`` endpoint to watch resource udpdates

### DIFF
--- a/cue/model/api/v1/role/action_go_gen.cue
+++ b/cue/model/api/v1/role/action_go_gen.cue
@@ -11,10 +11,12 @@ package role
 	#CreateAction |
 	#UpdateAction |
 	#DeleteAction |
+	#WatchAction |
 	#WildcardAction
 
 #ReadAction:     #Action & "read"
 #CreateAction:   #Action & "create"
 #UpdateAction:   #Action & "update"
 #DeleteAction:   #Action & "delete"
+#WatchAction:    #Action & "watch"
 #WildcardAction: #Action & "*"

--- a/internal/api/authorization/k8s/translation.go
+++ b/internal/api/authorization/k8s/translation.go
@@ -24,6 +24,7 @@ const (
 	k8sCreateAction   k8sAction = "create"
 	k8sUpdateAction   k8sAction = "patch"
 	k8sDeleteAction   k8sAction = "delete"
+	k8sWatchAction    k8sAction = "watch"
 	k8sWildcardAction k8sAction = "*"
 )
 
@@ -80,6 +81,8 @@ func getK8sAction(action v1Role.Action) k8sAction {
 		return k8sUpdateAction
 	case v1Role.DeleteAction:
 		return k8sDeleteAction
+	case v1Role.WatchAction:
+		return k8sWatchAction
 	case v1Role.WildcardAction:
 		return k8sWildcardAction
 	default: // not reachable

--- a/internal/api/core/server.go
+++ b/internal/api/core/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/perses/perses/internal/api/impl/v1/user"
 	"github.com/perses/perses/internal/api/impl/v1/variable"
 	"github.com/perses/perses/internal/api/impl/v1/view"
+	"github.com/perses/perses/internal/api/impl/v1/watch"
 	validateendpoint "github.com/perses/perses/internal/api/impl/validate"
 	"github.com/perses/perses/internal/api/route"
 	"github.com/perses/perses/internal/api/utils"
@@ -76,6 +77,7 @@ func NewPersesAPI(dependencyManager dependency.Manager, cfg config.Config) echoU
 		user.NewEndpoint(serviceManager.GetUser(), serviceManager.GetAuthorization(), cfg.Security.Authentication.DisableSignUp, readonly, caseSensitive),
 		variable.NewEndpoint(cfg.Variable, serviceManager.GetVariable(), serviceManager.GetAuthorization(), readonly, caseSensitive),
 		view.NewEndpoint(serviceManager.GetView(), serviceManager.GetAuthorization(), serviceManager.GetDashboard()),
+		watch.NewEndpoint(serviceManager.GetWatch(), serviceManager.GetAuthorization()),
 	}
 
 	if cfg.Security.Authorization.Provider.Native.Enable {

--- a/internal/api/database/database.go
+++ b/internal/api/database/database.go
@@ -23,16 +23,19 @@ import (
 	databaseFile "github.com/perses/perses/internal/api/database/file"
 	databaseModel "github.com/perses/perses/internal/api/database/model"
 	databaseSQL "github.com/perses/perses/internal/api/database/sql"
+	watchapi "github.com/perses/perses/internal/api/interface/v1/watch"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	"github.com/perses/perses/pkg/model/api/config"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/role"
 	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 
 type dao struct {
 	databaseModel.DAO
-	client databaseModel.DAO
+	client  databaseModel.DAO
+	watcher watchapi.EventPublisher
 }
 
 func (d *dao) Close() error {
@@ -46,10 +49,22 @@ func (d *dao) IsCaseSensitive() bool {
 	return d.client.IsCaseSensitive()
 }
 func (d *dao) Create(entity modelAPI.Entity) error {
-	return d.client.Create(entity)
+	if err := d.client.Create(entity); err != nil {
+		return err
+	}
+	if d.watcher != nil {
+		d.watcher.Publish(modelV1.NewWatchEventFromEntity(entity, role.CreateAction))
+	}
+	return nil
 }
 func (d *dao) Upsert(entity modelAPI.Entity) error {
-	return d.client.Upsert(entity)
+	if err := d.client.Upsert(entity); err != nil {
+		return err
+	}
+	if d.watcher != nil {
+		d.watcher.Publish(modelV1.NewWatchEventFromEntity(entity, role.UpdateAction))
+	}
+	return nil
 }
 func (d *dao) Get(kind modelV1.Kind, metadata modelAPI.Metadata, entity modelAPI.Entity) error {
 	return d.client.Get(kind, metadata, entity)
@@ -74,7 +89,13 @@ func (d *dao) RawMetadataQuery(query databaseModel.Query, kind modelV1.Kind) ([]
 	return result, nil
 }
 func (d *dao) Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error {
-	return d.client.Delete(kind, metadata)
+	if err := d.client.Delete(kind, metadata); err != nil {
+		return err
+	}
+	if d.watcher != nil {
+		d.watcher.Publish(modelV1.NewDeleteWatchEvent(kind, metadata))
+	}
+	return nil
 }
 func (d *dao) DeleteByQuery(query databaseModel.Query) error {
 	return d.client.DeleteByQuery(query)
@@ -86,7 +107,11 @@ func (d *dao) GetLatestUpdateTime(kind []modelV1.Kind) (*string, error) {
 	return d.client.GetLatestUpdateTime(kind)
 }
 
-func New(conf config.Database) (databaseModel.DAO, error) {
+func (d *dao) SetWatcher(watcher watchapi.EventPublisher) {
+	d.watcher = watcher
+}
+
+func New(conf config.Database) (databaseModel.WatchableDAO, error) {
 	var client databaseModel.DAO
 	if conf.File != nil {
 		client = &databaseFile.DAO{

--- a/internal/api/database/model/dao.go
+++ b/internal/api/database/model/dao.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"io"
 
+	watchapi "github.com/perses/perses/internal/api/interface/v1/watch"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 )
@@ -45,4 +46,9 @@ type DAO interface {
 	DeleteByQuery(query Query) error
 	HealthCheck() bool
 	GetLatestUpdateTime(kind []modelV1.Kind) (*string, error)
+}
+
+type WatchableDAO interface {
+	DAO
+	SetWatcher(watchDAO watchapi.EventPublisher)
 }

--- a/internal/api/dependency/persistence_manager.go
+++ b/internal/api/dependency/persistence_manager.go
@@ -32,6 +32,7 @@ import (
 	secretImpl "github.com/perses/perses/internal/api/impl/v1/secret"
 	userImpl "github.com/perses/perses/internal/api/impl/v1/user"
 	variableImpl "github.com/perses/perses/internal/api/impl/v1/variable"
+	watchImpl "github.com/perses/perses/internal/api/impl/v1/watch"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
@@ -48,6 +49,7 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/secret"
 	"github.com/perses/perses/internal/api/interface/v1/user"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
+	"github.com/perses/perses/internal/api/interface/v1/watch"
 	"github.com/perses/perses/pkg/model/api/config"
 )
 
@@ -69,6 +71,7 @@ type PersistenceManager interface {
 	GetSecret() secret.DAO
 	GetUser() user.DAO
 	GetVariable() variable.DAO
+	GetWatch() watch.DAOWatcher
 }
 
 type persistence struct {
@@ -90,6 +93,7 @@ type persistence struct {
 	secret             secret.DAO
 	user               user.DAO
 	variable           variable.DAO
+	watch              watch.DAOWatcher
 }
 
 func newPersistenceManager(conf config.Database) (PersistenceManager, error) {
@@ -97,6 +101,8 @@ func newPersistenceManager(conf config.Database) (PersistenceManager, error) {
 	if err != nil {
 		return nil, err
 	}
+	daoWatcher := watchImpl.NewDAOWatcher()
+	persesDAO.SetWatcher(daoWatcher)
 	dashboardDAO := dashboardImpl.NewDAO(persesDAO)
 	datasourceDAO := datasourceImpl.NewDAO(persesDAO)
 	ephemeralDashboardDAO := ephemeralDashboardImpl.NewDAO(persesDAO)
@@ -131,6 +137,7 @@ func newPersistenceManager(conf config.Database) (PersistenceManager, error) {
 		secret:             secretDAO,
 		user:               userDAO,
 		variable:           variableDAO,
+		watch:              daoWatcher,
 	}, nil
 }
 
@@ -200,4 +207,8 @@ func (p *persistence) GetUser() user.DAO {
 
 func (p *persistence) GetVariable() variable.DAO {
 	return p.variable
+}
+
+func (p *persistence) GetWatch() watch.DAOWatcher {
+	return p.watch
 }

--- a/internal/api/dependency/service_manager.go
+++ b/internal/api/dependency/service_manager.go
@@ -35,6 +35,7 @@ import (
 	userImpl "github.com/perses/perses/internal/api/impl/v1/user"
 	variableImpl "github.com/perses/perses/internal/api/impl/v1/variable"
 	viewImpl "github.com/perses/perses/internal/api/impl/v1/view"
+	watchImpl "github.com/perses/perses/internal/api/impl/v1/watch"
 	"github.com/perses/perses/internal/api/interface/v1/dashboard"
 	"github.com/perses/perses/internal/api/interface/v1/datasource"
 	"github.com/perses/perses/internal/api/interface/v1/ephemeraldashboard"
@@ -52,6 +53,7 @@ import (
 	"github.com/perses/perses/internal/api/interface/v1/user"
 	"github.com/perses/perses/internal/api/interface/v1/variable"
 	"github.com/perses/perses/internal/api/interface/v1/view"
+	"github.com/perses/perses/internal/api/interface/v1/watch"
 	"github.com/perses/perses/internal/api/plugin"
 	"github.com/perses/perses/internal/api/plugin/migrate"
 	"github.com/perses/perses/internal/api/plugin/schema"
@@ -82,6 +84,7 @@ type ServiceManager interface {
 	GetUser() user.Service
 	GetVariable() variable.Service
 	GetView() view.Service
+	GetWatch() watch.Service
 }
 
 type service struct {
@@ -109,6 +112,7 @@ type service struct {
 	user               user.Service
 	variable           variable.Service
 	view               view.Service
+	watch              watch.Service
 }
 
 func newServiceManager(dao PersistenceManager, conf config.Config) (ServiceManager, error) {
@@ -140,6 +144,7 @@ func newServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 	secretService := secretImpl.NewService(dao.GetSecret(), cryptoService)
 	userService := userImpl.NewService(dao.GetUser(), authzService)
 	viewService := viewImpl.NewMetricsViewService()
+	watchService := watchImpl.NewService(dao.GetWatch())
 
 	svc := &service{
 		authorization:      authzService,
@@ -165,6 +170,7 @@ func newServiceManager(dao PersistenceManager, conf config.Config) (ServiceManag
 		user:               userService,
 		variable:           variableService,
 		view:               viewService,
+		watch:              watchService,
 	}
 	return svc, nil
 }
@@ -259,4 +265,8 @@ func (s *service) GetVariable() variable.Service {
 
 func (s *service) GetView() view.Service {
 	return s.view
+}
+
+func (s *service) GetWatch() watch.Service {
+	return s.watch
 }

--- a/internal/api/impl/v1/watch/endpoint.go
+++ b/internal/api/impl/v1/watch/endpoint.go
@@ -1,0 +1,105 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/perses/perses/internal/api/authorization"
+	apiinterface "github.com/perses/perses/internal/api/interface"
+	watchapi "github.com/perses/perses/internal/api/interface/v1/watch"
+	"github.com/perses/perses/internal/api/route"
+	"github.com/perses/perses/internal/api/utils"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/role"
+)
+
+const keepAlivePeriod = 30 * time.Second
+
+type endpoint struct {
+	service watchapi.Service
+	authz   authorization.Authorization
+}
+
+func NewEndpoint(service watchapi.Service, authz authorization.Authorization) route.Endpoint {
+	return &endpoint{service: service, authz: authz}
+}
+
+func (e *endpoint) CollectRoutes(g *route.Group) {
+	g.GET(fmt.Sprintf("/%s", utils.PathWatch), e.watch, false)
+}
+
+func (e *endpoint) watch(ctx echo.Context) error {
+	if e.authz.IsEnabled() {
+		if ok := e.authz.HasPermission(ctx, role.WatchAction, v1.WildcardProject, role.WildcardScope); !ok {
+			return apiinterface.HandleForbiddenError(fmt.Sprintf("missing '%s' global permission for '%s' scope", role.WatchAction, role.WildcardScope))
+		}
+	}
+
+	flusher, ok := ctx.Response().Writer.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("%w: streaming is not supported", apiinterface.InternalError)
+	}
+
+	header := ctx.Response().Header()
+	header.Set(echo.HeaderContentType, "text/event-stream")
+	header.Set(echo.HeaderCacheControl, "no-cache")
+	header.Set("Connection", "keep-alive")
+	ctx.Response().WriteHeader(http.StatusOK)
+
+	if err := writeSSE(ctx.Response().Writer, "connected", map[string]string{"status": "ok"}); err != nil {
+		return err
+	}
+	flusher.Flush()
+
+	events, unsubscribe := e.service.Subscribe(ctx.Request().Context())
+	defer unsubscribe()
+
+	ticker := time.NewTicker(keepAlivePeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Request().Context().Done():
+			return nil
+		case event, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if err := writeSSE(ctx.Response().Writer, "resource", event); err != nil {
+				return err
+			}
+			flusher.Flush()
+		case <-ticker.C:
+			if _, err := io.WriteString(ctx.Response().Writer, ": keepalive\n\n"); err != nil {
+				return err
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func writeSSE(writer io.Writer, eventType string, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(writer, fmt.Sprintf("event: %s\ndata: %s\n\n", eventType, data))
+	return err
+}

--- a/internal/api/impl/v1/watch/persistence.go
+++ b/internal/api/impl/v1/watch/persistence.go
@@ -1,0 +1,46 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+
+	"github.com/perses/perses/internal/api/interface/v1/watch"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+const eventQueueBufferSize = 256
+
+type watcherImpl struct {
+	events chan *v1.WatchEvent
+}
+
+func NewDAOWatcher() watch.DAOWatcher {
+	return &watcherImpl{events: make(chan *v1.WatchEvent, eventQueueBufferSize)}
+}
+
+func (p *watcherImpl) Publish(event *v1.WatchEvent) {
+	if event == nil {
+		return
+	}
+	select {
+	case p.events <- event:
+	default:
+		// Keep DB writes non-blocking when the watch queue is saturated.
+	}
+}
+
+func (p *watcherImpl) Subscribe(_ context.Context) (<-chan *v1.WatchEvent, func()) {
+	return p.events, func() {}
+}

--- a/internal/api/impl/v1/watch/service.go
+++ b/internal/api/impl/v1/watch/service.go
@@ -1,0 +1,81 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+	"sync"
+
+	"github.com/perses/perses/internal/api/interface/v1/watch"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+const subscriberBufferSize = 64
+
+type service struct {
+	mu          sync.RWMutex
+	nextID      int
+	daoWatcher  watch.EventSubscriber
+	subscribers map[int]chan *v1.WatchEvent
+}
+
+func NewService(daoWatcher watch.EventSubscriber) watch.Service {
+	svc := &service{
+		daoWatcher:  daoWatcher,
+		subscribers: map[int]chan *v1.WatchEvent{},
+	}
+	go svc.dispatch()
+	return svc
+}
+
+func (s *service) Subscribe(ctx context.Context) (<-chan *v1.WatchEvent, func()) {
+	ch := make(chan *v1.WatchEvent, subscriberBufferSize)
+
+	s.mu.Lock()
+	id := s.nextID
+	s.nextID++
+	s.subscribers[id] = ch
+	s.mu.Unlock()
+
+	unsubscribe := func() {
+		s.mu.Lock()
+		if existing, ok := s.subscribers[id]; ok {
+			delete(s.subscribers, id)
+			close(existing)
+		}
+		s.mu.Unlock()
+	}
+
+	go func() {
+		<-ctx.Done()
+		unsubscribe()
+	}()
+
+	return ch, unsubscribe
+}
+
+func (s *service) dispatch() {
+	events, _ := s.daoWatcher.Subscribe(context.Background())
+	for event := range events {
+		s.mu.RLock()
+		for _, subscriber := range s.subscribers {
+			select {
+			case subscriber <- event:
+			default:
+				// Slow subscribers are skipped to keep dispatch non-blocking.
+			}
+		}
+		s.mu.RUnlock()
+	}
+}

--- a/internal/api/impl/v1/watch/service_test.go
+++ b/internal/api/impl/v1/watch/service_test.go
@@ -1,0 +1,99 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/perses/pkg/model/api/v1/role"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServicePublishToSubscriber(t *testing.T) {
+	watcher := NewDAOWatcher()
+	svc := NewService(watcher)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, unsubscribe := svc.Subscribe(ctx)
+	defer unsubscribe()
+
+	expected := &v1.WatchEvent{
+		Kind:    v1.KindDashboard,
+		Project: "project-a",
+		Name:    "dashboard-a",
+		Action:  role.UpdateAction,
+	}
+	watcher.Publish(expected)
+
+	select {
+	case got := <-ch:
+		require.Equal(t, expected, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watch event")
+	}
+}
+
+func TestServicePublishBroadcastsToAllSubscribers(t *testing.T) {
+	watcher := NewDAOWatcher()
+	svc := NewService(watcher)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch1, unsubscribe1 := svc.Subscribe(ctx)
+	defer unsubscribe1()
+	ch2, unsubscribe2 := svc.Subscribe(ctx)
+	defer unsubscribe2()
+
+	expected := &v1.WatchEvent{
+		Kind:    v1.KindDashboard,
+		Project: "project-a",
+		Name:    "dashboard-a",
+		Action:  role.UpdateAction,
+	}
+	watcher.Publish(expected)
+
+	select {
+	case got := <-ch1:
+		require.Equal(t, expected, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watch event on subscriber 1")
+	}
+
+	select {
+	case got := <-ch2:
+		require.Equal(t, expected, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watch event on subscriber 2")
+	}
+}
+
+func TestServiceUnsubscribeClosesChannel(t *testing.T) {
+	watcher := NewDAOWatcher()
+	svc := NewService(watcher)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, unsubscribe := svc.Subscribe(ctx)
+	unsubscribe()
+
+	_, ok := <-ch
+	require.False(t, ok)
+
+	// Must remain non-blocking for publishers after a client unsubscribes.
+	watcher.Publish(&v1.WatchEvent{Kind: v1.KindDashboard, Action: role.DeleteAction})
+}

--- a/internal/api/interface/v1/watch/interface.go
+++ b/internal/api/interface/v1/watch/interface.go
@@ -1,0 +1,40 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+// EventPublisher is used by persistence/DAO code to emit low-level watch events.
+type EventPublisher interface {
+	Publish(event *v1.WatchEvent)
+}
+
+// EventSubscriber is used by watch service code to consume low-level events.
+type EventSubscriber interface {
+	Subscribe(ctx context.Context) (<-chan *v1.WatchEvent, func())
+}
+
+// DAOWatcher is the low-level watch event bus used by persistence and service layers.
+type DAOWatcher interface {
+	EventPublisher
+	EventSubscriber
+}
+
+type Service interface {
+	Subscribe(ctx context.Context) (<-chan *v1.WatchEvent, func())
+}

--- a/internal/api/utils/utils.go
+++ b/internal/api/utils/utils.go
@@ -55,6 +55,7 @@ const (
 	PathCurrentUser        = "user"
 	PathVariable           = "variables"
 	PathView               = "view"
+	PathWatch              = "watch"
 	PathWhoAmI             = "whoami"
 	ContextKeyAnonymous    = "anonymous"
 )

--- a/pkg/model/api/v1/role/action.go
+++ b/pkg/model/api/v1/role/action.go
@@ -26,6 +26,7 @@ const (
 	CreateAction   Action = "create"
 	UpdateAction   Action = "update"
 	DeleteAction   Action = "delete"
+	WatchAction    Action = "watch"
 	WildcardAction Action = "*"
 )
 
@@ -79,6 +80,9 @@ func GetAction(action string) (*Action, error) {
 		return &result, nil
 	case strings.ToLower(string(DeleteAction)):
 		result := DeleteAction
+		return &result, nil
+	case strings.ToLower(string(WatchAction)):
+		result := WatchAction
 		return &result, nil
 	case strings.ToLower(string(WildcardAction)):
 		result := WildcardAction

--- a/pkg/model/api/v1/watch_event.go
+++ b/pkg/model/api/v1/watch_event.go
@@ -1,0 +1,67 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	"github.com/perses/perses/pkg/model/api/v1/role"
+)
+
+// WatchEvent is emitted by the watch SSE endpoint to notify backend resource changes.
+type WatchEvent struct {
+	Kind    Kind        `json:"kind" yaml:"kind"`
+	Project string      `json:"project" yaml:"project"`
+	Name    string      `json:"name" yaml:"name"`
+	Action  role.Action `json:"action" yaml:"action"`
+}
+
+func NewWatchEventFromEntity(entity modelAPI.Entity, action role.Action) *WatchEvent {
+	if entity == nil || entity.GetMetadata() == nil {
+		return nil
+	}
+	kind, err := GetKind(entity.GetKind())
+	if err != nil {
+		return nil
+	}
+	metadata := entity.GetMetadata()
+	return &WatchEvent{
+		Kind:    *kind,
+		Project: getProjectFromMetadata(metadata),
+		Name:    metadata.GetName(),
+		Action:  action,
+	}
+}
+
+func NewDeleteWatchEvent(kind Kind, metadata modelAPI.Metadata) *WatchEvent {
+	if metadata == nil {
+		return nil
+	}
+	return &WatchEvent{
+		Kind:    kind,
+		Project: getProjectFromMetadata(metadata),
+		Name:    metadata.GetName(),
+		Action:  role.DeleteAction,
+	}
+}
+
+func getProjectFromMetadata(metadata modelAPI.Metadata) string {
+	switch met := metadata.(type) {
+	case *ProjectMetadata:
+		return met.Project
+	case *PublicProjectMetadata:
+		return met.Project
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Ref #4123 

Not ready yet. Exploring best ways to include into the existing code architecture. Here the watch is on the persistence side (DAOs) as close as possible to the DB queries. 
The benefit is to not miss and action, the problem will with the bulk update. Typically the DeleteByQuery method. I think there is only this one actually.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
