### PR TITLE
[BUGFIX] Go SDK set PanelGroup collapse properly

### DIFF
--- a/go-sdk/dashboard/options.go
+++ b/go-sdk/dashboard/options.go
@@ -26,6 +26,14 @@ import (
 	datasourceSpec "github.com/perses/spec/go/datasource"
 )
 
+// buildCollapsedSpec is building a grid layout collapse spec respecting the same default value as Cue SDK
+func buildCollapsedSpec(isCollapsed *bool) *dashboard.GridLayoutCollapse {
+	if isCollapsed == nil {
+		return nil // to have consistent default with Cue SDK
+	}
+	return &dashboard.GridLayoutCollapse{Open: !*isCollapsed}
+}
+
 type GridItem struct {
 	X, Y, W, H int
 }
@@ -120,9 +128,7 @@ func AddPanelGroup(title string, options ...panelgroup.Option) Option {
 			RepeatVariable: r.RepeatVariable,
 		}
 
-		if !r.IsCollapsed {
-			gridLayoutSpec.Display.Collapse = &dashboard.GridLayoutCollapse{Open: true}
-		}
+		gridLayoutSpec.Display.Collapse = buildCollapsedSpec(r.IsCollapsed)
 
 		for i := range r.Panels {
 			panelRef := fmt.Sprintf("%d_%d", len(builder.Dashboard.Spec.Layouts), i)
@@ -197,9 +203,7 @@ func AddCustomPanelGroup(title string, positions []GridItem, options ...panelgro
 			RepeatVariable: r.RepeatVariable,
 		}
 
-		if !r.IsCollapsed {
-			gridLayoutSpec.Display.Collapse = &dashboard.GridLayoutCollapse{Open: true}
-		}
+		gridLayoutSpec.Display.Collapse = buildCollapsedSpec(r.IsCollapsed)
 
 		builder.Dashboard.Spec.Layouts = append(builder.Dashboard.Spec.Layouts, dashboard.Layout{
 			Kind: "Grid",

--- a/go-sdk/panel-group/options.go
+++ b/go-sdk/panel-group/options.go
@@ -48,7 +48,7 @@ func PanelHeight(height int) Option {
 
 func Collapsed(isCollapsed bool) Option {
 	return func(builder *Builder) error {
-		builder.IsCollapsed = isCollapsed
+		builder.IsCollapsed = &isCollapsed
 		return nil
 	}
 }

--- a/go-sdk/panel-group/panel-group.go
+++ b/go-sdk/panel-group/panel-group.go
@@ -21,7 +21,7 @@ type PanelGroup struct {
 	Title          string
 	PanelsWidth    int
 	PanelsHeight   int
-	IsCollapsed    bool
+	IsCollapsed    *bool
 	RepeatVariable string
 	Panels         []dashboard.Panel
 }
@@ -41,7 +41,6 @@ func New(title string, options ...Option) (Builder, error) {
 		Title(title),
 		PanelWidth(12),
 		PanelHeight(8),
-		Collapsed(true),
 	}
 
 	for _, opt := range append(defaults, options...) {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

I discovered it playing with the new ``percli dac watch`` command that I'm working on. When we set ``panelgroup.Collapsed(true)`` option, the group is not collapsed. 

With that change, it is. I tested it locally with success.

<img width="1363" height="723" alt="image" src="https://github.com/user-attachments/assets/a7073885-ce9c-4d4a-8bcf-52dd722dd45d" />

<img width="1854" height="947" alt="image" src="https://github.com/user-attachments/assets/583611a5-2966-46b1-9bdc-aab332e2e7c5" />


<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
