### PR TITLE
[DOC] fix broken Go SDK examples in http-proxy.md

### DIFF
--- a/docs/dac/go/helper/http-proxy.md
+++ b/docs/dac/go/helper/http-proxy.md
@@ -43,7 +43,7 @@ Define the proxy allowed endpoints.
 ```golang
 import "github.com/perses/perses/go-sdk/http"
 
-http.Thresholds("GET", "/api/v1/labels")
+http.AddAllowedEndpoint("GET", "/api/v1/labels")
 ```
 
 Add an allowed endpoint to the http proxy.
@@ -53,8 +53,8 @@ Add an allowed endpoint to the http proxy.
 ```golang
 import "github.com/perses/perses/go-sdk/http" 
 
-var headers := make(map[string]string)
-http.WithSparkline(headers)
+headers := make(map[string]string)
+http.Headers(headers)
 ```
 
 Define the headers of the http proxy.
@@ -88,7 +88,7 @@ import (
 	"github.com/perses/perses/go-sdk/dashboard"
 	"github.com/perses/perses/go-sdk/http"
 	
-	promDs "github.com/perses/perses/go-sdk/prometheus/datasource"
+	promDs "github.com/perses/plugins/prometheus/sdk/go/datasource"
 )
 
 func main() {


### PR DESCRIPTION
# Description

The Go SDK examples in `docs/dac/go/helper/http-proxy.md` referenced functions and an
import path that do not exist, so a reader copying them would not be able to compile the
code. All are copy-paste leftovers that have been in the file since it was first added.

Three fixes:

- **`AddAllowedEndpoint` snippet** called `http.Thresholds("GET", "/api/v1/labels")`.
  `Thresholds` does not exist in `go-sdk/http`. The actual option is
  `http.AddAllowedEndpoint(method, endpointPattern)` (`go-sdk/http/options.go`), which is
  also what the section heading documents.
- **`Headers` snippet** called `http.WithSparkline(headers)` and declared the variable as
  `var headers := make(map[string]string)`. `WithSparkline` does not exist; the real option
  is `http.Headers(headers)` (`go-sdk/http/options.go`). `var x := ...` is also invalid Go
  (mixing `var` with `:=`), so the snippet did not even parse. Now `headers := make(...)`
  plus `http.Headers(headers)`.
- **`Example` block** imported `github.com/perses/perses/go-sdk/prometheus/datasource`,
  which does not exist (there is no `prometheus` package under `go-sdk/`). The prometheus
  datasource SDK lives in `github.com/perses/plugins/prometheus/sdk/go/datasource`, which is
  already the import used by `docs/dac/go/datasource.md` and `docs/dac/go/dashboard.md`.

After the change the snippets match the real `go-sdk/http` API and the example compiles.

# Screenshots

N/A (documentation only, no UI change).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention
      (`[DOC] ...`).
- [x] All commits have DCO signoffs.

## UI Changes

- [x] N/A - no UI changes (documentation only).
