### PR TITLE
[ignore] Modify ``WithServer...`` from e2e tests framework to support passing global manager

### DIFF
--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestAuth(t *testing.T) {
-	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usrEntity := e2eframework.NewUser("foo", "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
@@ -60,7 +60,7 @@ func TestAuth(t *testing.T) {
 }
 
 func TestAuth_EmptyPassword(t *testing.T) {
-	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usrEntity := e2eframework.NewUser("foo", "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
 			WithJSON(usrEntity).
@@ -90,7 +90,7 @@ func TestAuth_OAuthProvider_AuthEndpoint(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OAuth = append(conf.Security.Authentication.Providers.OAuth, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		expect.GET(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOAuth, providerConfig.SlugID, utils.PathLogin)).
 			Expect().
 			Status(http.StatusOK).
@@ -109,7 +109,7 @@ func TestAuth_OIDCProvider_AuthEndpoint(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OIDC = append(conf.Security.Authentication.Providers.OIDC, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		expect.GET(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOIDC, providerConfig.SlugID, utils.PathLogin)).
 			Expect().
 			Status(http.StatusOK).
@@ -129,7 +129,7 @@ func TestAuth_OAuthProvider_CallbackEndpoint(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OAuth = append(conf.Security.Authentication.Providers.OAuth, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		// Callback expect some inputs. If they're not given, the server return an error.
 		expect.GET(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOAuth, providerConfig.SlugID, utils.PathCallback)).
 			Expect().
@@ -159,7 +159,7 @@ func TestAuth_OIDCProvider_CallbackEndpoint(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OIDC = append(conf.Security.Authentication.Providers.OIDC, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		// Callback expect some inputs. If they're not given, the server return an error.
 		expect.GET(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOIDC, providerConfig.SlugID, utils.PathCallback)).
 			Expect().
@@ -189,7 +189,7 @@ func TestAuth_OAuthProvider_DeviceCode(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OAuth = append(conf.Security.Authentication.Providers.OAuth, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOAuth, providerConfig.SlugID, utils.PathDeviceCode)).
 			Expect().
 			Status(http.StatusOK).
@@ -215,7 +215,7 @@ func TestAuth_OIDCProvider_DeviceCode(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OIDC = append(conf.Security.Authentication.Providers.OIDC, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOIDC, providerConfig.SlugID, utils.PathDeviceCode)).
 			Expect().
 			Status(http.StatusOK).
@@ -240,7 +240,7 @@ func TestAuth_OAuthProvider_Token_FromDeviceCode(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OAuth = append(conf.Security.Authentication.Providers.OAuth, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			e2eframework.NewUser("john.doe", ""),
 		}
@@ -268,7 +268,7 @@ func TestAuth_OIDCProvider_Token_FromDeviceCode(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OIDC = append(conf.Security.Authentication.Providers.OIDC, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			e2eframework.NewUser("john.doeOIDC", ""),
 		}
@@ -296,7 +296,7 @@ func TestAuth_OAuthProvider_Token_FromClientCredentials(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OAuth = append(conf.Security.Authentication.Providers.OAuth, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			e2eframework.NewUser("john.doe", ""),
 		}
@@ -329,7 +329,7 @@ func TestAuth_OIDCProvider_Token_FromClientCredentials(t *testing.T) {
 	conf := e2eframework.DefaultAuthConfig()
 	conf.Security.Authentication.Providers.OIDC = append(conf.Security.Authentication.Providers.OIDC, providerConfig)
 
-	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			e2eframework.NewUser("client-id-oidc", ""),
 		}
@@ -361,7 +361,7 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 	conf.Security.Authentication.Providers.OAuth = append(conf.Security.Authentication.Providers.OAuth, providerConfig)
 
 	// Server with oauth provider configured.
-	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			e2eframework.NewUser("john.doe", ""),
 		}
@@ -397,7 +397,7 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 	})
 
 	// Server without oauth provider configured.
-	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		persesBaseURL := common.MustParseURL(server.URL)
 		persesTokenURL := common.MustParseURL(server.URL)
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOAuth, providerConfig.SlugID, utils.PathToken)
@@ -431,7 +431,7 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 	conf.Security.Authentication.Providers.OIDC = append(conf.Security.Authentication.Providers.OIDC, providerConfig)
 
 	// Server with OIDC provider configured.
-	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			e2eframework.NewUser("MyClientID", ""),
 		}
@@ -467,7 +467,7 @@ func TestAuth_OIDCProvider_Token_WithLib(t *testing.T) {
 	})
 
 	// Server without OIDC provider configured.
-	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServer(t, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		persesBaseURL := common.MustParseURL(server.URL)
 		persesTokenURL := common.MustParseURL(server.URL)
 		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOAuth, providerConfig.SlugID, utils.PathToken)

--- a/internal/api/e2e/api/cors_test.go
+++ b/internal/api/e2e/api/cors_test.go
@@ -46,7 +46,7 @@ func TestDefaultConfig(t *testing.T) {
 	config.Security.CORS = apiConfig.CORSConfig{
 		Enable: true,
 	}
-	e2eframework.WithServerConfig(t, config, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, config, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		resp := sendPreflightRequest(expect, "https://github.com")
 		resp.Status(http.StatusNoContent)
 		resp.Header("Access-Control-Allow-Origin").IsEqual("*")
@@ -69,7 +69,7 @@ func TestCustomConfig(t *testing.T) {
 		AllowMethods: []string{"OPTIONS", "GET"},
 		MaxAge:       86400,
 	}
-	e2eframework.WithServerConfig(t, config, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, config, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		// test allowed CORS request
 		resp := sendPreflightRequest(expect, "https://github.com")
 		resp.Status(http.StatusNoContent)

--- a/internal/api/e2e/api/dashboard_test.go
+++ b/internal/api/e2e/api/dashboard_test.go
@@ -39,10 +39,10 @@ func TestMainScenarioDashboard(t *testing.T) {
 }
 
 func TestCreateDashboardWithWrongName(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		entity := e2eframework.NewDashboard(t, "perses", "Incorrect Name With Space")
 		project := e2eframework.NewProject("perses")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
 
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, "perses", utils.PathDashboard)).
 			WithJSON(entity).
@@ -53,10 +53,10 @@ func TestCreateDashboardWithWrongName(t *testing.T) {
 }
 
 func TestUpdateDashboardIncreaseVersion(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		entity := e2eframework.NewDashboard(t, "perses", "test")
 		project := e2eframework.NewProject("perses")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
 
 		dashboard := extractDashboardFromHTTPBody(expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, entity.Metadata.Project, utils.PathDashboard)).
 			WithJSON(entity).
@@ -86,11 +86,11 @@ func TestUpdateDashboardIncreaseVersion(t *testing.T) {
 }
 
 func TestListDashboardInEmptyProject(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		demoDashboard := e2eframework.NewDashboard(t, "perses", "Demo")
 		persesProject := e2eframework.NewProject("perses")
 		demoProject := e2eframework.NewProject("Demo")
-		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, persesProject, demoProject, demoDashboard)
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager.Persistence(), persesProject, demoProject, demoDashboard)
 
 		expect.GET(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, demoProject.GetMetadata().GetName(), utils.PathDashboard)).
 			Expect().
@@ -105,10 +105,10 @@ func TestListDashboardInEmptyProject(t *testing.T) {
 }
 
 func TestListDashboardWithOnlyMetadata(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		demoDashboard := e2eframework.NewDashboard(t, "perses", "Demo")
 		persesProject := e2eframework.NewProject("perses")
-		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, persesProject, demoDashboard)
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager.Persistence(), persesProject, demoDashboard)
 
 		response := expect.GET(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, persesProject.GetMetadata().GetName(), utils.PathDashboard)).
 			WithQuery("metadata_only", true).
@@ -134,7 +134,7 @@ func extractDashboardFromHTTPBody(body interface{}) *modelV1.Dashboard {
 }
 
 func TestAuthListDashboardInProject(t *testing.T) {
-	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 
 		usrEntity := e2eframework.NewUser("creator", "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
@@ -157,7 +157,7 @@ func TestAuthListDashboardInProject(t *testing.T) {
 		firstProject := e2eframework.NewProject("first")
 		secondProject := e2eframework.NewProject("second")
 		thirdProject := e2eframework.NewProject("third")
-		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, firstProject, secondProject, thirdProject)
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager.Persistence(), firstProject, secondProject, thirdProject)
 		expect.GET(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathDashboard)).
 			WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).
 			Expect().
@@ -179,7 +179,7 @@ func TestAuthListDashboardInProject(t *testing.T) {
 		firstDashboard := e2eframework.NewDashboard(t, firstProject.Metadata.Name, "Demo-1")
 		secondDashboard := e2eframework.NewDashboard(t, secondProject.Metadata.Name, "Demo-2")
 		thirdDashboard := e2eframework.NewDashboard(t, thirdProject.Metadata.Name, "Demo-3")
-		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, firstDashboard, secondDashboard, thirdDashboard)
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager.Persistence(), firstDashboard, secondDashboard, thirdDashboard)
 
 		expect.GET(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathDashboard)).
 			WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).
