### PR TITLE
[FEATURE] pass the user pereferences tz to ViewDashboard

### DIFF
--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Box, CircularProgress, Stack } from '@mui/material';
-import { ErrorAlert, ErrorBoundary, getResourceDisplayName } from '@perses-dev/components';
+import { ErrorAlert, ErrorBoundary, getResourceDisplayName, useLocalStorage } from '@perses-dev/components';
 import { DashboardSpec } from '@perses-dev/spec';
 import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard } from '@perses-dev/dashboards';
 import { PluginRegistry, UsageMetricsProvider, ValidationProvider } from '@perses-dev/plugin-system';
@@ -31,6 +31,7 @@ import {
 } from '../../../context/Config';
 import { useRemotePluginLoader } from '../../../model/remote-plugin-loader';
 import { PERSES_APP_CONFIG } from '../../../config';
+import { UserPreferences } from '../../../model/userPreferences';
 
 export interface GenericDashboardViewProps {
   dashboardResource: DashboardResource;
@@ -56,15 +57,12 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
     isLeavingConfirmDialogEnabled = true,
   } = props;
   const breadcrumbVariant = isEditing || isCreating ? 'workspace' : 'default';
-
+  const [userPreferences] = useLocalStorage<UserPreferences>('PERSES_USER_PREFERENCES', { timezone: 'local' });
   const isLocalDatasourceEnabled = useIsLocalDatasourceEnabled();
   const isLocalVariableEnabled = useIsLocalVariableEnabled();
   const isKeyboardShortcutsEnabled = useIsKeyboardShortcutsEnabled();
   const datasourceApi = useDatasourceApi();
   const pluginLoader = useRemotePluginLoader();
-
-  //TODO: We should pass down userPreferenceTimezone to the dashboard view using a prop
-  // Picking the value from the useLocalStorage is a bad practice, because a component should technically have no clue about the app level local storage
 
   // Collect the Project variables and setup external variables from it
   const { data: project, isLoading: isLoadingProject } = useProject(dashboardResource.metadata.project);
@@ -136,6 +134,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
                   isEditing={isEditing}
                   isCreating={isCreating}
                   isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
+                  userPreferenceTimezone={userPreferences.timezone}
                 />
               </UsageMetricsProvider>
             </ErrorBoundary>


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3916
Closes https://github.com/perses/perses/issues/1382

# Description

Passes down the `user preferences time zone` to the dashboard view

## Reminder
As soon as a tz is persisted in the dashboard resource spec, the user preference tz will be ignored. 
```typescript
  const toolBarTimezone = useMemo((): string => {
    return dashboardResource.spec.timezone || userPreferenceTimezone || 'local';
  }, [dashboardResource.spec, userPreferenceTimezone]);
```


<img width="885" height="806" alt="image" src="https://github.com/user-attachments/assets/7a350104-1099-4438-8b18-f789b0fa3c4f" />


# Screenshots


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [X] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
