### PR TITLE
[BUGFIX] plugin: report the real error when a dev plugin package fails to load

### DIFF
--- a/internal/api/plugin/dev.go
+++ b/internal/api/plugin/dev.go
@@ -33,7 +33,7 @@ func (p *pluginFile) LoadDevPlugin(plugins []v1.PluginInDevelopment) error {
 		}
 		npmPackageData, readErr := ReadPackageFromNetwork(devURL, plg.Name)
 		if readErr != nil {
-			return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to load plugin package: %s", err))
+			return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to load plugin package: %s", readErr))
 		}
 		pluginModule := v1.PluginModule{
 			Kind: v1.PluginModuleKind,

--- a/internal/api/plugin/dev_test.go
+++ b/internal/api/plugin/dev_test.go
@@ -1,0 +1,59 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/perses/spec/go/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadDevPluginReportsPackageError(t *testing.T) {
+	// The manifest is reachable and valid, but reading the package fails. This
+	// reproduces the case where LoadDevPlugin must surface the real package error.
+	const invalidPackageBody = "this is not valid JSON"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, ManifestFileName):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"foo","name":"foo","metaData":{"buildInfo":{"buildVersion":"0.1.0"}}}`))
+		case strings.HasSuffix(r.URL.Path, PackageJSONFile):
+			_, _ = w.Write([]byte(invalidPackageBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	p := &pluginFile{}
+	err := p.LoadDevPlugin([]v1.PluginInDevelopment{
+		{
+			Name:          "foo",
+			URL:           common.MustParseURL(server.URL),
+			DisableSchema: true,
+			AbsolutePath:  "/tmp/foo",
+		},
+	})
+
+	assert.Error(t, err)
+	// The message must carry the actual cause of the package read failure, not the
+	// nil manifest error that used to be interpolated here (regression guard).
+	assert.Contains(t, err.Error(), "failed to load plugin package")
+	assert.NotContains(t, err.Error(), "%!s(<nil>)")
+}


### PR DESCRIPTION


`LoadDevPlugin` (`internal/api/plugin/dev.go`) reads the plugin manifest, then the
plugin package. When the package read fails, the error message interpolated the
manifest read error (`err`) instead of the package read error (`readErr`):

```go
npmPackageData, readErr := ReadPackageFromNetwork(devURL, plg.Name)
if readErr != nil {
    return apiinterface.HandleBadRequestError(fmt.Sprintf("failed to load plugin package: %s", err))
}
```

At that point `err` is always `nil`, because the manifest guard a few lines above
already returned on any manifest error. So a genuine `ReadPackageFromNetwork`
failure was surfaced to the user as:

```
failed to load plugin package: %!s(<nil>)
```

which discards the actual cause and makes a broken dev plugin hard to diagnose.

This changes that one line to interpolate `readErr`, matching the immediately
preceding manifest guard (which correctly uses its own `err`). Control flow is
unchanged; only the diagnostic string is corrected.

Added a regression test (`TestLoadDevPluginReportsPackageError`) that stands up an
`httptest` server serving a valid manifest but an unparseable `package.json`, so
`ReadPackageFromNetwork` fails, and asserts the returned bad-request message
carries the real cause and no longer contains `%!s(<nil>)`.

# Screenshots

<!-- N/A: backend-only change, no UI impact. -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.

<!-- The three UI boxes are intentionally left unchecked: this PR is backend-only
     (Go) and has no UI, e2e, or screenshot impact. -->
