### PR TITLE
[ENHANCEMENT] Config: `frontend.time_range.options` is sorted in ascending order and values are verified

### DIFF
--- a/pkg/model/api/config/frontend.go
+++ b/pkg/model/api/config/frontend.go
@@ -65,7 +65,44 @@ func (t *TimeRange) Verify() error {
 	if len(t.Options) == 0 {
 		t.Options = defaultTimeRangeOptions
 	}
+	sortedOptions, err := sortTimeRangeOptions(t.Options)
+	if err != nil {
+		return err
+	}
+	t.Options = sortedOptions
 	return nil
+}
+
+// sortTimeRangeOptions returns the given duration options sorted in ascending order,
+// so that the time range dropdown in the UI is always displayed from shortest to longest.
+func sortTimeRangeOptions(options []common.DurationString) ([]common.DurationString, error) {
+	type parsedOption struct {
+		raw      common.DurationString
+		duration common.Duration
+	}
+	parsedOptions := make([]parsedOption, 0, len(options))
+	for _, opt := range options {
+		duration, err := common.ParseDuration(string(opt))
+		if err != nil {
+			return nil, fmt.Errorf("invalid frontend.time_range.options value '%s': %w", opt, err)
+		}
+		parsedOptions = append(parsedOptions, parsedOption{raw: opt, duration: duration})
+	}
+	slices.SortStableFunc(parsedOptions, func(a, b parsedOption) int {
+		switch {
+		case a.duration < b.duration:
+			return -1
+		case a.duration > b.duration:
+			return 1
+		default:
+			return 0
+		}
+	})
+	sorted := make([]common.DurationString, len(parsedOptions))
+	for i, opt := range parsedOptions {
+		sorted[i] = opt.raw
+	}
+	return sorted, nil
 }
 
 type Frontend struct {

--- a/pkg/model/api/config/frontend_test.go
+++ b/pkg/model/api/config/frontend_test.go
@@ -20,39 +20,50 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTimeRange_VerifyDefaultsAreSorted(t *testing.T) {
-	tr := &TimeRange{}
-	assert.NoError(t, tr.Verify())
-	assert.Equal(t, defaultTimeRangeOptions, tr.Options)
-}
-
-func TestTimeRange_VerifySortsCustomOptions(t *testing.T) {
-	tr := &TimeRange{
-		Options: []common.DurationString{"1h", "5m", "7d", "30m"},
+func TestTimeRange_Verify(t *testing.T) {
+	testSuite := []struct {
+		title           string
+		options         []common.DurationString
+		errMessage      string
+		expectedOptions []common.DurationString
+	}{
+		{
+			title:           "defaults are used and already sorted when no options are provided",
+			options:         nil,
+			expectedOptions: defaultTimeRangeOptions,
+		},
+		{
+			title:           "custom options are sorted ascending",
+			options:         []common.DurationString{"1h", "5m", "7d", "30m"},
+			expectedOptions: []common.DurationString{"5m", "30m", "1h", "7d"},
+		},
+		{
+			title:      "invalid option returns an error",
+			options:    []common.DurationString{"1h", "not-a-duration"},
+			errMessage: "not-a-duration",
+		},
+		{
+			title:           "already sorted options are kept as-is",
+			options:         []common.DurationString{"5m", "1h", "7d"},
+			expectedOptions: []common.DurationString{"5m", "1h", "7d"},
+		},
+		{
+			title:           "relative order of equivalent durations is kept",
+			options:         []common.DurationString{"60m", "1h", "5m"},
+			expectedOptions: []common.DurationString{"5m", "60m", "1h"},
+		},
 	}
-	assert.NoError(t, tr.Verify())
-	assert.Equal(t, []common.DurationString{"5m", "30m", "1h", "7d"}, tr.Options)
-}
 
-func TestTimeRange_VerifyRejectsInvalidOption(t *testing.T) {
-	tr := &TimeRange{
-		Options: []common.DurationString{"1h", "not-a-duration"},
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			tr := &TimeRange{Options: test.options}
+			err := tr.Verify()
+			if len(test.errMessage) == 0 {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedOptions, tr.Options)
+			} else {
+				assert.ErrorContains(t, err, test.errMessage)
+			}
+		})
 	}
-	assert.Error(t, tr.Verify())
-}
-
-func TestTimeRange_VerifyKeepsAlreadySortedOptions(t *testing.T) {
-	tr := &TimeRange{
-		Options: []common.DurationString{"5m", "1h", "7d"},
-	}
-	assert.NoError(t, tr.Verify())
-	assert.Equal(t, []common.DurationString{"5m", "1h", "7d"}, tr.Options)
-}
-
-func TestTimeRange_VerifyKeepsRelativeOrderOfEquivalentDurations(t *testing.T) {
-	tr := &TimeRange{
-		Options: []common.DurationString{"60m", "1h", "5m"},
-	}
-	assert.NoError(t, tr.Verify())
-	assert.Equal(t, []common.DurationString{"5m", "60m", "1h"}, tr.Options)
 }