@@ -199,7 +199,7 @@ func TestAuthListDashboardInProject(t *testing.T) {
 			Length().
 			IsEqual(1)
 
-		e2eframework.ClearAllKeys(t, manager.GetPersesDAO(), usrEntity)
+		e2eframework.ClearAllKeys(t, manager.Persistence().GetPersesDAO(), usrEntity)
 		return []api.Entity{firstProject, secondProject, thirdProject, firstDashboard, secondDashboard, thirdDashboard}
 	})
 }

--- a/internal/api/e2e/api/datasource_test.go
+++ b/internal/api/e2e/api/datasource_test.go
@@ -35,7 +35,7 @@ func TestMainScenarioDatasource(t *testing.T) {
 }
 
 func TestCreateDatasourceWithEmptyProjectName(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		entity := e2eframework.NewDatasource(t, "", "myDTS")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathDatasource)).
 			WithJSON(entity).
@@ -46,7 +46,7 @@ func TestCreateDatasourceWithEmptyProjectName(t *testing.T) {
 }
 
 func TestCreateDatasourceWithNonExistingProject(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		entity := e2eframework.NewDatasource(t, "awesomeProjectThatDoesntExist", "myDTS")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathDatasource)).
 			WithJSON(entity).

--- a/internal/api/e2e/api/ephemeraldashboard_test.go
+++ b/internal/api/e2e/api/ephemeraldashboard_test.go
@@ -38,10 +38,10 @@ func TestMainScenarioEphemeralDashboard(t *testing.T) {
 }
 
 func TestCreateEphemeralDashboardWithWrongName(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		entity := e2eframework.NewEphemeralDashboard(t, "perses", "Incorrect Name With Space")
 		project := e2eframework.NewProject("perses")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
 
 		expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, "perses", utils.PathEphemeralDashboard)).
 			WithJSON(entity).
