### PR TITLE
[BUGFIX] Return the mkdir error when creating the CLI config directory

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -168,7 +168,7 @@ func Write(cfg *Config) error {
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 		mkdirError := os.Mkdir(directory, 0700)
 		if mkdirError != nil {
-			return err
+			return mkdirError
 		}
 	} else if err != nil {
 		return err
@@ -233,7 +233,7 @@ func WriteFromScratch(cfg *Config) error {
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 		mkdirError := os.Mkdir(directory, 0700)
 		if mkdirError != nil {
-			return err
+			return mkdirError
 		}
 	} else if err != nil {
 		return err

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -1,0 +1,63 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// setUnwritableFilePath points Global at a config file whose parent directory
+// cannot be created by os.Mkdir. os.Mkdir is non-recursive, so a path with a
+// missing intermediate directory makes the mkdir call fail while os.Stat on the
+// directory reports that it does not exist.
+func setUnwritableFilePath(t *testing.T) {
+	t.Helper()
+	previous := Global
+	t.Cleanup(func() {
+		Global = previous
+	})
+	filePath := filepath.Join(t.TempDir(), "missing-parent", ".perses", "config.json")
+	Global = &Config{}
+	Global.SetFilePath(filePath)
+}
+
+// assertMkdirError checks that the returned error comes from the failing
+// os.Mkdir call and not from the earlier os.Stat call. Both errors satisfy
+// os.IsNotExist, so the operation recorded on the PathError is what
+// distinguishes them.
+func assertMkdirError(t *testing.T, err error) {
+	t.Helper()
+	var pathErr *os.PathError
+	if assert.ErrorAs(t, err, &pathErr) {
+		assert.Equal(t, "mkdir", pathErr.Op)
+	}
+}
+
+func TestWriteReturnsMkdirError(t *testing.T) {
+	setUnwritableFilePath(t)
+	err := Write(&Config{})
+	assert.Error(t, err)
+	assertMkdirError(t, err)
+}
+
+func TestWriteFromScratchReturnsMkdirError(t *testing.T) {
+	setUnwritableFilePath(t)
+	err := WriteFromScratch(&Config{})
+	assert.Error(t, err)
+	assertMkdirError(t, err)
+}


### PR DESCRIPTION


`Write` and `WriteFromScratch` in `internal/cli/config/config.go` create the
config directory when it does not yet exist:

```go
if _, err := os.Stat(directory); os.IsNotExist(err) {
    mkdirError := os.Mkdir(directory, 0700)
    if mkdirError != nil {
        return err // <- returns the stale stat error, not mkdirError
    }
} else if err != nil {
    return err
}
```

On the `os.Mkdir` failure path both functions returned `err`, the earlier
`os.Stat` "does not exist" error, instead of `mkdirError`. Since `os.Mkdir` is
non-recursive it can fail for reasons unrelated to the leaf directory being
absent (a missing parent directory, or insufficient permissions), and when it
did the user saw a misleading "file does not exist" message rather than the real
reason the directory could not be created.

This returns `mkdirError` at both sites so the reported error reflects the actual
`os.Mkdir` failure. The `else if err != nil` branch is unchanged and still
surfaces a genuine stat error.

A regression test (`internal/cli/config/config_test.go`) points the config file
at a path with a missing intermediate directory, so `os.Mkdir` fails while
`os.Stat` reports the directory does not exist. Both errors satisfy
`os.IsNotExist`, so the test asserts on the failing operation recorded in the
returned `*os.PathError` (`Op == "mkdir"`), which is the only reliable way to
tell the two apart. It fails before the fix and passes after.

# Screenshots

N/A (no UI changes; Go CLI only).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

## UI Changes

N/A (no UI impact).

---

## Diff summary

```
 internal/cli/config/config.go      |  4 +--
 internal/cli/config/config_test.go | 63 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 65 insertions(+), 2 deletions(-)
```

- `config.go`: two one-line changes, `return err` -> `return mkdirError`, one in
  `Write` and one in `WriteFromScratch`.
- `config_test.go`: new file, two focused tests plus two small helpers, Apache
  license header copied from a sibling file in the same package.

## Checks run locally (all green)

- `go test ./internal/cli/config/...` -> ok
- `gofmt -l internal/cli/config/config.go internal/cli/config/config_test.go` -> clean
- `go vet ./internal/cli/config/...` -> rc 0
- `go build ./...` -> rc 0
- `./bin/golangci-lint run ./internal/cli/config/... --timeout 5m` -> 0 issues
