### PR TITLE
[ENHANCEMENT] Allow provisioning by watching folders

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -618,6 +618,10 @@ See the [TLS Config](../api/secret.md#tls-config-specification) specification.
 ```yaml
 interval: <duration> | default = 1h # Optional
 
+# Can be used to update provisioning on change instead of waiting for the configured interval.
+# Interval is still used to reconcile the state.
+enable_watch: <boolean> | default = false # Optional
+
 # List of folder that Perses will read periodically. 
 # Every known data found in the different folders will be injected in the database regardless what exist.
 folders:

--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -57,8 +57,11 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 	}
 
 	if len(conf.Provisioning.Folders) > 0 {
-		provisioningTask := provisioning.New(dependencyManager.Service(), conf.Provisioning.Folders, persesDAO.IsCaseSensitive())
+		provisioningTask, provisioningWatcher := provisioning.New(dependencyManager.Service(), conf.Provisioning.Folders, persesDAO.IsCaseSensitive())
 		runner.WithTimerTasks(time.Duration(conf.Provisioning.Interval), provisioningTask)
+		if conf.Provisioning.EnableWatch {
+			runner.WithTasks(provisioningWatcher)
+		}
 	}
 	if len(conf.Datasource.Global.Discovery) > 0 {
 		datasourceDiscoveryTasks, sdErr := discovery.New(conf, dependencyManager.Service(), persesDAO.IsCaseSensitive())

--- a/internal/api/e2e/api/provisioning_test.go
+++ b/internal/api/e2e/api/provisioning_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gavv/httpexpect/v2"
 	databaseModel "github.com/perses/perses/internal/api/database/model"
@@ -46,7 +47,8 @@ func TestProvisioningSkipsResourcesInUnknownProject(t *testing.T) {
 		writeEntityToFile(t, filepath.Join(provisioningDir, "valid.json"), roleInExistingProject)
 		writeEntityToFile(t, filepath.Join(provisioningDir, "orphan.json"), roleInUnknownProject)
 
-		if err := provisioning.New(manager.Service(), []string{provisioningDir}, true).Execute(context.Background(), func() {}); err != nil {
+		task, _ := provisioning.New(manager.Service(), []string{provisioningDir}, true)
+		if err := task.Execute(context.Background(), func() {}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -75,7 +77,8 @@ func TestProvisioningCreatesProjectBeforeItsResources(t *testing.T) {
 		writeEntityToFile(t, filepath.Join(provisioningDir, "a_role.json"), roleInProject)
 		writeEntityToFile(t, filepath.Join(provisioningDir, "z_project.json"), project)
 
-		if err := provisioning.New(manager.Service(), []string{provisioningDir}, true).Execute(context.Background(), func() {}); err != nil {
+		task, _ := provisioning.New(manager.Service(), []string{provisioningDir}, true)
+		if err := task.Execute(context.Background(), func() {}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -86,6 +89,41 @@ func TestProvisioningCreatesProjectBeforeItsResources(t *testing.T) {
 		assert.NoError(t, err, "role must be provisioned once its project is created in the same batch")
 
 		return []modelAPI.Entity{project, roleInProject}
+	})
+}
+
+func TestProvisioningWatcher(t *testing.T) {
+	e2eframework.WithServer(t, func(_ *httptest.Server, _ *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
+		provisioningDir := t.TempDir()
+		task, watcher := provisioning.New(manager.Service(), []string{provisioningDir}, true)
+
+		// Initial load like core.go does at startup.
+		if err := task.Execute(context.Background(), func() {}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Start the watcher in the background.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			_ = watcher.Execute(ctx, cancel)
+		}()
+
+		// Wait a bit for the watcher to settle and register its fs watchers.
+		time.Sleep(1 * time.Second)
+
+		// Drop a new file to trigger the watcher.
+		project := e2eframework.NewProject("watcherproject")
+		writeEntityToFile(t, filepath.Join(provisioningDir, "project.json"), project)
+
+		// Wait for debounce + some margin. watchDebounce is 500ms.
+		time.Sleep(2 * time.Second)
+
+		// The project should be provisioned.
+		_, err := manager.Persistence().GetProject().Get("watcherproject")
+		assert.NoError(t, err, "project should be provisioned by the watcher")
+
+		return []modelAPI.Entity{project}
 	})
 }
 

--- a/internal/api/provisioning/provisioning.go
+++ b/internal/api/provisioning/provisioning.go
@@ -16,237 +16,151 @@ package provisioning
 import (
 	"context"
 	"fmt"
-	"sort"
+	"os"
+	"path/filepath"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/perses/common/async"
-	databaseModel "github.com/perses/perses/internal/api/database/model"
 	"github.com/perses/perses/internal/api/dependency"
-	apiInterface "github.com/perses/perses/internal/api/interface"
-	"github.com/perses/perses/internal/cli/file"
-	"github.com/perses/perses/internal/cli/resource"
-	modelAPI "github.com/perses/perses/pkg/model/api"
-	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/sirupsen/logrus"
 )
 
-type insertFunc func() (modelAPI.Entity, error)
+// watchDebounce is the quiet period after the last filesystem event before a reload is
+// triggered. This batches rapid successive changes (e.g. a directory of files being
+// written at once) into a single applyEntity call.
+const watchDebounce = 500 * time.Millisecond
 
-func New(serviceManager dependency.ServiceManager, folders []string, caseSensitive bool) async.SimpleTask {
-	return &provisioning{
+func New(serviceManager dependency.ServiceManager, folders []string, caseSensitive bool) (async.SimpleTask, async.SimpleTask) {
+	svc := &provisioningService{
 		serviceManager: serviceManager,
-		folders:        folders,
 		caseSensitive:  caseSensitive,
 	}
+	return &provisioningTask{
+			folders: folders,
+			svc:     svc,
+		}, &provisioningWatcher{
+			folders: folders,
+			svc:     svc,
+		}
 }
 
-type provisioning struct {
-	async.SimpleTask
-	serviceManager dependency.ServiceManager
-	folders        []string
-	caseSensitive  bool
+type provisioningTask struct {
+	svc     provisioningServiceInterface
+	folders []string
 }
 
-func (p *provisioning) Execute(_ context.Context, _ context.CancelFunc) error {
+func (p *provisioningTask) Execute(_ context.Context, _ context.CancelFunc) error {
 	if len(p.folders) == 0 {
 		return nil
 	}
-	var entities []modelAPI.Entity
-	for _, dir := range p.folders {
-		objects, errors := file.UnmarshalEntitiesFromDirectory(dir)
-		for _, err := range errors {
-			logrus.WithError(err).Warningf("unable to load every entity from the folder %q", dir)
-		}
-
-		if len(objects) > 0 {
-			entities = append(entities, objects...)
-		}
-
-	}
-	p.applyEntity(entities)
+	p.svc.reloadAllEntities(p.folders)
 	return nil
 }
 
-func (p *provisioning) String() string {
-	return "provisioning service"
+func (p *provisioningTask) String() string {
+	return "provisioning task service"
 }
 
-func (p *provisioning) applyEntity(entities []modelAPI.Entity) {
-	// Provisioning files have no guaranteed order, yet a project-scoped resource
-	// can only be created once its parent project exists. So we apply every
-	// Project first, ensuring projects declared in the same provisioning batch
-	// are created before the resources that belong to them. This keeps the
-	// "refuse resources in a non-existing project" guard from rejecting valid
-	// resources whose project simply happens to be listed later.
-	sort.SliceStable(entities, func(i, j int) bool {
-		return modelV1.Kind(entities[i].GetKind()) == modelV1.KindProject &&
-			modelV1.Kind(entities[j].GetKind()) != modelV1.KindProject
-	})
-	for _, entity := range entities {
-		entity.GetMetadata().Flatten(p.caseSensitive)
-		kind := modelV1.Kind(entity.GetKind())
-		name := entity.GetMetadata().GetName()
-		project := resource.GetProject(entity.GetMetadata(), "")
-		// A project-scoped resource cannot be provisioned if its parent project doesn't exist:
-		// the resource would be silently persisted but never visible until the project is created.
-		// So we refuse to provision it and report the missing project.
-		if len(project) > 0 && !p.projectExists(project) {
-			logrus.Errorf("unable to provision the %q/%q: project %q doesn't exist", kind, name, project)
-			continue
-		}
-		param := apiInterface.Parameters{
-			Name:    name,
-			Project: project,
-		}
-		createFun, updateFunc, svcErr := p.getService(entity, param)
-		if svcErr != nil {
-			logrus.WithError(svcErr).Warningf("unable to retrieve the service associated to %q", kind)
-			continue
-		}
+type provisioningWatcher struct {
+	svc     provisioningServiceInterface
+	folders []string
+}
 
-		// the document doesn't exist, so we have to create it.
-		_, createErr := createFun()
+// Execute watches all configured folders recursively for changes and calls reload
+// whenever a relevant filesystem event is detected.
+//
+// Kubernetes compatibility: ConfigMaps are mounted via atomic double-symlink swaps
+// (..data → ..timestamp). fsnotify watching directories (not files) naturally catches
+// these RENAME events. On each Rename/Remove we re-register all directories so the
+// watcher follows the new inodes. A short debounce window batches bursts of events
+// into a single reload.
+func (p *provisioningWatcher) Execute(ctx context.Context, _ context.CancelFunc) error {
+	if len(p.folders) == 0 {
+		return nil
+	}
 
-		if createErr == nil {
-			continue
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("unable to create provisioning watcher: %w", err)
+	}
+	defer func() {
+		if closeErr := watcher.Close(); closeErr != nil {
+			logrus.WithError(closeErr).Error("failed to close provisioning watcher")
 		}
+	}()
 
-		if !databaseModel.IsKeyConflict(createErr) {
-			logrus.WithError(createErr).Errorf("unable to create the %q %q", kind, name)
-			continue
-		}
+	if registerErr := p.registerFoldersRecursively(watcher); registerErr != nil {
+		return fmt.Errorf("unable to register folders for watching: %w", registerErr)
+	}
 
-		if _, updateError := updateFunc(); updateError != nil {
-			logrus.WithError(updateError).Errorf("unable to update the %q %q", kind, name)
+	var debounceC <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			logrus.Debugf("provisioning watcher: %s %q", event.Op, event.Name)
+
+			// CHMOD only changes file permissions, not content – ignore it to
+			// avoid spurious reloads triggered by the OS or antivirus tools
+			// that chmod files after a write.
+			if event.Op == fsnotify.Chmod {
+				continue
+			}
+
+			if event.Has(fsnotify.Create) {
+				if info, statErr := os.Stat(event.Name); statErr == nil && info.IsDir() {
+					if watchErr := watcher.Add(event.Name); watchErr != nil {
+						logrus.WithError(watchErr).Warningf("unable to watch new directory %q", event.Name)
+					}
+				}
+			}
+
+			if event.Has(fsnotify.Rename) || event.Has(fsnotify.Remove) {
+				_ = p.registerFoldersRecursively(watcher)
+			}
+
+			debounceC = time.After(watchDebounce)
+
+		case watchErr, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			logrus.WithError(watchErr).Error("provisioning watcher error")
+
+		case <-debounceC:
+			debounceC = nil
+			p.svc.reloadAllEntities(p.folders)
 		}
 	}
 }
 
-// projectExists returns true if a project with the given name exists in the database.
-// In case the lookup fails for any reason other than a missing project, we assume the
-// project exists so that a transient database error doesn't silently drop the resource.
-func (p *provisioning) projectExists(name string) bool {
-	if _, err := p.serviceManager.GetProject().Get(apiInterface.Parameters{Name: name}); err != nil {
-		return !databaseModel.IsKeyNotFound(err)
-	}
-	return true
+func (p *provisioningWatcher) String() string {
+	return "provisioning watcher service"
 }
 
-func (p *provisioning) getService(object modelAPI.Entity, parameters apiInterface.Parameters) (createFunc insertFunc, updateFunc insertFunc, err error) {
-	switch entity := object.(type) {
-	case *modelV1.Dashboard:
-		svc := p.serviceManager.GetDashboard()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.Datasource:
-		svc := p.serviceManager.GetDatasource()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.Folder:
-		svc := p.serviceManager.GetFolder()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.GlobalDatasource:
-		svc := p.serviceManager.GetGlobalDatasource()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.GlobalRole:
-		svc := p.serviceManager.GetGlobalRole()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.GlobalRoleBinding:
-		svc := p.serviceManager.GetGlobalRoleBinding()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.GlobalSecret:
-		svc := p.serviceManager.GetGlobalSecret()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.GlobalVariable:
-		svc := p.serviceManager.GetGlobalVariable()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.Project:
-		svc := p.serviceManager.GetProject()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.Role:
-		svc := p.serviceManager.GetRole()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.RoleBinding:
-		svc := p.serviceManager.GetRoleBinding()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.Secret:
-		svc := p.serviceManager.GetSecret()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.User:
-		svc := p.serviceManager.GetUser()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	case *modelV1.Variable:
-		svc := p.serviceManager.GetVariable()
-		return func() (modelAPI.Entity, error) {
-				return svc.Create(nil, entity)
-			},
-			func() (modelAPI.Entity, error) {
-				return svc.Update(nil, entity, parameters)
-			}, nil
-	// We don't support the provisioning of the following resources: EphemeralDashboard
-	default:
-		return nil, nil, fmt.Errorf("resource %q not supported by the provisioning service", entity.GetKind())
+func (p *provisioningWatcher) registerFoldersRecursively(watcher *fsnotify.Watcher) error {
+	for _, dir := range p.folders {
+		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				logrus.WithError(err).Warningf("unable to access %q while registering watcher", path)
+				return nil
+			}
+			if d.IsDir() {
+				if watchErr := watcher.Add(path); watchErr != nil {
+					logrus.WithError(watchErr).Warningf("unable to watch directory %q", path)
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/internal/api/provisioning/service.go
+++ b/internal/api/provisioning/service.go
@@ -1,0 +1,234 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"fmt"
+	"sort"
+
+	databaseModel "github.com/perses/perses/internal/api/database/model"
+	"github.com/perses/perses/internal/api/dependency"
+	apiInterface "github.com/perses/perses/internal/api/interface"
+	"github.com/perses/perses/internal/cli/file"
+	"github.com/perses/perses/internal/cli/resource"
+	modelAPI "github.com/perses/perses/pkg/model/api"
+	modelV1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/sirupsen/logrus"
+)
+
+type insertFunc func() (modelAPI.Entity, error)
+
+// provisioningServiceInterface is the minimal interface used by both the task and the watcher.
+type provisioningServiceInterface interface {
+	reloadAllEntities(folders []string)
+}
+
+type provisioningService struct {
+	serviceManager dependency.ServiceManager
+	caseSensitive  bool
+}
+
+// reload reads all entities from the given folders and applies them.
+func (p *provisioningService) reloadAllEntities(folders []string) {
+	var entities []modelAPI.Entity
+	for _, dir := range folders {
+		objects, errors := file.UnmarshalEntitiesFromDirectory(dir)
+		for _, err := range errors {
+			logrus.WithError(err).Warningf("unable to load entity from folder %q", dir)
+		}
+		entities = append(entities, objects...)
+	}
+	p.applyEntity(entities)
+}
+
+func (p *provisioningService) applyEntity(entities []modelAPI.Entity) {
+	// Provisioning files have no guaranteed order, yet a project-scoped resource
+	// can only be created once its parent project exists. So we apply every
+	// Project first, ensuring projects declared in the same provisioning batch
+	// are created before the resources that belong to them. This keeps the
+	// "refuse resources in a non-existing project" guard from rejecting valid
+	// resources whose project simply happens to be listed later.
+	sort.SliceStable(entities, func(i, j int) bool {
+		return modelV1.Kind(entities[i].GetKind()) == modelV1.KindProject &&
+			modelV1.Kind(entities[j].GetKind()) != modelV1.KindProject
+	})
+	for _, entity := range entities {
+		entity.GetMetadata().Flatten(p.caseSensitive)
+		kind := modelV1.Kind(entity.GetKind())
+		name := entity.GetMetadata().GetName()
+		project := resource.GetProject(entity.GetMetadata(), "")
+		// A project-scoped resource cannot be provisioned if its parent project doesn't exist:
+		// the resource would be silently persisted but never visible until the project is created.
+		// So we refuse to provision it and report the missing project.
+		if len(project) > 0 && !p.projectExists(project) {
+			logrus.Errorf("unable to provision the %q/%q: project %q doesn't exist", kind, name, project)
+			continue
+		}
+		param := apiInterface.Parameters{
+			Name:    name,
+			Project: project,
+		}
+		createFun, updateFunc, svcErr := p.getService(entity, param)
+		if svcErr != nil {
+			logrus.WithError(svcErr).Warningf("unable to retrieve the service associated to %q", kind)
+			continue
+		}
+
+		// the document doesn't exist, so we have to create it.
+		_, createErr := createFun()
+
+		if createErr == nil {
+			continue
+		}
+
+		if !databaseModel.IsKeyConflict(createErr) {
+			logrus.WithError(createErr).Errorf("unable to create the %q %q", kind, name)
+			continue
+		}
+
+		if _, updateError := updateFunc(); updateError != nil {
+			logrus.WithError(updateError).Errorf("unable to update the %q %q", kind, name)
+		}
+	}
+}
+
+// projectExists returns true if a project with the given name exists in the database.
+// In case the lookup fails for any reason other than a missing project, we assume the
+// project exists so that a transient database error doesn't silently drop the resource.
+func (p *provisioningService) projectExists(name string) bool {
+	if _, err := p.serviceManager.GetProject().Get(apiInterface.Parameters{Name: name}); err != nil {
+		return !databaseModel.IsKeyNotFound(err)
+	}
+	return true
+}
+
+func (p *provisioningService) getService(object modelAPI.Entity, parameters apiInterface.Parameters) (createFunc insertFunc, updateFunc insertFunc, err error) {
+	switch entity := object.(type) {
+	case *modelV1.Dashboard:
+		svc := p.serviceManager.GetDashboard()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.Datasource:
+		svc := p.serviceManager.GetDatasource()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.Folder:
+		svc := p.serviceManager.GetFolder()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.GlobalDatasource:
+		svc := p.serviceManager.GetGlobalDatasource()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.GlobalRole:
+		svc := p.serviceManager.GetGlobalRole()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.GlobalRoleBinding:
+		svc := p.serviceManager.GetGlobalRoleBinding()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.GlobalSecret:
+		svc := p.serviceManager.GetGlobalSecret()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.GlobalVariable:
+		svc := p.serviceManager.GetGlobalVariable()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.Project:
+		svc := p.serviceManager.GetProject()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.Role:
+		svc := p.serviceManager.GetRole()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.RoleBinding:
+		svc := p.serviceManager.GetRoleBinding()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.Secret:
+		svc := p.serviceManager.GetSecret()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.User:
+		svc := p.serviceManager.GetUser()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	case *modelV1.Variable:
+		svc := p.serviceManager.GetVariable()
+		return func() (modelAPI.Entity, error) {
+				return svc.Create(nil, entity)
+			},
+			func() (modelAPI.Entity, error) {
+				return svc.Update(nil, entity, parameters)
+			}, nil
+	// We don't support the provisioning of the following resources: EphemeralDashboard
+	default:
+		return nil, nil, fmt.Errorf("resource %q not supported by the provisioning service", entity.GetKind())
+	}
+}

--- a/pkg/model/api/config/provisioning.go
+++ b/pkg/model/api/config/provisioning.go
@@ -21,6 +21,9 @@ type ProvisioningConfig struct {
 	Folders []string `json:"folders,omitempty" yaml:"folders,omitempty"`
 	// Interval is the refresh frequency
 	Interval common.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
+	// EnableWatch can be used to update provisioning on change instead of waiting for the configured interval.
+	// Interval is still used to reconcile the state.
+	EnableWatch bool `json:"enable_watch,omitempty" yaml:"enable_watch,omitempty"`
 }
 
 func (p *ProvisioningConfig) Verify() error {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Relates to #3899

#### 1/ Introduce a new config: 
```yaml
# Can be used to update provisioning on change instead of waiting for the configured interval.
# Interval is still used to reconcile the state.
enable_watch: <boolean> | default = false # Optional
```

Note that there is a debounce mechanism currently hardcoded to 500ms. I'm not sure it's relevant to have it in config.

#### ~~2/ No more force update~~
> This has been cancelled to not mix up things, and keep the provisioning mechanism a "no doubt" one. It's always updating the resources no matter what to actually be a source of truth. We'll see if the watch events mechanisms will have to deduplicate because of this or not.

As a bonus, this PR also fixes the always update behavior, that is leading to high version numbers and unnecessary writes in the DB. 
<img width="479" height="162" alt="image" src="https://github.com/user-attachments/assets/8db9e0a3-5c71-460a-81e1-50a4ae5f7e1c" />

Now it's only updating the resource if it's different from the database one. Excluding of course the always changing fields like ``version``, ``updatedAt``, ``createdAt``.
```go
// stripTransientMetadata removes metadata fields that are managed by the server and
// should not be considered when comparing whether an entity's content has changed.
func stripTransientMetadata(m map[string]interface{}) {
	meta, ok := m["metadata"].(map[string]interface{})
	if !ok {
		return
	}
	delete(meta, "version")
	delete(meta, "updatedAt")
	delete(meta, "createdAt")
}
```

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

N/A
