### PR TITLE
[DOC] fix panel Title example to use panel.Title

### DIFF
--- a/docs/dac/go/panel.md
+++ b/docs/dac/go/panel.md
@@ -22,7 +22,7 @@ Need to provide the name of the panel and a list of options.
 ```golang
 import "github.com/perses/perses/go-sdk/panel"
 
-panel.Name("My Super Panel")
+panel.Title("My Super Panel")
 ```
 
 Define the panel title.


### PR DESCRIPTION


The "Title" option example in the Go dashboard-as-code panel docs calls
`panel.Name(...)`, but the `go-sdk/panel` package has no `Name` function. The
title setter is `panel.Title`, defined in `go-sdk/panel/options.go`
(`func Title(title string) Option`). As written, the snippet does not compile
(`undefined: panel.Name`).

Everything around the snippet already refers to `Title`: the section heading is
`### Title`, the default-options list links `[Title()](#title)`, and the caption
below the block reads "Define the panel title." This change fixes the one
mismatched line so the example matches the actual API.

```diff
-panel.Name("My Super Panel")
+panel.Title("My Super Panel")
```

`docs/dac/go/panel.md` was the only place in the repo referencing `panel.Name`.
`make fmt-docs` (mdox) leaves the file otherwise unchanged, so the docs formatting
check stays green.

# Screenshots

_N/A - documentation-only change, no UI impact._

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

_N/A - no UI changes._
