### PR TITLE
[FEATURE] Add repeat_variable_max_values to frontend config to cap re…

### DIFF
--- a/pkg/model/api/config/frontend.go
+++ b/pkg/model/api/config/frontend.go
@@ -84,4 +84,6 @@ type Frontend struct {
 	TimeRange *TimeRange `json:"time_range,omitempty" yaml:"time_range,omitempty"`
 	// BannerInfo contains the content to be display in a banner at the top of each page along with the severity of the information
 	Banner *Banner `json:"banner,omitempty" yaml:"banner,omitempty"`
+	// RepeatVariableMaxValues is the maximum number of values rendered per repeat variable. 0 disables the limit.
+	RepeatVariableMaxValues int `json:"repeat_variable_max_values,omitempty" yaml:"repeat_variable_max_values,omitempty"`
 }

--- a/ui/app/src/context/Config.tsx
+++ b/ui/app/src/context/Config.tsx
@@ -181,3 +181,8 @@ export function useIsDelegatedAuthnProviderEnabled(): boolean {
   const { config } = useConfigContext();
   return !!config.security.authentication.providers.kubernetes?.enable;
 }
+
+export function useRepeatVariableMaxValues(): number {
+  const { config } = useConfigContext();
+  return config.frontend.repeat_variable_max_values ?? 0;
+}

--- a/ui/app/src/model/config-client.ts
+++ b/ui/app/src/model/config-client.ts
@@ -193,6 +193,7 @@ export interface FrontendConfig {
   explorer: ExplorerConfig;
   time_range?: TimeRangeConfig;
   banner?: Banner;
+  repeat_variable_max_values?: number;
 }
 
 export interface EphemeralDashboardConfig {

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -28,6 +28,7 @@ import {
   useIsKeyboardShortcutsEnabled,
   useIsLocalDatasourceEnabled,
   useIsLocalVariableEnabled,
+  useRepeatVariableMaxValues,
 } from '../../../context/Config';
 import { useRemotePluginLoader } from '../../../model/remote-plugin-loader';
 import { PERSES_APP_CONFIG } from '../../../config';
@@ -61,6 +62,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
   const isLocalDatasourceEnabled = useIsLocalDatasourceEnabled();
   const isLocalVariableEnabled = useIsLocalVariableEnabled();
   const isKeyboardShortcutsEnabled = useIsKeyboardShortcutsEnabled();
+  const repeatVariableMaxValues = useRepeatVariableMaxValues();
   const datasourceApi = useDatasourceApi();
   const pluginLoader = useRemotePluginLoader();
 
@@ -135,6 +137,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
                   isCreating={isCreating}
                   isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
                   userPreferenceTimezone={userPreferences.timezone}
+                  repeatVariableMaxValues={repeatVariableMaxValues}
                 />
               </UsageMetricsProvider>
             </ErrorBoundary>


### PR DESCRIPTION
…ndered panels per repeat variable

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Depends on: https://github.com/perses/shared/pull/149

Adds configuration for maximum repeat panels rendered. 

# Screenshots


<img width="1450" height="793" alt="Screenshot 2026-07-29 at 11 53 13" src="https://github.com/user-attachments/assets/ef727830-009a-4a8c-9558-5296073458e1" />

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
