### PR TITLE
[BUGFIX] use provider HTTP client for OAuth device code token exchange

### DIFF
--- a/internal/api/impl/auth/auth_test.go
+++ b/internal/api/impl/auth/auth_test.go
@@ -14,12 +14,16 @@
 package auth
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/perses/perses/internal/api/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestGetRedirectURI_WithAPIPrefix(t *testing.T) {
@@ -66,4 +70,36 @@ func TestDecodeOAuthState(t *testing.T) {
 
 	state = "short--"
 	assert.Equal(t, "", decodeOAuthState(state))
+}
+
+// TestOAuthRetrieveDeviceAccessToken_UsesProviderHTTPClient ensures the device code token
+// exchange goes through the provider-scoped http client (which carries the configured TLS
+// and timeout) rather than http.DefaultClient. The server is served over TLS with a test
+// certificate that only the provider client trusts, so the exchange can only succeed when
+// e.httpClient is used.
+func TestOAuthRetrieveDeviceAccessToken_UsesProviderHTTPClient(t *testing.T) {
+	const deviceCode = "device-code-123"
+	var gotGrantType, gotDeviceCode string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		gotGrantType = r.PostForm.Get("grant_type")
+		gotDeviceCode = r.PostForm.Get("device_code")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"an-access-token","token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	e := &oAuthEndpoint{
+		// srv.Client() trusts the server's test certificate, unlike http.DefaultClient.
+		httpClient: srv.Client(),
+		deviceCodeConf: oauth2.Config{
+			Endpoint: oauth2.Endpoint{TokenURL: srv.URL},
+		},
+	}
+
+	token, err := e.retrieveDeviceAccessToken(context.Background(), deviceCode)
+	require.NoError(t, err)
+	assert.Equal(t, "an-access-token", token.AccessToken)
+	assert.Equal(t, "urn:ietf:params:oauth:grant-type:device_code", gotGrantType)
+	assert.Equal(t, deviceCode, gotDeviceCode)
 }

--- a/internal/api/impl/auth/oauth.go
+++ b/internal/api/impl/auth/oauth.go
@@ -504,8 +504,8 @@ func (e *oAuthEndpoint) retrieveDeviceAccessToken(ctx context.Context, deviceCod
 	req.SetBasicAuth(e.deviceCodeConf.ClientID, e.deviceCodeConf.ClientSecret)
 	req = req.WithContext(ctx)
 
-	// Send the request using the default HTTP Client
-	resp, err := http.DefaultClient.Do(req)
+	// Send the request using the provider's HTTP client so the configured TLS and timeout are honored
+	resp, err := e.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


The OAuth device code token exchange was sending its token request through
`http.DefaultClient` instead of the provider-scoped client the endpoint builds
for itself.

When an `oAuthEndpoint` is constructed, it builds an `*http.Client` via
`newHTTPClient(provider.HTTP)`, which carries the provider's configured TLS
(custom CA, client certificates, `InsecureSkipVerify`) and timeout, and stores it
on `e.httpClient`. Every other flow uses it:

- the authorization code flow, via `newQueryContext`
  (`context.WithValue(..., oauth2.HTTPClient, e.httpClient)`) passed to
  `e.conf.Exchange`;
- the device code *initiation* step (`DeviceAuth`), which also goes through
  `newQueryContext`;
- the OIDC device code flow, via `rp.WithHTTPClient(httpClient)`.

Only the OAuth device code *token retrieval* (`retrieveDeviceAccessToken`), which
is hand-rolled because the `oauth2` package only exposes the device poll as a
whole, sent the request with `http.DefaultClient`. That silently dropped the
configured TLS and timeout, so device code login failed against an OAuth provider
served behind a private CA (`x509: certificate signed by unknown authority`),
even though the authorization code flow against the same provider worked.

This changes that one call to use `e.httpClient`, making the device code token
exchange consistent with the other flows.

The `http` package is still used in the same file (request construction, cookies,
status codes), so no import changes.

### Test

Added `TestOAuthRetrieveDeviceAccessToken_UsesProviderHTTPClient` next to the
existing auth tests. It stands up an `httptest.NewTLSServer` (self-signed cert)
and assigns `srv.Client()` (which trusts that cert) to `e.httpClient`. The
exchange succeeds only when the code uses `e.httpClient`; reverting the fix to
`http.DefaultClient` makes the test fail with the private-CA `x509` error. It also
asserts the server received
`grant_type=urn:ietf:params:oauth:grant-type:device_code` and the device code, so
the request is proven to flow through the intended client.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention using one of the following `catalog_entry` values: `FEATURE`,
  `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`, `IGNORE`.
- [x] All commits have DCO signoffs.

(No UI changes; the UI section of the template does not apply.)
