### PR TITLE
[FEATURE] Allow import of YAML dashboards

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -46,6 +46,7 @@
     "use-immer": "^0.11.0",
     "use-query-params": "^2.2.1",
     "use-resize-observer": "^9.0.0",
+    "yaml": "^2.9.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/ui/app/src/views/import/ImportView.tsx
+++ b/ui/app/src/views/import/ImportView.tsx
@@ -16,36 +16,14 @@ import AutoFix from 'mdi-material-ui/AutoFix';
 import Upload from 'mdi-material-ui/Upload';
 import { ChangeEvent, ReactElement, useState } from 'react';
 import { JSONEditor } from '@perses-dev/components';
-import { DashboardResource } from '@perses-dev/client';
 import { useIsMobileSize } from '../../utils/browser-size';
 import GrafanaFlow from './GrafanaFlow';
 import PersesFlow from './PersesFlow';
-
-type DashboardType = 'grafana' | 'perses';
-
-type Dashboard = GrafanaDashboard | PersesDashboard | undefined;
-
-interface GrafanaDashboard {
-  kind: 'grafana';
-  data: Record<string, unknown>;
-}
-
-interface PersesDashboard {
-  kind: 'perses';
-  data: DashboardResource;
-}
+import { Dashboard, parseDashboard } from './parse-dashboard';
 
 function ImportView(): ReactElement {
   const [dashboard, setDashboard] = useState<Dashboard>();
   const isMobileSize = useIsMobileSize();
-
-  const getDashboardType = (dashboard: Record<string, unknown>): DashboardType | undefined => {
-    if ('kind' in dashboard) {
-      return 'perses';
-    }
-
-    return 'grafana';
-  };
 
   const fileUploadOnChange = async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
     const files = event.target.files;
@@ -58,16 +36,9 @@ function ImportView(): ReactElement {
     }
   };
 
