### PR TITLE
[FEATURE] Validate panel-level annotation definitions

### DIFF
--- a/go-sdk/test/go.mod
+++ b/go-sdk/test/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/perses/plugins/staticlistvariable v0.9.0
 	github.com/perses/plugins/table v0.13.0
 	github.com/perses/plugins/timeserieschart v0.13.0
-	github.com/perses/spec v0.2.0
+	github.com/perses/spec v0.3.0-beta.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go-sdk/test/go.sum
+++ b/go-sdk/test/go.sum
@@ -37,8 +37,8 @@ github.com/perses/plugins/table v0.13.0 h1:lEBts7k2qsvZ9bw3zyYSPx/+K0E4aUZPw5OPE
 github.com/perses/plugins/table v0.13.0/go.mod h1:Se/GGhYWbisqgNUFDK9Ik58MSn9Hst6oTUMZNVK7aEM=
 github.com/perses/plugins/timeserieschart v0.13.0 h1:FQqAAqXyaLsoLeZocoh0mhIj9GASXxqbHDC8h6DNqTU=
 github.com/perses/plugins/timeserieschart v0.13.0/go.mod h1:nfSKLYdmxVEUgkHUzcBFzGpymr3f7BA6ivCH9xXG9co=
-github.com/perses/spec v0.2.0 h1:m/cdXVErAfjDft+dfxkfL+63Z+ggJ0sY08Wg7Q9Ruzk=
-github.com/perses/spec v0.2.0/go.mod h1:fyW8gFeaTXbF2TaE0N+iWrHtC7UZiRcT13qo+Y0ZEJM=
+github.com/perses/spec v0.3.0-beta.0 h1:OGnkHFFdISBGmTq6FmsJWprhG8kiAmkLWFNVMOT8G/g=
+github.com/perses/spec v0.3.0-beta.0/go.mod h1:fyW8gFeaTXbF2TaE0N+iWrHtC7UZiRcT13qo+Y0ZEJM=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/nexucis/lamenv v0.5.2
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/perses/common v0.31.2
-	github.com/perses/spec v0.2.0
+	github.com/perses/spec v0.3.0-beta.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,8 @@ github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7ol
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/perses/common v0.31.2 h1:klsl0KfWn6wVVG4rDJvsTvFO8Owf5ed4nj2VjbQST60=
 github.com/perses/common v0.31.2/go.mod h1:KgLB0ojBFzg93UwTNK8uAE1yuGexBiwqHiAvTFcHRDI=
-github.com/perses/spec v0.2.0 h1:m/cdXVErAfjDft+dfxkfL+63Z+ggJ0sY08Wg7Q9Ruzk=
-github.com/perses/spec v0.2.0/go.mod h1:fyW8gFeaTXbF2TaE0N+iWrHtC7UZiRcT13qo+Y0ZEJM=
+github.com/perses/spec v0.3.0-beta.0 h1:OGnkHFFdISBGmTq6FmsJWprhG8kiAmkLWFNVMOT8G/g=
+github.com/perses/spec v0.3.0-beta.0/go.mod h1:fyW8gFeaTXbF2TaE0N+iWrHtC7UZiRcT13qo+Y0ZEJM=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/internal/api/plugin/schema/schema.go
+++ b/internal/api/plugin/schema/schema.go
@@ -205,6 +205,15 @@ func (s *completeSchema) ValidatePanels(panels map[string]*dashboard.Panel) erro
 				errs = append(errs, fmt.Errorf("panel %q: %w", panelName, err))
 			}
 		}
