### PR TITLE
[IGNORE] fix changelog Write injecting new entries at wrong position

### DIFF
--- a/scripts/pkg/changelog/changelog.go
+++ b/scripts/pkg/changelog/changelog.go
@@ -204,16 +204,27 @@ func Write(clog *Changelog, version string) {
 	fileScanner := bufio.NewScanner(f)
 	fileScanner.Split(bufio.ScanLines)
 	var buffer bytes.Buffer
-	i := 0
+	newSection := generateChangelog(clog, version)
+	injected := false
 	for fileScanner.Scan() {
-		buffer.WriteString(fileScanner.Text())
-		buffer.WriteString("\n")
-		i++
-		if i == 1 {
-			// inject the new changelog entries after the title
+		line := fileScanner.Text()
+		// Inject the new section just before the first version heading (## ...).
+		// This works whether or not the file has a top-level "# Changelog" title.
+		if !injected && strings.HasPrefix(line, "## ") {
+			buffer.WriteString(newSection)
 			buffer.WriteString("\n")
-			buffer.WriteString(generateChangelog(clog, version))
+			injected = true
 		}
+		buffer.WriteString(line)
+		buffer.WriteString("\n")
+	}
+	if !injected {
+		// No existing version heading found; prepend the new section.
+		content := buffer.String()
+		buffer.Reset()
+		buffer.WriteString(newSection)
+		buffer.WriteString("\n")
+		buffer.WriteString(content)
 	}
 	if closeErr := f.Close(); closeErr != nil {
 		logrus.WithError(closeErr).Fatal("unable to close the file CHANGELOG.md")

--- a/scripts/pkg/changelog/changelog_test.go
+++ b/scripts/pkg/changelog/changelog_test.go
@@ -15,10 +15,13 @@ package changelog
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseCatalogEntry(t *testing.T) {
@@ -147,6 +150,53 @@ func TestParseAndFormatEntry(t *testing.T) {
 			kindEntry, newEntry := parseAndFormatEntry(test.entry)
 			assert.Equal(t, test.expectedKind, kindEntry)
 			assert.Equal(t, test.expectedEntry, newEntry)
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	clog := &Changelog{
+		Features: []string{"add new widget (#10)"},
+		BugFixes: []string{"fix crash on startup (#9)"},
+	}
+
+	now := time.Now()
+	date := now.Format("2006-01-02")
+	newSection := fmt.Sprintf("## 1.1.0 / %s\n\n- [FEATURE] add new widget (#10)\n- [BUGFIX] fix crash on startup (#9)\n", date)
+
+	testSuite := []struct {
+		title           string
+		existingContent string
+		expected        string
+	}{
+		{
+			title:           "changelog with top-level title",
+			existingContent: "# Changelog\n\n## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n",
+			expected:        fmt.Sprintf("# Changelog\n\n%s\n## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n", newSection),
+		},
+		{
+			title:           "changelog without top-level title (operator-style)",
+			existingContent: "## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n",
+			expected:        fmt.Sprintf("%s\n## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n", newSection),
+		},
+	}
+
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "CHANGELOG.md")
+			require.NoError(t, os.WriteFile(path, []byte(test.existingContent), 0600))
+
+			origDir, err := os.Getwd()
+			require.NoError(t, err)
+			require.NoError(t, os.Chdir(dir))
+			t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+			Write(clog, "1.1.0")
+
+			result, err := os.ReadFile(path) //nolint:gosec
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, string(result))
 		})
 	}
 }


### PR DESCRIPTION

Fixes: https://github.com/perses/perses-operator/pull/362

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
