### PR TITLE
[DOC] fix timeserieschart import path in query builder example

### DIFF
--- a/docs/dac/go/query.md
+++ b/docs/dac/go/query.md
@@ -33,7 +33,7 @@ import (
 	"github.com/perses/perses/go-sdk/panel"
 	panelgroup "github.com/perses/perses/go-sdk/panel-group"
 	"github.com/perses/plugins/prometheus/sdk/go/query"
-	timeseries "github.com/perses/plugins/timeserieschart/sdk/gop"
+	timeseries "github.com/perses/plugins/timeserieschart/sdk/go"
 )
 
 func main() {


### PR DESCRIPTION


The Go query builder example in `docs/dac/go/query.md` imports the
timeserieschart plugin from
`github.com/perses/plugins/timeserieschart/sdk/gop`, which does not resolve: the
plugin module only exposes an `sdk/go` package, so anyone copying the snippet
hits a build error on `go get`/`go build`.

This corrects the trailing typo (`sdk/gop` -> `sdk/go`) so the example compiles.
It also brings the example in line with the other Go DAC docs, which already
import the same plugin as `sdk/go` (`docs/dac/go/panel.md`,
`docs/dac/go/panel-group.md`). The `timeseries.Chart()` call used later in the
snippet matches the `Chart` constructor exported by that package.

```diff
-	timeseries "github.com/perses/plugins/timeserieschart/sdk/gop"
+	timeseries "github.com/perses/plugins/timeserieschart/sdk/go"
```

# Screenshots

<!-- none: docs-only, no UI change -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention (`DOC`).
- [x] All commits have DCO signoffs.

## UI Changes

- [x] N/A - documentation-only change, no UI impact.

---

## Verification summary (for the reviewer, not part of the PR body)

- Upstream `perses/plugins` `timeserieschart/sdk` contains only `go/` (no `gop/`);
  confirmed via `gh api repos/perses/plugins/contents/timeserieschart/sdk`.
- The plugin's `sdk/go` package declares `func Chart(...)`, matching
  `timeseries.Chart()` in the example.
- After the fix, all timeserieschart references in `docs/dac/go/` use `sdk/go`;
  zero `sdk/gop` remain in the repo.
- `checkdocs` gate is green: ran mdox exactly as CI
  (`go run github.com/bwplotka/mdox@latest fmt --soft-wraps docs/dac/go/query.md
  --links.validate.config-file=./.mdox.validate.yaml`), exit 0, no reformatting
  drift, `git diff --exit-code -- '*.md'` = 0. The changed line is inside a
  ```golang fence (not a markdown link), so link validation is unaffected.
- Branch is rebased on the latest `origin/main`, 1 ahead / 0 behind.
