### PR TITLE
[ENHANCEMENT] Allow opening dashboards and tabs in new tabs

### DIFF
--- a/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardDataGrid.tsx
+++ b/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardDataGrid.tsx
@@ -13,7 +13,6 @@
 
 import { DataGrid, GridRow, GridColumnHeaders } from '@mui/x-data-grid';
 import { memo, ReactElement, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { GridInitialStateCommunity } from '@mui/x-data-grid/models/gridStateCommunity';
 import { NoDataOverlay } from '@perses-dev/components';
 import {
@@ -43,8 +42,6 @@ function NoEphemeralDashboardRowOverlay(): ReactElement {
 export function EphemeralDashboardDataGrid(props: DataGridProperties<Row>): ReactElement {
   const { columns, rows, initialState, hideToolbar, isLoading } = props;
 
-  const navigate = useNavigate();
-
   // Merging default initial state with the props initial state (props initial state will overwrite properties)
   const mergedInitialState = useMemo(() => {
     return {
@@ -56,7 +53,6 @@ export function EphemeralDashboardDataGrid(props: DataGridProperties<Row>): Reac
   return (
     <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}>
       <DataGrid
-        onRowClick={(params) => navigate(`/projects/${params.row.project}/ephemeraldashboards/${params.row.name}`)}
         rows={rows}
         columns={columns}
         getRowId={(row) => row.name}

--- a/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardList.tsx
+++ b/ui/app/src/components/EphemeralDashboardList/EphemeralDashboardList.tsx
@@ -11,11 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Stack, Tooltip } from '@mui/material';
+import { Box, Link, Stack, Tooltip } from '@mui/material';
 import { GridColDef, GridRowParams } from '@mui/x-data-grid';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import PencilIcon from 'mdi-material-ui/Pencil';
 import { ReactElement, useCallback, useMemo, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { intlFormatDistance, add } from 'date-fns';
 import { getResourceDisplayName, getResourceExtendedDisplayName, useSnackbar } from '@perses-dev/components';
 import { EphemeralDashboardResource } from '@perses-dev/client';
@@ -124,7 +125,19 @@ export function EphemeralDashboardList(props: EphemeralDashboardListProperties):
   const columns = useMemo<Array<GridColDef<Row>>>(
     () => [
       PROJECT_COL_DEF,
-      DISPLAY_NAME_COL_DEF,
+      {
+        ...DISPLAY_NAME_COL_DEF,
+        renderCell: (params): ReactElement => (
+          <Link
+            component={RouterLink}
+            to={`/projects/${params.row.project}/ephemeraldashboards/${params.row.name}`}
+            color="inherit"
+            underline="hover"
+          >
+            {params.row.displayName}
+          </Link>
+        ),
+      },
       VERSION_COL_DEF,
       {
         field: 'expireAt',

--- a/ui/app/src/components/tabs.tsx
+++ b/ui/app/src/components/tabs.tsx
@@ -11,8 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, BoxProps, Chip, Stack, Tab, Tabs, styled } from '@mui/material';
-import { ReactElement } from 'react';
+import { Box, BoxProps, Chip, Stack, Tab, TabProps, Tabs, styled } from '@mui/material';
+import { forwardRef, ReactElement } from 'react';
+import { Link as RouterLink, LinkProps } from 'react-router-dom';
 
 export const MENU_TABS_HEIGHT = '54px';
 
@@ -21,6 +22,16 @@ export const MenuTabs = styled(Tabs)({
 });
 
 export const MenuTab = styled(Tab)({
+  minHeight: MENU_TABS_HEIGHT,
+});
+
+export type MenuLinkTabProps = TabProps<typeof RouterLink, LinkProps>;
+
+export const MenuLinkTab = styled(
+  forwardRef<HTMLAnchorElement, MenuLinkTabProps>(function MenuLinkTab(props, ref) {
+    return <Tab {...props} ref={ref} component={RouterLink} />;
+  })
+)({
   minHeight: MENU_TABS_HEIGHT,
 });
 

--- a/ui/app/src/views/admin/AdminTabs.tsx
+++ b/ui/app/src/views/admin/AdminTabs.tsx
@@ -12,11 +12,10 @@
 // limitations under the License.
 
 import { Box, Stack } from '@mui/material';
-import { ReactElement, SyntheticEvent, useCallback, useMemo, useState } from 'react';
+import { ReactElement, useCallback, useMemo, useState } from 'react';
 import CodeJsonIcon from 'mdi-material-ui/CodeJson';
 import DatabaseIcon from 'mdi-material-ui/Database';
 import KeyIcon from 'mdi-material-ui/Key';
-import { useNavigate } from 'react-router-dom';
 import { getResourceDisplayName, getResourceExtendedDisplayName, useSnackbar } from '@perses-dev/components';
 import ShieldAccountIcon from 'mdi-material-ui/ShieldAccount';
 import ShieldIcon from 'mdi-material-ui/Shield';
@@ -38,7 +37,7 @@ import {
   useIsGlobalVariableEnabled,
   useIsReadonly,
 } from '../../context/Config';
-import { MenuTab, MenuTabs, TabLabel, TabPanel } from '../../components/tabs';
+import { MenuLinkTab, MenuTabs, TabLabel, TabPanel } from '../../components/tabs';
 import { useCreateGlobalRoleBindingMutation, useGlobalRoleBindingList } from '../../model/global-rolebinding-client';
 import { useCreateGlobalRoleMutation, useGlobalRoleList } from '../../model/global-role-client';
 import { RoleDrawer } from '../../components/roles/RoleDrawer';
@@ -358,10 +357,9 @@ export function AdminTabs(props: AdminTabsProps): ReactElement {
   const isGlobalDatasourceEnabled = useIsGlobalDatasourceEnabled();
   const isGlobalVariableEnabled = useIsGlobalVariableEnabled();
 
-  const navigate = useNavigate();
   const isMobileSize = useIsMobileSize();
 
-  const [value, setValue] = useState((initialTab ?? variablesTabIndex).toLowerCase());
+  const value = (initialTab ?? variablesTabIndex).toLowerCase();
 
   // Fetch counts for tab badges
   const { data: globalVariables } = useGlobalVariableList();
@@ -378,10 +376,6 @@ export function AdminTabs(props: AdminTabsProps): ReactElement {
   const hasGlobalVariableReadPermission = useHasPermission('read', GlobalProject, 'GlobalVariable');
   const hasUserReadPermission = useHasPermission('read', GlobalProject, 'User');
 
-  const handleChange = (event: SyntheticEvent, newTabIndex: string): void => {
-    setValue(newTabIndex);
-    navigate(`/admin/${newTabIndex}`);
-  };
   return (
     <Box sx={{ width: '100%' }}>
       <Stack
@@ -400,67 +394,72 @@ export function AdminTabs(props: AdminTabsProps): ReactElement {
       >
         <MenuTabs
           value={value}
-          onChange={handleChange}
           variant="scrollable"
           scrollButtons="auto"
           allowScrollButtonsMobile
           aria-label="Admin tabs"
         >
           {isGlobalVariableEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Global Variables" count={globalVariables?.length} />}
               icon={<CodeJsonIcon />}
               iconPosition="start"
               {...a11yProps(variablesTabIndex)}
               value={variablesTabIndex}
+              to={`/admin/${variablesTabIndex}`}
               disabled={!hasGlobalVariableReadPermission}
             />
           )}
           {isGlobalDatasourceEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Global Datasources" count={globalDatasources?.length} />}
               icon={<DatabaseIcon />}
               iconPosition="start"
               {...a11yProps(datasourcesTabIndex)}
               value={datasourcesTabIndex}
+              to={`/admin/${datasourcesTabIndex}`}
               disabled={!hasGlobalDatasourceReadPermission}
             />
           )}
-          <MenuTab
+          <MenuLinkTab
             label={<TabLabel label="Global Secrets" count={globalSecrets?.length} />}
             icon={<KeyIcon />}
             iconPosition="start"
             {...a11yProps(secretsTabIndex)}
             value={secretsTabIndex}
+            to={`/admin/${secretsTabIndex}`}
             disabled={!hasGlobalSecretReadPermission}
           />
           {isAuthEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Global Roles" count={globalRoles?.length} />}
               icon={<ShieldIcon />}
               iconPosition="start"
               {...a11yProps(roleBindingsTabIndex)}
               value={rolesTabIndex}
+              to={`/admin/${rolesTabIndex}`}
               disabled={!hasGlobalRoleReadPermission}
             />
           )}
           {isAuthEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Global Role Bindings" count={globalRoleBindings?.length} />}
               icon={<ShieldAccountIcon />}
               iconPosition="start"
               {...a11yProps(roleBindingsTabIndex)}
               value={roleBindingsTabIndex}
+              to={`/admin/${roleBindingsTabIndex}`}
               disabled={!hasGlobalRoleBindingReadPermission}
             />
           )}
           {isAuthEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Users" count={users?.length} />}
               icon={<AccountIcon />}
               iconPosition="start"
               {...a11yProps(usersTabIndex)}
               value={usersTabIndex}
+              to={`/admin/${usersTabIndex}`}
               disabled={!hasUserReadPermission}
             />
           )}

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Box, Stack } from '@mui/material';
-import { ReactElement, SyntheticEvent, useCallback, useMemo, useState } from 'react';
+import { ReactElement, useCallback, useMemo, useState } from 'react';
 import ViewDashboardIcon from 'mdi-material-ui/ViewDashboard';
 import CodeJsonIcon from 'mdi-material-ui/CodeJson';
 import DatabaseIcon from 'mdi-material-ui/Database';
@@ -42,7 +42,7 @@ import {
   useIsProjectVariableEnabled,
   useIsReadonly,
 } from '../../context/Config';
-import { MenuTab, MenuTabs, TabLabel, TabPanel } from '../../components/tabs';
+import { MenuLinkTab, MenuTabs, TabLabel, TabPanel } from '../../components/tabs';
 import { useCreateRoleBindingMutation, useRoleBindingList } from '../../model/rolebinding-client';
 import { useCreateRoleMutation, useRoleList } from '../../model/role-client';
 import { RoleDrawer } from '../../components/roles/RoleDrawer';
@@ -420,11 +420,12 @@ export function ProjectTabs(props: DashboardVariableTabsProps): ReactElement {
   const isProjectDatasourceEnabled = useIsProjectDatasourceEnabled();
   const isProjectVariableEnabled = useIsProjectVariableEnabled();
 
-  const navigate = useNavigate();
   const isMobileSize = useIsMobileSize();
   const isEphemeralDashboardEnabled = useIsEphemeralDashboardEnabled();
   const { data } = useEphemeralDashboardList(projectName);
   const hasEphemeralDashboards = (data ?? []).length > 0;
+
+  const value = (tab ?? initialTab ?? dashboardsTabIndex).toLowerCase();
 
   // Fetch counts for tab badges
   const { data: dashboards } = useDashboardList({ project: projectName, metadataOnly: true });
@@ -434,8 +435,6 @@ export function ProjectTabs(props: DashboardVariableTabsProps): ReactElement {
   const { data: roles } = useRoleList(projectName);
   const { data: roleBindings } = useRoleBindingList(projectName);
 
-  const [value, setValue] = useState((initialTab ?? dashboardsTabIndex).toLowerCase());
-
   const hasDashboardReadPermission = useHasPermission('read', projectName, 'Dashboard');
   const hasDatasourceReadPermission = useHasPermission('read', projectName, 'Datasource');
   const hasEphemeralDashboardReadPermission = useHasPermission('read', projectName, 'EphemeralDashboard');
@@ -443,11 +442,6 @@ export function ProjectTabs(props: DashboardVariableTabsProps): ReactElement {
   const hasRoleBindingReadPermission = useHasPermission('read', projectName, 'RoleBinding');
   const hasSecretReadPermission = useHasPermission('read', projectName, 'Secret');
   const hasVariableReadPermission = useHasPermission('read', projectName, 'Variable');
-
-  const handleChange = (event: SyntheticEvent, newTabIndex: string): void => {
-    setValue(newTabIndex);
-    navigate(`/projects/${projectName}/${newTabIndex}`);
-  };
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -466,75 +460,81 @@ export function ProjectTabs(props: DashboardVariableTabsProps): ReactElement {
       >
         <MenuTabs
           value={value}
-          onChange={handleChange}
           variant="scrollable"
           scrollButtons="auto"
           allowScrollButtonsMobile
           aria-label="Project tabs"
         >
-          <MenuTab
+          <MenuLinkTab
             label={<TabLabel label="Dashboards" count={dashboards?.length} />}
             icon={<ViewDashboardIcon />}
             iconPosition="start"
             {...a11yProps(dashboardsTabIndex)}
             value={dashboardsTabIndex}
+            to={`/projects/${projectName}/${dashboardsTabIndex}`}
             disabled={!hasDashboardReadPermission}
           />
           {(hasEphemeralDashboards || tab === ephemeralDashboardsTabIndex) && (
-            <MenuTab
+            <MenuLinkTab
               label="Ephemeral Dashboards"
               icon={<ViewDashboardIcon />}
               iconPosition="start"
               {...a11yProps(ephemeralDashboardsTabIndex)}
               value={ephemeralDashboardsTabIndex}
+              to={`/projects/${projectName}/${ephemeralDashboardsTabIndex}`}
               disabled={!hasEphemeralDashboardReadPermission}
             />
           )}
           {isProjectVariableEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Variables" count={variables?.length} />}
               icon={<CodeJsonIcon />}
               iconPosition="start"
               {...a11yProps(variablesTabIndex)}
               value={variablesTabIndex}
+              to={`/projects/${projectName}/${variablesTabIndex}`}
               disabled={!hasVariableReadPermission}
             />
           )}
           {isProjectDatasourceEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Datasources" count={datasources?.length} />}
               icon={<DatabaseIcon />}
               iconPosition="start"
               {...a11yProps(datasourcesTabIndex)}
               value={datasourcesTabIndex}
+              to={`/projects/${projectName}/${datasourcesTabIndex}`}
               disabled={!hasDatasourceReadPermission}
             />
           )}
-          <MenuTab
+          <MenuLinkTab
             label={<TabLabel label="Secrets" count={secrets?.length} />}
             icon={<KeyIcon />}
             iconPosition="start"
             {...a11yProps(secretsTabIndex)}
             value={secretsTabIndex}
+            to={`/projects/${projectName}/${secretsTabIndex}`}
             disabled={!hasSecretReadPermission}
           />
           {isAuthEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Roles" count={roles?.length} />}
               icon={<ShieldIcon />}
               iconPosition="start"
               {...a11yProps(rolesTabIndex)}
               value={rolesTabIndex}
+              to={`/projects/${projectName}/${rolesTabIndex}`}
               disabled={!hasRoleReadPermission}
             />
           )}
           {isAuthEnabled && (
-            <MenuTab
+            <MenuLinkTab
               label={<TabLabel label="Role Bindings" count={roleBindings?.length} />}
               icon={<ShieldAccountIcon />}
               iconPosition="start"
               {...a11yProps(roleBindingsTabIndex)}
               value={roleBindingsTabIndex}
+              to={`/projects/${projectName}/${roleBindingsTabIndex}`}
               disabled={!hasRoleBindingReadPermission}
             />
           )}


### PR DESCRIPTION
## Summary
- Convert project and admin tab bars to use React Router `Link` components so tabs can be opened in a new browser tab
- Replace ephemeral dashboard list row clicks with hyperlinks on the display name column (matching regular dashboard list behavior)

Completes the remaining work for #1544 after the initial partial fix in #1548.

## Test plan
- [ ] Open a project page, middle-click or Ctrl+click a tab (Variables, Secrets, etc.) — opens in new tab
- [ ] Open `/admin`, middle-click a tab (Users, Global Secrets, etc.) — opens in new tab
- [ ] On ephemeral dashboards list, middle-click a dashboard name — opens dashboard in new tab
- [ ] Normal left-click navigation still works for all of the above

Fixes #1544