### PR TITLE
[BUGFIX] CLI describe: return service.New error instead of a nil err

### DIFF
--- a/internal/cli/cmd/describe/describe.go
+++ b/internal/cli/cmd/describe/describe.go
@@ -76,7 +76,7 @@ func (o *option) Complete(args []string) error {
 
 	svc, svcErr := service.New(o.kind, o.Project, apiClient)
 	if svcErr != nil {
-		return err
+		return svcErr
 	}
 	o.resourceService = svc
 	return nil


### PR DESCRIPTION


In `describe`'s `Complete` (`internal/cli/cmd/describe/describe.go`), the
`if svcErr != nil` branch returned `err` instead of `svcErr`:

```go
apiClient, err := config.Global.GetAPIClient()
if err != nil {
    return err
}

svc, svcErr := service.New(o.kind, o.Project, apiClient)
if svcErr != nil {
    return err   // <- always nil here; should be svcErr
}
```

At that point `err` is the result of `config.Global.GetAPIClient()`, which has
already been checked and returned on the preceding lines, so it is guaranteed
`nil`. Returning it swallows a real `service.New` failure: `Complete` reports
success while `o.resourceService` stays `nil`, and `Execute` then dereferences
it (`o.resourceService.GetResource(...)`).

This returns `svcErr`, matching every sibling command that follows the identical
pattern: `get` (`get.go`), `remove` (two call sites in `remove.go`), and
`dac preview` (`dac/preview/preview.go`). `describe` was the only outlier.

```diff
 	svc, svcErr := service.New(o.kind, o.Project, apiClient)
 	if svcErr != nil {
-		return err
+		return svcErr
 	}
```

Note on reachability: today the faulty branch is not reachable through valid
input, so this is not a user-visible crash yet. `describe` resolves the kind via
`resource.GetKind`, whose supported kinds are exactly the 15 kinds that
`service.New` also handles, so `service.New`'s error (`default`) case never fires
for a kind that got that far. The fix is a correctness/robustness change: it
removes an error-swallowing bug and keeps `describe` consistent with its siblings,
so the code stays correct if the kind sets ever drift or `service.New` gains a new
failure mode.

# Screenshots

<!-- none: CLI-only change, no UI impact -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

## UI Changes

- [x] N/A - CLI-only change, no UI impact.

---

## Note on the missing regression test (for the reviewer)

There is intentionally no new unit test, and here is the honest reasoning so a
reviewer can judge it:

- To exercise the fixed branch, `service.New` must return an error while
  `GetAPIClient` succeeds. That is currently impossible via the public
  `Complete` path because the kind universe of `resource.GetKind` and the kind
  universe of `service.New` are identical (15 == 15), so the `default` error
  case in `service.New` cannot be reached for a kind that survives `GetKind`.
- The in-repo fake API client (`pkg/client/fake/api/v1`) implements only a
  subset of kinds, so it cannot be used to drive `service.New` down its error
  path without unrelated changes.
- `service.New` is a package function (not an injectable seam), so forcing the
  error would require either introducing a production seam or expanding the fake,
  both of which exceed the scope of a self-evident wrong-variable one-liner.

Given that, this is submitted as a small, self-contained correctness fix aligned
with four existing siblings. Happy to add coverage if you would prefer a specific
approach (e.g. a test seam around `service.New`).

---

## Verification summary (for the reviewer, not part of the PR body)

Ran on the rebased branch:

- `gofmt -l internal/cli/cmd/describe/describe.go` -> empty (formatted).
- `go build ./internal/cli/...` -> rc 0.
- `go vet ./internal/cli/cmd/describe/...` -> rc 0.
- `go test -count=1` on `describe`, `get`, `remove`, `dac/preview`, and
  `internal/cli/service` -> all `ok`.
- `golangci-lint run ./internal/cli/cmd/describe/... --timeout 5m` (v2.12.1)
  -> `0 issues`.
- Working tree clean; no stray/regenerated files.
- Sibling pattern re-confirmed at current line numbers: `get.go:84`,
  `remove.go:101`, `remove.go:151`, `dac/preview/preview.go:113` each
  `return svcErr`.