@@ -52,10 +52,10 @@ func TestCreateEphemeralDashboardWithWrongName(t *testing.T) {
 }
 
 func TestUpdateEphemeralDashboardIncreaseVersion(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		entity := e2eframework.NewEphemeralDashboard(t, "perses", "test")
 		project := e2eframework.NewProject("perses")
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
 
 		ephemeralDashboard := extractEphemeralDashboardFromHTTPBody(expect.POST(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, entity.Metadata.Project, utils.PathEphemeralDashboard)).
 			WithJSON(entity).
@@ -85,11 +85,11 @@ func TestUpdateEphemeralDashboardIncreaseVersion(t *testing.T) {
 }
 
 func TestListEphemeralDashboardInEmptyProject(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		demoEphemeralDashboard := e2eframework.NewEphemeralDashboard(t, "perses", "Demo")
 		persesProject := e2eframework.NewProject("perses")
 		demoProject := e2eframework.NewProject("Demo")
-		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, persesProject, demoProject, demoEphemeralDashboard)
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager.Persistence(), persesProject, demoProject, demoEphemeralDashboard)
 
 		expect.GET(fmt.Sprintf("%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, demoProject.GetMetadata().GetName(), utils.PathEphemeralDashboard)).
 			Expect().

--- a/internal/api/e2e/api/globalsecret_test.go
+++ b/internal/api/e2e/api/globalsecret_test.go
@@ -54,9 +54,9 @@ func TestMainScenarioGlobalSecret(t *testing.T) {
 	e2eframework.CreateTestScenario(t, path, creator)
 	// Update test
 	t.Run(fmt.Sprintf("Update test (%s)", path), func(t *testing.T) {
-		e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+		e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 			entity := creator("myResource")
-			e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
+			e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), entity)
 
 			// call now the update endpoint, shouldn't return an error
 			o := expect.PUT(fmt.Sprintf("%s/%s/%s", utils.APIV1Prefix, path, entity.GetMetadata().GetName())).
@@ -68,7 +68,7 @@ func TestMainScenarioGlobalSecret(t *testing.T) {
 			result := decodePublicGlobalSecret(t, o)
 			assert.Equal(t, e2eframework.NewPublicGlobalSecret(entity.GetMetadata().GetName()).GetSpec(), result.GetSpec())
 
-			getFunc, _ := e2eframework.CreateGetFunc(t, manager, entity)
+			getFunc, _ := e2eframework.CreateGetFunc(t, manager.Persistence(), entity)
 			// check the document exists in the db
 			_, err := getFunc()
 			assert.NoError(t, err)

--- a/internal/api/e2e/api/migrate_test.go
+++ b/internal/api/e2e/api/migrate_test.go
@@ -53,7 +53,7 @@ func TestMigrateEndpoint(t *testing.T) {
 			var persesDashboard modelV1.Dashboard
 			testUtils.JSONUnmarshalFromFile(test.resultDashboardPath, &persesDashboard)
 
-			e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+			e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 				entity := modelAPI.Migrate{
 					GrafanaDashboard: grafanaDashboard,
 				}

--- a/internal/api/e2e/api/project_test.go
+++ b/internal/api/e2e/api/project_test.go
@@ -37,19 +37,19 @@ func TestMainScenarioProject(t *testing.T) {
 }
 
 func TestDeleteProjectWithSubResources(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		projectName := "perses"
 		dash := e2eframework.NewDashboard(t, "perses", "Demo")
 		project := e2eframework.NewProject(projectName)
 		datasource := e2eframework.NewDatasource(t, "perses", "Demo")
-		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, project, dash, datasource)
+		e2eframework.CreateAndWaitUntilEntitiesExist(t, manager.Persistence(), project, dash, datasource)
 		expect.DELETE(fmt.Sprintf("%s/%s/%s", utils.APIV1Prefix, utils.PathProject, projectName)).
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := manager.GetDashboard().Get(projectName, dash.Metadata.Name)
+		_, err := manager.Persistence().GetDashboard().Get(projectName, dash.Metadata.Name)
 		assert.True(t, databaseModel.IsKeyNotFound(err))
-		_, err = manager.GetDatasource().Get(projectName, datasource.Metadata.Name)
+		_, err = manager.Persistence().GetDatasource().Get(projectName, datasource.Metadata.Name)
 		assert.True(t, databaseModel.IsKeyNotFound(err))
 		return []api.Entity{}
 	})

--- a/internal/api/e2e/api/proxy_test.go
+++ b/internal/api/e2e/api/proxy_test.go
@@ -181,10 +181,10 @@ func newGlobalSQLDatasource(t *testing.T, name string) *v1.GlobalDatasource {
 }
 
 func TestHTTPProxyGlobalDatasource(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		dtsName := "myDTS"
 		dts := newGlobalHTTPDatasource(t, dtsName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, dts)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), dts)
 
 		expect.GET(fmt.Sprintf("/proxy/%s/%s/api/v1/status/config", utils.PathGlobalDatasource, dtsName)).
 			Expect().
@@ -194,10 +194,10 @@ func TestHTTPProxyGlobalDatasource(t *testing.T) {
 }
 
 func TestSQLProxyBadMethod(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		dtsName := "mySQLDTS"
 		dts := newGlobalSQLDatasource(t, dtsName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, dts)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), dts)
 
 		expect.GET(fmt.Sprintf("/proxy/%s/%s", utils.PathGlobalDatasource, dtsName)).
 			Expect().
@@ -207,15 +207,15 @@ func TestSQLProxyBadMethod(t *testing.T) {
 }
 
 func TestSQLProxyGlobalDatasource(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		// set the postgres user password since the secret isn't working in the test
 		t.Setenv("PGUSER", "user")
 		t.Setenv("PGPASSWORD", "password")
 		dtsName := "mySQLDTS"
 		dts := newGlobalSQLDatasource(t, dtsName)
 		s := e2eframework.NewGlobalSecret(dtsName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, s)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, dts)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), s)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), dts)
 
 		expect.POST(fmt.Sprintf("/proxy/%s/%s", utils.PathGlobalDatasource, dtsName)).
 			WithBytes([]byte(fmt.Sprintf(`{"query": "SELECT datname FROM pg_database"}`))).
