### PR TITLE
[BUGFIX] Support curly braces ${} variable in variable validation

### DIFF
--- a/pkg/model/api/v1/utils/variable_build_order.go
+++ b/pkg/model/api/v1/utils/variable_build_order.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 
 	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
@@ -29,7 +30,8 @@ import (
 
 // Not similar to variable validation regex (\w*?[^0-9]\w*), because some PromQL expression may need variable name with only number
 // For example in PromQL, in the function `label_replace`, it used the syntax $1, $2, for the placeholder.
-var variableSyntaxRegexp = regexp.MustCompile(`\$(\w+)`)
+// It also supports the curly braces syntax ${} to align with frontend.
+var variableSyntaxRegexp = regexp.MustCompile(`\$(\w+|{\w+})`)
 
 type VariableGroup struct {
 	Variables []string
@@ -239,6 +241,7 @@ func parseVariableUsed(str string) [][]string {
 	matches := variableSyntaxRegexp.FindAllStringSubmatch(str, -1)
 	var result [][]string
 	for _, match := range matches {
+		match[1] = strings.Trim(match[1], "{}")
 		if _, err := strconv.Atoi(match[1]); err != nil {
 			// We want to keep only variables that are not only a number.
 			// A number that represents a variable is not meaningful, and so we don't want to consider it.

--- a/pkg/model/api/v1/utils/variable_build_order_test.go
+++ b/pkg/model/api/v1/utils/variable_build_order_test.go
@@ -404,6 +404,67 @@ func TestBuildVariableDependencies(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "variable with curly braces syntax",
+			variables: []dashboard.Variable{
+				{
+					Kind: variable.KindText,
+					Spec: &dashboard.TextVariableSpec{
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
+						},
+						Name: "filter_platform",
+					},
+				},
+				{
+					Kind: variable.KindText,
+					Spec: &dashboard.TextVariableSpec{
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
+						},
+						Name: "PaaS",
+					},
+				},
+				{
+					Kind: variable.KindText,
+					Spec: &dashboard.TextVariableSpec{
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
+						},
+						Name: "filter_kube_sts",
+					},
+				},
+				{
+					Kind: variable.KindText,
+					Spec: &dashboard.TextVariableSpec{
+						TextSpec: variable.TextSpec{
+							Value: "myConstant",
+						},
+						Name: "extlabels_prometheus_namespace",
+					},
+				},
+				{
+					Kind: variable.KindList,
+					Spec: &dashboard.ListVariableSpec{
+						ListSpec: variable.ListSpec{
+							Plugin: plugin.Plugin{
+								Kind: "PrometheusPromQLVariable",
+								Spec: map[string]any{
+									"expr":      "group by(prometheus) (label_replace(kube_statefulset_labels{${filter_platform},stack=~\"$PaaS\",$filter_kube_sts,stack=~\"$PaaS\",namespace=~\"$extlabels_prometheus_namespace\"},\"prometheus\",\"$1\",\"label_app_kubernetes_io_instance\",\"([^-]+)-?.*\"))",
+									"labelName": "prometheus",
+								},
+							},
+						},
+						Name: "foo",
+					},
+				},
+			},
+			result: map[string][]string{
+				"foo": {
+					"filter_platform", "PaaS", "filter_kube_sts", "extlabels_prometheus_namespace",
+				},
+			},
+		},
 	}
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR fixes the validation of variable. Let's say a non existing variable is used with syntax $nonexistingvar, then the save of the dashboard will fail with message ``bad request: variable "nonexistingvar" is used in the variable "var" but not defined``

But when we use the syntax ${nonexistingvar}, the backend accepts it, and it shouldn't.

With this PR, it refuses it properly 
<img width="1092" height="587" alt="image" src="https://github.com/user-attachments/assets/5aa38a92-b983-4bfb-a07c-9c384def5e93" />


<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
