### PR TITLE
[BUGFIX] config: fix SQL max_allowed_packet YAML tag

### DIFF
--- a/pkg/model/api/config/database.go
+++ b/pkg/model/api/config/database.go
@@ -74,7 +74,7 @@ type SQL struct {
 	// Location for time.Time values
 	Loc *time.Location `json:"loc,omitempty" yaml:"loc,omitempty"`
 	// Max packet size allowed
-	MaxAllowedPacket int `json:"max_allowed_packet" yaml:"maxAllowedPacket"`
+	MaxAllowedPacket int `json:"max_allowed_packet" yaml:"max_allowed_packet"`
 	// Server public key name
 	ServerPubKey string `json:"server_pub_key" yaml:"server_pub_key"`
 	// Dial timeout

--- a/pkg/model/api/config/database_test.go
+++ b/pkg/model/api/config/database_test.go
@@ -1,0 +1,42 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+// The documented key for this field is the snake_case max_allowed_packet
+// (see docs/configuration/configuration.md and the surrounding struct fields),
+// so both the YAML and JSON tags must bind that key.
+func TestSQLMaxAllowedPacketFromYAML(t *testing.T) {
+	data := `
+db_name: mydb
+max_allowed_packet: 67108864
+`
+	sql := &SQL{}
+	assert.NoError(t, yaml.Unmarshal([]byte(data), sql))
+	assert.Equal(t, 67108864, sql.MaxAllowedPacket)
+}
+
+func TestSQLMaxAllowedPacketFromJSON(t *testing.T) {
+	data := `{"db_name":"mydb","max_allowed_packet":67108864}`
+	sql := &SQL{}
+	assert.NoError(t, json.Unmarshal([]byte(data), sql))
+	assert.Equal(t, 67108864, sql.MaxAllowedPacket)
+}


### PR DESCRIPTION


The `MaxAllowedPacket` field of the server-config SQL struct
(`pkg/model/api/config/database.go`) carries a camelCase yaml tag
(`yaml:"maxAllowedPacket"`), while its json tag and every sibling field of the
same struct use snake_case (`db_name`, `server_pub_key`, `read_timeout`, ...).

The server config is loaded YAML-first: `config.Resolve`
(`pkg/model/api/config/config.go`) uses `github.com/perses/common`'s
`NewResolver`, which decodes the config file with `gopkg.in/yaml.v3`
(`yaml.NewDecoder` + `KnownFields`). `yaml.v3` matches keys against the yaml tag
**case-sensitively**, so the documented key
[`max_allowed_packet`](https://github.com/perses/perses/blob/main/docs/configuration/configuration.md)
never binds to this field:

- With strict decoding (the resolver default), the documented
  `max_allowed_packet:` key is treated as an unknown field and config loading
  fails.
- With a plain `yaml.Unmarshal`, the key is silently dropped and
  `MaxAllowedPacket` stays `0`, falling back to the MySQL driver default.

The environment-variable override path keys off the same yaml tag, so it is
miswired identically.

This aligns the yaml tag with the json tag, the documentation, and the rest of
the struct (`max_allowed_packet`), and adds a regression test covering both YAML
and JSON binding. JSON serialization is unchanged (the json tag was already
correct).

Note: this is a different struct from the datasource SQL config
(`pkg/model/api/v1/datasource/sql/sql.go`), which intentionally uses camelCase
for both tags and is left untouched.

# Screenshots

<!-- No UI changes. -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

## UI Changes

- N/A (Go-only change; no UI impact).