@@ -228,13 +228,13 @@ func TestSQLProxyGlobalDatasource(t *testing.T) {
 }
 
 func TestHTTPProxyProjectDatasource(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		dtsName := "myDTS"
 		projectName := "perses"
 		dts := newHTTPDatasource(t, projectName, dtsName)
 		project := e2eframework.NewProject(projectName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, dts)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), dts)
 
 		expect.GET(fmt.Sprintf("/proxy/%s/%s/%s/%s/api/v1/status/config", utils.PathProject, projectName, utils.PathDatasource, dtsName)).
 			Expect().
@@ -244,7 +244,7 @@ func TestHTTPProxyProjectDatasource(t *testing.T) {
 }
 
 func TestSQLProxyProjectDatasource(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		// set the postgres user password since the secret isn't working in the test
 		t.Setenv("PGUSER", "user")
 		t.Setenv("PGPASSWORD", "password")
@@ -252,8 +252,8 @@ func TestSQLProxyProjectDatasource(t *testing.T) {
 		projectName := "perses"
 		dts := newSQLDatasource(t, projectName, dtsName)
 		project := e2eframework.NewProject(projectName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, dts)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), dts)
 
 		expect.POST(fmt.Sprintf("/proxy/%s/%s/%s/%s", utils.PathProject, projectName, utils.PathDatasource, dtsName)).
 			WithBytes([]byte(fmt.Sprintf(`{"query": "SELECT datname FROM pg_database"}`))).
