### PR TITLE
[BUGFIX] plugin: skip migrate.cue whose package is not migrate

### DIFF
--- a/internal/api/plugin/migrate/migrate.go
+++ b/internal/api/plugin/migrate/migrate.go
@@ -79,12 +79,9 @@ func Load(pluginPath string, moduleSpec v1.ModuleSpec) ([]schema.LoadSchema, err
 		migrateFilePath := filepath.Join(currentPath, "migrate.cue")
 		// We are verifying if the package is a package migrate. Otherwise, we won't be able to use it.
 		if isMigrate, openFileErr := isPackageMigrate(migrateFilePath); openFileErr != nil {
-			if openFileErr != nil {
-				return openFileErr
-			}
-			if !isMigrate {
-				return fs.SkipDir
-			}
+			return openFileErr
+		} else if !isMigrate {
+			return fs.SkipDir
 		}
 
 		instance, schemaErr := LoadMigrateSchema(currentPath)

--- a/internal/api/plugin/migrate/migrate_test.go
+++ b/internal/api/plugin/migrate/migrate_test.go
@@ -1,0 +1,45 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLoadSkipsMigrateFolderWithWrongPackage ensures that a "migrate" folder whose
+// migrate.cue does not belong to the "migrate" package is skipped instead of being
+// loaded. The package check is meant to ignore such folders, but a bug used to make
+// the skip unreachable, so the file was passed to LoadMigrateSchema and produced a
+// build error instead of being silently ignored.
+func TestLoadSkipsMigrateFolderWithWrongPackage(t *testing.T) {
+	pluginPath := t.TempDir()
+	migrateDir := filepath.Join(pluginPath, "schemas", "migrate")
+	if err := os.MkdirAll(migrateDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// migrate.cue that belongs to another package than "migrate".
+	migrateContent := []byte("package notmigrate\n\nkind: \"FooChart\"\nspec: {}\n")
+	if err := os.WriteFile(filepath.Join(migrateDir, "migrate.cue"), migrateContent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	schemas, err := Load(pluginPath, v1.ModuleSpec{SchemasPath: "schemas"})
+	assert.NoError(t, err)
+	assert.Empty(t, schemas)
+}

--- a/internal/api/plugin/schema/schema_test.go
+++ b/internal/api/plugin/schema/schema_test.go
@@ -16,6 +16,7 @@ package schema
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -477,5 +478,42 @@ func TestSch_load_SuccessAndMissingPlugin(t *testing.T) {
 		if !strings.Contains(err.Error(), "unable to find the plugin with the associated schema") {
 			t.Fatalf("unexpected error message: %v", err)
 		}
+	}
+}
+
+// TestSch_load_SkipsCueFileWithWrongPackage ensures that a .cue file that does not
+// belong to the "model" package is skipped instead of being loaded. The package
+// check is meant to ignore such files, but a bug used to make the skip unreachable,
+// so the file was passed to LoadModelSchema and produced a build error instead of
+// being silently ignored.
+func TestSch_load_SkipsCueFileWithWrongPackage(t *testing.T) {
+	pluginPath := t.TempDir()
+	schemaDir := filepath.Join(pluginPath, "first")
+	if err := os.MkdirAll(schemaDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// A .cue file that belongs to another package than "model".
+	content := []byte("package notmodel\n\nkind: \"FirstChart\"\nspec: {}\n")
+	if err := os.WriteFile(filepath.Join(schemaDir, "panel.cue"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newSch()
+	pluginModule := v1.PluginModule{
+		Spec: v1.ModuleSpec{
+			SchemasPath: "first",
+			Plugins: []module.Plugin{
+				{
+					Kind: plugin.KindPanel,
+					Spec: module.PluginSpec{Name: "FirstChart"},
+				},
+			},
+		},
+	}
+	if err := s.load(pluginPath, pluginModule); err != nil {
+		t.Fatalf("expected the non-model file to be skipped, got error: %v", err)
+	}
+	if _, ok := s.panels.Get("FirstChart", pluginModule.Metadata); ok {
+		t.Fatalf("expected no panel schema to be registered for a non-model file")
 	}
 }


### PR DESCRIPTION
# Description

While loading plugin schemas, `internal/api/plugin/migrate/migrate.go` walks the
plugin tree and, for each `migrate` folder, checks that `migrate.cue` belongs to
the `migrate` package before loading it. Folders whose `migrate.cue` declares a
different package are meant to be skipped. That skip is currently unreachable
because the check is nested inside the error branch of the same `if`:

```go
if isMigrate, openFileErr := isPackageMigrate(migrateFilePath); openFileErr != nil {
    if openFileErr != nil {
        return openFileErr
    }
    if !isMigrate {
        return fs.SkipDir
    }
}
```

The outer condition only enters when `openFileErr != nil`, so `if !isMigrate {
return fs.SkipDir }` can never run. When `isPackageMigrate` returns `(false, nil)`
(a readable `migrate.cue` that simply declares another package), the folder is not
skipped and instead reaches `LoadMigrateSchema`, which fails with:

```
build constraints exclude all CUE files ...: package is <other>, want migrate
```

instead of being silently ignored as intended.

This restructures the guard so the open error is returned and the package
mismatch is otherwise handled via `else if`:

```go
if isMigrate, openFileErr := isPackageMigrate(migrateFilePath); openFileErr != nil {
    return openFileErr
} else if !isMigrate {
    return fs.SkipDir
}
```

A regression test (`TestLoadSkipsMigrateFolderWithWrongPackage`) loads a `migrate`
folder containing a `migrate.cue` with a mismatching package and asserts it is
skipped rather than producing an error.

The model schema loader (`internal/api/plugin/schema/schema.go`) had the identical
dead-guard shape; it was already restructured to the reachable form as part of the
recent "Exposing complete dashboard and plugin CUE schema endpoint" change (#4031),
but without a test covering the skip path. This adds
`TestSch_load_SkipsCueFileWithWrongPackage` there too, so the skip behavior stays
covered against a future regression.

No behavior changes for well-formed plugins: valid `migrate`/`model` packages load
exactly as before; only the intended skip of mismatching-package `.cue` files is
restored (migrate) and locked in with tests (both).

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming
  convention using one of the following `catalog_entry` values: `FEATURE`,
  `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`, `IGNORE`.
- [x] All commits have DCO signoffs.
