### PR TITLE
[ENHANCEMENT] update the statchart version to 0.14.0

### DIFF
--- a/scripts/plugin/plugin.yaml
+++ b/scripts/plugin/plugin.yaml
@@ -39,7 +39,7 @@
 - name: "Splunk"
   version: "0.1.0"
 - name: "StatChart"
-  version: "0.13.0"
+  version: "0.14.0"
 - name: "StaticListVariable"
   version: "0.9.0"
 - name: "StatusHistoryChart"


### PR DESCRIPTION
Update the `Statchart` version to 0.14.0

Statchart has an important fix and the version increased to 0.14.0 yesterday. 
Could we have this updated on the Perses please?

```json
{
  "name": "@perses-dev/stat-chart-plugin",
  "version": "0.14.0",
  "license": "Apache-2.0",
```
