### PR TITLE
[BUGFIX/BREAKINGCHANGE] Fix health error with SQL database

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -555,14 +555,14 @@ allow_cleartext_passwords: <boolean> | default = false # Optional
 # Allows fallback to unencrypted connection if server does not support TLS
 allow_fallback_to_plaintext: <boolean> | default = false # Optional
 
-# Allows the native password authentication method
-allow_native_passwords: <boolean> | default = false # Optional
+# Allows the native password authentication method. When unset, the driver default (true) is used.
+allow_native_passwords: <boolean> | default = true # Optional
 
 # Allows the old insecure password method
 allow_old_passwords: <boolean> | default = false # Optional
 
-# Check connections for liveness before using them
-check_conn_liveness: <boolean> | default = false # Optional
+# Check connections for liveness before using them. When unset, the driver default (true) is used.
+check_conn_liveness: <boolean> | default = true # Optional
 
 # Return number of matching rows instead of rows changed
 client_found_rows: <boolean> | default = false # Optional
@@ -585,6 +585,19 @@ reject_read_only: <boolean> | default = false # Optional
 # Whether the database is case-sensitive.
 # Be aware that to reflect this config, metadata.project and metadata.name from the resources managed can be modified before the insertion in the database.
 case_sensitive: <string> | default = false # Optional
