### PR TITLE
[ENHANCEMENT] migrate G2P dashboard links

### DIFF
--- a/internal/api/plugin/migrate/grafana.go
+++ b/internal/api/plugin/migrate/grafana.go
@@ -34,6 +34,8 @@ type GrafanaLink struct {
 	Title       string `json:"title"`
 	URL         string `json:"url"`
 	TargetBlank bool   `json:"targetBlank"`
+	IncludeVars bool   `json:"includeVars"`
+	Tooltip     string `json:"tooltip"`
 }
 
 type Panel struct {
@@ -181,10 +183,11 @@ func (v *TemplateVar) getDefaultValue() *variable.DefaultValue {
 }
 
 type SimplifiedDashboard struct {
-	UID        string   `json:"uid,omitempty"`
-	Title      string   `json:"title"`
-	Tags       []string `json:"tags"`
-	Panels     []Panel  `json:"panels"`
+	UID        string        `json:"uid,omitempty"`
+	Title      string        `json:"title"`
+	Tags       []string      `json:"tags"`
+	Panels     []Panel       `json:"panels"`
+	Links      []GrafanaLink `json:"links"`
 	Templating struct {
 		List []TemplateVar `json:"list"`
 	} `json:"templating"`

--- a/internal/api/plugin/migrate/migrate.go
+++ b/internal/api/plugin/migrate/migrate.go
@@ -262,7 +262,26 @@ func (m *completeMigration) Migrate(grafanaDashboard *SimplifiedDashboard, useDe
 	result.Spec.Panels = panels
 	result.Spec.Variables = m.migrateVariables(grafanaDashboard)
 	result.Spec.Layouts = m.migrateGrid(grafanaDashboard)
+	result.Spec.Links = m.migrateDashboardLinks(grafanaDashboard)
 	return result, nil
+}
+
+func (m *completeMigration) migrateDashboardLinks(grafanaDashboard *SimplifiedDashboard) []dashboard.Link {
+	links := []dashboard.Link{}
+	for _, l := range grafanaDashboard.Links {
+		if len(l.URL) == 0 {
+			continue
+		}
+		link := dashboard.Link{
+			URL:             l.URL,
+			Name:            l.Title,
+			RenderVariables: l.IncludeVars,
+			Tooltip:         l.Tooltip,
+			TargetBlank:     l.TargetBlank,
+		}
+		links = append(links, link)
+	}
+	return links
 }
 
 func (m *completeMigration) migrateGrid(grafanaDashboard *SimplifiedDashboard) []dashboard.Layout {

--- a/internal/api/plugin/migrate_test.go
+++ b/internal/api/plugin/migrate_test.go
@@ -116,9 +116,24 @@ func TestMigrateDashboardLinks(t *testing.T) {
 	testCases := []struct {
 		name          string
 		grafanaLink   migrate.GrafanaLink
-		expectedLink  *dashboard.Link
-		expectNilLink bool
+		expectedLinks []dashboard.Link
 	}{
+		{
+			name: "Link with URL only",
+			grafanaLink: migrate.GrafanaLink{
+				URL:     "http://fakedomain/${samplevar}/$samplevar",
+				Tooltip: "",
+			},
+			expectedLinks: []dashboard.Link{
+				{
+					URL:             "http://fakedomain/${samplevar}/$samplevar",
+					TargetBlank:     false,
+					RenderVariables: false,
+					Tooltip:         "",
+					Name:            "",
+				},
+			},
+		},
 		{
 			name: "Full link with variables and target blank",
 			grafanaLink: migrate.GrafanaLink{
@@ -128,12 +143,14 @@ func TestMigrateDashboardLinks(t *testing.T) {
 				Tooltip:     "sample link",
 				URL:         "http://fakedomain/${samplevar}/$samplevar",
 			},
-			expectedLink: &dashboard.Link{
-				Name:            "sample link",
-				Tooltip:         "sample link",
-				URL:             "http://fakedomain/${samplevar}/$samplevar",
-				TargetBlank:     true,
-				RenderVariables: true,
+			expectedLinks: []dashboard.Link{
+				{
+					Name:            "sample link",
+					Tooltip:         "sample link",
+					URL:             "http://fakedomain/${samplevar}/$samplevar",
+					TargetBlank:     true,
+					RenderVariables: true,
+				},
 			},
 		},
 		{
@@ -142,18 +159,20 @@ func TestMigrateDashboardLinks(t *testing.T) {
 				Title: "sample link",
 				URL:   "http://fakedomain/${samplevar}/$samplevar",
 			},
-			expectedLink: &dashboard.Link{
-				Name:            "sample link",
-				URL:             "http://fakedomain/${samplevar}/$samplevar",
-				TargetBlank:     false,
-				RenderVariables: false,
-				Tooltip:         "",
+			expectedLinks: []dashboard.Link{
+				{
+					Name:            "sample link",
+					URL:             "http://fakedomain/${samplevar}/$samplevar",
+					TargetBlank:     false,
+					RenderVariables: false,
+					Tooltip:         "",
+				},
 			},
 		},
 		{
 			name:          "Empty or invalid link should be dropped",
 			grafanaLink:   migrate.GrafanaLink{Title: "sample link"},
-			expectNilLink: true,
+			expectedLinks: []dashboard.Link{},
 		},
 	}
 
@@ -168,18 +187,7 @@ func TestMigrateDashboardLinks(t *testing.T) {
 			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, persesDashboard)
-
-			if tc.expectNilLink {
-				assert.Len(t, persesDashboard.Spec.Links, 0)
-			} else {
-				assert.Len(t, persesDashboard.Spec.Links, 1)
-				actualLink := persesDashboard.Spec.Links[0]
-				assert.Equal(t, tc.expectedLink.Name, actualLink.Name)
-				assert.Equal(t, tc.expectedLink.Tooltip, actualLink.Tooltip)
-				assert.Equal(t, tc.expectedLink.URL, actualLink.URL)
-				assert.Equal(t, tc.expectedLink.TargetBlank, actualLink.TargetBlank)
-				assert.Equal(t, tc.expectedLink.RenderVariables, actualLink.RenderVariables)
-			}
+			assert.Equal(t, tc.expectedLinks, persesDashboard.Spec.Links)
 		})
 	}
 }

--- a/internal/api/plugin/migrate_test.go
+++ b/internal/api/plugin/migrate_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/perses/perses/internal/api/plugin/migrate"
 	testUtils "github.com/perses/perses/internal/test"
 	"github.com/perses/perses/pkg/model/api/config"
+	"github.com/perses/spec/go/dashboard"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -107,6 +108,80 @@ func TestMig_MigrateTags(t *testing.T) {
 	persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false)
 	assert.NoError(t, err)
 	assert.Equal(t, set.New("ops", "prod"), persesDashboard.Metadata.Tags)
+}
+
+func TestMigrateDashboardLinks(t *testing.T) {
+	pl := LoadTestPlugins()
+
+	testCases := []struct {
+		name          string
+		grafanaLink   migrate.GrafanaLink
+		expectedLink  *dashboard.Link
+		expectNilLink bool
+	}{
+		{
+			name: "Full link with variables and target blank",
+			grafanaLink: migrate.GrafanaLink{
+				IncludeVars: true,
+				TargetBlank: true,
+				Title:       "sample link",
+				Tooltip:     "sample link",
+				URL:         "http://fakedomain/${samplevar}/$samplevar",
+			},
+			expectedLink: &dashboard.Link{
+				Name:            "sample link",
+				Tooltip:         "sample link",
+				URL:             "http://fakedomain/${samplevar}/$samplevar",
+				TargetBlank:     true,
+				RenderVariables: true,
+			},
+		},
+		{
+			name: "Link with defaults",
+			grafanaLink: migrate.GrafanaLink{
+				Title: "sample link",
+				URL:   "http://fakedomain/${samplevar}/$samplevar",
+			},
+			expectedLink: &dashboard.Link{
+				Name:            "sample link",
+				URL:             "http://fakedomain/${samplevar}/$samplevar",
+				TargetBlank:     false,
+				RenderVariables: false,
+				Tooltip:         "",
+			},
+		},
+		{
+			name:          "Empty or invalid link should be dropped",
+			grafanaLink:   migrate.GrafanaLink{Title: "sample link"},
+			expectNilLink: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			grafanaDashboard := &migrate.SimplifiedDashboard{
+				UID:   "dashboard-with-links",
+				Title: "Dashboard with links",
+				Links: []migrate.GrafanaLink{tc.grafanaLink},
+			}
+
+			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false)
+			assert.NoError(t, err)
+			assert.NotNil(t, persesDashboard)
+
+			if tc.expectNilLink {
+				assert.Len(t, persesDashboard.Spec.Links, 0)
+			} else {
+				assert.Len(t, persesDashboard.Spec.Links, 1)
+				actualLink := persesDashboard.Spec.Links[0]
+				assert.Equal(t, tc.expectedLink.Name, actualLink.Name)
+				assert.Equal(t, tc.expectedLink.Tooltip, actualLink.Tooltip)
+				assert.Equal(t, tc.expectedLink.URL, actualLink.URL)
+				assert.Equal(t, tc.expectedLink.TargetBlank, actualLink.TargetBlank)
+				assert.Equal(t, tc.expectedLink.RenderVariables, actualLink.RenderVariables)
+			}
+		})
+	}
 }
 
 func TestLinkConversionLogic(t *testing.T) {


### PR DESCRIPTION
fixes https://github.com/perses/perses/issues/4162
fixes https://github.com/perses/perses/issues/1642

This enhancement migrates the Grafana Dashboard Links into the Perses Dashboard Spec structure. 
The following screenshots demonstrate a successful migration.

The variables are replaced by client. Therefore, the original URL with the template variables could be kept intact and as it is.  For instance here, 

1. I used both `${myvar}` and `$myvar`
2. Since the variable had been created already, it was successfully replaced


<img width="1278" height="611" alt="image" src="https://github.com/user-attachments/assets/2761c114-46d4-4a02-ac48-6b4c035dd9eb" />


<img width="1277" height="384" alt="image" src="https://github.com/user-attachments/assets/2ca2f6b6-10bb-4469-b316-1488eb05f49b" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
