### PR TITLE
[FEATURE ] Vendor-neutral initial implementation of analytics tracking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ dev/kubernetes/local
 
 ui-sbom.cdx.json
 /**/*.sbom.spdx.json
+
+.yalc
+yalc.lock

--- a/ui/app/src/Router.tsx
+++ b/ui/app/src/Router.tsx
@@ -91,9 +91,12 @@ function AppProviders(): ReactElement {
               <QueryParamProvider adapter={ReactRouter6Adapter}>
                 <NavHistoryProvider>
                   <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
+                    {/* Use the Analytics provider */}
+                    {/*<AnalyticsProvider config={PERSES_APP_CONFIG.analytics}>*/}
                     <AuthorizationProvider>
                       <App />
                     </AuthorizationProvider>
+                    {/*</AnalyticsProvider>*/}
                   </SnackbarProvider>
                 </NavHistoryProvider>
               </QueryParamProvider>

--- a/ui/app/src/analytics-config.local.ts
+++ b/ui/app/src/analytics-config.local.ts
@@ -11,8 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//export * from './analytics';
-export * from './constants';
-export * from './model';
-export * from './schema';
-export * from './utils';
+/**
+ * Local analytics configuration - NOT checked into git
+ *
+ * This file contains sensitive keys and is gitignored.
+ */
+
+export const SEGMENT_WRITE_KEY = 'qylQB4US91okwS4xtHIxtnka9FFHcC7g';

--- a/ui/app/src/components/Header/ThemeSwitch.tsx
+++ b/ui/app/src/components/Header/ThemeSwitch.tsx
@@ -17,13 +17,17 @@ import Brightness4 from 'mdi-material-ui/Brightness4';
 import { IconButton, ListItemIcon, MenuItem, Tooltip } from '@mui/material';
 import React, { ReactElement } from 'react';
 import { useDarkMode } from '../../context/DarkMode';
+import { useAnalytics } from '../../context/Analytics';
 
 export function ThemeSwitch(props: { isAuthEnabled: boolean }): ReactElement {
   const { isDarkModeEnabled, setDarkMode } = useDarkMode();
   const { exceptionSnackbar } = useSnackbar();
+  const { trackEvent } = useAnalytics();
   const handleDarkModeChange = (): void => {
+    const targetTheme = isDarkModeEnabled ? 'light' : 'dark';
     try {
       setDarkMode(!isDarkModeEnabled);
+      trackEvent('Theme Switched', { theme: targetTheme });
     } catch (e) {
       exceptionSnackbar(e);
     }

--- a/ui/app/src/context/Analytics.tsx
+++ b/ui/app/src/context/Analytics.tsx
@@ -1,0 +1,92 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { createContext, ReactElement, useContext, useEffect, useMemo } from 'react';
+import {
+  configureAnalytics,
+  trackEvent as coreTrackEvent,
+  trackPageView as coreTrackPageView,
+  identifyUser as coreIdentifyUser,
+  resetAnalytics as coreResetAnalytics,
+  AnalyticsConfig,
+  EventProperties,
+  UserTraits,
+} from '@perses-dev/core';
+
+/**
+ * Analytics context type with tracking methods.
+ */
+interface AnalyticsContextType {
+  trackEvent: (eventName: string, properties?: EventProperties) => void;
+  trackPageView: (pageName: string, properties?: EventProperties) => void;
+  identifyUser: (userId: string, traits?: UserTraits) => void;
+  reset: () => void;
+}
+
+const AnalyticsContext = createContext<AnalyticsContextType | undefined>(undefined);
+
+/**
+ * Props for the AnalyticsProvider component.
+ */
+export interface AnalyticsProviderProps {
+  /**
+   * Analytics configuration with providers and optional event prefix.
+   * If not provided, analytics will be disabled (no-op).
+   */
+  config?: AnalyticsConfig;
+  children: React.ReactNode;
+}
+
+/**
+ * Provider component that initializes the analytics system.
+ * Wrap your application with this component to enable analytics tracking.
+ * @example
+ * <AnalyticsProvider config={{ providers: [new PostHogProvider()], eventPrefix: 'perses_' }}>
+ *   <App />
+ * </AnalyticsProvider>
+ */
+export function AnalyticsProvider({ config, children }: AnalyticsProviderProps): ReactElement {
+  useEffect(() => {
+    if (config) {
+      configureAnalytics(config);
+    }
+  }, [config]);
+
+  const contextValue = useMemo(
+    () => ({
+      trackEvent: coreTrackEvent,
+      trackPageView: coreTrackPageView,
+      identifyUser: coreIdentifyUser,
+      reset: coreResetAnalytics,
+    }),
+    []
+  );
+
+  return <AnalyticsContext.Provider value={contextValue}>{children}</AnalyticsContext.Provider>;
+}
+
+/**
+ * Hook to access analytics tracking methods.
+ * @returns Analytics tracking methods
+ * @throws Error if used outside of AnalyticsProvider
+ * @example
+ * const { trackEvent } = useAnalytics();
+ * trackEvent('button_clicked', { button_name: 'save' });
+ */
+export function useAnalytics(): AnalyticsContextType {
+  const ctx = useContext(AnalyticsContext);
+  if (ctx === undefined) {
+    throw new Error('No AnalyticsContext found. Did you forget a Provider?');
+  }
+  return ctx;
+}

--- a/ui/app/src/utils/analytics-tracker-adapter.ts
+++ b/ui/app/src/utils/analytics-tracker-adapter.ts
@@ -1,0 +1,36 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { IAnalyticsTracker, EventProperties } from '@perses-dev/dashboards';
+import { useAnalytics } from '../context/Analytics';
+
+/**
+ * Adapter that bridges perses-upstream analytics to the IAnalyticsTracker interface
+ * expected by @perses-dev/dashboards components.
+ */
+export class AnalyticsTrackerAdapter implements IAnalyticsTracker {
+  constructor(private trackEventFn: (eventName: string, properties?: EventProperties) => void) {}
+
+  trackEvent(eventName: string, properties?: EventProperties): void {
+    console.log('[AnalyticsTrackerAdapter] Received event:', eventName, properties);
+    this.trackEventFn(eventName, properties);
+  }
+}
+
+/**
+ * Hook to create an analytics tracker adapter from the current analytics context
+ */
+export function useAnalyticsTracker(): IAnalyticsTracker {
+  const { trackEvent } = useAnalytics();
+  return new AnalyticsTrackerAdapter(trackEvent);
+}

--- a/ui/app/src/utils/dialog-analytics.ts
+++ b/ui/app/src/utils/dialog-analytics.ts
@@ -1,0 +1,98 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback } from 'react';
+import { EventProperties } from '@perses-dev/core';
+import { useAnalytics } from '../context/Analytics';
+
+/**
+ * Helper to convert action verb to past tense.
+ * @param action - Action verb (create, edit, delete, duplicate, update)
+ * @returns Past tense form
+ */
+function toPastTense(action: string): string {
+  const pastTenseMap: Record<string, string> = {
+    create: 'Created',
+    edit: 'Updated',
+    update: 'Updated',
+    delete: 'Deleted',
+    duplicate: 'Duplicated',
+    rename: 'Renamed',
+  };
+  return pastTenseMap[action.toLowerCase()] || action;
+}
+
+/**
+ * Hook for tracking dialog interactions with descriptive event names.
+ * Generates event names in the format: "<Resource> <PastTenseAction>"
+ * Example: "Dashboard Created", "Variable Updated", "Datasource Deleted"
+ *
+ * @param resourceKind - Resource kind (e.g., 'Dashboard', 'Variable', 'Datasource')
+ * @param action - Action type (e.g., 'create', 'edit', 'duplicate', 'delete')
+ * @returns Object with trackSubmit and trackCancel methods
+ *
+ * @example
+ * const dialogAnalytics = useDialogAnalytics('Dashboard', 'create');
+ *
+ * // On successful submission - tracks event "Dashboard Created"
+ * dialogAnalytics.trackSubmit(true);
+ *
+ * // On failed submission - tracks event "Dashboard Creation Failed"
+ * dialogAnalytics.trackSubmit(false);
+ *
+ * // On cancel - tracks event "Dashboard Creation Cancelled"
+ * dialogAnalytics.trackCancel();
+ */
+export function useDialogAnalytics(resourceKind: string, action: string) {
+  const { trackEvent } = useAnalytics();
+
+  /**
+   * Track dialog submission with success/failure status.
+   * Event: "{Resource} {PastTense}" (e.g., "Dashboard Created")
+   * Properties include: submit=true, success=true/false
+   * @param success - Whether the submission was successful
+   * @param additionalProperties - Optional additional properties to include
+   */
+  const trackSubmit = useCallback(
+    (success: boolean, additionalProperties?: EventProperties) => {
+      const eventName = `${resourceKind} ${toPastTense(action)}`;
+
+      trackEvent(eventName, {
+        submit: true,
+        success,
+        ...additionalProperties,
+      });
+    },
+    [trackEvent, resourceKind, action]
+  );
+
+  /**
+   * Track dialog cancellation.
+   * Event: "{Resource} {PastTense}" (e.g., "Dashboard Created")
+   * Properties: submit=false
+   * @param additionalProperties - Optional additional properties to include
+   */
+  const trackCancel = useCallback(
+    (additionalProperties?: EventProperties) => {
+      const eventName = `${resourceKind} ${toPastTense(action)}`;
+
+      trackEvent(eventName, {
+        submit: false,
+        ...additionalProperties,
+      });
+    },
+    [trackEvent, resourceKind, action]
+  );
+
+  return { trackSubmit, trackCancel };
+}

--- a/ui/app/src/views/config/ConfigView.tsx
+++ b/ui/app/src/views/config/ConfigView.tsx
@@ -22,6 +22,7 @@ import AppBreadcrumbs from '../../components/breadcrumbs/AppBreadcrumbs';
 import PageHeader from '../../components/page-header/PageHeader';
 import { useConfigContext } from '../../context/Config';
 import { useIsMobileSize } from '../../utils/browser-size';
+import { useAnalytics } from '../../context/Analytics';
 import { PluginsList } from './PluginsList';
 
 interface TabPanelProps {
@@ -42,9 +43,12 @@ function TabPanel(props: TabPanelProps): ReactElement | null {
 function ConfigView(): ReactElement {
   const { config } = useConfigContext();
   const isMobileSize = useIsMobileSize();
+  const { trackEvent } = useAnalytics();
   const [tabIndex, setTabIndex] = useState(0);
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number): void => {
+    const tabNames = ['Server Configuration', 'Installed Plugins'];
+    trackEvent('Tab Switched', { tab: tabNames[newValue], section: 'Configuration' });
     setTabIndex(newValue);
   };
 

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -32,6 +32,8 @@ import { useMigrate } from '../../model/migrate-client';
 import { useProjectList } from '../../model/project-client';
 import { useCreateDashboardMutation } from '../../model/dashboard-client';
 import { useIsReadonly } from '../../context/Config';
+import { useAnalytics } from '../../context/Analytics';
+import { ImportMethod } from './ImportView';
 
 type Input = {
   name: string;
@@ -49,13 +51,15 @@ interface GrafanaLightDashboard {
 
 interface GrafanaFlowProps {
   dashboard: GrafanaLightDashboard;
+  importMethod?: ImportMethod;
 }
 
-function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
+function GrafanaFlow({ dashboard, importMethod }: GrafanaFlowProps): ReactElement {
   const migrateMutation = useMigrate();
   const navigate = useNavigate();
   const isReadonly = useIsReadonly();
   const { exceptionSnackbar } = useSnackbar();
+  const { trackEvent } = useAnalytics();
   const [projectName, setProjectName] = useState<string>('');
   const [grafanaInput, setGrafanaInput] = useState<Record<string, string>>({});
   const [useDefaultDatasource, setUseDefaultDatasource] = useState(false);
@@ -80,7 +84,23 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
       return;
     }
     dashboard.metadata.project = projectName;
-    dashboardMutation.mutate(dashboard);
+    dashboardMutation.mutate(dashboard, {
+      onSuccess: () => {
+        trackEvent('Dashboard Imported', {
+          dashboard_type: 'grafana',
+          import_method: importMethod ?? 'unknown',
+          success: true,
+        });
+      },
+      onError: (err) => {
+        trackEvent('Dashboard Imported', {
+          dashboard_type: 'grafana',
+          import_method: importMethod ?? 'unknown',
+          success: false,
+          error: err.message,
+        });
+      },
+    });
   };
 
   if (error) {

--- a/ui/app/src/views/import/PersesFlow.tsx
+++ b/ui/app/src/views/import/PersesFlow.tsx
@@ -20,15 +20,19 @@ import { DashboardResource } from '@perses-dev/client';
 import { useProjectList } from '../../model/project-client';
 import { useCreateDashboardMutation } from '../../model/dashboard-client';
 import { useIsReadonly } from '../../context/Config';
+import { useAnalytics } from '../../context/Analytics';
+import { ImportMethod } from './ImportView';
 
 interface PersesFlowProps {
   dashboard: DashboardResource;
+  importMethod?: ImportMethod;
 }
 
-function PersesFlow({ dashboard }: PersesFlowProps): ReactElement {
+function PersesFlow({ dashboard, importMethod }: PersesFlowProps): ReactElement {
   const navigate = useNavigate();
   const isReadonly = useIsReadonly();
   const { exceptionSnackbar } = useSnackbar();
+  const { trackEvent } = useAnalytics();
   const [projectName, setProjectName] = useState<string>('');
   const { data, error } = useProjectList();
   const dashboardMutation = useCreateDashboardMutation((data) => {
@@ -37,7 +41,14 @@ function PersesFlow({ dashboard }: PersesFlowProps): ReactElement {
 
   const importOnClick = (): void => {
     dashboard.metadata.project = projectName;
-    dashboardMutation.mutate(dashboard);
+    dashboardMutation.mutate(dashboard, {
+      onSuccess: () => {
+        trackEvent('Dashboard Imported', { dashboard_type: 'perses', import_method: importMethod ?? 'unknown', success: true });
+      },
+      onError: (err) => {
+        trackEvent('Dashboard Imported', { dashboard_type: 'perses', import_method: importMethod ?? 'unknown', success: false, error: err.message });
+      },
+    });
   };
 
   if (error) {

--- a/ui/app/src/views/projects/ProjectTabs.tsx
+++ b/ui/app/src/views/projects/ProjectTabs.tsx
@@ -53,6 +53,7 @@ import { useCreateSecretMutation, useSecretList } from '../../model/secret-clien
 import { useEphemeralDashboardList } from '../../model/ephemeral-dashboard-client';
 import { useHasPermission } from '../../context/Authorization';
 import { useDashboardList } from '../../model/dashboard-client';
+import { useAnalytics } from '../../context/Analytics';
 import { ProjectDashboards } from './tabs/ProjectDashboards';
 import { ProjectEphemeralDashboards } from './tabs/ProjectEphemeralDashboards';
 import { ProjectVariables } from './tabs/ProjectVariables';
@@ -416,6 +417,7 @@ interface DashboardVariableTabsProps {
 export function ProjectTabs(props: DashboardVariableTabsProps): ReactElement {
   const { projectName, initialTab } = props;
   const { tab } = useParams();
+  const { trackEvent } = useAnalytics();
   const isAuthEnabled = useIsAuthEnabled();
   const isProjectDatasourceEnabled = useIsProjectDatasourceEnabled();
   const isProjectVariableEnabled = useIsProjectVariableEnabled();
@@ -445,6 +447,7 @@ export function ProjectTabs(props: DashboardVariableTabsProps): ReactElement {
   const hasVariableReadPermission = useHasPermission('read', projectName, 'Variable');
 
   const handleChange = (event: SyntheticEvent, newTabIndex: string): void => {
+    trackEvent('Tab Switched', { tab: newTabIndex, project: projectName });
     setValue(newTabIndex);
     navigate(`/projects/${projectName}/${newTabIndex}`);
   };

--- a/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
+++ b/ui/app/src/views/projects/dashboards/HelperDashboardView.tsx
@@ -14,7 +14,7 @@
 import { Box, CircularProgress, Stack } from '@mui/material';
 import { ErrorAlert, ErrorBoundary, getResourceDisplayName, useLocalStorage } from '@perses-dev/components';
 import { DashboardSpec } from '@perses-dev/spec';
-import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard } from '@perses-dev/dashboards';
+import { ExternalVariableDefinition, OnSaveDashboard, ViewDashboard, AnalyticsProvider } from '@perses-dev/dashboards';
 import { PluginRegistry, UsageMetricsProvider, ValidationProvider } from '@perses-dev/plugin-system';
 import { ReactElement, useMemo } from 'react';
 import { DashboardResource } from '@perses-dev/client';
@@ -32,6 +32,7 @@ import {
 import { useRemotePluginLoader } from '../../../model/remote-plugin-loader';
 import { PERSES_APP_CONFIG } from '../../../config';
 import { UserPreferences } from '../../../model/userPreferences';
+import { useAnalyticsTracker } from '../../../utils/analytics-tracker-adapter';
 
 export interface GenericDashboardViewProps {
   dashboardResource: DashboardResource;
@@ -63,6 +64,7 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
   const isKeyboardShortcutsEnabled = useIsKeyboardShortcutsEnabled();
   const datasourceApi = useDatasourceApi();
   const pluginLoader = useRemotePluginLoader();
+  const analyticsTracker = useAnalyticsTracker();
 
   // Collect the Project variables and setup external variables from it
   const { data: project, isLoading: isLoadingProject } = useProject(dashboardResource.metadata.project);
@@ -111,31 +113,33 @@ export function HelperDashboardView(props: GenericDashboardViewProps): ReactElem
                 project={project.metadata.name}
                 dashboard={dashboardResource.metadata.name}
               >
-                <ViewDashboard
-                  key={`${dashboardResource.metadata.project}/${dashboardResource.metadata.name}`}
-                  dashboardResource={dashboardResource}
-                  datasourceApi={datasourceApi}
-                  externalVariableDefinitions={externalVariableDefinitions}
-                  dashboardTitleComponent={
-                    <ProjectBreadcrumbs
-                      dashboardName={getResourceDisplayName(dashboardResource)}
-                      project={project}
-                      variant={breadcrumbVariant}
-                    />
-                  }
-                  onSave={onSave}
-                  onDiscard={onDiscard}
-                  isInitialVariableSticky={true}
-                  isReadonly={isReadonly}
-                  isAnnotationEnabled={true}
-                  isVariableEnabled={isLocalVariableEnabled}
-                  isDatasourceEnabled={isLocalDatasourceEnabled}
-                  disableShortcuts={!isKeyboardShortcutsEnabled}
-                  isEditing={isEditing}
-                  isCreating={isCreating}
-                  isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
-                  userPreferenceTimezone={userPreferences.timezone}
-                />
+                <AnalyticsProvider tracker={analyticsTracker}>
+                  <ViewDashboard
+                    key={`${dashboardResource.metadata.project}/${dashboardResource.metadata.name}`}
+                    dashboardResource={dashboardResource}
+                    datasourceApi={datasourceApi}
+                    externalVariableDefinitions={externalVariableDefinitions}
+                    dashboardTitleComponent={
+                      <ProjectBreadcrumbs
+                        dashboardName={getResourceDisplayName(dashboardResource)}
+                        project={project}
+                        variant={breadcrumbVariant}
+                      />
+                    }
+                    onSave={onSave}
+                    onDiscard={onDiscard}
+                    isInitialVariableSticky={true}
+                    isReadonly={isReadonly}
+                    isAnnotationEnabled={true}
+                    isVariableEnabled={isLocalVariableEnabled}
+                    isDatasourceEnabled={isLocalDatasourceEnabled}
+                    disableShortcuts={!isKeyboardShortcutsEnabled}
+                    isEditing={isEditing}
+                    isCreating={isCreating}
+                    isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
+                    userPreferenceTimezone={userPreferences.timezone}
+                  />
+                </AnalyticsProvider>
               </UsageMetricsProvider>
             </ErrorBoundary>
           </ValidationProvider>

--- a/ui/core/src/analytics/README.md
+++ b/ui/core/src/analytics/README.md
@@ -1,0 +1,166 @@
+# Perses Analytics System
+
+A pluggable analytics system for tracking user interactions in Perses. This system allows consuming applications to provide their own analytics providers without adding hard dependencies to the Perses core.
+
+## Architecture
+
+The analytics system follows a provider pattern inspired by the [PatternFly Chatbot tracking system](https://github.com/patternfly/chatbot/tree/main/packages/module/src/tracking):
+
+- **SPI (Service Provider Interface)**: Defines the contract that all analytics providers must implement
+- **Registry**: Manages registered analytics providers
+- **Proxy**: Routes tracking calls to all registered providers with error isolation
+- **API**: Public interface for tracking events, page views, and user identification
+
+## Basic Usage
+
+### 1. Configure Analytics in Your Application
+
+```typescript
+import { AnalyticsProvider } from '@perses-dev/app';
+import { ConsoleAnalyticsProvider } from '@perses-dev/core';
+
+// Use the built-in console provider for development
+const config = {
+  providers: [new ConsoleAnalyticsProvider()],
+  eventPrefix: 'perses_', // Optional: prefix all events
+};
+
+function App() {
+  return (
+    <AnalyticsProvider config={config}>
+      <YourAppComponents />
+    </AnalyticsProvider>
+  );
+}
+```
+
+### 2. Track Events in Components
+
+```typescript
+import { useAnalytics } from '../context/Analytics';
+
+function CreateDashboardButton() {
+  const { trackEvent } = useAnalytics();
+
+  const handleClick = () => {
+    trackEvent('button_clicked', {
+      button_name: 'create_dashboard',
+      location: 'header',
+    });
+    // ... rest of click handler
+  };
+
+  return <button onClick={handleClick}>Create Dashboard</button>;
+}
+```
+
+### 3. Track Wizard Steps
+
+```typescript
+function ProjectCreationWizard() {
+  const { trackEvent } = useAnalytics();
+
+  const handleStepComplete = (stepNumber: number, stepName: string) => {
+    trackEvent('wizard_step_completed', {
+      wizard_name: 'create_project',
+      step_number: stepNumber,
+      step_name: stepName,
+    });
+  };
+
+  // ... wizard implementation
+}
+```
+
+## Event Prefix
+
+The `eventPrefix` configuration option allows you to namespace all events:
+
+```typescript
+const config = {
+  providers: [myProvider],
+  eventPrefix: 'myapp_',
+};
+
+// Later when tracking:
+trackEvent('button_clicked'); // Sent as 'myapp_button_clicked'
+```
+
+## Creating Custom Providers
+
+Implement the `AnalyticsProvider` interface to create your own analytics provider:
+
+```typescript
+import { AnalyticsProvider, EventProperties, UserTraits } from '@perses-dev/core';
+
+export class PostHogAnalyticsProvider implements AnalyticsProvider {
+  readonly name = 'PostHogAnalyticsProvider';
+  private posthog: PostHog;
+
+  constructor(apiKey: string) {
+    this.posthog = posthog.init(apiKey);
+  }
+
+  trackEvent(eventName: string, properties?: EventProperties): void {
+    this.posthog.capture(eventName, properties);
+  }
+
+  trackPageView(pageName: string, properties?: EventProperties): void {
+    this.posthog.capture('$pageview', { ...properties, page: pageName });
+  }
+
+  identifyUser(userId: string, traits?: UserTraits): void {
+    this.posthog.identify(userId, traits);
+  }
+
+  reset(): void {
+    this.posthog.reset();
+  }
+}
+```
+
+## Using Multiple Providers
+
+You can register multiple providers simultaneously:
+
+```typescript
+const config = {
+  providers: [
+    new ConsoleAnalyticsProvider(), // Log to console
+    new PostHogAnalyticsProvider('api-key'), // Send to PostHog
+    new SegmentAnalyticsProvider('write-key'), // Send to Segment
+  ],
+  eventPrefix: 'perses_',
+};
+```
+
+All providers will receive tracking calls. If one provider throws an error, others continue to work.
+
+## API Reference
+
+### Core Functions
+
+- `configureAnalytics(config)` - Initialize the analytics system with providers
+- `trackEvent(eventName, properties?)` - Track a custom event
+- `trackPageView(pageName, properties?)` - Track a page view
+- `identifyUser(userId, traits?)` - Identify a user
+- `resetAnalytics()` - Clear user identity (e.g., on logout)
+
+### React Hooks
+
+- `useAnalytics()` - Access analytics tracking methods in React components
+
+### Types
+
+- `AnalyticsProvider` - Interface for implementing custom providers
+- `EventProperties` - Type for event metadata (Record<string, unknown>)
+- `UserTraits` - Type for user attributes (Record<string, unknown>)
+- `AnalyticsConfig` - Configuration object with providers and optional eventPrefix
+
+## No-Op Behavior
+
+If `AnalyticsProvider` is used without a config, or if no providers are registered, all tracking calls become no-ops (silent, no errors thrown). This allows Perses to work perfectly without analytics configured.
+
+## Error Handling
+
+Each provider runs in isolation. If one provider throws an error, it's logged to the console and other providers continue to execute.

--- a/ui/core/src/analytics/analytics-api.ts
+++ b/ui/core/src/analytics/analytics-api.ts
@@ -1,0 +1,67 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EventProperties, UserTraits } from './analytics-spi';
+import { analyticsProviderProxy } from './analytics-provider-proxy';
+import { analyticsRegistry, AnalyticsConfig } from './analytics-registry';
+
+/**
+ * Configure the analytics system.
+ * Must be called before using analytics tracking methods.
+ * @param config - Analytics configuration with providers and optional event prefix
+ */
+export function configureAnalytics(config: AnalyticsConfig): void {
+  analyticsRegistry.configure(config);
+}
+
+/**
+ * Track a custom event.
+ * Event name will be prefixed with the configured prefix if set.
+ * @param eventName - Name of the event to track
+ * @param properties - Optional properties associated with the event
+ * @example
+ * trackEvent('button_clicked', { button_name: 'create_dashboard', location: 'header' })
+ */
+export function trackEvent(eventName: string, properties?: EventProperties): void {
+  analyticsProviderProxy.trackEvent(eventName, properties);
+}
+
+/**
+ * Track a page view.
+ * @param pageName - Name or path of the page
+ * @param properties - Optional properties associated with the page view
+ * @example
+ * trackPageView('/dashboards', { project: 'my-project' })
+ */
+export function trackPageView(pageName: string, properties?: EventProperties): void {
+  analyticsProviderProxy.trackPageView(pageName, properties);
+}
+
+/**
+ * Identify a user for analytics tracking.
+ * @param userId - Unique identifier for the user
+ * @param traits - Optional traits/attributes of the user
+ * @example
+ * identifyUser('user-123', { email: 'user@example.com', role: 'admin' })
+ */
+export function identifyUser(userId: string, traits?: UserTraits): void {
+  analyticsProviderProxy.identifyUser(userId, traits);
+}
+
+/**
+ * Reset/clear the current user identity.
+ * Should be called on logout or when switching users.
+ */
+export function resetAnalytics(): void {
+  analyticsProviderProxy.reset();
+}

--- a/ui/core/src/analytics/analytics-provider-proxy.ts
+++ b/ui/core/src/analytics/analytics-provider-proxy.ts
@@ -1,0 +1,77 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AnalyticsProvider, EventProperties, UserTraits } from './analytics-spi';
+import { analyticsRegistry } from './analytics-registry';
+
+/**
+ * Proxy that routes analytics calls to all registered providers.
+ * Handles event name prefixing and error isolation per provider.
+ */
+class AnalyticsProviderProxy implements AnalyticsProvider {
+  readonly name = 'AnalyticsProviderProxy';
+
+  /**
+   * Apply the configured prefix to an event name.
+   * @param eventName - Original event name
+   * @returns Prefixed event name
+   */
+  private applyPrefix(eventName: string): string {
+    const prefix = analyticsRegistry.getEventPrefix();
+    return prefix ? `${prefix}${eventName}` : eventName;
+  }
+
+  /**
+   * Execute a function on all registered providers with error isolation.
+   * If one provider throws, others still execute.
+   * @param fn - Function to execute on each provider
+   */
+  private executeOnProviders(fn: (provider: AnalyticsProvider) => void): void {
+    const providers = analyticsRegistry.getProviders();
+    providers.forEach((provider) => {
+      try {
+        fn(provider);
+      } catch (error) {
+        console.error(`Analytics provider '${provider.name}' error:`, error);
+      }
+    });
+  }
+
+  trackEvent(eventName: string, properties?: EventProperties): void {
+    const prefixedEventName = this.applyPrefix(eventName);
+    this.executeOnProviders((provider) => {
+      provider.trackEvent(prefixedEventName, properties);
+    });
+  }
+
+  trackPageView(pageName: string, properties?: EventProperties): void {
+    this.executeOnProviders((provider) => {
+      provider.trackPageView(pageName, properties);
+    });
+  }
+
+  identifyUser(userId: string, traits?: UserTraits): void {
+    this.executeOnProviders((provider) => {
+      provider.identifyUser(userId, traits);
+    });
+  }
+
+  reset(): void {
+    this.executeOnProviders((provider) => {
+      provider.reset();
+    });
+  }
+}
+
+// Singleton proxy instance
+export const analyticsProviderProxy = new AnalyticsProviderProxy();

--- a/ui/core/src/analytics/analytics-registry.ts
+++ b/ui/core/src/analytics/analytics-registry.ts
@@ -1,0 +1,102 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AnalyticsProvider } from './analytics-spi';
+
+/**
+ * Configuration for the analytics system.
+ */
+export interface AnalyticsConfig {
+  /**
+   * Optional prefix to prepend to all event names.
+   * Example: if prefix is 'perses_', event 'button_clicked' becomes 'perses_button_clicked'
+   */
+  eventPrefix?: string;
+
+  /**
+   * List of analytics providers to use.
+   * Multiple providers can be active simultaneously.
+   */
+  providers: AnalyticsProvider[];
+}
+
+/**
+ * Registry for managing analytics providers.
+ * Singleton pattern to maintain global analytics configuration.
+ */
+class AnalyticsRegistry {
+  private providers: AnalyticsProvider[] = [];
+  private eventPrefix = '';
+
+  /**
+   * Configure the analytics system with providers and settings.
+   * @param config - Analytics configuration
+   */
+  configure(config: AnalyticsConfig): void {
+    this.providers = config.providers;
+    this.eventPrefix = config.eventPrefix ?? '';
+  }
+
+  /**
+   * Register a single analytics provider.
+   * @param provider - Provider to register
+   */
+  registerProvider(provider: AnalyticsProvider): void {
+    if (!this.providers.find((p) => p.name === provider.name)) {
+      this.providers.push(provider);
+    }
+  }
+
+  /**
+   * Unregister a provider by name.
+   * @param providerName - Name of provider to remove
+   */
+  unregisterProvider(providerName: string): void {
+    this.providers = this.providers.filter((p) => p.name !== providerName);
+  }
+
+  /**
+   * Get all registered providers.
+   * @returns Array of registered providers
+   */
+  getProviders(): AnalyticsProvider[] {
+    return [...this.providers];
+  }
+
+  /**
+   * Get the configured event prefix.
+   * @returns Event prefix string
+   */
+  getEventPrefix(): string {
+    return this.eventPrefix;
+  }
+
+  /**
+   * Set the event prefix.
+   * @param prefix - Prefix to prepend to event names
+   */
+  setEventPrefix(prefix: string): void {
+    this.eventPrefix = prefix;
+  }
+
+  /**
+   * Clear all providers and reset configuration.
+   */
+  reset(): void {
+    this.providers = [];
+    this.eventPrefix = '';
+  }
+}
+
+// Singleton instance
+export const analyticsRegistry = new AnalyticsRegistry();

--- a/ui/core/src/analytics/analytics-spi.ts
+++ b/ui/core/src/analytics/analytics-spi.ts
@@ -1,0 +1,62 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Properties associated with an analytics event.
+ * Key-value pairs of event metadata.
+ */
+export type EventProperties = Record<string, unknown>;
+
+/**
+ * User traits for identification.
+ * Key-value pairs of user attributes.
+ */
+export type UserTraits = Record<string, unknown>;
+
+/**
+ * Service Provider Interface for analytics providers.
+ * All analytics implementations must implement this interface.
+ */
+export interface AnalyticsProvider {
+  /**
+   * Unique identifier for this provider.
+   */
+  readonly name: string;
+
+  /**
+   * Track a custom event.
+   * @param eventName - Name of the event to track
+   * @param properties - Optional properties associated with the event
+   */
+  trackEvent(eventName: string, properties?: EventProperties): void;
+
+  /**
+   * Track a page view.
+   * @param pageName - Name or path of the page
+   * @param properties - Optional properties associated with the page view
+   */
+  trackPageView(pageName: string, properties?: EventProperties): void;
+
+  /**
+   * Identify a user.
+   * @param userId - Unique identifier for the user
+   * @param traits - Optional traits/attributes of the user
+   */
+  identifyUser(userId: string, traits?: UserTraits): void;
+
+  /**
+   * Reset/clear the current user identity.
+   * Called on logout or when switching users.
+   */
+  reset(): void;
+}

--- a/ui/core/src/analytics/index.ts
+++ b/ui/core/src/analytics/index.ts
@@ -11,8 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//export * from './analytics';
-export * from './constants';
-export * from './model';
-export * from './schema';
-export * from './utils';
+// Public API
+export { configureAnalytics, trackEvent, trackPageView, identifyUser, resetAnalytics } from './analytics-api';
+
+// Types for implementing custom providers
+export type { AnalyticsProvider, EventProperties, UserTraits } from './analytics-spi';
+export type { AnalyticsConfig } from './analytics-registry';
+
+// Built-in providers
+export { ConsoleAnalyticsProvider } from './providers/console-analytics-provider';
+export {default as SegmentAnalyticsProvider} from './providers/segment-analytics-provider'

--- a/ui/core/src/analytics/providers/console-analytics-provider.ts
+++ b/ui/core/src/analytics/providers/console-analytics-provider.ts
@@ -1,0 +1,38 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AnalyticsProvider, EventProperties, UserTraits } from '../analytics-spi';
+
+/**
+ * Console-based analytics provider for development and debugging.
+ * Logs all analytics calls to the browser console.
+ */
+export class ConsoleAnalyticsProvider implements AnalyticsProvider {
+  readonly name = 'ConsoleAnalyticsProvider';
+
+  trackEvent(eventName: string, properties?: EventProperties): void {
+    console.log('[Analytics] Event:', eventName, properties ?? {});
+  }
+
+  trackPageView(pageName: string, properties?: EventProperties): void {
+    console.log('[Analytics] Page View:', pageName, properties ?? {});
+  }
+
+  identifyUser(userId: string, traits?: UserTraits): void {
+    console.log('[Analytics] Identify User:', userId, traits ?? {});
+  }
+
+  reset(): void {
+    console.log('[Analytics] Reset');
+  }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,6 +13,10 @@
         "e2e",
         "internal-utils"
       ],
+      "dependencies": {
+        "@perses-dev/dashboards": "file:.yalc/@perses-dev/dashboards",
+        "perses-shared": "file:.yalc/perses-shared"
+      },
       "devDependencies": {
         "@swc/cli": "^0.8.1",
         "@swc/core": "^1.15.33",
@@ -51,6 +55,231 @@
         "typedoc": "^0.25.8",
         "typescript": "5.4.5"
       }
+    },
+    ".yalc/@perses-dev/dashboards": {
+      "version": "0.54.0-rc.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@perses-dev/client": "0.54.0-rc.0",
+        "@perses-dev/components": "0.54.0-rc.0",
+        "@perses-dev/plugin-system": "0.54.0-rc.0",
+        "@perses-dev/spec": "0.2.0-beta.9",
+        "@tanstack/hotkeys": "^0.8.0",
+        "@tanstack/react-hotkeys": "^0.9.1",
+        "immer": "^10.1.1",
+        "mdi-material-ui": "^7.9.2",
+        "react-grid-layout": "^1.3.4",
+        "react-hook-form": "^7.46.1",
+        "react-intersection-observer": "^9.4.0",
+        "use-immer": "^0.11.0",
+        "use-query-params": "^2.2.1",
+        "use-resize-observer": "^9.0.0",
+        "yaml": "^2.7.0",
+        "zustand": "^4.3.3"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.1.10",
+        "@tanstack/react-query": "^4.39.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@perses-dev/client": {
+      "version": "0.54.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/client/-/client-0.54.0-rc.0.tgz",
+      "integrity": "sha512-PtomWGg2FlqkraMDHbrWNGVr2lGs4OMYa6Uh4QSKeuviH8F1kcR3HtxYF9mbh/3al+iqJc5GSEGvuMnXJ2YAqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@perses-dev/spec": "0.2.0-beta.9",
+        "zod": "^3.21.4"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@perses-dev/components": {
+      "version": "0.54.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.54.0-rc.0.tgz",
+      "integrity": "sha512-ZQ6xGG5FikOktGxpd5rp0VlKBfo+Z0DwnW1ZABKyQ4B23ZaSTvrbESC4boWPo12Odjq7nRZoJUOBKaFCRcHQHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+        "@codemirror/lang-json": "^6.0.1",
+        "@date-fns/tz": "^1.4.1",
+        "@fontsource/inter": "^5.0.0",
+        "@mui/x-date-pickers": "^7.23.1",
+        "@perses-dev/client": "0.54.0-rc.0",
+        "@perses-dev/spec": "0.2.0-beta.9",
+        "@tanstack/match-sorter-utils": "^8.19.4",
+        "@tanstack/react-table": "^8.20.5",
+        "@uiw/react-codemirror": "^4.19.1",
+        "date-fns": "^4.1.0",
+        "echarts": "5.5.0",
+        "immer": "^10.1.1",
+        "lodash": "^4.17.21",
+        "mathjs": "^10.6.4",
+        "mdi-material-ui": "^7.9.2",
+        "notistack": "^3.0.2",
+        "numbro": "^2.3.6",
+        "react-colorful": "^5.6.1",
+        "react-error-boundary": "^3.1.4",
+        "react-virtuoso": "^4.12.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/material": "^6.1.10",
+        "lodash": "^4.17.21",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@perses-dev/core": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.53.0.tgz",
+      "integrity": "sha512-mOs+lNXo4Cy8RvFD1dhPQuXp7+57njEVbF5e3iNrqbgxmmEcP2SdAaNASWB7ki4IgFiJuZwqLH56SlqARWN7hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "lodash": "^4.17.21",
+        "mathjs": "^10.6.4",
+        "numbro": "^2.3.6",
+        "zod": "^3.21.4"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@perses-dev/plugin-system": {
+      "version": "0.54.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.54.0-rc.0.tgz",
+      "integrity": "sha512-ROOU4uTpIWanZ8MaRTyvuY9HTjVQfgCLwFH1yByLOMxFDn4DAT+Mdk4HXA14gX0HC4UvIHOpti+4LhDRb9ezuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@module-federation/enhanced": "^2.6.0",
+        "@perses-dev/client": "0.54.0-rc.0",
+        "@perses-dev/components": "0.54.0-rc.0",
+        "@perses-dev/core": "0.53.0",
+        "@perses-dev/spec": "0.2.0-beta.9",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
+        "immer": "^10.1.1",
+        "react-hook-form": "^7.46.1",
+        "semver": "^7.8.0",
+        "use-query-params": "^2.2.1",
+        "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@hookform/resolvers": "^3.2.0",
+        "@mui/material": "^6.1.10",
+        "@tanstack/react-query": "^4.39.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@perses-dev/spec": {
+      "version": "0.2.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@perses-dev/spec/-/spec-0.2.0-beta.9.tgz",
+      "integrity": "sha512-hB+xmz5nnFWOypYF8UBzqL8YuHaqKVHzRBVlFj6f88ZtLw3j8bxrnMkQ/bSGwgsrEKzbdKWrCrtraokzl6nccA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "mathjs": "^15.1.1",
+        "zod": "^3.21.4"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@perses-dev/spec/node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@tanstack/hotkeys": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/hotkeys/-/hotkeys-0.8.0.tgz",
+      "integrity": "sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/@tanstack/store": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.0.tgz",
+      "integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    ".yalc/@perses-dev/dashboards/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    ".yalc/perses-shared": {
+      "version": "0.54.0-rc.0",
+      "workspaces": [
+        "components",
+        "dashboards",
+        "plugin-system",
+        "explore",
+        "client"
+      ]
     },
     "app": {
       "name": "@perses-dev/app",
@@ -4258,6 +4487,37 @@
       "link": true
     },
     "node_modules/@perses-dev/dashboards": {
+      "resolved": ".yalc/@perses-dev/dashboards",
+      "link": true
+    },
+    "node_modules/@perses-dev/e2e": {
+      "resolved": "e2e",
+      "link": true
+    },
+    "node_modules/@perses-dev/explore": {
+      "version": "0.54.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.54.0-beta.11.tgz",
+      "integrity": "sha512-BBGzZ0aQgdnO9jaBfOrtjFaJ5L8t0pXlQvgHPmogt8M7fziYvT7QFPnQvwihRW1Vm12px4wjpEMVlHBDJS7ZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nexucis/fuzzy": "^0.5.1",
+        "@perses-dev/components": "0.54.0-beta.11",
+        "@perses-dev/dashboards": "0.54.0-beta.11",
+        "@perses-dev/plugin-system": "0.54.0-beta.11",
+        "mdi-material-ui": "^7.9.2",
+        "qs": "^6.14.0",
+        "react-virtuoso": "^4.12.2",
+        "use-query-params": "^2.2.1",
+        "use-resize-observer": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.1.10",
+        "@tanstack/react-query": "^4.39.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/@perses-dev/explore/node_modules/@perses-dev/dashboards": {
       "version": "0.54.0-beta.11",
       "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.54.0-beta.11.tgz",
       "integrity": "sha512-Zh8gQYTZ8Aez4VF21M1YKjRV9rCM1+VW77IlnuPcBLsdo3Uu0pFAXGqZmuXDyknq9mbmY0TanNhpZia7b8pEfg==",
@@ -4287,7 +4547,7 @@
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
-    "node_modules/@perses-dev/dashboards/node_modules/@tanstack/hotkeys": {
+    "node_modules/@perses-dev/explore/node_modules/@tanstack/hotkeys": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@tanstack/hotkeys/-/hotkeys-0.8.0.tgz",
       "integrity": "sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==",
@@ -4303,7 +4563,7 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@perses-dev/dashboards/node_modules/@tanstack/store": {
+    "node_modules/@perses-dev/explore/node_modules/@tanstack/store": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.0.tgz",
       "integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==",
@@ -4313,7 +4573,7 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@perses-dev/dashboards/node_modules/yaml": {
+    "node_modules/@perses-dev/explore/node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
@@ -4326,33 +4586,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@perses-dev/e2e": {
-      "resolved": "e2e",
-      "link": true
-    },
-    "node_modules/@perses-dev/explore": {
-      "version": "0.54.0-beta.11",
-      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.54.0-beta.11.tgz",
-      "integrity": "sha512-BBGzZ0aQgdnO9jaBfOrtjFaJ5L8t0pXlQvgHPmogt8M7fziYvT7QFPnQvwihRW1Vm12px4wjpEMVlHBDJS7ZWg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@nexucis/fuzzy": "^0.5.1",
-        "@perses-dev/components": "0.54.0-beta.11",
-        "@perses-dev/dashboards": "0.54.0-beta.11",
-        "@perses-dev/plugin-system": "0.54.0-beta.11",
-        "mdi-material-ui": "^7.9.2",
-        "qs": "^6.14.0",
-        "react-virtuoso": "^4.12.2",
-        "use-query-params": "^2.2.1",
-        "use-resize-observer": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "@tanstack/react-query": "^4.39.1",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@perses-dev/internal-utils": {
@@ -4545,8 +4778,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
       "version": "2.0.1",
@@ -4559,8 +4791,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
       "version": "2.0.1",
@@ -4573,8 +4804,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
       "version": "2.0.1",
@@ -4587,8 +4817,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
       "version": "2.0.1",
@@ -4601,8 +4830,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
       "version": "2.0.1",
@@ -4615,8 +4843,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
       "version": "2.0.1",
@@ -4627,7 +4854,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -4640,7 +4866,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -4652,7 +4877,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4663,7 +4887,6 @@
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4679,8 +4902,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
       "version": "2.0.1",
@@ -4693,8 +4915,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
       "version": "2.0.1",
@@ -4707,8 +4928,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/core": {
       "version": "2.0.1",
@@ -6732,19 +6952,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@xhmikosr/bin-check/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@xhmikosr/bin-check/node_modules/is-stream": {
@@ -11636,6 +11843,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -15123,6 +15343,10 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/perses-shared": {
+      "resolved": ".yalc/perses-shared",
+      "link": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -63,5 +63,9 @@
     "typedoc": "^0.25.8",
     "typescript": "5.4.5"
   },
-  "packageManager": "npm@10.9.2"
+  "packageManager": "npm@10.9.2",
+  "dependencies": {
+    "@perses-dev/dashboards": "file:.yalc/@perses-dev/dashboards",
+    "perses-shared": "file:.yalc/perses-shared"
+  }
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

To understand the users interactions with Perses in order to improve the user experience requires analytics tracking of the interactions.
This PR introduces a vendor-neutral implementation of an API with some already coded usages. The implementation follows what I have done a while ago in PatternFly-Chatbot ( see https://github.com/patternfly/chatbot/tree/main/packages/module/src/tracking ), but does not provide any tracking provider other than the console one. Implementations that use Perses would need to write their own integration code and tracking provider as described in core/src/analytics/README.md 
cc @jgbernalp 
There will be a corresponding PR for the perses/shared repo, that uses this functionality.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
