### PR TITLE
[BUGFIX] Honor kubeconfig exec credential plugins during Kubernetes login

### DIFF
--- a/internal/cli/cmd/login/k8s.go
+++ b/internal/cli/cmd/login/k8s.go
@@ -27,6 +27,7 @@ import (
 type k8sLogin struct {
 	apiClient          api.ClientInterface
 	kubeconfigLocation string
+	baseTransport      http.RoundTripper
 }
 
 func NewK8sLogin(apiClient api.ClientInterface, kubeconfigLocation string) *k8sLogin {
@@ -43,12 +44,14 @@ func (k *k8sLogin) Login() (*oauth2.Token, error) {
 		httpClient = &http.Client{Timeout: http.DefaultClient.Timeout}
 		restClient.Client = httpClient
 	}
-	roundTripper := httpClient.Transport
-	if roundTripper == nil {
-		roundTripper = http.DefaultTransport
+	if k.baseTransport == nil {
+		k.baseTransport = httpClient.Transport
+		if k.baseTransport == nil {
+			k.baseTransport = http.DefaultTransport
+		}
 	}
 
-	roundTripper, err := (&config.K8sAuth{KubeconfigFile: k.kubeconfigLocation}).WrapRoundTripper(roundTripper)
+	roundTripper, err := (&config.K8sAuth{KubeconfigFile: k.kubeconfigLocation}).WrapRoundTripper(k.baseTransport)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/cmd/login/k8s.go
+++ b/internal/cli/cmd/login/k8s.go
@@ -14,7 +14,7 @@
 package login
 
 import (
-	"fmt"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -37,24 +37,29 @@ func NewK8sLogin(apiClient api.ClientInterface, kubeconfigLocation string) *k8sL
 }
 
 func (k *k8sLogin) Login() (*oauth2.Token, error) {
-	kubeconfig, err := config.InitKubeConfig(k.kubeconfigLocation)
+	restClient := k.apiClient.RESTClient()
+	httpClient := restClient.Client
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: http.DefaultClient.Timeout}
+		restClient.Client = httpClient
+	}
+	roundTripper := httpClient.Transport
+	if roundTripper == nil {
+		roundTripper = http.DefaultTransport
+	}
+
+	roundTripper, err := (&config.K8sAuth{KubeconfigFile: k.kubeconfigLocation}).WrapRoundTripper(roundTripper)
 	if err != nil {
 		return nil, err
 	}
-
-	if len(k.apiClient.RESTClient().Headers) == 0 {
-		k.apiClient.RESTClient().Headers = map[string]string{}
-	}
-	k.apiClient.RESTClient().Headers["Authorization"] = fmt.Sprintf("Bearer %s", kubeconfig.BearerToken)
+	httpClient.Transport = roundTripper
 
 	_, err = k.apiClient.V1().User().WhoAmI()
 	if err != nil {
 		return nil, err
 	}
 
-	return &oauth2.Token{
-		AccessToken: kubeconfig.BearerToken,
-	}, nil
+	return &oauth2.Token{}, nil
 }
 
 func (k *k8sLogin) Refresh() (*oauth2.Token, error) {

--- a/internal/cli/cmd/login/login_test.go
+++ b/internal/cli/cmd/login/login_test.go
@@ -152,6 +152,64 @@ func TestK8sLoginExecCredentialsRotate(t *testing.T) {
 	}
 }
 
+func TestK8sLoginRefreshDoesNotStackWrappers(t *testing.T) {
+	authorizations := make(chan string, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizations <- r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(server.Close)
+
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	tempDir := t.TempDir()
+	stateID := strconv.Itoa(os.Getpid())
+	stateFile := filepath.Join(tempDir, "perses-k8s-exec-state-"+stateID)
+	require.NoError(t, os.WriteFile(stateFile, []byte("0"), 0o600))
+	kubeconfigFile := filepath.Join(tempDir, "config")
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cluster": {Server: "https://kubernetes.example"},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {Exec: &clientcmdapi.ExecConfig{
+				APIVersion:      "client.authentication.k8s.io/v1",
+				Command:         executable,
+				Args:            []string{"-test.run=^TestK8sExecCredentialPlugin$"},
+				InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
+				Env: []clientcmdapi.ExecEnvVar{
+					{Name: "PERSES_K8S_EXEC_PLUGIN", Value: "1"},
+					{Name: "PERSES_K8S_EXEC_STATE_DIR", Value: tempDir},
+					{Name: "PERSES_K8S_EXEC_STATE_ID", Value: stateID},
+				},
+			}},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"context": {Cluster: "cluster", AuthInfo: "user"},
+		},
+		CurrentContext: "context",
+	}
+	require.NoError(t, clientcmd.WriteToFile(kubeconfig, kubeconfigFile))
+
+	baseURL := common.MustParseURL(server.URL)
+	loginClient, err := clientConfig.NewRESTClient(clientConfig.RestConfigClient{URL: baseURL})
+	require.NoError(t, err)
+	k8s := NewK8sLogin(api.NewWithClient(loginClient), kubeconfigFile)
+	_, err = k8s.Login()
+	require.NoError(t, err)
+	_, err = k8s.Refresh()
+	require.NoError(t, err)
+	_, err = k8s.Refresh()
+	require.NoError(t, err)
+
+	// Login + 2 Refresh each issue one WhoAmI. Stacked HTTPWrappersForConfig
+	// layers would invoke the exec plugin once per wrap (1+2+3=6).
+	require.Equal(t, 3, len(authorizations))
+	for i := 1; i <= 3; i++ {
+		require.Equal(t, fmt.Sprintf("Bearer token-%d", i), <-authorizations)
+	}
+}
+
 func TestK8sExecCredentialPlugin(t *testing.T) {
 	if os.Getenv("PERSES_K8S_EXEC_PLUGIN") != "1" {
 		return

--- a/internal/cli/cmd/login/login_test.go
+++ b/internal/cli/cmd/login/login_test.go
@@ -14,9 +14,21 @@
 package login
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	cmdTest "github.com/perses/perses/internal/cli/test"
+	"github.com/perses/perses/pkg/client/api"
+	clientConfig "github.com/perses/perses/pkg/client/config"
+	"github.com/perses/spec/go/common"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestLoginCMD(t *testing.T) {
@@ -78,4 +90,81 @@ func TestLoginCMD(t *testing.T) {
 		},
 	}
 	cmdTest.ExecuteSuiteTest(t, NewCMD, testSuite)
+}
+
+func TestK8sLoginExecCredentialsRotate(t *testing.T) {
+	authorizations := make(chan string, 3)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizations <- r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(server.Close)
+
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	tempDir := t.TempDir()
+	kubeconfigFile := filepath.Join(tempDir, "config")
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cluster": {Server: "https://kubernetes.example"},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {Exec: &clientcmdapi.ExecConfig{
+				APIVersion:      "client.authentication.k8s.io/v1",
+				Command:         executable,
+				Args:            []string{"-test.run=^TestK8sExecCredentialPlugin$"},
+				InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
+				Env:             []clientcmdapi.ExecEnvVar{
+					{Name: "PERSES_K8S_EXEC_PLUGIN", Value: "1"},
+					{Name: "PERSES_K8S_EXEC_STATE", Value: filepath.Join(tempDir, "state")},
+				},
+			}},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"context": {Cluster: "cluster", AuthInfo: "user"},
+		},
+		CurrentContext: "context",
+	}
+	require.NoError(t, clientcmd.WriteToFile(kubeconfig, kubeconfigFile))
+
+	baseURL := common.MustParseURL(server.URL)
+	loginClient, err := clientConfig.NewRESTClient(clientConfig.RestConfigClient{URL: baseURL})
+	require.NoError(t, err)
+	token, err := NewK8sLogin(api.NewWithClient(loginClient), kubeconfigFile).Login()
+	require.NoError(t, err)
+	require.Empty(t, token.AccessToken)
+
+	persistentClient, err := clientConfig.NewRESTClient(clientConfig.RestConfigClient{
+		URL:     baseURL,
+		K8sAuth: &clientConfig.K8sAuth{KubeconfigFile: kubeconfigFile},
+	})
+	require.NoError(t, err)
+	for range 2 {
+		require.NoError(t, persistentClient.Get().APIPrefix("").APIVersion("").Do().Error())
+	}
+
+	for i := 1; i <= 3; i++ {
+		require.Equal(t, fmt.Sprintf("Bearer token-%d", i), <-authorizations)
+	}
+}
+
+func TestK8sExecCredentialPlugin(t *testing.T) {
+	if os.Getenv("PERSES_K8S_EXEC_PLUGIN") != "1" {
+		return
+	}
+
+	stateFile := os.Getenv("PERSES_K8S_EXEC_STATE")
+	data, err := os.ReadFile(stateFile)
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	count, _ := strconv.Atoi(string(data))
+	count++
+	if err := os.WriteFile(stateFile, []byte(strconv.Itoa(count)), 0o600); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf(`{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","status":{"expirationTimestamp":"2000-01-01T00:00:00Z","token":"token-%d"}}`, count)
+	os.Exit(0)
 }

