### PR TITLE
[BUGFIX] honor datasource TLS config when fetching OAuth token

### DIFF
--- a/internal/api/impl/proxy/proxy.go
+++ b/internal/api/impl/proxy/proxy.go
@@ -402,7 +402,7 @@ func (h *httpProxy) getToken(ctx context.Context, oauth *secretModel.OAuth) (*oa
 		return nil, err
 	}
 
-	httpClient := http.Client{
+	httpClient := &http.Client{
 		Transport: transport,
 	}
 

--- a/internal/api/impl/proxy/proxy_test.go
+++ b/internal/api/impl/proxy/proxy_test.go
@@ -14,9 +14,15 @@
 package proxy
 
 import (
+	"context"
 	"crypto/tls"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	secretModel "github.com/perses/perses/pkg/model/api/v1/secret"
 	datasourceSQL "github.com/perses/spec/go/datasource/proxy/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -255,4 +261,42 @@ func TestSQLProxy_sqlOpen(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHTTPProxy_getToken_honorsTLSConfig ensures the OAuth token request is
+// performed with the transport built from the datasource secret's TLS config.
+// The token endpoint is served over TLS with a self-signed certificate, so the
+// request only succeeds when the configured transport (trusting that certificate
+// through the secret's CA) is used. If getToken stored a plain http.Client value
+// instead of a *http.Client under the oauth2.HTTPClient context key, oauth2 would
+// silently fall back to http.DefaultClient and the handshake would fail.
+func TestHTTPProxy_getToken_honorsTLSConfig(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"secret-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+
+	h := &httpProxy{
+		secret: &v1.SecretSpec{
+			TLSConfig: &secretModel.TLSConfig{
+				CA:         string(caPEM),
+				MinVersion: "TLS12",
+				MaxVersion: "TLS13",
+			},
+		},
+	}
+
+	oauth := &secretModel.OAuth{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		TokenURL:     server.URL,
+	}
+
+	token, err := h.getToken(context.Background(), oauth)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "secret-token", token.AccessToken)
 }


### PR DESCRIPTION


When an HTTP datasource proxy is configured with an OAuth 2.0 client-credentials
secret, `httpProxy.getToken` (`internal/api/impl/proxy/proxy.go`) builds an
`*http.Transport` from the datasource secret's TLS config and stores it on an
HTTP client under the `oauth2.HTTPClient` context key. It stored the client as a
value (`http.Client{...}`), but `golang.org/x/oauth2` retrieves it with a
`ctx.Value(oauth2.HTTPClient).(*http.Client)` type assertion. That assertion
fails for a value, so oauth2 silently falls back to `http.DefaultClient`.

The effect: the datasource secret's TLS settings (custom CA, client certificate
for mTLS, `InsecureSkipVerify`) and the transport's dial/handshake timeouts are
ignored specifically when fetching the OAuth token. A datasource whose token
endpoint uses a private CA or requires a client certificate would fail the token
handshake (or bypass the intended verification), even though the same TLS config
is correctly applied to the proxied data requests themselves.

The two other places in the codebase that put a client under this context key
already pass a pointer (`pkg/client/config/config.go` and
`internal/api/impl/auth/oauth.go`, the latter referencing golang/oauth2#187,
which is the upstream note that TLS-via-context needs a `*http.Client`). This
change makes the proxy path consistent with them.

Fix: pass `&http.Client{...}` so the configured transport is carried through the
context and used for the token request.

A regression test (`TestHTTPProxy_getToken_honorsTLSConfig`) serves the token
endpoint over TLS with a self-signed certificate wired in as the secret's CA. It
only passes when the transport built from the secret's TLS config is honored;
with the previous value-typed client it fails with
`x509: certificate signed by unknown authority` (oauth2 having fallen back to
`http.DefaultClient`).

# Screenshots

<!-- No UI changes. -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention using one of the following `catalog_entry` values: `FEATURE`,
  `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`, `IGNORE`.
- [x] All commits have DCO signoffs.

## UI Changes

- [ ] N/A - no UI changes (Go backend only).
