### PR TITLE
[ENHANCEMENT] Add option to generate dashboard name from title during Grafana migration

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -71,6 +71,15 @@ Note: In case you would like to have the result as a K8s CustomResource, you can
     percli migrate -f grafana-dashboard.json --online --use-default-datasource -o json > perses-dashboard.json
     ```
 
+!!! tip
+    By default the migrated dashboard reuses the Grafana UID as its technical name (`metadata.name`),
+    which is often a cryptic auto-generated string. If you want the technical name to be generated from
+    the dashboard title instead, you can use the `--generate-dashboard-name` flag.
+
+    ```bash
+    percli migrate -f grafana-dashboard.json --online --generate-dashboard-name -o json > perses-dashboard.json
+    ```
+
 - You should check the unsupported migrations. For example, in case of a variable, you will get a static variable like this:
 
 ```json

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/mod v0.38.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/text v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
@@ -236,7 +237,6 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/internal/api/impl/migrate/migrate.go
+++ b/internal/api/impl/migrate/migrate.go
@@ -55,7 +55,7 @@ func (e *endpoint) Migrate(ctx echo.Context) error {
 	if err := json.Unmarshal(rawGrafanaDashboard, grafanaDashboard); err != nil {
 		return apiinterface.HandleBadRequestError(err.Error())
 	}
-	persesDashboard, err := e.migrationService.Migrate(grafanaDashboard, body.UseDefaultDatasource)
+	persesDashboard, err := e.migrationService.Migrate(grafanaDashboard, body.UseDefaultDatasource, body.GenerateDashboardName)
 	if err != nil {
 		return err
 	}

--- a/internal/api/plugin/migrate/metadata.go
+++ b/internal/api/plugin/migrate/metadata.go
@@ -1,0 +1,51 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"regexp"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// maxMetadataNameLength is the maximum length allowed for a resource name (metadata.name).
+// It matches the limit enforced by github.com/perses/spec/go/common.ValidateID.
+const maxMetadataNameLength = 75
+
+// invalidMetadataNameChar matches every character that is not allowed in a resource name.
+var invalidMetadataNameChar = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
+
+// generateMetadataName generates a valid Perses resource name (metadata.name) from a display
+// string. It mirrors the frontend helper of the same name (ui/app/src/utils/metadata.ts):
+// accents are removed from alphabetical characters and every character that is not allowed in
+// an ID is replaced by an underscore. It additionally truncates the result to the maximum name
+// length so that the generated name always satisfies common.ValidateID.
+func generateMetadataName(display string) string {
+	// NFD normalization splits accented characters into their base letter and a combining mark,
+	// then runes.Remove drops those marks (Unicode category Mn, "Mark, nonspacing").
+	name, _, err := transform.String(transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC), display)
+	if err != nil {
+		// transform.String only fails if the underlying transformer fails, which cannot happen
+		// with the chain above. Fall back to the raw display to stay defensive.
+		name = display
+	}
+	name = invalidMetadataNameChar.ReplaceAllString(name, "_")
+	if len(name) > maxMetadataNameLength {
+		name = name[:maxMetadataNameLength]
+	}
+	return name
+}

--- a/internal/api/plugin/migrate/metadata_test.go
+++ b/internal/api/plugin/migrate/metadata_test.go
@@ -1,0 +1,66 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/perses/spec/go/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateMetadataName(t *testing.T) {
+	tests := []struct {
+		title    string
+		expected string
+	}{
+		{
+			title:    "My Awesome Dashboard",
+			expected: "My_Awesome_Dashboard",
+		},
+		{
+			title:    "cpu.usage-per_node",
+			expected: "cpu.usage-per_node",
+		},
+		{
+			title:    "Café Métriques",
+			expected: "Cafe_Metriques",
+		},
+		{
+			title:    "Load (%) / node #1",
+			expected: "Load_______node__1",
+		},
+		{
+			title:    "",
+			expected: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			result := generateMetadataName(test.title)
+			assert.Equal(t, test.expected, result)
+			if len(result) > 0 {
+				assert.NoError(t, common.ValidateID(result))
+			}
+		})
+	}
+}
+
+func TestGenerateMetadataNameIsTruncatedToValidLength(t *testing.T) {
+	result := generateMetadataName(strings.Repeat("a", 200))
+	assert.Len(t, result, maxMetadataNameLength)
+	require.NoError(t, common.ValidateID(result))
+}

