### PR TITLE
[BUGFIX] Allow client to auto-refresh token

### DIFF
--- a/internal/api/crypto/jwt.go
+++ b/internal/api/crypto/jwt.go
@@ -66,6 +66,7 @@ type JWT interface {
 	CreateRefreshTokenCookie(refreshToken string) *http.Cookie
 	DeleteRefreshTokenCookie() *http.Cookie
 	ValidateRefreshToken(token string) (*JWTClaims, error)
+	GetExpiresIn() int64
 }
 
 type jwtImpl struct {
@@ -165,4 +166,9 @@ func (j *jwtImpl) ValidateRefreshToken(token string) (*JWTClaims, error) {
 		return nil, err
 	}
 	return parsedToken.Claims.(*JWTClaims), nil
+}
+
+// GetExpiresIn returns the number of seconds until the access token expires.
+func (j *jwtImpl) GetExpiresIn() int64 {
+	return int64(j.accessTokenTTL.Seconds())
 }

--- a/internal/api/e2e/api/auth_test.go
+++ b/internal/api/e2e/api/auth_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gavv/httpexpect/v2"
 	"github.com/perses/perses/internal/api/dependency"
@@ -418,6 +419,41 @@ func TestAuth_OAuthProvider_Token_WithLib(t *testing.T) {
 		assert.ErrorContains(t, err, "oauth2: cannot fetch token: 405 Method Not Allowed")
 
 		return nil
+	})
+
+	conf2 := e2eframework.DefaultAuthConfig()
+	conf2.Security.Authentication.Providers.OAuth = append(conf2.Security.Authentication.Providers.OAuth, providerConfig)
+	conf2.Security.Authentication.AccessTokenTTL = common.Duration(3 * time.Second)
+	conf2.Security.Authentication.RefreshTokenTTL = common.Duration(time.Hour)
+
+	// Server with oauth provider configured with low TTL.
+	e2eframework.WithServerConfig(t, conf2, func(server *httptest.Server, expect *httpexpect.Expect, manager dependency.Manager) []modelAPI.Entity {
+		usersCreatedByTheSuite := []modelAPI.Entity{
+			e2eframework.NewUser("john.doe", ""),
+		}
+
+		persesBaseURL := common.MustParseURL(server.URL)
+		persesTokenURL := common.MustParseURL(server.URL)
+		persesTokenURL.Path = fmt.Sprintf("%s/%s/%s/%s/%s", utils.APIPrefix, utils.PathAuthProviders, utils.AuthnKindOAuth, providerConfig.SlugID, utils.PathToken)
+
+		authenticatedClient, err := config.NewRESTClient(config.RestConfigClient{
+			URL: persesBaseURL,
+			OAuth: &secret.OAuth{
+				ClientID:     "MyClientID",     // Can be anything as our provider is very permissive
+				ClientSecret: "MyClientSecret", // Can be anything as our provider is very permissive
+				TokenURL:     persesTokenURL.String(),
+				AuthStyle:    int(oauth2.AuthStyleInHeader),
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = v1.NewWithClient(authenticatedClient).Project().List("")
+		assert.NoError(t, err)
+		time.Sleep(5 * time.Second)
+		_, err = v1.NewWithClient(authenticatedClient).Project().List("")
+		assert.NoError(t, err)
+
+		return usersCreatedByTheSuite
 	})
 }
 

--- a/internal/api/e2e/api/rbac_test.go
+++ b/internal/api/e2e/api/rbac_test.go
@@ -89,7 +89,7 @@ func TestAnonymousEndpoints(t *testing.T) {
 			Expect().
 			Status(http.StatusOK)
 
-		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token", "expiry", "token_type")
+		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token", "expiry", "expires_in", "token_type")
 		token := authResponse.JSON().Object().Value("access_token").String().Raw()
 
 		expect.GET("/api/config").WithHeader("Authorization", fmt.Sprintf("Bearer %s", token)).Expect().Status(http.StatusOK)
@@ -119,7 +119,7 @@ func TestUnauthorizedEndpoints(t *testing.T) {
 			Expect().
 			Status(http.StatusOK)
 
-		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token", "expiry", "token_type")
+		authResponse.JSON().Object().Keys().ContainsOnly("access_token", "refresh_token", "expiry", "expires_in", "token_type")
 		token := authResponse.JSON().Object().Value("access_token").String().Raw()
 
 		glRole := e2eframework.NewGlobalRole("test")

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gavv/httpexpect/v2"
 	"github.com/go-jose/go-jose/v4"
@@ -266,7 +265,7 @@ func NewOAuthProviderTestServer(t *testing.T) (*httptest.Server, apiConfig.OAuth
 				AccessToken:  "myToken",
 				TokenType:    "myTokenType",
 				RefreshToken: "myRefreshToken",
-				Expiry:       time.Now().Add(4 * time.Hour),
+				ExpiresIn:    3600,
 			})
 			assert.NoError(t, err)
 			writer.Header().Set("Content-Type", "application/json")

--- a/internal/api/impl/auth/auth.go
+++ b/internal/api/impl/auth/auth.go
@@ -189,6 +189,7 @@ func (e *endpoint) refresh(ctx echo.Context) error {
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		TokenType:    oidc.BearerToken,
+		ExpiresIn:    e.jwt.GetExpiresIn(),
 	})
 }
 

--- a/internal/api/impl/auth/native.go
+++ b/internal/api/impl/auth/native.go
@@ -97,5 +97,6 @@ func (e *nativeEndpoint) auth(ctx echo.Context) error {
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		TokenType:    oidc.BearerToken,
+		ExpiresIn:    e.jwt.GetExpiresIn(),
 	})
 }

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -479,6 +479,7 @@ func (e *oAuthEndpoint) performUserSync(userInfo externalUserInfo, setCookie fun
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		TokenType:    oidc.BearerToken,
+		ExpiresIn:    e.jwt.GetExpiresIn(),
 	}, nil
 }
 

--- a/internal/api/impl/auth/oidc.go
+++ b/internal/api/impl/auth/oidc.go
@@ -416,6 +416,7 @@ func (e *oIDCEndpoint) performUserSync(userInfo *oidcUserInfo, setCookie func(co
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		TokenType:    oidc.BearerToken,
+		ExpiresIn:    e.jwt.GetExpiresIn(),
 	}, nil
 }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

fix #3977 

We need to return the ``expires_in`` in the token answer to be sure that the client library will automatically do the refresh of the token. 

Ref: https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2

Specially the oauth2 client_credentials go library that is explicitely checking this field. 

Retrieval of the info https://github.com/golang/oauth2/blob/master/internal/token.go#L279-L322
verify if expired: https://github.com/golang/oauth2/blob/master/token.go#L138-L148

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
