### PR TITLE
[BUGFIX] Pin timeZone to UTC in date unit tests to prevent locale/tim…

### DIFF
--- a/ui/core/src/model/units/date.test.ts
+++ b/ui/core/src/model/units/date.test.ts
@@ -49,7 +49,7 @@ const TEST_CASES: DateTestCase[] = [
   // DateTime Local format (depends on locale)
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'datetime-local', locale: 'en-US' } as DateFormatOptions,
+    format: { unit: 'datetime-local', locale: 'en-US', timeZone: 'UTC' } as DateFormatOptions,
     expected: '01/01/2024, 12:30:45',
   },
 
@@ -70,14 +70,14 @@ const TEST_CASES: DateTestCase[] = [
   // Date Local format
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'date-local', locale: 'en-US' } as DateFormatOptions,
+    format: { unit: 'date-local', locale: 'en-US', timeZone: 'UTC' } as DateFormatOptions,
     expected: '01/01/2024',
   },
 
   // Time Local format
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'time-local', locale: 'en-US' } as DateFormatOptions,
+    format: { unit: 'time-local', locale: 'en-US', timeZone: 'UTC' } as DateFormatOptions,
     expected: '12:30:45',
   },
 
@@ -174,27 +174,27 @@ const TEST_CASES: DateTestCase[] = [
   // Different locales tests
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'datetime-local', locale: 'de-DE' } as DateFormatOptions,
+    format: { unit: 'datetime-local', locale: 'de-DE', timeZone: 'UTC' } as DateFormatOptions,
     expected: '01.01.2024, 12:30:45',
   },
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'date-local', locale: 'de-DE' } as DateFormatOptions,
+    format: { unit: 'date-local', locale: 'de-DE', timeZone: 'UTC' } as DateFormatOptions,
     expected: '01.01.2024',
   },
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'time-local', locale: 'de-DE' } as DateFormatOptions,
+    format: { unit: 'time-local', locale: 'de-DE', timeZone: 'UTC' } as DateFormatOptions,
     expected: '12:30:45',
   },
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'datetime-local', locale: 'fr-FR' } as DateFormatOptions,
+    format: { unit: 'datetime-local', locale: 'fr-FR', timeZone: 'UTC' } as DateFormatOptions,
     expected: '01/01/2024 12:30:45',
   },
   {
     value: TEST_TIMESTAMP_MS,
-    format: { unit: 'date-local', locale: 'ja-JP' } as DateFormatOptions,
+    format: { unit: 'date-local', locale: 'ja-JP', timeZone: 'UTC' } as DateFormatOptions,
     expected: '2024/01/01',
   },
 
@@ -329,13 +329,13 @@ describe('Date formatting', () => {
 
     it('should handle default options', () => {
       const result = formatDate(TEST_TIMESTAMP_MS);
-      // Should default to datetime-local with en-US locale
-      expect(result).toContain('01/01/2024');
-      expect(result).toContain('12:30:45');
+      // Should default to datetime-local with en-US locale — verify MM/DD/YYYY format only,
+      // since the time portion varies by the runner's local timezone.
+      expect(result).toMatch(/\d{2}\/\d{2}\/\d{4}/);
     });
 
     it('should handle different locales', () => {
-      const options: DateFormatOptions = { unit: 'date-local', locale: 'de-DE' };
+      const options: DateFormatOptions = { unit: 'date-local', locale: 'de-DE', timeZone: 'UTC' };
       const result = formatDate(TEST_TIMESTAMP_MS, options);
       expect(result).toEqual('01.01.2024');
     });
@@ -495,12 +495,12 @@ describe('Date formatting', () => {
 
       // Midnight tests
       expect(formatDate(midnight, { unit: 'time-iso' })).toBe('00:00:00.000');
-      expect(formatDate(midnight, { unit: 'time-local', locale: 'en-US' })).toBe('00:00:00');
+      expect(formatDate(midnight, { unit: 'time-local', locale: 'en-US', timeZone: 'UTC' })).toBe('00:00:00');
       expect(formatDate(midnight, { unit: 'time-us', locale: 'en-US' })).toBe('07:00:00 PM'); // EST previous day
 
       // Noon tests
       expect(formatDate(noon, { unit: 'time-iso' })).toBe('12:00:00.000');
-      expect(formatDate(noon, { unit: 'time-local', locale: 'en-US' })).toBe('12:00:00');
+      expect(formatDate(noon, { unit: 'time-local', locale: 'en-US', timeZone: 'UTC' })).toBe('12:00:00');
       expect(formatDate(noon, { unit: 'time-us', locale: 'en-US' })).toBe('07:00:00 AM'); // EST
     });
 


### PR DESCRIPTION
While working on date formatting in the codebase I noticed that several tests  in `ui/core/src/model/units/date.test.ts` were silently relying on the test  runner being in UTC to pass.

The affected tests cover the *-local date units — `datetime-local`, `date-local`,  and `time-local`. These units are designed to format timestamps using the  browser's local timezone, so the `formatDate` function intentionally inherits  the host timezone when none is specified. The tests, however, were asserting  exact time strings like `"12:30:45"` or `"01/01/2024, 12:30:45"` which are  only correct if the runner happens to be in UTC.

The `npm test` script sets `cross-env TZ=UTC` as a band-aid, but this doesn't  hold in all environments. On containerized CI runners the OS-level timezone is  set independently of the process environment, so `TZ=UTC` has no effect and  the tests fail. On a developer machine set to a non-UTC timezone (e.g.  Asia/Tokyo, America/Los_Angeles) the same failures show up locally.

To reproduce: running the suite with `TZ=Asia/Tokyo` (UTC+9) before this fix  produces 7 failures like:

  Expected: "12:30:45"
  Received: "21:30:45"

  Expected: "01/01/2024, 12:30:45"
  Received: "01/01/2024, 21:30:45"

The fix is to make each of these test cases self-contained. Since the tests are  validating locale-specific formatting (not timezone conversion), passing  `timeZone: 'UTC'` alongside the existing `locale` option is the right call —  it pins the time component to a known value without changing what the test is  actually checking.

The `"should handle default options"` test is also updated separately. That test  calls `formatDate` with no options at all, which means it uses the system timezone by design. Asserting on the exact time string there is wrong in principle — the test should only verify that the output looks like a date, not what the time portion says. It now checks for the `MM/DD/YYYY` pattern only.

After the fix, all 63 tests pass with both `TZ=UTC` and `TZ=Asia/Tokyo`.
