### PR TITLE
[FEATURE] Enable decompress middleware for all route

### DIFF
--- a/internal/api/core/core.go
+++ b/internal/api/core/core.go
@@ -110,6 +110,7 @@ func New(conf config.Config, enablePprof bool, registry *prometheus.Registry, ba
 				// When serving the plugins from a dev server, we don't want to compress the response since it's already compressed by rsbuild.
 				(conf.Plugin.EnableDev && strings.HasPrefix(c.Request().URL.Path, fmt.Sprintf("%s/plugins", conf.APIPrefix)))
 		}).
+		PreMiddleware(echoMiddleware.Decompress()).
 		Middleware(middleware.HandleError()).
 		Middleware(middleware.CheckProject(dependencyManager.Service().GetProject()))
 	if !conf.Frontend.Disable {


### PR DESCRIPTION
This PR enables the middleware to decompress body that would have been compressed. The header `Content-Encoding` needs to be set with the value `gzip` to use this functionality.