### PR TITLE
[DOC] Fix Kubernetes SD example to use service_type key

### DIFF
--- a/docs/configuration/datasource-discovery.md
+++ b/docs/configuration/datasource-discovery.md
@@ -62,7 +62,7 @@ datasource:
         service_configuration:
           enable: true
           port_name: "http"
-          serviceType: "ClusterIP"
+          service_type: "ClusterIP"
         labels:
           app: prometheus
 ```


### PR DESCRIPTION


The Kubernetes service discovery example in `docs/configuration/datasource-discovery.md`
sets the service type with the key `serviceType`, but the config field's yaml tag
is snake_case `service_type`:

```go
// pkg/model/api/config/datasourcediscovery.go
ServiceType string `json:"service_type,omitempty" yaml:"service_type,omitempty"`
```

The config loader is strict about unknown keys (it decodes with known-fields
enabled), so an unrecognized key like `serviceType` is a hard error. Copy-pasting
the documented example therefore makes Perses fail to start with a
`field serviceType not found` decode error.

This aligns the example with the field tag and with the schema reference in
`docs/configuration/configuration.md` (`service_type: < enum | possibleValue =
'ClusterIP' | ... >`). Every other key in the same example block
(`kubernetes_sd`, `datasource_plugin_kind`, `service_configuration`, `port_name`)
is already snake_case; `serviceType` was the only outlier.

Docs-only, one line:

```diff
         service_configuration:
           enable: true
           port_name: "http"
-          serviceType: "ClusterIP"
+          service_type: "ClusterIP"
```

# Screenshots

_No UI changes._

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention (`DOC`).
- [x] All commits have DCO signoffs.
