### PR TITLE
[IGNORE] Use readErrorFile when yaml unmarshalling is failing

### DIFF
--- a/internal/cli/file/file.go
+++ b/internal/cli/file/file.go
@@ -185,14 +185,14 @@ func (u *unmarshaller) read() error {
 	if u.isJSON {
 		if jsonErr := json.Unmarshal(data, &objects); jsonErr != nil {
 			if jsonErr = json.Unmarshal(data, &object); jsonErr != nil {
-				return newReadFileErr(jsonErr)
+				return newReadFileErr(u.file, jsonErr)
 			}
 			objects = append(objects, object)
 		}
 	} else {
 		decodedObjects, decodeErr := decodeYAMLDocumentsAsObjects(data)
 		if decodeErr != nil {
-			return fmt.Errorf("unable to read file %q, format invalid: %w", u.file, decodeErr)
+			return newReadFileErr(u.file, decodeErr)
 		}
 		objects = decodedObjects
 	}

--- a/internal/cli/file/read.go
+++ b/internal/cli/file/read.go
@@ -37,6 +37,6 @@ func readAndDetect(file string) (data []byte, isJSON bool, err error) {
 	return
 }
 
-func newReadFileErr(err error) error {
-	return fmt.Errorf("unable to read file, format invalid: %w", err)
+func newReadFileErr(file string, err error) error {
+	return fmt.Errorf("unable to read file %q, format invalid: %w", file, err)
 }


### PR DESCRIPTION
small correction after https://github.com/perses/perses/pull/4332 changes