### PR TITLE
[BUGFIX] check all markdown files in checkdocs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,16 +46,21 @@ In the usual workflow, all PRs are squashed. There is two exceptions to this rul
 
 ## Documentation
 
-Documentation is written in Markdown. To ensure some quality on our documentation, we are
-running [mdox](https://github.com/bwplotka/mdox) that will ensure the doc is well formatted and all links are working.
+Documentation is written in Markdown. To ensure some quality on our documentation, we are running
+[mdox](https://github.com/bwplotka/mdox) on Markdown files that use GitHub Flavored Markdown. mdox ensures these files
+are well formatted and all links are working.
 
-To format the docs, you will have to install the tool mentioned above. An easy way is to run the following command:
+The `docs/` tree is imported by the [Perses website](https://github.com/perses/website) and rendered with MkDocs
+Material, so it is not formatted with mdox.
+
+To format mdox-managed Markdown, you will have to install the tool mentioned above. An easy way is to run the following
+command:
 
 ```bash
 go install github.com/bwplotka/mdox@latest
 ```
 
-Then to format the doc, run:
+Then to format mdox-managed Markdown, run:
 
 ```bash
 make fmt-docs

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ CUE                   ?= cue
 GOCI                  ?= golangci-lint
 GOFMT                 ?= $(GO)fmt
 MDOX                  ?= mdox
+# docs/ is imported by perses/website and rendered with MkDocs Material.
+# mdox formats GitHub Flavored Markdown and can break MkDocs-specific syntax.
+MDOX_MD_FILES_CMD     = find . -name '*.md' -not -path "./docs/*" -not -path "./.github/perses-ci/*" -not -path "./ui/node_modules/*" -not -path "./ui/app/node_modules/*" -not -path "./ui/storybook/node_modules/*" -print
 GOOS                  ?= $(shell $(GO) env GOOS)
 GOARCH                ?= $(shell $(GO) env GOARCH)
 GOHOSTOS              ?= $(shell $(GO) env GOHOSTOS)
@@ -56,9 +59,8 @@ checkformat:
 
 .PHONY: checkdocs
 checkdocs:
-	@echo ">> Check markdown docs format"
-	@make fmt-docs
-	@git diff --exit-code -- *.md
+	@echo ">> Check mdox-managed markdown documents"
+	$(MDOX) fmt --check --soft-wraps -l $$($(MDOX_MD_FILES_CMD)) --links.validate.config-file=./.mdox.validate.yaml
 
 .PHONY: checkunused
 checkunused:
@@ -95,8 +97,8 @@ fmt:
 
 .PHONY: fmt-docs
 fmt-docs:
-	@echo ">> Format markdown documents"
-	$(MDOX) fmt --soft-wraps -l $$(find . -name '*.md' -not -path "./ui/node_modules/*" -not -path "./ui/app/node_modules/*"  -not -path "./ui/storybook/node_modules/*" -print) --links.validate.config-file=./.mdox.validate.yaml
+	@echo ">> Format mdox-managed markdown documents"
+	$(MDOX) fmt --soft-wraps -l $$($(MDOX_MD_FILES_CMD)) --links.validate.config-file=./.mdox.validate.yaml
 
 .PHONY: cue-eval
 cue-eval:


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

`checkdocs` ran `fmt-docs` over every markdown file but only verified root-level *.md files with git diff.
Formatting drift under docs/ and other nested paths was never caught by the docs-fmt CI job.
In this commit we share the find command between fmt-docs and checkdocs so both targets operate on the same file set.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
