### PR TITLE
[ENHANCEMENT]: Multi yaml file support for provisioning

### DIFF
--- a/internal/cli/file/file.go
+++ b/internal/cli/file/file.go
@@ -14,6 +14,7 @@
 package file
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -189,15 +190,51 @@ func (u *unmarshaller) read() error {
 			objects = append(objects, object)
 		}
 	} else {
-		if yamlErr := yaml.Unmarshal(data, &objects); yamlErr != nil {
-			if yamlErr = yaml.Unmarshal(data, &object); yamlErr != nil {
-				return newReadFileErr(yamlErr)
-			}
-			objects = append(objects, object)
+		decodedObjects, decodeErr := decodeYAMLDocumentsAsObjects(data)
+		if decodeErr != nil {
+			return fmt.Errorf("unable to read file %q, format invalid: %w", u.file, decodeErr)
 		}
+		objects = decodedObjects
 	}
 	u.objects = objects
 	return nil
+}
+
+func decodeYAMLDocumentsAsObjects(data []byte) ([]map[string]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var objects []map[string]any
+
+	for {
+		var document any
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+
+		// Empty YAML documents (e.g. consecutive '---') are ignored.
+		if document == nil {
+			continue
+		}
+
+		switch doc := document.(type) {
+		case []any:
+			for i, item := range doc {
+				obj, ok := item.(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("list item[%d] must be an object, got %T", i, item)
+				}
+				objects = append(objects, obj)
+			}
+		case map[string]any:
+			objects = append(objects, doc)
+		default:
+			return nil, fmt.Errorf("expected an object or list of objects, got %T", doc)
+		}
+	}
+
+	return objects, nil
 }
 
 func (u *unmarshaller) unmarshalEntities() ([]modelAPI.Entity, error) {

--- a/internal/cli/file/file_test.go
+++ b/internal/cli/file/file_test.go
@@ -1,0 +1,158 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("unable to write test file: %v", err)
+	}
+	return p
+}
+
+func TestUnmarshalEntitiesFromFile(t *testing.T) {
+	testSuite := []struct {
+		title           string
+		content         string
+		isErrorExpected bool
+		expectedCount   int
+		expectedKinds   []string
+		expectedNames   []string
+	}{
+		{
+			title: "single YAML document",
+			content: `kind: Project
+metadata:
+  name: my-project
+`,
+			expectedCount: 1,
+			expectedKinds: []string{"Project"},
+			expectedNames: []string{"my-project"},
+		},
+		{
+			// multi-document YAML separated by --- markers
+			title: "multi-document YAML",
+			content: `kind: Project
+metadata:
+  name: first-project
+---
+kind: Project
+metadata:
+  name: second-project
+`,
+			expectedCount: 2,
+			expectedKinds: []string{"Project", "Project"},
+			expectedNames: []string{"first-project", "second-project"},
+		},
+		{
+			// consecutive --- separators produce empty documents that must be skipped
+			title: "multi-document YAML with empty documents",
+			content: `---
+kind: Project
+metadata:
+  name: first-project
+---
+---
+kind: Project
+metadata:
+  name: second-project
+---
+`,
+			expectedCount: 2,
+			expectedKinds: []string{"Project", "Project"},
+			expectedNames: []string{"first-project", "second-project"},
+		},
+		{
+			// top-level YAML list treated as multiple resources in a single document
+			title: "YAML list",
+			content: `- kind: Project
+  metadata:
+    name: first-project
+- kind: Project
+  metadata:
+    name: second-project
+`,
+			expectedCount: 2,
+			expectedKinds: []string{"Project", "Project"},
+			expectedNames: []string{"first-project", "second-project"},
+		},
+		{
+			title:           "invalid YAML content",
+			content:         ":\tinvalid: yaml: content\n",
+			isErrorExpected: true,
+		},
+		{
+			// a scalar YAML document (not an object or list) must return an error
+			title:           "scalar YAML document",
+			isErrorExpected: true,
+			content: `---
+kind: Project
+metadata:
+  name: first-project
+---
+---
+---
+error-message-testing
+---
+`,
+		},
+		{
+			// a YAML list containing a non-object item must return an error
+			title:           "YAML list with non-object item",
+			isErrorExpected: true,
+			content: `- kind: Project
+  metadata:
+    name: my-project
+- just-a-string
+`,
+		},
+	}
+
+	for _, tc := range testSuite {
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+			p := writeTemp(t, "resources.yaml", tc.content)
+			entities, err := UnmarshalEntitiesFromFile(p)
+			if tc.isErrorExpected {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if len(entities) != tc.expectedCount {
+				t.Fatalf("expected %d entities, got %d", tc.expectedCount, len(entities))
+			}
+			for i, expectedKind := range tc.expectedKinds {
+				if entities[i].GetKind() != expectedKind {
+					t.Errorf("entities[%d]: expected kind %q, got %q", i, expectedKind, entities[i].GetKind())
+				}
+			}
+			for i, expectedName := range tc.expectedNames {
+				if entities[i].GetMetadata().GetName() != expectedName {
+					t.Errorf("entities[%d]: expected name %q, got %q", i, expectedName, entities[i].GetMetadata().GetName())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/4341

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Support for multi yaml separated with dashlanes (---) .

<img width="2342" height="1818" alt="image" src="https://github.com/user-attachments/assets/948c9a3d-a037-4c7b-866b-d48ebf8b346f" />

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