@@ -266,15 +266,15 @@ func TestSQLProxyProjectDatasource(t *testing.T) {
 }
 
 func TestHTTPProxyLocalDatasource(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		dtsName := "myDTS"
 		dashboardName := "myDashboard"
 		projectName := "perses"
 		dts := newHTTPDatasource(t, projectName, dtsName)
 		dash := newDashboard(projectName, dashboardName, dtsName, dts)
 		project := e2eframework.NewProject(projectName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, dash)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), dash)
 
 		expect.GET(fmt.Sprintf("/proxy/%s/%s/%s/%s/%s/%s/api/v1/status/config", utils.PathProject, projectName, utils.PathDashboard, dashboardName, utils.PathDatasource, dtsName)).
 			Expect().
@@ -284,7 +284,7 @@ func TestHTTPProxyLocalDatasource(t *testing.T) {
 }
 
 func TestSQLProxyLocalDatasource(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		// set the postgres user password since the secret isn't working in the test
 		t.Setenv("PGUSER", "user")
 		t.Setenv("PGPASSWORD", "password")
@@ -294,8 +294,8 @@ func TestSQLProxyLocalDatasource(t *testing.T) {
 		dts := newSQLDatasource(t, projectName, dtsName)
 		dash := newDashboard(projectName, dashboardName, dtsName, dts)
 		project := e2eframework.NewProject(projectName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, dash)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), dash)
 
 		expect.POST(fmt.Sprintf("/proxy/%s/%s/%s/%s/%s/%s", utils.PathProject, projectName, utils.PathDashboard, dashboardName, utils.PathDatasource, dtsName)).
 			WithBytes([]byte(fmt.Sprintf(`{"query": "SELECT datname FROM pg_database"}`))).
@@ -308,15 +308,15 @@ func TestSQLProxyLocalDatasource(t *testing.T) {
 }
 
 func TestHTTPProxyLocalDatasourceWithRealDashboard(t *testing.T) {
-	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+	e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 		var dash v1.Dashboard
 		testUtils.JSONUnmarshalFromFile(filepath.Join("testdata", "dashboard.json"), &dash)
 		dtsName := "Victoria Metrics"
 		dashboardName := "myDashboard"
 		projectName := "perses"
 		project := e2eframework.NewProject(projectName)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, project)
-		e2eframework.CreateAndWaitUntilEntityExists(t, manager, &dash)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), project)
+		e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), &dash)
 
 		expect.GET(fmt.Sprintf("/proxy/%s/%s/%s/%s/%s/%s/api/v1/status/config", utils.PathProject, projectName, utils.PathDashboard, dashboardName, utils.PathDatasource, dtsName)).
 			Expect().