-  const completeDashboard = (dashboard: string | undefined): void => {
+  const completeDashboard = (definition: string | undefined): void => {
     try {
-      const json = JSON.parse(dashboard ?? '{}');
-      const type = getDashboardType(json);
-      if (type !== undefined) {
-        setDashboard({
-          kind: type,
-          data: json,
-        });
-      }
+      setDashboard(parseDashboard(definition));
     } catch (_) {
       setDashboard(undefined);
     }
@@ -84,7 +55,7 @@ function ImportView(): ReactElement {
           1. Provide a dashboard
         </Typography>
         <Button fullWidth startIcon={<Upload />} variant="outlined" component="label">
-          Upload JSON file
+          Upload JSON or YAML file
           <input type="file" onChange={fileUploadOnChange} hidden style={{ width: '100%' }} />
         </Button>
         <Divider>OR</Divider>
@@ -94,7 +65,7 @@ function ImportView(): ReactElement {
           minHeight="10rem"
           maxHeight="30rem"
           width="100%"
-          placeholder="Paste your Dashboard JSON here..."
+          placeholder="Paste your Dashboard JSON or YAML here..."
         />
         {dashboard !== undefined && dashboard.kind === 'grafana' && <GrafanaFlow dashboard={dashboard?.data} />}
         {dashboard !== undefined && dashboard.kind === 'perses' && <PersesFlow dashboard={dashboard?.data} />}

--- a/ui/app/src/views/import/parse-dashboard.test.tsx
+++ b/ui/app/src/views/import/parse-dashboard.test.tsx
@@ -1,0 +1,74 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '@testing-library/jest-dom';
+import { getDashboardType, parseDashboard } from './parse-dashboard';
+
+const GRAFANA_DASHBOARD = { panels: [{ title: 'CPU Usage', type: 'graph' }] };
+const PERSES_DASHBOARD = { kind: 'perses', spec: { duration: '1h' } };
+
+const YAML_GRAFANA = `
+panels:
+  - title: CPU Usage
+    type: graph
+`;
+
+const YAML_PERSES = `
+kind: perses
+spec:
+  duration: 1h
+`;
+
+const JSON_GRAFANA = JSON.stringify(GRAFANA_DASHBOARD);
+
+const JSON_PERSES = JSON.stringify(PERSES_DASHBOARD);
+
+describe('getDashboardType', () => {
+  it.each([
+    { name: 'detects grafana dashboard', input: { panels: [] }, expectedKind: 'grafana' as const },
+    { name: 'detects perses dashboard', input: { kind: 'perses' }, expectedKind: 'perses' as const },
+    { name: 'returns undefined when undefined is given', input: undefined, expectedKind: undefined },
+  ])('$name', ({ input, expectedKind }) => {
+    expect(getDashboardType(input)).toBe(expectedKind);
+  });
+});
+
+describe('parseDashboard - YAML', () => {
+  const cases = [
+    {
+      title: 'parses grafana dashboard',
+      data: YAML_GRAFANA,
+      expected: { kind: 'grafana', data: GRAFANA_DASHBOARD },
+    },
+    { title: 'parses perses dashboard', data: YAML_PERSES, expected: { kind: 'perses', data: PERSES_DASHBOARD } },
+    { title: 'returns undefined for invalid yaml', data: ':invalid: yaml: [broken', expected: undefined },
+  ];
+
+  it.each(cases)('$title', ({ data, expected }) => {
+    const result = parseDashboard(data);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('parseDashboard - JSON', () => {
+  const cases = [
+    { title: 'parses grafana dashboard', data: JSON_GRAFANA, expected: { kind: 'grafana', data: GRAFANA_DASHBOARD } },
+    { title: 'parses perses dashboard', data: JSON_PERSES, expected: { kind: 'perses', data: PERSES_DASHBOARD } },
+    { title: 'returns undefined for invalid json', data: '{not valid', expected: undefined },
+  ];
+
+  it.each(cases)('$title', ({ data, expected }) => {
+    const result = parseDashboard(data);
+    expect(result).toEqual(expected);
+  });
+});

--- a/ui/app/src/views/import/parse-dashboard.ts
+++ b/ui/app/src/views/import/parse-dashboard.ts
@@ -1,0 +1,45 @@
+import { DashboardResource } from '@perses-dev/client';
+import { parse } from 'yaml';
+
+type DashboardType = 'grafana' | 'perses';
+export type Dashboard = GrafanaDashboard | PersesDashboard | undefined;
+
+interface GrafanaDashboard {
+  kind: 'grafana';
+  data: Record<string, unknown>;
+}
+
+interface PersesDashboard {
+  kind: 'perses';
+  data: DashboardResource;
+}
+
+export function getDashboardType(dashboard: unknown): DashboardType | undefined {
+  if (typeof dashboard !== 'object' || dashboard === null) {
+    return undefined;
+  }
+
+  if ('kind' in dashboard) {
+    return 'perses';
+  } else {
+    return 'grafana';
+  }
+}
+
+export function parseDashboard(data: string | undefined): Dashboard | undefined {
+  try {
+    const value = parse(data ?? '{}');
+    const type = getDashboardType(value);
+
+    switch (type) {
+      case 'grafana':
+        return { kind: 'grafana', data: value };
+      case 'perses':
+        return { kind: 'perses', data: value };
+      default:
+        return undefined;
+    }
+  } catch (_) {
+    return undefined;
+  }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -87,6 +87,7 @@
         "use-immer": "^0.11.0",
         "use-query-params": "^2.2.1",
         "use-resize-observer": "^9.0.0",
+        "yaml": "^2.9.0",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -130,6 +131,21 @@
         "@rspack/core": {
           "optional": true
         }
+      }
+    },
+    "app/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "core": {


### PR DESCRIPTION
# Description

I've been surprised to not be able to directly import dashboards from the community mixins directly in Perses interface. Here is a PR allowing to load them without transforming them in JSON first.

Note: keeping in draft as it needs an update on the JSONEditor component to not display an error when YAML is pasted.

# Screenshots

<img width="1186" height="821" alt="image" src="https://github.com/user-attachments/assets/7a362a29-f689-4ba9-a1e3-1309e0be73f9" />

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