--- a/internal/cli/cmd/login/login_test.go
+++ b/internal/cli/cmd/login/login_test.go
@@ -103,6 +103,10 @@ func TestK8sLoginExecCredentialsRotate(t *testing.T) {
 	executable, err := os.Executable()
 	require.NoError(t, err)
 	tempDir := t.TempDir()
+	stateID := strconv.Itoa(os.Getpid())
+	stateFile := filepath.Join(os.TempDir(), "perses-k8s-exec-state-"+stateID)
+	require.NoError(t, os.WriteFile(stateFile, []byte("0"), 0o600))
+	t.Cleanup(func() { require.NoError(t, os.Remove(stateFile)) })
 	kubeconfigFile := filepath.Join(tempDir, "config")
 	kubeconfig := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
@@ -114,9 +118,9 @@ func TestK8sLoginExecCredentialsRotate(t *testing.T) {
 				Command:         executable,
 				Args:            []string{"-test.run=^TestK8sExecCredentialPlugin$"},
 				InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
-				Env:             []clientcmdapi.ExecEnvVar{
+				Env: []clientcmdapi.ExecEnvVar{
 					{Name: "PERSES_K8S_EXEC_PLUGIN", Value: "1"},
-					{Name: "PERSES_K8S_EXEC_STATE", Value: filepath.Join(tempDir, "state")},
+					{Name: "PERSES_K8S_EXEC_STATE_ID", Value: stateID},
 				},
 			}},
 		},
