### PR TITLE
[DOC] Fix stale panel group defaults in go-sdk doc

### DIFF
--- a/docs/dac/go/panel-group.md
+++ b/docs/dac/go/panel-group.md
@@ -15,8 +15,7 @@ Need to provide a title and a list of options.
 
 - [Title()](#title): with the title provided in the constructor.
 - [PanelWidth()](#panelwidth): 12
-- [PanelHeight()](#panelheight): 6
-- [Collapsed()](#collapsed): true
+- [PanelHeight()](#panelheight): 8
 
 ## Available options
 


### PR DESCRIPTION


The "Default options" list in the Go SDK panel group documentation
(`docs/dac/go/panel-group.md`) listed two defaults that no longer match the
default constructor in `go-sdk/panel-group/panel-group.go`:

- `PanelHeight()` was listed as `6`, but the constructor sets `PanelHeight(8)`.
  The code default was changed from 6 to 8 in #2921, which also updated the
  `### PanelHeight` example lower in the same file but missed the "Default
  options" list at the top.
- `Collapsed()` was listed as a default of `true`, but a panel group is no
  longer collapsed by default. In #4150, `IsCollapsed` became a `*bool` (nil by
  default) and `Collapsed(true)` was removed from the constructor defaults. That
  PR did not touch this doc.

This change aligns the list with the actual constructor defaults
(`Title(title)`, `PanelWidth(12)`, `PanelHeight(8)`): it corrects `PanelHeight`
to `8` and drops the stale `Collapsed(): true` line. The `### PanelHeight`
example (already `8`) and the `### Collapsed` option section are left untouched,
so their anchor links stay valid. Docs only, no code change.

# Screenshots

<!-- No UI changes. -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.

(No UI changes; the UI checklist items do not apply to this docs-only PR.)