--- a/internal/api/plugin/migrate/migrate.go
+++ b/internal/api/plugin/migrate/migrate.go
@@ -188,7 +188,7 @@ type Migration interface {
 	Load(pluginPath string, module v1.PluginModule) error
 	LoadDevPlugin(pluginPath string, module v1.PluginModule) error
 	UnLoadDevPlugin(module v1.PluginModule)
-	Migrate(grafanaDashboard *SimplifiedDashboard, useDefaultDatasource bool) (*v1.Dashboard, error)
+	Migrate(grafanaDashboard *SimplifiedDashboard, useDefaultDatasource bool, generateDashboardName bool) (*v1.Dashboard, error)
 }
 
 func New() Migration {
@@ -233,14 +233,25 @@ func (m *completeMigration) UnLoadDevPlugin(module v1.PluginModule) {
 	}
 }
 
-func (m *completeMigration) Migrate(grafanaDashboard *SimplifiedDashboard, useDefaultDatasource bool) (*v1.Dashboard, error) {
+func (m *completeMigration) Migrate(grafanaDashboard *SimplifiedDashboard, useDefaultDatasource bool, generateDashboardName bool) (*v1.Dashboard, error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
+	// By default the Perses dashboard name (metadata.name) reuses the Grafana UID, which is often a
+	// cryptic auto-generated string. When generateDashboardName is enabled, we derive a more
+	// meaningful name from the dashboard title instead, the same way a brand-new dashboard is named.
+	// We keep the UID as a fallback in case the title is empty or only contains characters that get
+	// stripped away during the name generation.
+	name := grafanaDashboard.UID
+	if generateDashboardName {
+		if generatedName := generateMetadataName(grafanaDashboard.Title); len(generatedName) > 0 {
+			name = generatedName
+		}
+	}
 	result := &v1.Dashboard{
 		Kind: v1.KindDashboard,
 		Metadata: v1.ProjectMetadata{
 			Metadata: v1.Metadata{
-				Name: grafanaDashboard.UID,
+				Name: name,
 				Tags: set.New(grafanaDashboard.Tags...),
 			},
 		},

--- a/internal/api/plugin/migrate_test.go
+++ b/internal/api/plugin/migrate_test.go
@@ -75,7 +75,7 @@ func TestNoRegMigration(t *testing.T) {
 			if unmarshallErr := json.Unmarshal(input, grafanaDashboard); unmarshallErr != nil {
 				t.Fatal(unmarshallErr)
 			}
-			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false)
+			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -128,7 +128,7 @@ func TestMig_Migrate(t *testing.T) {
 			if unmarshallErr := json.Unmarshal(input, grafanaDashboard); unmarshallErr != nil {
 				t.Fatal(unmarshallErr)
 			}
-			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false)
+			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -146,9 +146,33 @@ func TestMig_MigrateTags(t *testing.T) {
 		Tags:  []string{"ops", "prod", "ops"},
 	}
 
-	persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false)
+	persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false, false)
 	assert.NoError(t, err)
 	assert.Equal(t, set.New("ops", "prod"), persesDashboard.Metadata.Tags)
+}
+
+func TestMig_MigrateGenerateDashboardName(t *testing.T) {
+	pl := loadDefaultTestPlugins()
+	grafanaDashboard := &migrate.SimplifiedDashboard{
+		UID:   "aead1k2js",
+		Title: "My Awesome Dashboard",
+	}
+
+	// By default the Grafana UID is reused as the technical name.
+	persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "aead1k2js", persesDashboard.Metadata.Name)
+
+	// When generateDashboardName is enabled, the technical name is derived from the title.
+	persesDashboard, err = pl.Migration().Migrate(grafanaDashboard, false, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "My_Awesome_Dashboard", persesDashboard.Metadata.Name)
+
+	// When the title is empty, generateDashboardName falls back to the Grafana UID.
+	emptyTitleDashboard := &migrate.SimplifiedDashboard{UID: "aead1k2js", Title: ""}
+	persesDashboard, err = pl.Migration().Migrate(emptyTitleDashboard, false, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "aead1k2js", persesDashboard.Metadata.Name)
 }
 
 func TestMigrateDashboardLinks(t *testing.T) {
@@ -225,7 +249,7 @@ func TestMigrateDashboardLinks(t *testing.T) {
 				Links: []migrate.GrafanaLink{tc.grafanaLink},
 			}
 
-			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false)
+			persesDashboard, err := pl.Migration().Migrate(grafanaDashboard, false, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, persesDashboard)
 			assert.Equal(t, tc.expectedLinks, persesDashboard.Spec.Links)