@@ -153,9 +157,14 @@ func TestK8sExecCredentialPlugin(t *testing.T) {
 		return
 	}
 
-	stateFile := os.Getenv("PERSES_K8S_EXEC_STATE")
+	stateID, err := strconv.Atoi(os.Getenv("PERSES_K8S_EXEC_STATE_ID"))
+	if err != nil || stateID <= 0 {
+		fmt.Fprintln(os.Stderr, "invalid state ID")
+		os.Exit(1)
+	}
+	stateFile := filepath.Join(os.TempDir(), fmt.Sprintf("perses-k8s-exec-state-%d", stateID))
 	data, err := os.ReadFile(stateFile)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/internal/cli/cmd/login/login_test.go
+++ b/internal/cli/cmd/login/login_test.go
@@ -104,9 +104,8 @@ func TestK8sLoginExecCredentialsRotate(t *testing.T) {
 	require.NoError(t, err)
 	tempDir := t.TempDir()
 	stateID := strconv.Itoa(os.Getpid())
-	stateFile := filepath.Join(os.TempDir(), "perses-k8s-exec-state-"+stateID)
+	stateFile := filepath.Join(tempDir, "perses-k8s-exec-state-"+stateID)
 	require.NoError(t, os.WriteFile(stateFile, []byte("0"), 0o600))
-	t.Cleanup(func() { require.NoError(t, os.Remove(stateFile)) })
 	kubeconfigFile := filepath.Join(tempDir, "config")
 	kubeconfig := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
@@ -120,6 +119,7 @@ func TestK8sLoginExecCredentialsRotate(t *testing.T) {
 				InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
 				Env: []clientcmdapi.ExecEnvVar{
 					{Name: "PERSES_K8S_EXEC_PLUGIN", Value: "1"},
+					{Name: "PERSES_K8S_EXEC_STATE_DIR", Value: tempDir},
 					{Name: "PERSES_K8S_EXEC_STATE_ID", Value: stateID},
 				},
 			}},
@@ -162,15 +162,21 @@ func TestK8sExecCredentialPlugin(t *testing.T) {
 		fmt.Fprintln(os.Stderr, "invalid state ID")
 		os.Exit(1)
 	}