--- a/internal/api/e2e/api/rbac_test.go
+++ b/internal/api/e2e/api/rbac_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestNewProjectEndpoints(t *testing.T) {
-	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		creator := "foo"
 		usrEntity := e2eframework.NewUser(creator, "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
@@ -62,17 +62,17 @@ func TestNewProjectEndpoints(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := manager.GetVariable().Get(projectName, variableEntity.Metadata.Name)
+		_, err := manager.Persistence().GetVariable().Get(projectName, variableEntity.Metadata.Name)
 		assert.True(t, databaseModel.IsKeyNotFound(err))
-		_, err = manager.GetProject().Get(projectName)
+		_, err = manager.Persistence().GetProject().Get(projectName)
 		assert.True(t, databaseModel.IsKeyNotFound(err))
-		e2eframework.ClearAllKeys(t, manager.GetPersesDAO(), usrEntity)
+		e2eframework.ClearAllKeys(t, manager.Persistence().GetPersesDAO(), usrEntity)
 		return []modelAPI.Entity{}
 	})
 }
 
 func TestAnonymousEndpoints(t *testing.T) {
-	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		creator := "foo"
 		usrEntity := e2eframework.NewUser(creator, "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
@@ -96,13 +96,13 @@ func TestAnonymousEndpoints(t *testing.T) {
 		expect.GET("/api/config").WithHeader("Authorization", "Bearer <bad token>").Expect().Status(http.StatusOK)
 		expect.GET("/api/config").Expect().Status(http.StatusOK)
 
-		e2eframework.ClearAllKeys(t, manager.GetPersesDAO(), usrEntity)
+		e2eframework.ClearAllKeys(t, manager.Persistence().GetPersesDAO(), usrEntity)
 		return []modelAPI.Entity{}
 	})
 }
 
 func TestUnauthorizedEndpoints(t *testing.T) {
-	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, e2eframework.DefaultAuthConfig(), func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		creator := "foo"
 		usrEntity := e2eframework.NewUser(creator, "password")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathUser)).
@@ -131,7 +131,7 @@ func TestUnauthorizedEndpoints(t *testing.T) {
 		project2Entity := e2eframework.NewProject("mysuperproject2")
 		expect.POST(fmt.Sprintf("%s/%s", utils.APIV1Prefix, utils.PathProject)).WithJSON(project2Entity).WithHeader("Authorization", "Bearer <bad token>").Expect().Status(http.StatusUnauthorized)
 
-		e2eframework.ClearAllKeys(t, manager.GetPersesDAO(), usrEntity)
+		e2eframework.ClearAllKeys(t, manager.Persistence().GetPersesDAO(), usrEntity)
 		return []modelAPI.Entity{}
 	})
 }