+
+# Maximum amount of time a connection may be reused. Keep it shorter than the server's wait_timeout
+# to avoid reusing connections the server has already closed.
+conn_max_lifetime: <duration> | default = 3m # Optional
+
+# Maximum amount of time a connection may be idle before it is closed.
+conn_max_idle_time: <duration> | default = 1m # Optional
+
+# Maximum number of open connections to the database. A value <= 0 means unlimited.
+max_open_conns: <int> # Optional
+
+# Maximum number of connections in the idle connection pool. A value <= 0 keeps the Go default (2).
+max_idle_conns: <int> # Optional
 ```
 
 ### Schemas config

--- a/internal/api/database/database.go
+++ b/internal/api/database/database.go
@@ -96,31 +96,46 @@ func New(conf config.Database) (databaseModel.DAO, error) {
 		}
 	} else if conf.SQL != nil {
 		c := conf.SQL
-		mysqlConfig := mysql.Config{
-			User:                     string(c.User),
-			Passwd:                   string(c.Password),
-			Net:                      c.Net,
-			Addr:                     string(c.Addr),
-			DBName:                   c.DBName,
-			Collation:                c.Collation,
-			Loc:                      c.Loc,
-			MaxAllowedPacket:         c.MaxAllowedPacket,
-			ServerPubKey:             c.ServerPubKey,
-			Timeout:                  time.Duration(c.Timeout),
-			ReadTimeout:              time.Duration(c.ReadTimeout),
-			WriteTimeout:             time.Duration(c.WriteTimeout),
-			AllowAllFiles:            c.AllowAllFiles,
-			AllowCleartextPasswords:  c.AllowCleartextPasswords,
-			AllowFallbackToPlaintext: c.AllowFallbackToPlaintext,
-			AllowNativePasswords:     c.AllowNativePasswords,
-			AllowOldPasswords:        c.AllowOldPasswords,
-			CheckConnLiveness:        c.CheckConnLiveness,
-			ClientFoundRows:          c.ClientFoundRows,
-			ColumnsWithAlias:         c.ColumnsWithAlias,
-			InterpolateParams:        c.InterpolateParams,
-			MultiStatements:          c.MultiStatements,
-			ParseTime:                c.ParseTime,
-			RejectReadOnly:           c.RejectReadOnly,
+		// Start from the driver's default config (via NewConfig) rather than a bare
+		// struct literal, so that sane defaults such as CheckConnLiveness=true,
+		// AllowNativePasswords=true, Loc=time.UTC and MaxAllowedPacket are preserved
+		// unless explicitly overridden.
+		mysqlConfig := mysql.NewConfig()
+		mysqlConfig.User = string(c.User)
+		mysqlConfig.Passwd = string(c.Password)
+		mysqlConfig.Net = c.Net
+		mysqlConfig.Addr = string(c.Addr)
+		mysqlConfig.DBName = c.DBName
+		if c.Collation != "" {
+			mysqlConfig.Collation = c.Collation
+		}
+		if c.Loc != nil {
+			mysqlConfig.Loc = c.Loc
+		}
+		if c.MaxAllowedPacket != 0 {
+			mysqlConfig.MaxAllowedPacket = c.MaxAllowedPacket
+		}
+		mysqlConfig.ServerPubKey = c.ServerPubKey
+		mysqlConfig.Timeout = time.Duration(c.Timeout)
+		mysqlConfig.ReadTimeout = time.Duration(c.ReadTimeout)
+		mysqlConfig.WriteTimeout = time.Duration(c.WriteTimeout)
+		mysqlConfig.AllowAllFiles = c.AllowAllFiles
+		mysqlConfig.AllowCleartextPasswords = c.AllowCleartextPasswords
+		mysqlConfig.AllowFallbackToPlaintext = c.AllowFallbackToPlaintext
+		mysqlConfig.AllowOldPasswords = c.AllowOldPasswords
+		mysqlConfig.ClientFoundRows = c.ClientFoundRows
+		mysqlConfig.ColumnsWithAlias = c.ColumnsWithAlias
+		mysqlConfig.InterpolateParams = c.InterpolateParams
+		mysqlConfig.MultiStatements = c.MultiStatements
+		mysqlConfig.ParseTime = c.ParseTime
+		mysqlConfig.RejectReadOnly = c.RejectReadOnly
+		// AllowNativePasswords and CheckConnLiveness default to true via NewConfig.
+		// Only override them when the user explicitly set a value in the config.
+		if c.AllowNativePasswords != nil {
+			mysqlConfig.AllowNativePasswords = *c.AllowNativePasswords
+		}
+		if c.CheckConnLiveness != nil {
+			mysqlConfig.CheckConnLiveness = *c.CheckConnLiveness
 		}
 
 		// (OPTIONAL) Configure TLS
@@ -141,6 +156,17 @@ func New(conf config.Database) (databaseModel.DAO, error) {
 		db, err := sql.Open("mysql", mysqlConfig.FormatDSN())
 		if err != nil {
 			return nil, err
+		}
+		// Configure the connection pool. Retiring connections before the server's
+		// wait_timeout prevents stale connections from being reused, which is the
+		// main cause of intermittent health check ping failures.
+		db.SetConnMaxLifetime(time.Duration(c.ConnMaxLifetime))
+		db.SetConnMaxIdleTime(time.Duration(c.ConnMaxIdleTime))
+		if c.MaxOpenConns > 0 {
+			db.SetMaxOpenConns(c.MaxOpenConns)
+		}
+		if c.MaxIdleConns > 0 {
+			db.SetMaxIdleConns(c.MaxIdleConns)
 		}
 		client = &databaseSQL.DAO{
 			DB:            db,

--- a/internal/api/e2e/framework/server.go
+++ b/internal/api/e2e/framework/server.go
@@ -167,13 +167,12 @@ func CreateServer(t *testing.T, conf apiConfig.Config) (*httptest.Server, *httpe
 	if useSQL == "true" {
 		conf.Database = apiConfig.Database{
 			SQL: &apiConfig.SQL{
-				User:                 "user",
-				Password:             "password",
-				Net:                  "tcp",
-				Addr:                 "localhost:3306",
-				DBName:               "perses",
-				AllowNativePasswords: true,
-				CaseSensitive:        true,
+				User:          "user",
+				Password:      "password",
+				Net:           "tcp",
+				Addr:          "localhost:3306",
+				DBName:        "perses",
+				CaseSensitive: true,
 			},
 		}
 	} else {

--- a/pkg/model/api/config/database.go
+++ b/pkg/model/api/config/database.go
@@ -25,6 +25,15 @@ import (
 
 const defaultFileDBFolder = "./local_db"
 
+// defaultSQLConnMaxLifetime is the default maximum lifetime of a SQL connection.
+// It is intentionally kept short (shorter than the usual server wait_timeout) so
+// that connections are retired before the server closes them, which otherwise
+// leads to stale connections being handed out (e.g. to the health check ping).
+const defaultSQLConnMaxLifetime = 3 * time.Minute
+
+// defaultSQLConnMaxIdleTime is the default maximum idle time of a SQL connection.
+const defaultSQLConnMaxIdleTime = time.Minute
+
 type FileExtension string
 
 const (
@@ -89,12 +98,14 @@ type SQL struct {
 	AllowCleartextPasswords bool `json:"allow_cleartext_passwords" yaml:"allow_cleartext_passwords"`
 	// Allows fallback to unencrypted connection if server does not support TLS
 	AllowFallbackToPlaintext bool `json:"allow_fallback_to_plaintext" yaml:"allow_fallback_to_plaintext"`
-	// Allows the native password authentication method
-	AllowNativePasswords bool `json:"allow_native_passwords" yaml:"allow_native_passwords"`
+	// Allows the native password authentication method.
+	// When unset, the driver default (true) is used.
+	AllowNativePasswords *bool `json:"allow_native_passwords,omitempty" yaml:"allow_native_passwords,omitempty"`
 	// Allows the old insecure password method
 	AllowOldPasswords bool `json:"allow_old_passwords" yaml:"allow_old_passwords"`
-	// Check connections for liveness before using them
-	CheckConnLiveness bool `json:"check_conn_liveness" yaml:"check_conn_liveness"`
+	// Check connections for liveness before using them.
+	// When unset, the driver default (true) is used.
+	CheckConnLiveness *bool `json:"check_conn_liveness,omitempty" yaml:"check_conn_liveness,omitempty"`
 	// Return number of matching rows instead of rows changed
 	ClientFoundRows bool `json:"client_found_rows" yaml:"client_found_rows"`
 	// Prepend table alias to column names
@@ -108,6 +119,19 @@ type SQL struct {
 	// Reject read-only connections
 	RejectReadOnly bool `json:"reject_read_only" yaml:"reject_read_only"`
 	CaseSensitive  bool `json:"case_sensitive" yaml:"case_sensitive"`
+	// ConnMaxLifetime is the maximum amount of time a connection may be reused.
+	// It should be kept shorter than the server's wait_timeout to avoid reusing
+	// connections that the server has already closed. Defaults to 3 minutes.
+	ConnMaxLifetime common.Duration `json:"conn_max_lifetime,omitempty" yaml:"conn_max_lifetime,omitempty"`
+	// ConnMaxIdleTime is the maximum amount of time a connection may be idle
+	// before it is closed. Defaults to 1 minute.
+	ConnMaxIdleTime common.Duration `json:"conn_max_idle_time,omitempty" yaml:"conn_max_idle_time,omitempty"`
+	// MaxOpenConns is the maximum number of open connections to the database.
+	// A value <= 0 means unlimited (the Go default).
+	MaxOpenConns int `json:"max_open_conns,omitempty" yaml:"max_open_conns,omitempty"`
+	// MaxIdleConns is the maximum number of connections in the idle connection
+	// pool. A value <= 0 keeps the Go default (2).
+	MaxIdleConns int `json:"max_idle_conns,omitempty" yaml:"max_idle_conns,omitempty"`
 }
 
 func (s *SQL) Verify() error {
@@ -147,6 +171,12 @@ func (s *SQL) Verify() error {
 			return err
 		}
 		s.Addr = secret.Hidden(data)
+	}
+	if s.ConnMaxLifetime == 0 {
+		s.ConnMaxLifetime = common.Duration(defaultSQLConnMaxLifetime)
+	}
+	if s.ConnMaxIdleTime == 0 {
+		s.ConnMaxIdleTime = common.Duration(defaultSQLConnMaxIdleTime)
 	}
 	return nil
 }

--- a/ui/app/src/components/Footer.tsx
+++ b/ui/app/src/components/Footer.tsx
@@ -63,7 +63,6 @@ function VersionInfo({
 }
 
 export default function Footer(): ReactElement {
-
   const { data, isLoading } = useHealth();
 
   return (

--- a/ui/app/src/components/Footer.tsx
+++ b/ui/app/src/components/Footer.tsx
@@ -14,7 +14,6 @@
 import { Box, CircularProgress, Link, Theme } from '@mui/material';
 import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
 import Github from 'mdi-material-ui/Github';
-import { useSnackbar } from '@perses-dev/components';
 import { ReactElement } from 'react';
 import { useHealth } from '../model/health-client';
 
@@ -64,12 +63,8 @@ function VersionInfo({
 }
 
 export default function Footer(): ReactElement {
-  const { exceptionSnackbar } = useSnackbar();
-  const { data, isLoading, error } = useHealth();
 
-  if (error) {
-    exceptionSnackbar(error);
-  }
+  const { data, isLoading } = useHealth();
 
   return (
     <Box component="footer" sx={style}>

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -63,9 +63,9 @@ export interface DatabaseSQL {
   allow_all_files: boolean;
   allow_cleartext_passwords: boolean;
   allow_fallback_to_plaintext: boolean;
-  allow_native_passwords: boolean;
+  allow_native_passwords?: boolean;
   allow_old_passwords: boolean;
-  check_conn_liveness: boolean;
+  check_conn_liveness?: boolean;
   client_found_rows: boolean;
   columns_with_alias: boolean;
   interpolate_params: boolean;
@@ -73,6 +73,10 @@ export interface DatabaseSQL {
   parse_time: boolean;
   reject_read_only: boolean;
   case_sensitive: boolean;
+  conn_max_lifetime?: string;
+  conn_max_idle_time?: string;
+  max_open_conns?: number;
+  max_idle_conns?: number;
 }
 
 export interface Database {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
This check is spamming error toasts (on each re-render), when there is a "database" issue. I suspect an issue with this endpoint, because it often happen and data (dashboard, project, ...) is well loaded so there should be no database issue...

I prefer to remove this error toast, if there is issue other fetch will handle it. And let it handle version only.

My guess about the health endpoint issue:
Go keeps a connection idle in its pool longer than the database's wait_timeout, the database's closes it, then Go tries to reuse the now-dead connection.

> [!IMPORTANT]
> **BREAKING CHANGE**
> Some default config change for SQL database to be aligned with driver: https://github.com/go-sql-driver/mysql/blob/master/dsn.go#L97
> 
> allow_native_passwords: `false`to `true`
> check_conn_liveness: `false`to `true`


# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
