### PR TITLE
[BUGFIX] Respect api_prefix in dashboard list navigation links

### DIFF
--- a/ui/app/src/components/DashboardList/NameCell.test.tsx
+++ b/ui/app/src/components/DashboardList/NameCell.test.tsx
@@ -14,15 +14,18 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
 import { NameCell, NameCellProps } from './NameCell';
 
 const theme = createTheme();
 
 function renderCell(props: NameCellProps): ReturnType<typeof render> {
   return render(
-    <ThemeProvider theme={theme}>
-      <NameCell {...props} />
-    </ThemeProvider>
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <NameCell {...props} />
+      </ThemeProvider>
+    </MemoryRouter>
   );
 }
 

--- a/ui/app/src/components/DashboardList/NameCell.tsx
+++ b/ui/app/src/components/DashboardList/NameCell.tsx
@@ -17,6 +17,7 @@ import ChevronRightIcon from 'mdi-material-ui/ChevronRight';
 import FolderOutlineIcon from 'mdi-material-ui/FolderOutline';
 import FolderOpenOutlineIcon from 'mdi-material-ui/FolderOpenOutline';
 import ViewDashboardOutlineIcon from 'mdi-material-ui/ViewDashboardOutline';
+import { Link as RouterLink } from 'react-router-dom';
 import { ReactElement } from 'react';
 import { DashboardTreeTableRow } from './DashboardTreeList';
 
@@ -68,7 +69,7 @@ export function NameCell({
       return (
         <Box sx={{ paddingLeft: `${paddingLeft}px`, display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <ViewDashboardOutlineIcon fontSize="small" />
-          <Link href={`/projects/${project}/dashboards/${name}`} color="inherit" underline="hover">
+          <Link component={RouterLink} to={`/projects/${project}/dashboards/${name}`} color="inherit" underline="hover">
             {displayName}
           </Link>
         </Box>


### PR DESCRIPTION
# Description

  When Perses runs behind a reverse proxy under a custom sub-path, that path is configured via `api_prefix`. The backend injects it into the frontend and the React Router is configured with `basename: PERSES_APP_CONFIG.api_prefix`, so any
  navigation done through react-router (`<Link to>`, `useNavigate`, `<Navigate>`) automatically includes the prefix.
  
  The **Dashboard list view** (`NameCell.tsx`) bypassed this: dashboard names were rendered with a plain MUI `<Link href=...>`. An `href` triggers a full browser navigation that ignores the router `basename`, so clicking a dashboard navigated to `/projects/...` instead of `/<api_prefix>/projects/...`. Switched to react-router's link (`component={RouterLink}` + `to`), matching how the dashboard cards, recent, and important dashboard links already behave. The unit test is wrapped in a `MemoryRouter` to provide the required router context.

  # Screenshots
  
 Behavioral fix only; no visual change. The difference is the target URL of the dashboard link when `api_prefix` is set.

  
  # Checklist
  
  - [x] Pull request has a descriptive title and context useful to a reviewer.
  - [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
    following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
  - [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

  ## UI Changes
  
  - [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
  - [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
  - [x] E2E tests are stable and unlikely to be flaky.
