### PR TITLE
[BUGFIX] set PERSES_CLI env on the Windows plugin dev server

### DIFF
--- a/internal/cli/cmd/plugin/start/devserver_windows.go
+++ b/internal/cli/cmd/plugin/start/devserver_windows.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -102,6 +103,8 @@ func (d *devserver) Execute(ctx context.Context, _ context.CancelFunc) error {
 	cmd.Stdout = d.writer
 	cmd.Stderr = d.errWriter
 	cmd.Dir = d.pluginPath
+	// PERSES_CLI indicates to the plugin dev server that it is run by the perses CLI
+	cmd.Env = append(os.Environ(), "PERSES_CLI=true")
 	if err := cmd.Start(); err != nil {
 		return err
 	}


### PR DESCRIPTION

On non-Windows, `percli plugin start` runs the plugin's rsbuild dev server with
`PERSES_CLI=true` in its environment (`internal/cli/cmd/plugin/start/devserver.go`).
The generated plugin rsbuild config keys its `printUrls` formatter off that
variable (`internal/cli/cmd/plugin/generate/templates/module/rsbuild.config.ts.tmpl`):

```ts
printUrls: process.env.PERSES_CLI
  ? ({ port, protocol }) => {
      // custom output for `percli plugin start` to detect port for dev server
      console.log(`[PERSES_PLUGIN] NAME="${name}" PORT="${port}" PROTOCOL="${protocol}"\n`);
      ...
```

That `[PERSES_PLUGIN] ... PORT="<port>"` line is exactly what `percli`'s
`portCapturingWriter` regex parses to detect the dev server port.

The Windows implementation
(`internal/cli/cmd/plugin/start/devserver_windows.go`) builds its command inline
in `Execute` and never set `cmd.Env`, so `PERSES_CLI` was not passed to the dev
server on Windows. As a result `printUrls` stays at the rsbuild default, the
`[PERSES_PLUGIN]` marker is never emitted, and `percli plugin start` cannot
reliably detect the plugin dev server port on Windows.

`PERSES_CLI=true` was introduced for the dev server process in #3435, but that
change only touched the non-Windows `devserver.go`; the Windows sibling was not
updated. This PR ports that same env setup to `Execute` in
`devserver_windows.go`, mirroring `devserver.go`, and adds the missing `os`
import.

```go
cmd.Dir = d.pluginPath
// PERSES_CLI indicates to the plugin dev server that it is run by the perses CLI
cmd.Env = append(os.Environ(), "PERSES_CLI=true")
```

No behavior change on non-Windows platforms; the file is `//go:build windows`.

# Screenshots

<!-- No UI changes. -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.

<!-- No UI changes: Go-only fix in the CLI dev server, Windows build only. -->