--- a/internal/api/e2e/api/secret_test.go
+++ b/internal/api/e2e/api/secret_test.go
@@ -54,9 +54,9 @@ func TestMainScenarioSecret(t *testing.T) {
 	e2eframework.CreateTestScenarioWithProject(t, path, creator)
 
 	t.Run(fmt.Sprintf("Update test (%s)", path), func(t *testing.T) {
-		e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []api.Entity {
+		e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []api.Entity {
 			parent, entity := creator("myProject", "myResource")
-			e2eframework.CreateAndWaitUntilEntitiesExist(t, manager, parent, entity)
+			e2eframework.CreateAndWaitUntilEntitiesExist(t, manager.Persistence(), parent, entity)
 
 			// call now the update endpoint, shouldn't return an error
 			o := expect.PUT(fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIV1Prefix, utils.PathProject, parent.GetMetadata().GetName(), path, entity.GetMetadata().GetName())).
@@ -68,7 +68,7 @@ func TestMainScenarioSecret(t *testing.T) {
 			result := decodePublicSecret(t, o)
 			assert.Equal(t, e2eframework.NewPublicSecret(parent.GetMetadata().GetName(), entity.GetMetadata().GetName()).GetSpec(), result.GetSpec())
 
-			getFunc, _ := e2eframework.CreateGetFunc(t, manager, entity)
+			getFunc, _ := e2eframework.CreateGetFunc(t, manager.Persistence(), entity)
 			// check the document exists in the db
 			_, err := getFunc()
 			assert.NoError(t, err)

--- a/internal/api/e2e/api/user_test.go
+++ b/internal/api/e2e/api/user_test.go
@@ -54,9 +54,9 @@ func TestMainScenarioUser(t *testing.T) {
 	e2eframework.CreateTestScenario(t, path, creator)
 	// Update test
 	t.Run(fmt.Sprintf("Update test (%s)", path), func(t *testing.T) {
-		e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+		e2eframework.WithServer(t, func(_ *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 			entity := creator("myResource")
-			e2eframework.CreateAndWaitUntilEntityExists(t, manager, entity)
+			e2eframework.CreateAndWaitUntilEntityExists(t, manager.Persistence(), entity)
 
 			// call now the update endpoint, shouldn't return an error
 			o := expect.PUT(fmt.Sprintf("%s/%s/%s", utils.APIV1Prefix, path, entity.GetMetadata().GetName())).
@@ -68,7 +68,7 @@ func TestMainScenarioUser(t *testing.T) {
 			result := decodePublicUser(t, o)
 			assert.Equal(t, e2eframework.NewPublicUser(entity.GetMetadata().GetName()).GetSpec(), result.GetSpec())
 
-			getFunc, _ := e2eframework.CreateGetFunc(t, manager, entity)
+			getFunc, _ := e2eframework.CreateGetFunc(t, manager.Persistence(), entity)
 			// check the document exists in the db
 			_, err := getFunc()
 			assert.NoError(t, err)

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -197,12 +197,12 @@ func CreateServer(t *testing.T, conf apiConfig.Config) (*httptest.Server, *httpe
 	}), dependencyManager
 }
 
-func WithServer(t *testing.T, testFunc func(*httptest.Server, *httpexpect.Expect, dependency.PersistenceManager) []modelAPI.Entity) {
+func WithServer(t *testing.T, testFunc func(*httptest.Server, *httpexpect.Expect, dependency.Manager) []modelAPI.Entity) {
 	conf := DefaultConfig()
 	server, expect, dependencyManager := CreateServer(t, conf)
 	defer dependencyManager.Persistence().GetPersesDAO().Close()
 	defer server.Close()
-	entities := testFunc(server, expect, dependencyManager.Persistence())
+	entities := testFunc(server, expect, dependencyManager)
 	ClearAllKeys(t, dependencyManager.Persistence().GetPersesDAO(), entities...)
 }
 
@@ -217,11 +217,11 @@ func WithServerAuthConfig(t *testing.T, testFunc func(*httptest.Server, *httpexp
 	ClearAllKeys(t, dependencyManager.Persistence().GetPersesDAO(), append(entities, usrEntity, globalRole, globalRoleBinding)...)
 }
 
-func WithServerConfig(t *testing.T, config apiConfig.Config, testFunc func(*httptest.Server, *httpexpect.Expect, dependency.PersistenceManager) []modelAPI.Entity) {
+func WithServerConfig(t *testing.T, config apiConfig.Config, testFunc func(*httptest.Server, *httpexpect.Expect, dependency.Manager) []modelAPI.Entity) {
 	server, expect, dependencyManager := CreateServer(t, config)
 	defer dependencyManager.Persistence().GetPersesDAO().Close()
 	defer server.Close()
-	entities := testFunc(server, expect, dependencyManager.Persistence())
+	entities := testFunc(server, expect, dependencyManager)
 	ClearAllKeys(t, dependencyManager.Persistence().GetPersesDAO(), entities...)
 }
 

--- a/internal/cli/cmd/login/login_int_test.go
+++ b/internal/cli/cmd/login/login_int_test.go
@@ -35,7 +35,7 @@ func TestLoginOAuth(t *testing.T) {
 	conf.Security.Authentication.Providers.OAuth = append(conf.Security.Authentication.Providers.OAuth, providerConfig)
 
 	// Server with oauth provider configured.
-	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			//TODO: At the difference with the OIDC flow, we don't use the client id as username, but query /userinfos
 			//  with provider's token. (in this case returning john.doe like the other flow)
@@ -76,7 +76,7 @@ func TestLoginOIDC(t *testing.T) {
 	conf.Security.Authentication.Providers.OIDC = append(conf.Security.Authentication.Providers.OIDC, providerConfig)
 
 	// Server with oauth provider configured.
-	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.PersistenceManager) []modelAPI.Entity {
+	e2eframework.WithServerConfig(t, conf, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
 		usersCreatedByTheSuite := []modelAPI.Entity{
 			e2eframework.NewUser("anything", "password"),
 			e2eframework.NewUser("john.doeOIDC", "password"),


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This is allowing to use directly service manager if needed. It will be particular useful to make some provisioning tests.

linked with #4154
<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