-	stateFile := filepath.Join(os.TempDir(), fmt.Sprintf("perses-k8s-exec-state-%d", stateID))
-	data, err := os.ReadFile(stateFile)
+	stateRoot, err := os.OpenRoot(os.Getenv("PERSES_K8S_EXEC_STATE_DIR"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer func() { _ = stateRoot.Close() }()
+	stateFile := fmt.Sprintf("perses-k8s-exec-state-%d", stateID)
+	data, err := stateRoot.ReadFile(stateFile)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	count, _ := strconv.Atoi(string(data))
 	count++
-	if err := os.WriteFile(stateFile, []byte(strconv.Itoa(count)), 0o600); err != nil {
+	if err := stateRoot.WriteFile(stateFile, []byte(strconv.Itoa(count)), 0o600); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -172,14 +172,17 @@ func NewRESTClient(config RestConfigClient) (*perseshttp.RESTClient, error) {
 		httpClient = oauthConfig.Client(ctx)
 	}
 	if config.K8sAuth != nil {
-		token, getTokenErr := config.K8sAuth.GetToken()
-		if getTokenErr != nil {
-			return nil, getTokenErr
+		baseRoundTripper := roundTripper
+		if httpClient != nil {
+			baseRoundTripper = httpClient.Transport
 		}
-		if len(config.Headers) == 0 {
-			config.Headers = map[string]string{}
+		roundTripper, err = config.K8sAuth.WrapRoundTripper(baseRoundTripper)
+		if err != nil {
+			return nil, err
 		}
-		config.Headers["Authorization"] = fmt.Sprintf("Bearer %s", token)
+		if httpClient != nil {
+			httpClient.Transport = roundTripper
+		}
 	}
 
 	if httpClient == nil {

--- a/pkg/client/config/k8s_auth.go
+++ b/pkg/client/config/k8s_auth.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"fmt"
+	"net/http"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -24,12 +25,13 @@ type K8sAuth struct {
 	KubeconfigFile string `json:"kubeconfig,omitempty" yaml:"kubeconfig,omitempty"`
 }
 
-func (b *K8sAuth) GetToken() (string, error) {
+// WrapRoundTripper applies the authentication configured by Kubernetes without replacing the Perses transport.
+func (b *K8sAuth) WrapRoundTripper(roundTripper http.RoundTripper) (http.RoundTripper, error) {
 	kubeconfig, err := InitKubeConfig(b.KubeconfigFile)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return kubeconfig.BearerToken, nil
+	return rest.HTTPWrappersForConfig(kubeconfig, roundTripper)
 }
 
 // InitKubeConfig returns initialized config, allows local usage (outside cluster) based on provided kubeconfig or in-cluster

--- a/pkg/client/config/k8s_auth.go
+++ b/pkg/client/config/k8s_auth.go
@@ -26,6 +26,7 @@ type K8sAuth struct {
 }
 
 // WrapRoundTripper applies the authentication configured by Kubernetes without replacing the Perses transport.
+// Cert-based kubeconfigs are not applied here, so those requests send no credentials and fail with 401.
 func (b *K8sAuth) WrapRoundTripper(roundTripper http.RoundTripper) (http.RoundTripper, error) {
 	kubeconfig, err := InitKubeConfig(b.KubeconfigFile)
 	if err != nil {


### PR DESCRIPTION
## Description

Kubernetes login only ever used `rest.Config.BearerToken`. For any kubeconfig that authenticates through a client-go credential plugin (`user.exec`), that field is empty: client-go applies exec credentials through its HTTP transport wrappers instead of populating `BearerToken`.

As a result `percli login --kube` sent `Authorization: Bearer ` with an empty token, the exec command was never executed, and `WhoAmI` failed with 401. The same applied to a persisted client built from `K8sAuth`, which snapshotted the (empty) token once and could never rotate short-lived credentials.

## Changes

- Replace `K8sAuth.GetToken` with `K8sAuth.WrapRoundTripper`, which builds the client-go authentication wrappers via `rest.HTTPWrappersForConfig` and layers them over the existing Perses transport. Only the auth wrappers are taken from the kubeconfig, so the Perses TLS/proxy configuration is untouched.
- Use that helper in `k8sLogin.Login` instead of writing a static `Authorization` header.
- Use the same helper in `NewRESTClient` so a persisted Kubernetes-authenticated client re-executes and refreshes the credential plugin per request instead of caching a token taken at construction time.

Static-token and basic-auth kubeconfigs keep working, since `HTTPWrappersForConfig` installs the corresponding round trippers for those too.

Note for reviewers: `K8sAuth.GetToken` is exported and is removed here rather than deprecated, because the value it returned is meaningless for exec-based kubeconfigs. Happy to keep a deprecated shim instead if backwards compatibility of `pkg/client/config` matters for this release.

## Testing

Added a test that writes a kubeconfig whose `exec` command is the test binary itself, emitting an `ExecCredential` with an already-expired `expirationTimestamp` and an incrementing token. It asserts that:

- `login` triggers the plugin and sends `Authorization: Bearer token-1`,
- a persisted REST client built from `K8sAuth` re-executes the plugin and sends `token-2` and `token-3` on subsequent requests, proving credential rotation.

```
go test ./pkg/client/config ./internal/cli/cmd/login -run 'Test.*K8s.*Exec' -count=1
```

No UI changes.
