### PR TITLE
[BUGFIX] accept bits/decbits/sek/sgd/usd units in go-sdk Format validation

### DIFF
--- a/go-sdk/common/format.go
+++ b/go-sdk/common/format.go
@@ -114,14 +114,14 @@ func (f *Format) validate() error {
 	switch *f.Unit {
 	case string(NanoSecondsUnit), string(MicroSecondsUnit), string(MilliSecondsUnit), string(SecondsUnit), string(MinutesUnit),
 		string(HoursUnit), string(DaysUnit), string(WeeksUnit), string(MonthsUnit),
-		string(YearsUnit), string(PercentUnit), string(PercentDecimalUnit), DecimalUnit, string(BinaryBytesUnit), string(DecimalBytesUnit),
+		string(YearsUnit), string(PercentUnit), string(PercentDecimalUnit), DecimalUnit, string(BinaryBitsUnit), string(DecimalBitsUnit), string(BinaryBytesUnit), string(DecimalBytesUnit),
 		string(BitsPerSecondsUnit), string(BitsDecPerSecondsUnit), string(BytesPerSecondsUnit), string(BytesDecPerSecondsUnit), string(CountsPerSecondsUnit), string(EventsPerSecondsUnit),
 		string(MessagesPerSecondsUnit), string(OpsPerSecondsUnit), string(PacketsPerSecondsUnit),
 		string(ReadsPerSecondsUnit), string(RecordsPerSecondsUnit), string(RequestsPerSecondsUnit),
 		string(RowsPerSecondsUnit), string(WritesPerSecondsUnit), string(AustralianDollarUnit), string(CanadianDollarUnit),
 		string(SwissFrancUnit), string(RenminbiUnit), string(EuroUnit), string(PoundUnit),
 		string(HongKongDollarUnit), string(IndianRupeeUniit), string(YenUnit), string(SouthKoreanWonUnit),
-		string(NorwegianKroneUnit), string(NewZealandDollarUnit):
+		string(NorwegianKroneUnit), string(NewZealandDollarUnit), string(SwedishKronaDollarUnit), string(SingaporeDollarUnit), string(USDollarUnit):
 		return nil
 	default:
 		return fmt.Errorf("unknown format")

--- a/go-sdk/common/format_test.go
+++ b/go-sdk/common/format_test.go
@@ -1,0 +1,83 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// validUnits lists every unit string the package exports as a legal Format
+// unit. Format.validate must accept all of them; keeping this list next to the
+// switch guards against a newly-added constant being forgotten in validate.
+var validUnits = []string{
+	string(NanoSecondsUnit), string(MicroSecondsUnit), string(MilliSecondsUnit), string(SecondsUnit),
+	string(MinutesUnit), string(HoursUnit), string(DaysUnit), string(WeeksUnit), string(MonthsUnit), string(YearsUnit),
+	string(PercentUnit), string(PercentDecimalUnit),
+	DecimalUnit,
+	string(BinaryBitsUnit), string(DecimalBitsUnit), string(BinaryBytesUnit), string(DecimalBytesUnit),
+	string(BitsPerSecondsUnit), string(BitsDecPerSecondsUnit), string(BytesPerSecondsUnit), string(BytesDecPerSecondsUnit),
+	string(CountsPerSecondsUnit), string(EventsPerSecondsUnit), string(MessagesPerSecondsUnit), string(OpsPerSecondsUnit),
+	string(PacketsPerSecondsUnit), string(ReadsPerSecondsUnit), string(RecordsPerSecondsUnit), string(RequestsPerSecondsUnit),
+	string(RowsPerSecondsUnit), string(WritesPerSecondsUnit),
+	string(AustralianDollarUnit), string(CanadianDollarUnit), string(SwissFrancUnit), string(RenminbiUnit),
+	string(EuroUnit), string(PoundUnit), string(HongKongDollarUnit), string(IndianRupeeUniit), string(YenUnit),
+	string(SouthKoreanWonUnit), string(NorwegianKroneUnit), string(NewZealandDollarUnit), string(SwedishKronaDollarUnit),
+	string(SingaporeDollarUnit), string(USDollarUnit),
+}
+
+func TestFormatUnmarshalJSONValidUnits(t *testing.T) {
+	for _, unit := range validUnits {
+		t.Run(unit, func(t *testing.T) {
+			var f Format
+			err := json.Unmarshal([]byte(`{"unit":"`+unit+`"}`), &f)
+			assert.NoError(t, err)
+			if assert.NotNil(t, f.Unit) {
+				assert.Equal(t, unit, *f.Unit)
+			}
+		})
+	}
+}
+
+func TestFormatUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name        string
+		json        string
+		expectError bool
+	}{
+		// Regression cases: these exported units were rejected as "unknown format".
+		{name: "bits", json: `{"unit":"bits"}`},
+		{name: "decbits", json: `{"unit":"decbits"}`},
+		{name: "sek", json: `{"unit":"sek"}`},
+		{name: "sgd", json: `{"unit":"sgd"}`},
+		{name: "usd", json: `{"unit":"usd"}`},
+		{name: "no unit", json: `{"decimalPlaces":2}`},
+		{name: "unknown unit", json: `{"unit":"not-a-unit"}`, expectError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var f Format
+			err := json.Unmarshal([]byte(tc.json), &f)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown format")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION

---


`go-sdk` `common.Format.validate()` rejected five of the package's own exported
unit constants with an `unknown format` error. The allow-list `switch` in
`validate()` was not kept in sync when two features added new units:

- `BinaryBitsUnit` (`bits`) and `DecimalBitsUnit` (`decbits`) were declared in
  #3583 but only `BitsDecPerSecondsUnit` got wired into the switch; the two
  base bits units were left out.
- The currency cases added in #3132 stop at `NewZealandDollarUnit`, so
  `SwedishKronaDollarUnit` (`sek`), `SingaporeDollarUnit` (`sgd`) and
  `USDollarUnit` (`usd`) fall through to the `default` branch.

Because `validate()` runs from `UnmarshalJSON`/`UnmarshalYAML`, any
dashboard-as-code `Format` built with one of these otherwise valid units fails
to unmarshal, even though the same package publicly exports the constant as a
legal value.

All five are legitimate Perses units with full formatting support in the
frontend (`ui/core/src/model/units/bits.ts` defines `BitsUnit = 'bits' |
'decbits'`; `ui/core/src/model/units/currency.ts` lists `sek`, `sgd`, `usd`
with config entries), which confirms the validator was wrong to reject them,
not the constants.

This adds the five missing constants to the switch (no other behavior change)
and adds a table test in a new `go-sdk/common/format_test.go`. One of the tests
iterates every exported unit constant so a newly added unit that is forgotten
in `validate()` is caught in the future.

# Screenshots

N/A (Go-only change, no UI impact).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention (`BUGFIX`).
- [x] All commits have DCO signoffs.

## UI Changes

N/A - no UI changes.

---

## Diff summary

- `go-sdk/common/format.go` (+2/-2 on the switch): add
  `string(BinaryBitsUnit), string(DecimalBitsUnit)` next to the byte units and
  `string(SwedishKronaDollarUnit), string(SingaporeDollarUnit),
  string(USDollarUnit)` after `NewZealandDollarUnit`.
- `go-sdk/common/format_test.go` (new, +83): `TestFormatUnmarshalJSONValidUnits`
  (every exported unit round-trips), `TestFormatUnmarshalJSON` (the 5 regression
  units, a no-unit case, and a negative `not-a-unit` case).
