### PR TITLE
[IGNORE] Speed up integration tests using an explicit plugins archive path

### DIFF
--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -161,6 +161,10 @@ func CreateAuthorizationHeader(token string) (string, string) {
 }
 
 func CreateServer(t *testing.T, conf apiConfig.Config) (*httptest.Server, *httpexpect.Expect, dependency.Manager) {
+	// Integration tests don't need to re-extract archives at each server boot.
+	// Redirect archives to an empty temp folder to avoid heavy I/O on Windows CI.
+	conf.Plugin.ArchivePaths = []string{t.TempDir()}
+
 	if useSQL == "true" {
 		conf.Database = apiConfig.Database{
 			SQL: &apiConfig.SQL{


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

We mobilized AI on finding why the windows tests are so long and here is the answer :

> [!TIP]
> 
> ### Why we changed plugin archive path to `t.TempDir()` in integration tests
> 
> #### What changed
> In `internal/api/e2e/framework/server.go` (`CreateServer`), we set:
> 
> - `conf.Plugin.ArchivePaths = []string{t.TempDir()}`
> 
> for integration test server startup.
> 
> #### Why
> CI logs showed timeouts/stalls in plugin archive extraction on Windows (`plugin.UnzipArchives()`), not in test assertions.
> 
> #### Why this fixes it
> `core.New(...)` always calls plugin archive extraction during startup.
> 
> Before:
> - Each test server startup could scan/extract many plugin archives from `plugins-archive`.
> 
> After:
> - Archive path points to an empty temp directory.
> - Extraction becomes effectively a no-op.
> - Startup is much faster and avoids repeated heavy disk I/O.
> 
> #### Why CI improved (about 16m -> 11-12m)
> This removed a repeated fixed startup cost across many tests:
> - much less archive I/O
> - fewer filesystem bottlenecks on Windows
> - fewer long stalls that can push jobs toward timeout



<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
