### PR TITLE
[BUGFIX] Schema: validate dev variable plugins against the variables tree

### DIFF
--- a/internal/api/plugin/schema/schema.go
+++ b/internal/api/plugin/schema/schema.go
@@ -277,7 +277,7 @@ func (s *completeSchema) ValidateDashboardVariables(variables []dashboard.Variab
 func (s *completeSchema) ValidateVariable(plugin plugin.Plugin, varName string) error {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	if _, ok := s.devSch.panels.GetWithPluginMetadata(plugin.Kind, plugin.Metadata); ok {
+	if _, ok := s.devSch.variables.GetWithPluginMetadata(plugin.Kind, plugin.Metadata); ok {
 		return s.devSch.validateVariable(plugin, varName)
 	}
 	return s.sch.validateVariable(plugin, varName)

--- a/internal/api/plugin/schema/schema_test.go
+++ b/internal/api/plugin/schema/schema_test.go
@@ -160,6 +160,25 @@ func loadVariablePlugins(variablePath string, sch Schema, t *testing.T) {
 	loadPlugin(variablePath, modules, sch, t)
 }
 
+func loadDevVariablePlugin(variablePath string, sch Schema, t *testing.T) {
+	module := v1.PluginModule{
+		Spec: v1.ModuleSpec{
+			SchemasPath: "first",
+			Plugins: []module.Plugin{
+				{
+					Kind: plugin.KindVariable,
+					Spec: module.PluginSpec{
+						Name: "FirstVariable",
+					},
+				},
+			},
+		},
+	}
+	if err := sch.LoadDevPlugin(variablePath, module); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValidatePanels(t *testing.T) {
 	s := New()
 	loadPanelPlugins("testdata/schemas/panels", s, t)
@@ -432,6 +451,32 @@ func TestValidateDashboardVariables(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateVariableWithDevSchema ensures a variable plugin loaded only in
+// development mode is validated against the dev variable schema. It guards
+// against dispatching the dev-load probe to the wrong tree (e.g. panels), which
+// would make ValidateVariable fall through to the production set and reject a
+// dev-only variable plugin.
+func TestValidateVariableWithDevSchema(t *testing.T) {
+	s := New()
+	loadDevVariablePlugin("testdata/schemas/variables", s, t)
+	validFirstVariable := loadPluginFromJSON("testdata/samples/variables/valid_first_variable.json", t)
+
+	variables := []dashboard.Variable{
+		{
+			Kind: variable.KindList,
+			Spec: &dashboard.ListVariableSpec{
+				ListSpec: variable.ListSpec{
+					Plugin: validFirstVariable,
+				},
+				Name: "my1rstVar",
+			},
+		},
+	}
+
+	assert.NoError(t, s.ValidateDashboardVariables(variables))
+	assert.NoError(t, s.ValidateVariable(validFirstVariable, "my1rstVar"))
 }
 
 func TestSch_load_SuccessAndMissingPlugin(t *testing.T) {


### PR DESCRIPTION


`completeSchema.ValidateVariable` (`internal/api/plugin/schema/schema.go`) routes
validation to the development schema set when a variable plugin is loaded in dev
mode, then dispatches to `validateVariable`. But its dev-load probe queried the
wrong tree:

```go
if _, ok := s.devSch.panels.GetWithPluginMetadata(plugin.Kind, plugin.Metadata); ok {
    return s.devSch.validateVariable(plugin, varName)
}
```

It probed the dev **panels** tree while dispatching to the **variables** schema
set. A variable plugin loaded only in development mode is therefore never found
(the panels probe misses it), so validation falls through to the production set
`s.sch`; when that plugin exists only in dev, `s.sch.variables` lacks it and
validation fails with "variable schemas are not loaded".

Every sibling validator probes its own tree:

- `ValidateDatasource` -> `s.devSch.datasources`
- `ValidatePanel` -> `s.devSch.panels`
- `ValidateAnnotations` -> `s.devSch.annotations`
- `validateQuery` -> `s.devSch.queries`

This changes `ValidateVariable` to probe `s.devSch.variables`, matching the
`validateVariable` dispatch and the sibling pattern. It affects the write paths
that route through `ValidateVariable`: `ValidateGlobalVariable` and
`ValidateDashboardVariables`.

A regression test (`TestValidateVariableWithDevSchema`) loads a variable plugin
only into the dev schema (via `LoadDevPlugin`) and asserts both
`ValidateDashboardVariables` and `ValidateVariable` succeed. Reverting the fix to
`panels` makes the new test fail at both assertions with "variable schemas are
not loaded".

# Screenshots

<!-- none: backend-only change, no UI impact -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

## UI Changes

- [x] N/A - no UI changes (backend Go only).

---

## Suggested issue linkage

No upstream issue exists for this bug (hunt-found). Do not fabricate one. Optional:
open a short issue first, or just file the PR - the description is self-contained.
Do NOT reference internal task ids or the hunt.

Related, non-duplicate context worth a one-liner in the PR if desired: open PR
**#4031** ("[FEATURE] Exposing complete dashboard and plugin CUE schema endpoint")
adds a new schema-lookup switch that correctly maps `plugin.KindVariable` ->
`s.devSch.variables`, but it does NOT touch this buggy `ValidateVariable` probe.
That is independent corroboration that variables should probe the variables tree.
