### PR TITLE
Fix SecretSpec validation of mutually exclusive auth methods

### DIFF
--- a/pkg/model/api/v1/secret.go
+++ b/pkg/model/api/v1/secret.go
@@ -58,7 +58,17 @@ func (s *SecretSpec) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 func (s *SecretSpec) validate() error {
-	if s.BasicAuth != nil && s.Authorization != nil && s.OAuth != nil {
+	nbAuthConfigured := 0
+	if s.BasicAuth != nil {
+		nbAuthConfigured++
+	}
+	if s.Authorization != nil {
+		nbAuthConfigured++
+	}
+	if s.OAuth != nil {
+		nbAuthConfigured++
+	}
+	if nbAuthConfigured > 1 {
 		return fmt.Errorf("basicAuth, authorization and oauth are mutually exclusive, use one of them")
 	}
 	return nil

--- a/pkg/model/api/v1/secret_test.go
+++ b/pkg/model/api/v1/secret_test.go
@@ -1,0 +1,82 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	secretBasicAuth     = `"basicAuth": {"username": "Magical", "password": "Girl"}`
+	secretAuthorization = `"authorization": {"type": "Bearer", "credentials": "token"}`
+	secretOAuth         = `"oauth": {"clientID": "id", "clientSecret": "secret", "tokenURL": "https://example.com/token"}`
+)
+
+func TestUnmarshalJSONSecretSpecMutuallyExclusiveAuth(t *testing.T) {
+	mutuallyExclusiveErr := fmt.Errorf("basicAuth, authorization and oauth are mutually exclusive, use one of them")
+
+	testSuite := []struct {
+		title string
+		jason string
+		err   error
+	}{
+		{
+			title: "only basicAuth",
+			jason: fmt.Sprintf(`{%s}`, secretBasicAuth),
+		},
+		{
+			title: "only authorization",
+			jason: fmt.Sprintf(`{%s}`, secretAuthorization),
+		},
+		{
+			title: "only oauth",
+			jason: fmt.Sprintf(`{%s}`, secretOAuth),
+		},
+		{
+			title: "basicAuth and authorization",
+			jason: fmt.Sprintf(`{%s, %s}`, secretBasicAuth, secretAuthorization),
+			err:   mutuallyExclusiveErr,
+		},
+		{
+			title: "basicAuth and oauth",
+			jason: fmt.Sprintf(`{%s, %s}`, secretBasicAuth, secretOAuth),
+			err:   mutuallyExclusiveErr,
+		},
+		{
+			title: "authorization and oauth",
+			jason: fmt.Sprintf(`{%s, %s}`, secretAuthorization, secretOAuth),
+			err:   mutuallyExclusiveErr,
+		},
+		{
+			title: "basicAuth, authorization and oauth",
+			jason: fmt.Sprintf(`{%s, %s, %s}`, secretBasicAuth, secretAuthorization, secretOAuth),
+			err:   mutuallyExclusiveErr,
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			result := &SecretSpec{}
+			err := json.Unmarshal([]byte(test.jason), result)
+			if test.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, test.err.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/pkg/model/api/v1/secret_test.go
+++ b/pkg/model/api/v1/secret_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	secretBasicAuth     = `"basicAuth": {"username": "Magical", "password": "Girl"}`
-	secretAuthorization = `"authorization": {"type": "Bearer", "credentials": "token"}`
-	secretOAuth         = `"oauth": {"clientID": "id", "clientSecret": "secret", "tokenURL": "https://example.com/token"}`
+	basicAuthJSON     = `"basicAuth": {"username": "Magical", "password": "Girl"}`
+	authorizationJSON = `"authorization": {"type": "Bearer", "credentials": "token"}`
+	oauthJSON         = `"oauth": {"clientID": "id", "clientSecret": "secret", "tokenURL": "https://example.com/token"}`
 )
 
 func TestUnmarshalJSONSecretSpecMutuallyExclusiveAuth(t *testing.T) {
@@ -37,34 +37,34 @@ func TestUnmarshalJSONSecretSpecMutuallyExclusiveAuth(t *testing.T) {
 	}{
 		{
 			title: "only basicAuth",
-			jason: fmt.Sprintf(`{%s}`, secretBasicAuth),
+			jason: fmt.Sprintf(`{%s}`, basicAuthJSON),
 		},
 		{
 			title: "only authorization",
-			jason: fmt.Sprintf(`{%s}`, secretAuthorization),
+			jason: fmt.Sprintf(`{%s}`, authorizationJSON),
 		},
 		{
 			title: "only oauth",
-			jason: fmt.Sprintf(`{%s}`, secretOAuth),
+			jason: fmt.Sprintf(`{%s}`, oauthJSON),
 		},
 		{
 			title: "basicAuth and authorization",
-			jason: fmt.Sprintf(`{%s, %s}`, secretBasicAuth, secretAuthorization),
+			jason: fmt.Sprintf(`{%s, %s}`, basicAuthJSON, authorizationJSON),
 			err:   mutuallyExclusiveErr,
 		},
 		{
 			title: "basicAuth and oauth",
-			jason: fmt.Sprintf(`{%s, %s}`, secretBasicAuth, secretOAuth),
+			jason: fmt.Sprintf(`{%s, %s}`, basicAuthJSON, oauthJSON),
 			err:   mutuallyExclusiveErr,
 		},
 		{
 			title: "authorization and oauth",
-			jason: fmt.Sprintf(`{%s, %s}`, secretAuthorization, secretOAuth),
+			jason: fmt.Sprintf(`{%s, %s}`, authorizationJSON, oauthJSON),
 			err:   mutuallyExclusiveErr,
 		},
 		{
 			title: "basicAuth, authorization and oauth",
-			jason: fmt.Sprintf(`{%s, %s, %s}`, secretBasicAuth, secretAuthorization, secretOAuth),
+			jason: fmt.Sprintf(`{%s, %s, %s}`, basicAuthJSON, authorizationJSON, oauthJSON),
 			err:   mutuallyExclusiveErr,
 		},
 	}


### PR DESCRIPTION
`SecretSpec.validate()` guards the three auth methods with `&&`, so it only rejects a secret that sets **all three** at once. Every pair passes:

```go
if s.BasicAuth != nil && s.Authorization != nil && s.OAuth != nil {
    return fmt.Errorf("basicAuth, authorization and oauth are mutually exclusive, use one of them")
}
```

| payload | expected | actual on main |
|---|---|---|
| only basicAuth / only authorization / only oauth | accepted | accepted |
| all three | rejected | rejected |
| **basicAuth + oauth** | rejected | **accepted** |
| **basicAuth + authorization** | rejected | **accepted** |
| **authorization + oauth** | rejected | **accepted** |

That contradicts the error message the guard itself raises, and `docs/api/secret.md` ("Basic Auth, Authorization and OAuth are mutually exclusive").

**It matters downstream.** `httpProxy.setupAuthentication` (`internal/api/impl/proxy/proxy.go:365`) applies all three in sequence to the same `Authorization` header — `SetBasicAuth` first, then `Header.Set` for authorization, then `Header.Set` for oauth. Last one wins. So a secret with `basicAuth` + `oauth` is accepted today and then sends only the OAuth bearer token; the basicAuth credentials never reach the datasource, silently. This validation is what should stop that combination from existing.

The fix counts the configured methods, which is how `RestConfigClient.Validate` already does the same job in `pkg/client/config/config.go:85-103`.

Added `pkg/model/api/v1/secret_test.go` — the file had no test coverage, which is presumably how this survived. It covers all seven combinations; the three pair cases fail on `main` and pass here, and the four existing-behaviour cases pass on both.

`go test ./pkg/...` is green, `gofmt` and `go vet` clean.

Disclosure: written with Claude Code. I verified the reproduction, the downstream header behaviour, and the test red/green myself.
