### PR TITLE
fix(cli): skip non-main Go packages when building a directory (#3819)

### DIFF
--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -42,6 +42,20 @@ const (
 
 var folderToIgnore = []string{".git", ".github", ".idea", config.DefaultOutputFolder, "cue.mod"}
 
+// isGoMainPackage reports whether the Go source file at path belongs to
+// package main. Files in non-main packages (library helpers, sub-packages)
+// cannot be passed to `go run` directly and must be skipped during a
+// directory walk.
+func isGoMainPackage(path string) bool {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.PackageClauseOnly)
+	if err != nil {
+		// If parsing fails, fall through so `go run` surfaces the real error.
+		return true
+	}
+	return f.Name.Name == "main"
+}
+
 type option struct {
 	persesCMD.Option
 	opt.FileOption
@@ -93,26 +107,21 @@ func (o *option) Execute() error {
 		}
 
 		extension := filepath.Ext(path)
-		if extension == goExtension {
-			// Only process files declared as package main. Supporting packages that
-			// live alongside a main entrypoint (e.g. helper packages in sub-dirs)
-			// are valid Go code but cannot be passed to `go run` directly.
-			if !isGoMainPackage(path) {
-				logrus.Debugf("file %q has been ignored (not in package main)", path)
-				return nil
+		if extension == goExtension || extension == cueExtension {
+			if extension == goExtension {
+				// Only process files declared as package main. Supporting packages that
+				// live alongside a main entrypoint (e.g. helper packages in sub-dirs)
+				// are valid Go code but cannot be passed to `go run` directly.
+				if !isGoMainPackage(path) {
+					logrus.Debugf("file %q has been ignored (not in package main)", path)
+					return nil
+				}
 			}
-			err = o.processFile(path, extension)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("error processing file %q: %w", path, err))
-			}
-		} else if extension == cueExtension {
 			err = o.processFile(path, extension)
 			if err != nil {
 				// Append the error to highlight the issue to the user on a later stage but don't stop the processing
 				errs = append(errs, fmt.Errorf("error processing file %q: %w", path, err))
 			}
-		} else {
-			logrus.Debugf("file %q has been ignored", path)
 		}
 
 		return nil
@@ -131,20 +140,6 @@ func (o *option) Execute() error {
 	}
 
 	return nil
-}
-
-// isGoMainPackage reports whether the Go source file at path belongs to
-// package main. Files in non-main packages (library helpers, sub-packages)
-// cannot be passed to `go run` directly and must be skipped during a
-// directory walk.
-func isGoMainPackage(path string) bool {
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, path, nil, parser.PackageClauseOnly)
-	if err != nil {
-		// If parsing fails, fall through so `go run` surfaces the real error.
-		return true
-	}
-	return f.Name.Name == "main"
 }
 
 func (o *option) processFile(file string, extension string) error {

--- a/internal/cli/cmd/dac/build/build.go
+++ b/internal/cli/cmd/dac/build/build.go
@@ -16,6 +16,8 @@ package build
 import (
 	"errors"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"os/exec"
@@ -91,7 +93,19 @@ func (o *option) Execute() error {
 		}
 
 		extension := filepath.Ext(path)
-		if extension == goExtension || extension == cueExtension {
+		if extension == goExtension {
+			// Only process files declared as package main. Supporting packages that
+			// live alongside a main entrypoint (e.g. helper packages in sub-dirs)
+			// are valid Go code but cannot be passed to `go run` directly.
+			if !isGoMainPackage(path) {
+				logrus.Debugf("file %q has been ignored (not in package main)", path)
+				return nil
+			}
+			err = o.processFile(path, extension)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("error processing file %q: %w", path, err))
+			}
+		} else if extension == cueExtension {
 			err = o.processFile(path, extension)
 			if err != nil {
 				// Append the error to highlight the issue to the user on a later stage but don't stop the processing
@@ -117,6 +131,20 @@ func (o *option) Execute() error {
 	}
 
 	return nil
+}
+
+// isGoMainPackage reports whether the Go source file at path belongs to
+// package main. Files in non-main packages (library helpers, sub-packages)
+// cannot be passed to `go run` directly and must be skipped during a
+// directory walk.
+func isGoMainPackage(path string) bool {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.PackageClauseOnly)
+	if err != nil {
+		// If parsing fails, fall through so `go run` surfaces the real error.
+		return true
+	}
+	return f.Name.Name == "main"
 }
 
 func (o *option) processFile(file string, extension string) error {

--- a/internal/cli/cmd/dac/build/build_test.go
+++ b/internal/cli/cmd/dac/build/build_test.go
@@ -108,6 +108,21 @@ func TestDacBuildCMD(t *testing.T) {
 			IsErrorExpected: false,
 			ExpectedMessage: fmt.Sprintf("Successfully built %s at %s\n", filepath.Join("testdata", "go", "cmd", "main.go"), filepath.Join("built", "testdata", "go", "cmd", "main_output.yaml")),
 		},
+		{
+			// Regression test for https://github.com/perses/perses/issues/3819:
+			// non-main Go files in sub-packages must be silently skipped; only
+			// files in package main are passed to `go run`.
+			Title:           "directory with non-main sub-packages skips them without error",
+			Args:            []string{"-d", filepath.Join("testdata", "go")},
+			IsErrorExpected: false,
+			// args/main.go and cmd/main.go are both package main and must be built;
+			// prometheus/query/*.go are package query and must be silently skipped.
+			ExpectedMessage: fmt.Sprintf(
+				"Successfully built %s at %s\nSuccessfully built %s at %s\n",
+				filepath.Join("testdata", "go", "args", "main.go"), filepath.Join("built", "testdata", "go", "args", "main_output.yaml"),
+				filepath.Join("testdata", "go", "cmd", "main.go"), filepath.Join("built", "testdata", "go", "cmd", "main_output.yaml"),
+			),
+		},
 	}
 	cmdTest.ExecuteSuiteTest(t, NewCMD, testSuiteCommonAndGo)
 


### PR DESCRIPTION
## Summary

- `percli dac build -d <dir>` recursed into every subdirectory and tried to pass each `.go` file directly to `go run`. Files in non-main support packages (e.g. a helper library in a sub-directory) are not `package main`, so `go run` rejected them with *"package command-line-arguments is not a main package"* and the whole build failed.
- Fix: parse just the package clause of each `.go` file encountered during a directory walk using `go/parser.ParseFile(..., parser.PackageClauseOnly)`. Files not declaring `package main` are silently skipped with a debug-level log. The explicit `-f` / single-file path is unchanged — there the user pointed at a specific file and `go run` will report any error naturally.

## Changes

- `internal/cli/cmd/dac/build/build.go`: split the `goExtension` and `cueExtension` branches in the `filepath.Walk` callback; add `isGoMainPackage` helper that parses the package clause and returns `false` for non-main packages.
- `internal/cli/cmd/dac/build/build_test.go`: add regression test `"directory with non-main sub-packages skips them without error"` that walks `testdata/go` (which already contains `args/main.go` and `cmd/main.go` as `package main` alongside `prometheus/query/*.go` as `package query`) and asserts only the two main-package files are built.

Fixes #3819

## Checklist

- [x] Existing Go tests still pass (`nominal case with a single Go file`, `nominal case with a Go project`)
- [x] New regression test passes (`directory with non-main sub-packages skips them without error`)
- [x] `go build ./internal/cli/cmd/dac/build/...` clean
- [x] Only relevant files staged (no lockfiles, no generated code)
- [x] DCO `Signed-off-by` present in commit