### PR TITLE
[ENHANCEMENT] Ensure ``flag.Parse()`` is called by the go sdk itself.

### DIFF
--- a/docs/dac/getting-started.md
+++ b/docs/dac/getting-started.md
@@ -184,7 +184,6 @@ import (
 )
 
 func main() {
-	flag.Parse()
 	exec := sdk.NewExec()
 	builder, buildErr := dashboard.New("ContainersMonitoring",
 		dashboard.ProjectName("MyProject"),

--- a/go-sdk/exec.go
+++ b/go-sdk/exec.go
@@ -54,6 +54,7 @@ func executeDashboardBuilder(builder dashboard.Builder, outputFormat string, wri
 }
 
 func NewExec() Exec {
+	flag.Parse()
 	output := flag.Lookup("output").Value.String()
 
 	return Exec{

--- a/internal/cli/cmd/dac/setup/setup.go
+++ b/internal/cli/cmd/dac/setup/setup.go
@@ -49,8 +49,6 @@ import (
 )
 
 func main() {
-	flag.Parse()
-
 	exec := sdk.NewExec()
 	builder, buildErr := dashboard.New("myDashboardAsCode",
 		dashboard.ProjectName("myProject"),


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This is fixing #3994. When ``flag.Parse()`` is called in corresponding main.go, it works well. I don't know if there's a reason why this needs to be called by the user but I prefer to encapsulate it. From what I undetstood ``sdk.NewExec()`` should be called only once at the beginning so it seems to be the perfect place to have that call.


<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

