### PR TITLE
[BUGFIX] api: prevent path traversal in the file database backend

### DIFF
--- a/internal/api/database/file/file.go
+++ b/internal/api/database/file/file.go
@@ -68,7 +68,10 @@ func (d *DAO) Create(entity modelAPI.Entity) error {
 	if generateIDErr != nil {
 		return generateIDErr
 	}
-	filePath := d.buildPath(key)
+	filePath, buildPathErr := d.buildPath(key)
+	if buildPathErr != nil {
+		return buildPathErr
+	}
 	if _, err := os.Stat(filePath); err == nil {
 		// The file exists, so we should return a conflict error.
 		return &databaseModel.Error{Key: key, Code: databaseModel.ErrorCodeConflict}
@@ -89,7 +92,10 @@ func (d *DAO) Get(kind modelV1.Kind, metadata modelAPI.Metadata, entity modelAPI
 	if generateIDErr != nil {
 		return generateIDErr
 	}
-	filePath := d.buildPath(key)
+	filePath, buildPathErr := d.buildPath(key)
+	if buildPathErr != nil {
+		return buildPathErr
+	}
 	data, err := os.ReadFile(filePath) //nolint: gosec
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -239,7 +245,10 @@ func (d *DAO) Delete(kind modelV1.Kind, metadata modelAPI.Metadata) error {
 	if generateIDErr != nil {
 		return generateIDErr
 	}
-	filePath := d.buildPath(key)
+	filePath, buildPathErr := d.buildPath(key)
+	if buildPathErr != nil {
+		return buildPathErr
+	}
 	err := os.Remove(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -286,7 +295,10 @@ func (d *DAO) GetLatestUpdateTime(_ []modelV1.Kind) (*string, error) {
 }
 
 func (d *DAO) upsert(key string, entity modelAPI.Entity) error {
-	filePath := d.buildPath(key)
+	filePath, buildPathErr := d.buildPath(key)
+	if buildPathErr != nil {
+		return buildPathErr
+	}
 	if err := os.MkdirAll(filepath.Dir(filePath), 0750); err != nil {
 		return err
 	}
@@ -297,8 +309,17 @@ func (d *DAO) upsert(key string, entity modelAPI.Entity) error {
 	return os.WriteFile(filePath, data, 0600)
 }
 
-func (d *DAO) buildPath(key string) string {
-	return filepath.Join(d.Folder, fmt.Sprintf("%s.%s", key, d.Extension))
+func (d *DAO) buildPath(key string) (string, error) {
+	filePath := filepath.Join(d.Folder, fmt.Sprintf("%s.%s", key, d.Extension))
+	// The key is derived from user-controlled resource name/project values. Even
+	// though filepath.Join cleans the result, a key containing ".." segments can
+	// still resolve to a path outside d.Folder, allowing arbitrary file read or
+	// delete. Reject any path that is not contained within d.Folder.
+	rel, err := filepath.Rel(d.Folder, filePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", &databaseModel.Error{Key: key, Code: databaseModel.ErrorCodeNotFound}
+	}
+	return filePath, nil
 }
 
 func (d *DAO) unmarshal(data []byte, entity any) error {

--- a/internal/api/database/file/file_test.go
+++ b/internal/api/database/file/file_test.go
@@ -15,6 +15,7 @@ package databasefile
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	databaseModel "github.com/perses/perses/internal/api/database/model"
@@ -109,4 +110,47 @@ func TestDAO_Delete(t *testing.T) {
 	result := &modelV1.Project{}
 	assert.True(t, databaseModel.IsKeyNotFound(d.Get(modelV1.KindProject, projectEntity.GetMetadata(), result)))
 	removeAllFiles(t)
+}
+
+// TestDAO_GetPathTraversal ensures a resource name containing ".." segments
+// cannot be used to read a file located outside the configured data folder.
+func TestDAO_GetPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	folder := filepath.Join(root, "data")
+	if err := os.MkdirAll(folder, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// A sensitive file sitting outside the data folder. Its name matches the
+	// traversal payload so that the case-sensitivity check in Get cannot mask a
+	// successful read.
+	outsideFile := filepath.Join(root, "secret.json")
+	if err := os.WriteFile(outsideFile, []byte(`{"kind":"GlobalDatasource","metadata":{"name":"../../secret"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &DAO{Folder: folder, Extension: config.JSONExtension}
+	result := &modelV1.GlobalDatasource{}
+	err := d.Get(modelV1.KindGlobalDatasource, modelV1.NewMetadata("../../secret"), result)
+	assert.True(t, databaseModel.IsKeyNotFound(err))
+	assert.Empty(t, result.Metadata.Name)
+}
+
+// TestDAO_DeletePathTraversal ensures a resource name containing ".." segments
+// cannot be used to delete a file located outside the configured data folder.
+func TestDAO_DeletePathTraversal(t *testing.T) {
+	root := t.TempDir()
+	folder := filepath.Join(root, "data")
+	if err := os.MkdirAll(folder, 0750); err != nil {
+		t.Fatal(err)
+	}
+	outsideFile := filepath.Join(root, "secret.json")
+	if err := os.WriteFile(outsideFile, []byte(`{}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &DAO{Folder: folder, Extension: config.JSONExtension}
+	err := d.Delete(modelV1.KindGlobalDatasource, modelV1.NewMetadata("../../secret"))
+	assert.True(t, databaseModel.IsKeyNotFound(err))
+	_, statErr := os.Stat(outsideFile)
+	assert.NoError(t, statErr, "the file outside the data folder must not be deleted")
 }


### PR DESCRIPTION


The file database backend (`internal/api/database/file`) is the default database
for the Perses API (`database.file`, `defaultFileDBFolder = "./local_db"`). Its DAO
builds a filesystem path by joining the configured data folder with a key derived
from the resource `name` (and `project`) that comes from the request URL. Those
values are not validated before they reach the DAO on the read and delete paths, so
a resource name containing `..` segments resolves to a path outside the data folder.

Concretely, a request such as `GET /api/v1/globaldatasources/../../<file>` (or the
`DELETE` equivalent) reaches `DAO.Get` / `DAO.Delete`, where the name flows through
`generateID` into `buildPath` and then into `os.ReadFile` / `os.Remove`. Because
`filepath.Join` cleans the `..` segments, the resolved path escapes the data folder,
allowing arbitrary `.json` / `.yaml` files on the host to be read or deleted. When
authentication is disabled (the default per `SECURITY.md`), this is reachable
unauthenticated.

This change adds a containment check in `buildPath`: after the path is joined, it is
rejected if it does not resolve inside `d.Folder`, returning a not-found error
instead of touching the filesystem. `buildPath` is the single chokepoint for
`Create`, `Get`, `Delete` and `upsert`, so one guard covers read, write and delete.
The SQL backend and the shared request toolbox are left untouched.

Two regression tests are added (`internal/api/database/file/file_test.go`):
`TestDAO_GetPathTraversal` and `TestDAO_DeletePathTraversal`. Each writes a sentinel
file outside the data folder, calls `Get` / `Delete` with a `../../secret` name, and
asserts the call returns key-not-found and that the outside file is neither read nor
removed. Both fail without the guard and pass with it.

Scope note: this targets the single-resource read/delete path, which is the proven
vector. The list/query path (`Query` / `DeleteByQuery`) is not modified here.

# Screenshots

N/A (backend-only change; no UI impact).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

## UI Changes

- [x] N/A - no UI changes.
