### PR TITLE
[BUGFIX] Group changelog entries by pull request

### DIFF
--- a/scripts/pkg/changelog/changelog.go
+++ b/scripts/pkg/changelog/changelog.go
@@ -35,6 +35,12 @@ const (
 	doc            = "DOC"
 )
 
+const (
+	gitLogFieldSeparator  = "\x00"
+	gitLogRecordSeparator = "\x1e"
+	gitLogFormat          = "--pretty=format:%h%x00%P%x00%s%x00%b%x1e"
+)
+
 // kind represents the type of change.
 type kind int
 
@@ -47,6 +53,13 @@ const (
 	KindToBeIgnored
 	kindDoc
 )
+
+type gitLogEntry struct {
+	hash    string
+	parents string
+	subject string
+	body    string
+}
 
 func getStringInBetweenTwoString(str string, startS string, endS string) (result string, found bool) {
 	s := strings.Index(str, startS)
@@ -124,6 +137,139 @@ func parseAndFormatEntry(entry string) (kind, string) {
 	return catalogKind, strings.TrimSpace(strings.ReplaceAll(newEntry, fmt.Sprintf("[%s]", catalogEntry), ""))
 }
 
+func mergePullRequestNumber(subject string) (string, bool) {
+	const prefix = "merge pull request #"
+	lowerSubject := strings.ToLower(subject)
+	if !strings.HasPrefix(lowerSubject, prefix) {
+		return "", false
+	}
+	rest := subject[len(prefix):]
+	end := 0
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			break
+		}
+		end++
+	}
+	if end == 0 {
+		return "", false
+	}
+	return rest[:end], true
+}
+
+func firstNonEmptyLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		if trimmedLine := strings.TrimSpace(line); trimmedLine != "" {
+			return trimmedLine
+		}
+	}
+	return ""
+}
+
+func formatGitLogEntry(hash, subject, body string) string {
+	message := subject
+	if number, ok := mergePullRequestNumber(subject); ok {
+		if title := firstNonEmptyLine(body); title != "" {
+			message = title
+			if !strings.Contains(message, fmt.Sprintf("(#%s)", number)) {
+				message = fmt.Sprintf("%s (#%s)", message, number)
+			}
+		}
+	}
+	return fmt.Sprintf("%s %s", hash, message)
+}
+
+func (g gitLogEntry) raw() string {
+	return fmt.Sprintf("%s %s", g.hash, g.subject)
+}
+
+func (g gitLogEntry) pullRequestEntry() string {
+	return formatGitLogEntry(g.hash, g.subject, g.body)
+}
+
+func parseGitLogEntries(gitLogs []byte) []gitLogEntry {
+	records := strings.Split(string(gitLogs), gitLogRecordSeparator)
+	entries := make([]gitLogEntry, 0, len(records))
+	for _, record := range records {
+		record = strings.Trim(record, "\n")
+		if strings.TrimSpace(record) == "" {
+			continue
+		}
+		fields := strings.SplitN(record, gitLogFieldSeparator, 4)
+		if len(fields) < 4 {
+			continue
+		}
+		entries = append(entries, gitLogEntry{
+			hash:    fields[0],
+			parents: fields[1],
+			subject: fields[2],
+			body:    fields[3],
+		})
+	}
+	return entries
+}
+
+func getGitLogEntries(revisionRange string) []gitLogEntry {
+	// nolint: gosec
+	gitLogs, err := exec.Command("git", "log", revisionRange, gitLogFormat, "--no-decorate").Output()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to get the git logs")
+	}
+	return parseGitLogEntries(gitLogs)
+}
+
+func shouldGroupPullRequest(mergeEntry gitLogEntry, pullRequestEntries []gitLogEntry) bool {
+	mergeKind, _ := parseAndFormatEntry(mergeEntry.pullRequestEntry())
+	if mergeKind == kindUnknown || mergeKind == KindToBeIgnored {
+		return false
+	}
+	for _, entry := range pullRequestEntries {
+		entryKind, _ := parseAndFormatEntry(entry.raw())
+		if entryKind == KindToBeIgnored || entryKind == kindUnknown {
+			continue
+		}
+		if entryKind != mergeKind {
+			return false
+		}
+	}
+	return true
+}
+
+func groupPullRequestEntries(gitLogEntries []gitLogEntry, getPullRequestEntries func(string) []gitLogEntry) []string {
+	groupedCommits := map[string]struct{}{}
+	groupedMergeEntries := map[string]string{}
+	for _, entry := range gitLogEntries {
+		if _, ok := mergePullRequestNumber(entry.subject); !ok {
+			continue
+		}
+		parents := strings.Fields(entry.parents)
+		if len(parents) < 2 {
+			continue
+		}
+		pullRequestEntries := getPullRequestEntries(fmt.Sprintf("%s..%s", parents[0], parents[1]))
+		if !shouldGroupPullRequest(entry, pullRequestEntries) {
+			continue
+		}
+		groupedMergeEntries[entry.hash] = entry.pullRequestEntry()
+		for _, pullRequestEntry := range pullRequestEntries {
+			groupedCommits[pullRequestEntry.hash] = struct{}{}
+		}
+	}
+
+	entries := make([]string, 0, len(gitLogEntries))
+	for _, entry := range gitLogEntries {
+		if _, ok := groupedCommits[entry.hash]; ok {
+			continue
+		}
+		if groupedEntry, ok := groupedMergeEntries[entry.hash]; ok {
+			entries = append(entries, groupedEntry)
+			continue
+		}
+		entries = append(entries, entry.raw())
+	}
+	return entries
+}
+
 func InjectEntries(buffer *bytes.Buffer, entries []string, catalogEntry string) {
 	for _, entry := range entries {
 		buffer.WriteString(fmt.Sprintf("- %s %s\n", formatChangelogCategory(catalogEntry), entry)) //nolint: staticcheck
@@ -131,16 +277,8 @@ func InjectEntries(buffer *bytes.Buffer, entries []string, catalogEntry string) 
 }
 
 func GetGitLogs(previousVersion string) []string {
-	// nolint: gosec
-	gitLogs, err := exec.Command("git", "log", fmt.Sprintf("%s...HEAD", previousVersion), "--pretty=oneline", "--no-decorate").Output()
-	if err != nil {
-		logrus.WithError(err).Fatal("unable to get the git logs")
-	}
-	entries := strings.Split(string(gitLogs), "\n")
-	if lastLine := entries[len(entries)-1]; strings.TrimSpace(lastLine) == "" {
-		entries = entries[0 : len(entries)-1]
-	}
-	return entries
+	gitLogEntries := getGitLogEntries(fmt.Sprintf("%s...HEAD", previousVersion))
+	return groupPullRequestEntries(gitLogEntries, getGitLogEntries)
 }
 
 type Changelog struct {

--- a/scripts/pkg/changelog/changelog_test.go
+++ b/scripts/pkg/changelog/changelog_test.go
@@ -151,6 +151,241 @@ func TestParseAndFormatEntry(t *testing.T) {
 	}
 }
 
+func TestFormatGitLogEntry(t *testing.T) {
+	testSuite := []struct {
+		title    string
+		hash     string
+		subject  string
+		body     string
+		expected string
+	}{
+		{
+			title:    "commit entry is unchanged",
+			hash:     "f19355e87558177e6ad77d45bdd070fe99d62db6",
+			subject:  "[ENHANCEMENT] visual options and reset btn ux feedback (#850)",
+			expected: "f19355e87558177e6ad77d45bdd070fe99d62db6 [ENHANCEMENT] visual options and reset btn ux feedback (#850)",
+		},
+		{
+			title:   "merge pull request uses body title",
+			hash:    "6efcbec6538cec7bb674510ade1657a8f0292b24",
+			subject: "Merge pull request #439 from contributor/feat/bump-perses-0.54.0",
+			body: `[FEATURE] update perses dependency to v0.54.0
+
+Additional context.`,
+			expected: "6efcbec6538cec7bb674510ade1657a8f0292b24 [FEATURE] update perses dependency to v0.54.0 (#439)",
+		},
+		{
+			title:    "merge pull request does not duplicate PR number",
+			hash:     "28b82ced25c856799594bea0c733bede85bca18a",
+			subject:  "Merge pull request #456 from contributor/add-priority-class-name",
+			body:     "[FEATURE] add priorityClassName to Perses spec (#456)",
+			expected: "28b82ced25c856799594bea0c733bede85bca18a [FEATURE] add priorityClassName to Perses spec (#456)",
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			assert.Equal(t, test.expected, formatGitLogEntry(test.hash, test.subject, test.body))
+		})
+	}
+}
+
+func TestMergePullRequestNumber(t *testing.T) {
+	testSuite := []struct {
+		title          string
+		subject        string
+		expectedNumber string
+		expectedFound  bool
+	}{
+		{
+			title:          "GitHub merge commit",
+			subject:        "Merge pull request #428 from contributor/metrics-label",
+			expectedNumber: "428",
+			expectedFound:  true,
+		},
+		{
+			title:          "case insensitive",
+			subject:        "merge pull request #456 from contributor/add-priority-class-name",
+			expectedNumber: "456",
+			expectedFound:  true,
+		},
+		{
+			title:         "missing pull request number",
+			subject:       "Merge pull request # from repository/feature",
+			expectedFound: false,
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			number, found := mergePullRequestNumber(test.subject)
+			assert.Equal(t, test.expectedNumber, number)
+			assert.Equal(t, test.expectedFound, found)
+		})
+	}
+}
+
+func TestParseGitLogEntries(t *testing.T) {
+	gitLogs := []byte("ad29ece\x00base head\x00Merge pull request #428 from contributor/metrics-label\x00[ENHANCEMENT] Use specific reason labels in reconciliation error metrics\n\nAdditional context.\x1e")
+
+	assert.Equal(t, []gitLogEntry{
+		{
+			hash:    "ad29ece",
+			parents: "base head",
+			subject: "Merge pull request #428 from contributor/metrics-label",
+			body: `[ENHANCEMENT] Use specific reason labels in reconciliation error metrics
+
+Additional context.`,
+		},
+	}, parseGitLogEntries(gitLogs))
+}
+
+func TestGroupPullRequestEntries(t *testing.T) {
+	testSuite := []struct {
+		title              string
+		gitLogEntries      []gitLogEntry
+		pullRequestEntries []gitLogEntry
+		expectedEntries    []string
+		expectedChangelog  *Changelog
+	}{
+		{
+			title: "single kind PR is represented by its title",
+			gitLogEntries: []gitLogEntry{
+				{
+					hash:    "ad29ece08bb51cafa80df458ba0c79bc8f7ebaf9",
+					parents: "base head",
+					subject: "Merge pull request #428 from contributor/metrics-label",
+					body:    "[ENHANCEMENT] Use specific reason labels in reconciliation error metrics",
+				},
+				{
+					hash:    "15dd438928adc01edc8d116f25bd5bcef10203f6",
+					subject: "[ENHANCEMENT] Add promtool to managed tools and run alert tests in CI",
+				},
+				{
+					hash:    "e8d54754549de7d1dcf7f90da6094b9d56ab7804",
+					subject: "[ENHANCEMENT Use specific reason labels in reconciliation error metrics",
+				},
+			},
+			pullRequestEntries: []gitLogEntry{
+				{
+					hash:    "15dd438928adc01edc8d116f25bd5bcef10203f6",
+					subject: "[ENHANCEMENT] Add promtool to managed tools and run alert tests in CI",
+				},
+				{
+					hash:    "e8d54754549de7d1dcf7f90da6094b9d56ab7804",
+					subject: "[ENHANCEMENT Use specific reason labels in reconciliation error metrics",
+				},
+			},
+			expectedEntries: []string{
+				"ad29ece08bb51cafa80df458ba0c79bc8f7ebaf9 [ENHANCEMENT] Use specific reason labels in reconciliation error metrics (#428)",
+			},
+			expectedChangelog: &Changelog{
+				Enhancements: []string{"Use specific reason labels in reconciliation error metrics (#428)"},
+			},
+		},
+		{
+			title: "multi kind PR retains its commit entries",
+			gitLogEntries: []gitLogEntry{
+				{
+					hash:    "6efcbec6538cec7bb674510ade1657a8f0292b24",
+					parents: "base head",
+					subject: "Merge pull request #439 from repository/multi-kind",
+					body:    "[FEATURE] Add mixed changes",
+				},
+				{
+					hash:    "1b4e5f19c48b1a260749a047efb844a0d6af7b5d",
+					subject: "[FEATURE] Add user-facing feature",
+				},
+				{
+					hash:    "2348638d368dceda261775ff72badc74c56649b1",
+					subject: "[BUGFIX] Fix related behavior",
+				},
+			},
+			pullRequestEntries: []gitLogEntry{
+				{
+					hash:    "1b4e5f19c48b1a260749a047efb844a0d6af7b5d",
+					subject: "[FEATURE] Add user-facing feature",
+				},
+				{
+					hash:    "2348638d368dceda261775ff72badc74c56649b1",
+					subject: "[BUGFIX] Fix related behavior",
+				},
+			},
+			expectedEntries: []string{
+				"6efcbec6538cec7bb674510ade1657a8f0292b24 Merge pull request #439 from repository/multi-kind",
+				"1b4e5f19c48b1a260749a047efb844a0d6af7b5d [FEATURE] Add user-facing feature",
+				"2348638d368dceda261775ff72badc74c56649b1 [BUGFIX] Fix related behavior",
+			},
+			expectedChangelog: &Changelog{
+				Features: []string{"Add user-facing feature"},
+				BugFixes: []string{"Fix related behavior"},
+			},
+		},
+		{
+			title: "uncategorized merge retains existing ignore behavior",
+			gitLogEntries: []gitLogEntry{
+				{
+					hash:    "9b35947a2e3ed969dae2cbd0e248096305249c57",
+					parents: "base head",
+					subject: "Merge pull request #4323 from repository/release/v0.54",
+					body:    "Merge back release v0.54.0 to main",
+				},
+				{
+					hash:    "1b4e5f19c48b1a260749a047efb844a0d6af7b5d",
+					subject: "[FEATURE] Add user-facing feature",
+				},
+			},
+			pullRequestEntries: []gitLogEntry{
+				{
+					hash:    "1b4e5f19c48b1a260749a047efb844a0d6af7b5d",
+					subject: "[FEATURE] Add user-facing feature",
+				},
+			},
+			expectedEntries: []string{
+				"9b35947a2e3ed969dae2cbd0e248096305249c57 Merge pull request #4323 from repository/release/v0.54",
+				"1b4e5f19c48b1a260749a047efb844a0d6af7b5d [FEATURE] Add user-facing feature",
+			},
+			expectedChangelog: &Changelog{
+				Features: []string{"Add user-facing feature"},
+			},
+		},
+		{
+			title: "merge without a body retains existing ignore behavior",
+			gitLogEntries: []gitLogEntry{
+				{
+					hash:    "b5c64544efc4e4c71e0e6853de70d334a806a522",
+					parents: "base head",
+					subject: "Merge pull request #4324 from repository/feature",
+				},
+				{
+					hash:    "1b4e5f19c48b1a260749a047efb844a0d6af7b5d",
+					subject: "[FEATURE] Add user-facing feature",
+				},
+			},
+			pullRequestEntries: []gitLogEntry{
+				{
+					hash:    "1b4e5f19c48b1a260749a047efb844a0d6af7b5d",
+					subject: "[FEATURE] Add user-facing feature",
+				},
+			},
+			expectedEntries: []string{
+				"b5c64544efc4e4c71e0e6853de70d334a806a522 Merge pull request #4324 from repository/feature",
+				"1b4e5f19c48b1a260749a047efb844a0d6af7b5d [FEATURE] Add user-facing feature",
+			},
+			expectedChangelog: &Changelog{
+				Features: []string{"Add user-facing feature"},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			entries := groupPullRequestEntries(test.gitLogEntries, func(string) []gitLogEntry {
+				return test.pullRequestEntries
+			})
+			assert.Equal(t, test.expectedEntries, entries)
+			assert.Equal(t, test.expectedChangelog, New(entries))
+		})
+	}
+}
+
 func TestGenerateChangelog(t *testing.T) {
 	now := time.Now()
 	title := fmt.Sprintf("## 0.20.0 / %s", now.Format("2006-01-02"))


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

This commit addresses the issue where a pull request containing several commits of the same type were listed as individual entries in the changelog. It now uses the PR title and number as a single changelog entry.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
