### PR TITLE
[BUGFIX] escape LIKE metacharacters in name-prefix filter

### DIFF
--- a/internal/api/database/sql/query.go
+++ b/internal/api/database/sql/query.go
@@ -91,6 +91,16 @@ func (d *DAO) generateUpdateQuery(entity modelAPI.Entity) (string, []any, error)
 	return sql, args, nil
 }
 
+// escapeLikePattern escapes the LIKE metacharacters ('%' and '_') and the
+// escape character itself ('\') in s so they are matched literally. This keeps
+// the SQL backend's name-prefix filter consistent with the file backend, which
+// uses a literal strings.HasPrefix. MySQL uses '\' as the default LIKE escape
+// character, so no explicit ESCAPE clause is required.
+func escapeLikePattern(s string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(s)
+}
+
 func (d *DAO) generateSelectQuery(tableName string, project string, name string) (string, []any) {
 	p := project
 	n := name
@@ -102,7 +112,7 @@ func (d *DAO) generateSelectQuery(tableName string, project string, name string)
 		Select(colDoc).
 		From(tableName)
 	if len(n) > 0 {
-		queryBuilder.Where(queryBuilder.Like(colName, fmt.Sprintf("%s%%", n)))
+		queryBuilder.Where(queryBuilder.Like(colName, fmt.Sprintf("%s%%", escapeLikePattern(n))))
 	}
 	if len(p) > 0 {
 		queryBuilder.Where(queryBuilder.Equal(colProject, p))
@@ -161,7 +171,7 @@ func (d *DAO) generateDeleteQuery(tableName string, project string, name string)
 	queryBuilder := sqlbuilder.NewDeleteBuilder().
 		DeleteFrom(tableName)
 	if len(n) > 0 {
-		queryBuilder.Where(queryBuilder.Like(colName, fmt.Sprintf("%s%%", n)))
+		queryBuilder.Where(queryBuilder.Like(colName, fmt.Sprintf("%s%%", escapeLikePattern(n))))
 	}
 	if len(p) > 0 {
 		queryBuilder.Where(queryBuilder.Equal(colProject, p))

--- a/internal/api/database/sql/query_test.go
+++ b/internal/api/database/sql/query_test.go
@@ -49,6 +49,27 @@ func TestGenerateProjectResourceSelectQuery(t *testing.T) {
 			sqlArgs:  []any{"bar%", "foo"},
 		},
 		{
+			title:    "a prefix name with an underscore is escaped",
+			project:  "",
+			name:     "foo_bar",
+			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ?",
+			sqlArgs:  []any{`foo\_bar%`},
+		},
+		{
+			title:    "a prefix name with a percent sign is escaped",
+			project:  "",
+			name:     "100%",
+			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ?",
+			sqlArgs:  []any{`100\%%`},
+		},
+		{
+			title:    "a prefix name with a backslash is escaped",
+			project:  "",
+			name:     `foo\bar`,
+			sqlQuery: "SELECT doc FROM perses.dashboard WHERE name LIKE ?",
+			sqlArgs:  []any{`foo\\bar%`},
+		},
+		{
 			title:    "empty query",
 			project:  "",
 			name:     "",


### PR DESCRIPTION
<!-- everything below the divider is the exact upstream PR description -->
---

The SQL persistence backend builds its name-prefix filter by interpolating the
raw, user-supplied prefix straight into a `LIKE` pattern:

```go
queryBuilder.Where(queryBuilder.Like(colName, fmt.Sprintf("%s%%", n)))
```

Resource names legitimately contain `_` (the name spec is `^[a-zA-Z0-9_.-]+$`),
and `LIKE` treats `_` as a single-character wildcard and `%` as a multi-character
wildcard. So filtering by a prefix like `?name=node_exporter` is sent as
`name LIKE 'node_exporter%'`, where each `_` matches *any* single character. The
result over-matches (for example it also returns `nodeXexporter`).

This also makes the two supported persistence backends disagree for the same
query: the file backend filters with a literal `strings.HasPrefix`
(`internal/api/database/file/file.go`), while the SQL backend treats the prefix
as a wildcard pattern.

This change adds a small `escapeLikePattern` helper that escapes `%`, `_`, and
the `\` escape character in the prefix before it is turned into a `LIKE`
pattern, so the prefix is matched literally. It is applied at both `LIKE`
call sites in `internal/api/database/sql/query.go` (the select and delete
query builders), keeping the SQL backend consistent with the file backend.

MySQL is the only SQL driver used by the persistence layer, and it treats `\`
as the default `LIKE` escape character, so no explicit `ESCAPE` clause is
needed. The prefix is passed as a bound parameter, so the escaping happens once
at the `LIKE`-pattern level and is not re-interpreted as an SQL string literal.

Regression tests are added to `query_test.go` covering the `_`, `%`, and `\`
cases (they fail without this change and pass with it).

# Screenshots

<!-- N/A: no UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] N/A: this change does not impact the UI.