--- a/pkg/model/api/config/frontend_test.go
+++ b/pkg/model/api/config/frontend_test.go
@@ -1,0 +1,58 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/perses/spec/go/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeRange_VerifyDefaultsAreSorted(t *testing.T) {
+	tr := &TimeRange{}
+	assert.NoError(t, tr.Verify())
+	assert.Equal(t, defaultTimeRangeOptions, tr.Options)
+}
+
+func TestTimeRange_VerifySortsCustomOptions(t *testing.T) {
+	tr := &TimeRange{
+		Options: []common.DurationString{"1h", "5m", "7d", "30m"},
+	}
+	assert.NoError(t, tr.Verify())
+	assert.Equal(t, []common.DurationString{"5m", "30m", "1h", "7d"}, tr.Options)
+}
+
+func TestTimeRange_VerifyRejectsInvalidOption(t *testing.T) {
+	tr := &TimeRange{
+		Options: []common.DurationString{"1h", "not-a-duration"},
+	}
+	assert.Error(t, tr.Verify())
+}
+
+func TestTimeRange_VerifyKeepsAlreadySortedOptions(t *testing.T) {
+	tr := &TimeRange{
+		Options: []common.DurationString{"5m", "1h", "7d"},
+	}
+	assert.NoError(t, tr.Verify())
+	assert.Equal(t, []common.DurationString{"5m", "1h", "7d"}, tr.Options)
+}
+
+func TestTimeRange_VerifyKeepsRelativeOrderOfEquivalentDurations(t *testing.T) {
+	tr := &TimeRange{
+		Options: []common.DurationString{"60m", "1h", "5m"},
+	}
+	assert.NoError(t, tr.Verify())
+	assert.Equal(t, []common.DurationString{"5m", "60m", "1h"}, tr.Options)
+}


### PR DESCRIPTION
# Description

The `frontend.time_range.options` config value lets an admin customize the list of
quick time range options shown in the UI's time range dropdown. `TimeRange.Verify()`
only checked whether the list was empty (falling back to the built-in defaults) but
never validated or sorted the values, so if an admin listed the durations out of
order in `config.yaml` (e.g. `1h, 5m, 7d, 30m`), the UI dropdown rendered them in
that same out-of-order sequence.

This PR sorts `frontend.time_range.options` ascending by parsed duration inside
`TimeRange.Verify()`, using `common.ParseDuration` from `github.com/perses/spec/go/common`.
As a side effect, a duration string that fails to parse now causes `Verify()` to
return an error instead of silently being kept in the list — previously such a value
could only reach `Verify()` via a value with an empty duration or a value assembled by
Go code (not by loading a real YAML/JSON config, since `common.DurationString`
already validates non-empty strings on unmarshal). This is a defensive tightening,
not expected to affect any currently working deployment.

The built-in default list (`5m, 15m, 30m, 1h, 6h, 12h, 24h, 7d, 14d`) was already in
ascending order, so default deployments are unaffected; only deployments with a
custom, out-of-order `options` list in their config will see a behavior change (the
dropdown will now render sorted).

# Screenshots

N/A — this is a backend config-validation change; no UI code in this repository was
modified. (The dropdown rendering component itself now lives in a separate
`perses/shared` repository and simply renders the `options` array in the order it
receives it, so sorting at the config layer here fixes the root cause for the config-driven case.)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

## Validation

- `go build ./pkg/model/api/config/...` — passes.
- `go vet ./pkg/model/api/config/...` — passes.
- `gofmt -l pkg/model/api/config/frontend.go pkg/model/api/config/frontend_test.go` — no output (correctly formatted).
- `golangci-lint run --timeout 5m ./pkg/model/api/config/...` (v2.12.2, matching CI's v2.12.1) — 0 issues.
- `go test ./pkg/model/api/config/... -count=1 -v` — all tests pass, including pre-existing tests
  (`TestJSONMarshalConfig`, `TestUnmarshalYAMLConfig`, etc.) and 5 new tests covering: sorting an
  out-of-order custom list, keeping an already-sorted list unchanged, stable ordering of
  equal-duration values, the (already-sorted) defaults, and rejecting an invalid duration string.
- Confirmed the new `TestTimeRange_VerifySortsCustomOptions` test fails on the pre-fix code
  (verified via `git stash`) and passes after the fix — this is the reproduction for the bug.
- Not run: `go build ./...` / `make test` — these require a prebuilt UI frontend dist to satisfy an
  `embedFS` symbol in `ui/endpoint.go`, and `make integration-test` requires Postgres/Prometheus
  service containers per CI. This is unrelated to the change (confirmed the same `embedFS` build
  failure exists on `main` without this diff) and out of scope for a change scoped entirely to
  `pkg/model/api/config`.