+		for i, annotation := range panel.Spec.Annotations {
+			name := annotation.Display.Name
+			if name == "" {
+				name = fmt.Sprintf("n°%d", i+1)
+			}
+			if err := s.ValidateAnnotations(annotation.Plugin, name); err != nil {
+				errs = append(errs, fmt.Errorf("panel %q: %w", panelName, err))
+			}
+		}
 	}
 	if len(errs) == 0 {
 		logrus.Debug("All panels are valid")

--- a/internal/api/plugin/schema/schema_test.go
+++ b/internal/api/plugin/schema/schema_test.go
@@ -133,6 +133,23 @@ func loadQueryPlugins(queryPath string, sch Schema, t *testing.T) {
 	loadPlugin(queryPath, modules, sch, t)
 }
 
+func loadAnnotationPlugins(annotationPath string, sch Schema, t *testing.T) {
+	modules := []v1.ModuleSpec{
+		{
+			SchemasPath: "first",
+			Plugins: []module.Plugin{
+				{
+					Kind: plugin.KindAnnotation,
+					Spec: module.PluginSpec{
+						Name: "FirstAnnotation",
+					},
+				},
+			},
+		},
+	}
+	loadPlugin(annotationPath, modules, sch, t)
+}
+
 func loadVariablePlugins(variablePath string, sch Schema, t *testing.T) {
 	modules := []v1.ModuleSpec{
 		{
@@ -333,6 +350,66 @@ func TestValidatePanels(t *testing.T) {
 
 			err := s.ValidatePanels(test.dashboard.Spec.Panels)
 
+			if test.expectedErrorStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, test.expectedErrorStr)
+			}
+		})
+	}
+}
+
+func TestValidatePanelsWithAnnotations(t *testing.T) {
+	s := New()
+	loadPanelPlugins("testdata/schemas/panels", s, t)
+	loadQueryPlugins("testdata/schemas/queries", s, t)
+	loadAnnotationPlugins("testdata/schemas/annotations", s, t)
+
+	validFirstPanel := loadPluginFromJSON("testdata/samples/panels/valid_first_panel.json", t)
+	validCustomQueries := loadQueriesFromJSON("testdata/samples/queries/valid_custom_queries.json", t)
+	validAnnotation := loadPluginFromJSON("testdata/samples/annotations/valid_first_annotation.json", t)
+	invalidAnnotation := loadPluginFromJSON("testdata/samples/annotations/invalid_kind_annotation.json", t)
+
+	panelWithAnnotations := func(annotations []dashboard.AnnotationSpec) map[string]*dashboard.Panel {
+		return map[string]*dashboard.Panel{
+			"MyPanel": {
+				Spec: dashboard.PanelSpec{
+					Plugin:      validFirstPanel,
+					Queries:     validCustomQueries,
+					Annotations: annotations,
+				},
+			},
+		}
+	}
+
+	testSuite := []struct {
+		title            string
+		panels           map[string]*dashboard.Panel
+		expectedErrorStr string
+	}{
+		{
+			title: "panel with a valid panel-local annotation definition",
+			panels: panelWithAnnotations([]dashboard.AnnotationSpec{
+				{Display: dashboard.AnnotationDisplay{Name: "Deploys"}, Plugin: validAnnotation},
+			}),
+			expectedErrorStr: "",
+		},
+		{
+			title: "panel with an invalid panel-local annotation definition (unknown kind)",
+			panels: panelWithAnnotations([]dashboard.AnnotationSpec{
+				{Display: dashboard.AnnotationDisplay{Name: "Deploys"}, Plugin: invalidAnnotation},
+			}),
+			expectedErrorStr: "schema not found for plugin UnknownAnnotation",
+		},
+		{
+			title:            "panel without any annotations",
+			panels:           panelWithAnnotations(nil),
+			expectedErrorStr: "",
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			err := s.ValidatePanels(test.panels)
 			if test.expectedErrorStr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/internal/api/plugin/schema/testdata/samples/annotations/invalid_kind_annotation.json
+++ b/internal/api/plugin/schema/testdata/samples/annotations/invalid_kind_annotation.json
@@ -1,0 +1,6 @@
+{
+  "kind": "UnknownAnnotation",
+  "spec": {
+    "query": "up"
+  }
+}

--- a/internal/api/plugin/schema/testdata/samples/annotations/valid_first_annotation.json
+++ b/internal/api/plugin/schema/testdata/samples/annotations/valid_first_annotation.json
@@ -1,0 +1,6 @@
+{
+  "kind": "FirstAnnotation",
+  "spec": {
+    "query": "up"
+  }
+}

--- a/internal/api/plugin/schema/testdata/schemas/annotations/first/annotation.cue
+++ b/internal/api/plugin/schema/testdata/schemas/annotations/first/annotation.cue
@@ -1,0 +1,19 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+kind: "FirstAnnotation"
+spec: close({
+	query: string
+})

--- a/internal/cli/cmd/dac/build/testdata/go/go.mod
+++ b/internal/cli/cmd/dac/build/testdata/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/perses/perses v0.54.0-rc.1
 	github.com/perses/plugins/prometheus v0.58.0
 	github.com/perses/plugins/timeserieschart v0.13.0
-	github.com/perses/spec v0.2.0
+	github.com/perses/spec v0.3.0-beta.0
 )
 
 require (

--- a/internal/cli/cmd/dac/build/testdata/go/go.sum
+++ b/internal/cli/cmd/dac/build/testdata/go/go.sum
@@ -33,8 +33,8 @@ github.com/perses/plugins/prometheus v0.58.0 h1:9bJYloepRXUcFzPf30/bt6jU8Nj4CCPK
 github.com/perses/plugins/prometheus v0.58.0/go.mod h1:oBDxlUgQvrSRVPqFIG8+nMLDticPrUdrj8y0YnZDyp0=
 github.com/perses/plugins/timeserieschart v0.13.0 h1:FQqAAqXyaLsoLeZocoh0mhIj9GASXxqbHDC8h6DNqTU=
 github.com/perses/plugins/timeserieschart v0.13.0/go.mod h1:nfSKLYdmxVEUgkHUzcBFzGpymr3f7BA6ivCH9xXG9co=
-github.com/perses/spec v0.2.0 h1:m/cdXVErAfjDft+dfxkfL+63Z+ggJ0sY08Wg7Q9Ruzk=
-github.com/perses/spec v0.2.0/go.mod h1:fyW8gFeaTXbF2TaE0N+iWrHtC7UZiRcT13qo+Y0ZEJM=
+github.com/perses/spec v0.3.0-beta.0 h1:OGnkHFFdISBGmTq6FmsJWprhG8kiAmkLWFNVMOT8G/g=
+github.com/perses/spec v0.3.0-beta.0/go.mod h1:fyW8gFeaTXbF2TaE0N+iWrHtC7UZiRcT13qo+Y0ZEJM=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=


### PR DESCRIPTION
## What this does

This validates panel-local annotation definitions on the backend, the same way dashboard-level annotations are already validated.

`ValidatePanels` in `internal/api/plugin/schema/schema.go` now walks `panel.Spec.Annotations.Definitions` for each panel and runs every definition's plugin through the existing `ValidateAnnotations` path. No new code path, and no new plugin kind: `KindAnnotation` already exists and the definitions reuse `AnnotationSpec`, so a panel-local annotation goes through the same schema check as a dashboard-level one.

The `Enabled` toggle is not validated, since it only controls whether dashboard annotations show on the panel. A panel with no `annotations` block is skipped.

## Dependency

This is stacked on perses/spec#61, which adds the `PanelSpec.Annotations` field to the data model. It will not compile until that lands and the `github.com/perses/spec` version is bumped here. I developed it against a local `replace` pointing at the spec branch, so I left the go.mod bump out of this PR on purpose.

## Testing

There were no annotation fixtures under `internal/api/plugin/schema/testdata`, so I added a small annotation schema (`FirstAnnotation`) and two sample plugins, one valid and one with an unknown kind. `TestValidatePanelsWithAnnotations` covers four cases: a valid panel-local definition, an unknown annotation kind that gets rejected, a panel with only the toggle set, and a panel with no annotations block.

`go test ./internal/api/plugin/schema/...` passes. Two failures in `internal/api/validate` also happen on a clean checkout, because those tests need built plugin archives that are not present locally.

## Open questions

Same points as on perses/spec#61 and the design thread in #3001:

1. Is a single per-panel boolean enough for the toggle, or would you want per-annotation opt-out by name?
2. Should panel-local definitions be in the first iteration, or a follow-up after the toggle?