--- a/internal/cli/cmd/migrate/migrate.go
+++ b/internal/cli/cmd/migrate/migrate.go
@@ -74,17 +74,18 @@ type option struct {
 	persesCMD.Option
 	opt.FileOption
 	opt.OutputOption
-	writer               io.Writer
-	errWriter            io.Writer
-	rowInput             []string
-	input                map[string]string
-	project              string
-	pluginPath           string
-	online               bool
-	useDefaultDatasource bool
-	mig                  migrate.Migration
-	apiClient            api.ClientInterface
-	migrationFormat      migrationFormat
+	writer                io.Writer
+	errWriter             io.Writer
+	rowInput              []string
+	input                 map[string]string
+	project               string
+	pluginPath            string
+	online                bool
+	useDefaultDatasource  bool
+	generateDashboardName bool
+	mig                   migrate.Migration
+	apiClient             api.ClientInterface
+	migrationFormat       migrationFormat
 }
 
 func (o *option) Complete(args []string) error {
@@ -170,9 +171,10 @@ func (o *option) Execute() error {
 
 func (o *option) onlineExecution(grafanaDashboard json.RawMessage) (*modelV1.Dashboard, error) {
 	return o.apiClient.Migrate(&modelAPI.Migrate{
-		Input:                o.input,
-		GrafanaDashboard:     grafanaDashboard,
-		UseDefaultDatasource: o.useDefaultDatasource,
+		Input:                 o.input,
+		GrafanaDashboard:      grafanaDashboard,
+		UseDefaultDatasource:  o.useDefaultDatasource,
+		GenerateDashboardName: o.generateDashboardName,
 	})
 }
 
@@ -182,7 +184,7 @@ func (o *option) offlineExecution(grafanaDashboard json.RawMessage) (*modelV1.Da
 	if err := json.Unmarshal(rawGrafanaDashboard, dash); err != nil {
 		return nil, err
 	}
-	return o.mig.Migrate(dash, o.useDefaultDatasource)
+	return o.mig.Migrate(dash, o.useDefaultDatasource, o.generateDashboardName)
 }
 
 func (o *option) SetWriter(writer io.Writer) {
@@ -214,6 +216,7 @@ percli migrate -f ./dashboard.json --input=DS_PROMETHEUS=PrometheusDemo --online
 	cmd.Flags().StringVar(&o.pluginPath, "plugin.path", "", "Path to the Perses plugins.")
 	cmd.Flags().BoolVar(&o.online, "online", false, "When enabled, it can request the API to use it to perform the migration")
 	cmd.Flags().BoolVar(&o.useDefaultDatasource, "use-default-datasource", false, "When enabled, the default Perses datasource will be used for all panels. This will remove any reference to a specific datasource in the migrated dashboard.")
+	cmd.Flags().BoolVar(&o.generateDashboardName, "generate-dashboard-name", false, "When enabled, the dashboard's technical name (metadata.name) is generated from its title instead of reusing the Grafana UID.")
 	cmd.Flags().StringVar(&o.project, "project", "", "The project to use for the migration. If not set, then the field 'project' in the dashboard will not be set. When the format 'cr' is used, the project will be set to the namespace of the custom resource.")
 	// When "online" flag is used, the CLI will call the endpoint /migrate that will then use the schema from the server.
 	// So no need to use / load the schemas with the CLI.

--- a/pkg/model/api/migrate.go
+++ b/pkg/model/api/migrate.go
@@ -22,6 +22,9 @@ type Migrate struct {
 	Input                map[string]string `json:"input,omitempty"`
 	GrafanaDashboard     json.RawMessage   `json:"grafanaDashboard"`
 	UseDefaultDatasource bool              `json:"useDefaultDatasource,omitempty"`
+	// GenerateDashboardName generates the dashboard's technical name (metadata.name) from its
+	// title instead of reusing the Grafana UID.
+	GenerateDashboardName bool `json:"generateDashboardName,omitempty"`
 }
 
 func (m *Migrate) UnmarshalJSON(data []byte) error {

--- a/ui/app/src/model/migrate-client.ts
+++ b/ui/app/src/model/migrate-client.ts
@@ -22,6 +22,7 @@ export interface MigrateBodyRequest {
   input?: Record<string, string>;
   grafanaDashboard: Record<string, unknown>;
   useDefaultDatasource?: boolean;
+  generateDashboardName?: boolean;
 }
 
 export function useMigrate(): UseMutationResult<DashboardResource, StatusError, MigrateBodyRequest> {
@@ -33,6 +34,7 @@ export function useMigrate(): UseMutationResult<DashboardResource, StatusError, 
         input: body.input || {},
         grafanaDashboard: body.grafanaDashboard,
         useDefaultDatasource: !!body.useDefaultDatasource,
+        generateDashboardName: !!body.generateDashboardName,
       };
       return fetchJson<DashboardResource>(url, {
         method: HTTPMethodPOST,

--- a/ui/app/src/views/import/GrafanaFlow.test.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.test.tsx
@@ -1,0 +1,85 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import GrafanaFlow from './GrafanaFlow';
+
+const migrateMock = jest.fn();
+
+jest.mock('../../model/migrate-client', () => ({
+  useMigrate: (): object => ({
+    mutate: migrateMock,
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    data: undefined,
+    error: undefined,
+  }),
+}));
+
+jest.mock('../../model/project-client', () => ({
+  useProjectList: (): object => ({ data: [], isLoading: false, error: null }),
+}));
+
+jest.mock('../../model/dashboard-client', () => ({
+  useCreateDashboardMutation: (): object => ({ mutate: jest.fn(), isPending: false, isError: false }),
+}));
+
+jest.mock('../../context/Config', () => ({
+  useIsReadonly: (): boolean => false,
+}));
+
+jest.mock('@perses-dev/components', () => ({
+  useSnackbar: (): object => ({ exceptionSnackbar: jest.fn() }),
+  JSONEditor: (): null => null,
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: (): (() => void) => jest.fn(),
+}));
+
+function renderFlow(): void {
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <GrafanaFlow dashboard={{ title: 'My Dashboard' }} />
+    </ThemeProvider>
+  );
+}
+
+describe('GrafanaFlow', () => {
+  beforeEach(() => {
+    migrateMock.mockClear();
+  });
+
+  it('renders the "Generate dashboard name from title" checkbox, unchecked by default', () => {
+    renderFlow();
+    const checkbox = screen.getByLabelText('Generate dashboard name from title') as HTMLInputElement;
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('does not set generateDashboardName when the checkbox is left unchecked', () => {
+    renderFlow();
+    fireEvent.click(screen.getByRole('button', { name: /migrate/i }));
+    expect(migrateMock).toHaveBeenCalledWith(expect.objectContaining({ generateDashboardName: false }));
+  });
+
+  it('sets generateDashboardName to true once the checkbox is checked', () => {
+    renderFlow();
+    fireEvent.click(screen.getByLabelText('Generate dashboard name from title'));
+    fireEvent.click(screen.getByRole('button', { name: /migrate/i }));
+    expect(migrateMock).toHaveBeenCalledWith(expect.objectContaining({ generateDashboardName: true }));
+  });
+});

--- a/ui/app/src/views/import/GrafanaFlow.tsx
+++ b/ui/app/src/views/import/GrafanaFlow.tsx
@@ -59,6 +59,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
   const [projectName, setProjectName] = useState<string>('');
   const [grafanaInput, setGrafanaInput] = useState<Record<string, string>>({});
   const [useDefaultDatasource, setUseDefaultDatasource] = useState(false);
+  const [generateDashboardName, setGenerateDashboardName] = useState(false);
   const { data, isLoading, error } = useProjectList();
   const dashboardMutation = useCreateDashboardMutation((data) => {
     navigate(`/projects/${data.metadata.project}/dashboards/${data.metadata.name}`);
@@ -122,6 +123,16 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
           }
           label="Use default datasource in Perses"
         />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={generateDashboardName}
+              onChange={(e) => setGenerateDashboardName(e.target.checked)}
+              color="primary"
+            />
+          }
+          label="Generate dashboard name from title"
+        />
         <Button
           fullWidth
           variant="contained"
@@ -132,6 +143,7 @@ function GrafanaFlow({ dashboard }: GrafanaFlowProps): ReactElement {
               input: grafanaInput,
               grafanaDashboard: dashboard ?? {},
               useDefaultDatasource: useDefaultDatasource,
+              generateDashboardName: generateDashboardName,
             });
           }}
         >


### PR DESCRIPTION
# Description

When migrating a Grafana dashboard, the resulting Perses dashboard reused the Grafana UID as its `metadata.name`. Since the UID is often a cryptic auto-generated string (e.g. `aead1k2js`), it ends up being displayed in the search bar, home page, etc. rather than something readable.

This adds an opt-in to generate the technical name from the dashboard **title** instead — the same way a brand new dashboard is named (via the existing `generateMetadataName` helper). The Grafana UID is kept as a fallback when the title is empty or only contains characters that get stripped out during name generation.

The option is available across the three migration entry points:

- `generateDashboardName` field on the `/migrate` API request
- `--generate-dashboard-name` flag on `percli migrate`
- a checkbox in the Grafana import view

Example: a dashboard titled `Node Exporter Full` with UID `aead1k2js-4f21` migrates to `metadata.name: Node_Exporter_Full` when the option is enabled, and to `aead1k2js-4f21` when it isn't.

One note on naming: title-derived names are not guaranteed unique, which is why this stays opt-in and the UID remains the default behaviour.

Closes #3718

# Screenshots

New "Generate dashboard name from title" checkbox in the Grafana import view, next to the existing "Use default datasource in Perses" option (unchecked / checked):

_Screenshots attached below._
<img width="1444" height="1126" alt="image" src="https://github.com/user-attachments/assets/25feb525-78ee-4232-bfee-abbd3a394f44" />

<img width="1640" height="960" alt="image" src="https://github.com/user-attachments/assets/4535be3d-220b-4fd2-a424-a1e0dc1d517b" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`, `IGNORE`.
- [x] All commits have DCO signoffs.

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the UI guidelines.
- [ ] E2E tests are stable and unlikely to be flaky.