### PR TITLE
[DOC] fix invalid time.minutes in go-sdk RefreshInterval example

### DIFF
--- a/docs/dac/go/dashboard.md
+++ b/docs/dac/go/dashboard.md
@@ -55,7 +55,7 @@ Define the dashboard duration.
 import "time"
 import "github.com/perses/perses/go-sdk/dashboard" 
 
-dashboard.RefreshInterval(15*time.minutes)
+dashboard.RefreshInterval(15*time.Minute)
 ```
 
 Define the dashboard refresh interval.


### PR DESCRIPTION


The `RefreshInterval` example in the Go SDK dashboard docs
(`docs/dac/go/dashboard.md`) uses `15*time.minutes`, but the standard library
`time` package exports the constant as `time.Minute` (capitalized, singular).
As written the snippet does not compile: `undefined: time.minutes`.

`dashboard.RefreshInterval` takes a `time.Duration`
(`go-sdk/dashboard/options.go`: `func RefreshInterval(seconds time.Duration) Option`),
so `15*time.Minute` is the correct argument. This matches the `Duration` example
just above it and the full example further down the same page, both of which
already use the correct `time.Hour` / `time.Minute` constants.

Docs-only, one line:

```diff
-dashboard.RefreshInterval(15*time.minutes)
+dashboard.RefreshInterval(15*time.Minute)
```

# Screenshots

_No UI changes._

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention (`DOC`).
- [x] All commits have DCO signoffs.
