### PR TITLE
[BUGFIX] config: fix Plugin.Verify lowercasing to not prepend empty strings

### DIFF
--- a/pkg/model/api/config/plugin.go
+++ b/pkg/model/api/config/plugin.go
@@ -89,14 +89,14 @@ func (p *Plugin) Verify() error {
 		return fmt.Errorf("the 'activated' and 'deactivated' attributes can not be used at the same time. Please use either one of them")
 	}
 	if len(p.Enabled) > 0 {
-		newEnabled := make([]string, len(p.Enabled))
+		newEnabled := make([]string, 0, len(p.Enabled))
 		for _, s := range p.Enabled {
 			newEnabled = append(newEnabled, strings.ToLower(s))
 		}
 		p.Enabled = newEnabled
 	}
 	if len(p.Disabled) > 0 {
-		newDisabled := make([]string, len(p.Disabled))
+		newDisabled := make([]string, 0, len(p.Disabled))
 		for _, s := range p.Disabled {
 			newDisabled = append(newDisabled, strings.ToLower(s))
 		}

--- a/pkg/model/api/config/plugin_test.go
+++ b/pkg/model/api/config/plugin_test.go
@@ -1,0 +1,40 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlugin_VerifyLowercaseEnabled(t *testing.T) {
+	p := &Plugin{
+		Path:         "plugins",
+		ArchivePaths: []string{"plugins-archive"},
+		Enabled:      []string{"Prometheus", "Tempo"},
+	}
+	assert.NoError(t, p.Verify())
+	assert.Equal(t, []string{"prometheus", "tempo"}, p.Enabled)
+}
+
+func TestPlugin_VerifyLowercaseDisabled(t *testing.T) {
+	p := &Plugin{
+		Path:         "plugins",
+		ArchivePaths: []string{"plugins-archive"},
+		Disabled:     []string{"Prometheus", "Tempo"},
+	}
+	assert.NoError(t, p.Verify())
+	assert.Equal(t, []string{"prometheus", "tempo"}, p.Disabled)
+}


### PR DESCRIPTION


`Plugin.Verify()` normalizes the configured `enabled` and `disabled` plugin
lists to lowercase. Each destination slice is allocated with
`make([]string, len(...))`, which pre-fills it with N empty strings, and the
loop then `append`s the lowercased names after those empties.

For `enabled: ["Prometheus", "Tempo"]`, `p.Enabled` ends up as
`["", "", "prometheus", "tempo"]` (length doubled, two leading empty entries)
instead of `["prometheus", "tempo"]`. The `disabled` list has the same defect.

The fix allocates each slice with zero length and the intended capacity
(`make([]string, 0, len(...))`), so the existing append loop produces the
lowercased slice with no leading empties. Both the `enabled` and `disabled`
branches are corrected.

I also added a `Plugin.Verify()` test covering both lists. This method had no
test coverage before, so the normalization was never exercised.

Impact is limited in practice: these values feed the enable/disable plugin
filter, which compares them with `slices.Contains` against real (non-empty)
plugin and module names, so the phantom empty entries never matched anything and
filtering behaved correctly. The stored slices were still wrong (doubled, with
leading empties), which is surprising for anything reading them and would
over-match if an empty name ever reached the filter.

# Screenshots

N/A (no UI changes).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

## UI Changes

- [x] N/A (backend/config only, no UI impact).
