### PR TITLE
[BUGFIX] apply default AuthorizerDenyTTL in kubernetes authz provider

### DIFF
--- a/pkg/model/api/config/authorization.go
+++ b/pkg/model/api/config/authorization.go
@@ -65,7 +65,7 @@ func (k *KubernetesAuthorizationProvider) Verify() error {
 	if k.AuthorizerAllowTTL == 0 {
 		k.AuthorizerAllowTTL = common.Duration(DefaultKubernetesAuthorizationAllowTTL)
 	}
-	if k.AuthenticatorTTL == 0 {
+	if k.AuthorizerDenyTTL == 0 {
 		k.AuthorizerDenyTTL = common.Duration(DefaultKubernetesAuthorizationDenyTTL)
 	}
 	return nil

--- a/pkg/model/api/config/authorization_test.go
+++ b/pkg/model/api/config/authorization_test.go
@@ -1,0 +1,38 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/perses/spec/go/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubernetesAuthorizationProvider_VerifyDefaults(t *testing.T) {
+	k := &KubernetesAuthorizationProvider{Enable: true}
+	assert.NoError(t, k.Verify())
+	assert.Equal(t, 500, k.QPS)
+	assert.Equal(t, 1000, k.Burst)
+	assert.Equal(t, common.Duration(DefaultKubernetesAuthenticationTTL), k.AuthenticatorTTL)
+	assert.Equal(t, common.Duration(DefaultKubernetesAuthorizationAllowTTL), k.AuthorizerAllowTTL)
+	assert.Equal(t, common.Duration(DefaultKubernetesAuthorizationDenyTTL), k.AuthorizerDenyTTL)
+}
+
+func TestKubernetesAuthorizationProvider_VerifyKeepsExplicitDenyTTL(t *testing.T) {
+	k := &KubernetesAuthorizationProvider{Enable: true, AuthorizerDenyTTL: common.Duration(time.Minute)}
+	assert.NoError(t, k.Verify())
+	assert.Equal(t, common.Duration(time.Minute), k.AuthorizerDenyTTL)
+}


### PR DESCRIPTION


`KubernetesAuthorizationProvider.Verify()` guards the `AuthorizerDenyTTL`
default with the wrong field. It checks `AuthenticatorTTL` instead of
`AuthorizerDenyTTL`:

```go
if k.AuthenticatorTTL == 0 {
    k.AuthorizerDenyTTL = common.Duration(DefaultKubernetesAuthorizationDenyTTL)
}
```

`AuthenticatorTTL` is defaulted to a non-zero value a few lines earlier in the
same method, so this condition is always false by the time it is reached. As a
result the documented 30s deny-cache default (`pkg/model/api/config/authorization.go`
field doc `// time an authorizer denied will be cached for. Default: 30s`, and
`docs/configuration/configuration.md`: `authorizer_deny_ttl <duration> | default 30s`)
is never applied, and `AuthorizerDenyTTL` stays at `0` whenever the operator
does not set it explicitly.

The resolved value is passed straight through to
`authorizerfactory.DelegatingAuthorizerConfig.DenyCacheTTL` in
`internal/api/authorization/k8s/k8s.go`. A `DenyCacheTTL` of `0` disables caching
of DENY authorization decisions, so every denied request re-issues a
`SubjectAccessReview` to the Kubernetes apiserver instead of being served from
the intended 30s deny cache. That is extra apiserver load and latency on the
deny path, and a silent divergence from the documented default.

## Fix

- Change the guard to check `AuthorizerDenyTTL == 0` (the assignment in the body
  is already correct). One-line change, consistent with the two sibling default
  blocks just above it.
- Add a colocated regression test (`pkg/model/api/config/authorization_test.go`)
  that asserts the applied defaults (`QPS`, `Burst`, `AuthenticatorTTL`,
  `AuthorizerAllowTTL`, `AuthorizerDenyTTL`) and that an explicitly set
  `AuthorizerDenyTTL` is preserved.

Introduced in #3065 (the initial Kubernetes authorization provider) and still
present on `main`.

# Screenshots

N/A (no UI changes).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
