### PR TITLE
[DOC] fix dialog JSDoc @param names to match props

### DIFF
--- a/ui/app/src/components/dialogs/CreateDashboardDialog.tsx
+++ b/ui/app/src/components/dialogs/CreateDashboardDialog.tsx
@@ -49,7 +49,7 @@ interface CreateDashboardProps {
 /**
  * Dialog used to create a dashboard.
  * @param props.open Define if the dialog should be opened or not.
- * @param props.projectOptions The project where the dashboard will be created.
+ * @param props.projects The project where the dashboard will be created.
  * If it contains only one element, it will be used as project value and will hide the project selection.
  * @param props.onClose Provides the function to close itself.
  * @param props.onSuccess Action to perform when user confirmed.

--- a/ui/app/src/components/dialogs/DeleteFolderDialog.tsx
+++ b/ui/app/src/components/dialogs/DeleteFolderDialog.tsx
@@ -30,7 +30,6 @@ interface DeleteFolderDialogProps {
  * @param folder The folder resource containing the subfolder to delete.
  * @param path The path of the subfolder to delete. If empty, the root folder will be deleted.
  * @param open Define if the dialog should be opened or not.
- * @param onSubmit Action to perform when user confirmed.
  * @param onClose Provides the function to close itself.
  * @returns A React element representing the delete folder dialog.
  */

--- a/ui/app/src/components/dialogs/UpdateEphemeralDashboardDialog.tsx
+++ b/ui/app/src/components/dialogs/UpdateEphemeralDashboardDialog.tsx
@@ -34,8 +34,8 @@ interface UpdateEphemeralDashboardDialog {
 /**
  * Dialog used to rename an ephemeral dashboard.
  * @param props.open Define if the dialog should be opened or not.
- * @param props.closeDialog Provides the function to close itself.
- * @param props.onConfirm Action to perform when user confirmed.
+ * @param props.onClose Provides the function to close itself.
+ * @param props.onSuccess Action to perform when user confirmed.
  * @param props.ephemeralDashboard The ephemeral dashboard resource to rename.
  */
 export const UpdateEphemeralDashboardDialog = (props: UpdateEphemeralDashboardDialog): ReactElement => {


### PR DESCRIPTION


While reading the dashboard dialog components in `ui/app/src/components/dialogs/`,
I noticed three JSDoc blocks document `@param` names that do not exist on the
components' typed props. They drifted from the props during earlier
copy-paste/rename changes, so the docs describe parameters the components never
receive.

This corrects each `@param` to the real prop name. Documentation only, no runtime
or behavioral change.

- `UpdateEphemeralDashboardDialog.tsx`: documented `props.closeDialog` and
  `props.onConfirm`, but the interface exposes `onClose` and `onSuccess` (the body
  destructures `onClose, onSuccess`). The sibling `EditDashboardDialog.tsx`
  documents the same two props correctly as `onClose` / `onSuccess`, which is the
  pattern this file drifted from.
- `CreateDashboardDialog.tsx`: documented `props.projectOptions`, but the prop is
  `projects: ProjectResource[]` (destructured as `projects`). `projectOptions`
  appears nowhere in the file.
- `DeleteFolderDialog.tsx`: documented `@param onSubmit`, but the component's props
  are only `folder` / `path` / `open` / `onClose`. `onSubmit` belongs to the inner
  `DeleteDialog` (which really has an `onSubmit` prop and the identical docline);
  the line was copied along with it. Removed the stray `@param`.

# Screenshots

<!-- No UI changes; comment-only. -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention using one of the following `catalog_entry` values: `FEATURE`,
  `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the
  relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.

(No UI behavior changes: this PR only edits JSDoc comments, so the UI-changes
items above do not apply.)
