### PR TITLE
[BUGFIX] plugin: return the real error when reading a plugin package.json fails

### DIFF
--- a/internal/api/plugin/validate.go
+++ b/internal/api/plugin/validate.go
@@ -44,7 +44,7 @@ func IsRequiredFileExists(frontendFolder string, schemaFolder string, distFolder
 	// check if the package.json file exists
 	npmPackageData, readErr := ReadPackage(frontendFolder)
 	if readErr != nil {
-		return err
+		return readErr
 	}
 	// check if the schema folder exists only if it requires schema
 	if IsSchemaRequired(v1.ModuleSpec{

--- a/internal/api/plugin/validate_test.go
+++ b/internal/api/plugin/validate_test.go
@@ -1,0 +1,68 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRequiredFileExists(t *testing.T) {
+	testSuites := []struct {
+		title       string
+		packageJSON *string
+		expectError bool
+	}{
+		{
+			title:       "package.json is missing",
+			packageJSON: nil,
+			expectError: true,
+		},
+		{
+			title:       "package.json is not valid JSON",
+			packageJSON: strPtr("{"),
+			expectError: true,
+		},
+		{
+			title:       "package.json is present and valid",
+			packageJSON: strPtr(`{"version": "0.1.0"}`),
+			expectError: false,
+		},
+	}
+	for _, test := range testSuites {
+		t.Run(test.title, func(t *testing.T) {
+			folder := t.TempDir()
+			// the manifest file must exist so that the first check passes and the
+			// package.json reading is actually reached.
+			require.NoError(t, os.WriteFile(filepath.Join(folder, ManifestFileName), []byte("{}"), 0600))
+			if test.packageJSON != nil {
+				require.NoError(t, os.WriteFile(filepath.Join(folder, PackageJSONFile), []byte(*test.packageJSON), 0600))
+			}
+			err := IsRequiredFileExists(folder, folder, folder)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION


`IsRequiredFileExists` (`internal/api/plugin/validate.go`) reads a plugin's
`package.json` via `ReadPackage`, but the guard on the result returned the wrong
error variable:

```go
npmPackageData, readErr := ReadPackage(frontendFolder)
if readErr != nil {
    return err   // <- returns the earlier `err`, not `readErr`
}
```

`err` here is the variable from the manifest existence check a few lines above
(`exist, err := file.Exists(...)`), which was already checked and returned, so it
is guaranteed to be `nil` at this point. When `ReadPackage` fails (the
`package.json` is missing or is invalid JSON) the read error was therefore
swallowed: the function returned `nil`, then went on to dereference a zero-value
`NPMPackage` (`npmPackageData.Perses.SchemasPath` / `.Plugins`), skipped the
schema-folder check, and reported the plugin as valid.

The fix returns `readErr` so the real failure surfaces instead of being silently
discarded.

I also added a regression test (`internal/api/plugin/validate_test.go`) that drives
`IsRequiredFileExists` against a folder with a present manifest but a missing
`package.json`, an invalid `package.json`, and a valid one, asserting the first two
error and the last does not.

# Screenshots

N/A (no UI changes; Go backend only).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

(UI-changes section of the template is not applicable.)
