### PR TITLE
[FEATURE] (go-sdk): add dashboard.Timezone option for Spec.timezone

### DIFF
--- a/docs/concepts/timezone.md
+++ b/docs/concepts/timezone.md
@@ -61,19 +61,49 @@ When formatting dates, the following options are available:
 - **`timeZone`**: The timezone to use for formatting (default: browser's timezone)
 - **`referenceTime`**: Reference time for relative formatting (default: current time)
 
-## Future Enhancements
+## Resolution hierarchy
 
-Perses plans to support a multi-level timezone configuration system. The following levels are expected (in order of precedence, highest to lowest):
+Timezone configuration follows this precedence (highest to lowest):
 
-1. **Panel-Level**: Timezone specified directly on a panel
-2. **Dashboard-Level**: Timezone specified for an entire dashboard
+1. **Panel-Level**: Timezone specified directly on a panel (when supported by the plugin)
+2. **Dashboard-Level**: `spec.timezone` on the dashboard resource
 3. **User Preference**: User's personal timezone preference set in their profile
-4. **Project-Level**: Default timezone for a project
-5. **Global Configuration**: System-wide default configured on the Perses server
-6. **Browser Default**: Fallback to the browser's detected timezone
+4. **Server default**: `frontend.default_user_preferences.timezone` (and related global config)
+5. **Browser Default**: Fallback to the browser's detected timezone
 
-!!! note
-    These configuration levels are still being developed. This document will be updated as the feature evolves.
+### Dashboard-level (`spec.timezone`)
+
+Set an IANA timezone name on the dashboard so all users see the same wall clock (e.g. ops dashboards in GMT/UTC):
+
+| Value | Meaning |
+|-------|---------|
+| omitted / `""` | inherit lower levels |
+| `"local"` | browser local timezone |
+| `"UTC"` | UTC (GMT) |
+| `"Europe/Paris"`, … | any valid IANA zone |
+
+#### Dashboard-as-Code (Go SDK)
+
+```go
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+)
+
+builder, err := dashboard.New("SpaceView",
+	dashboard.ProjectName("irt"),
+	dashboard.Duration(/* … */),
+	dashboard.Timezone("UTC"), // GMT wall clock for all viewers
+)
+```
+
+The field is stored on the dashboard JSON/YAML as:
+
+```yaml
+spec:
+  timezone: UTC
+```
+
+Validation accepts `""`, `"local"`, or any name loadable by the Go `time` package (`time.LoadLocation`).
 
 ## Best Practices
 

--- a/go-sdk/dashboard/options.go
+++ b/go-sdk/dashboard/options.go
@@ -105,6 +105,35 @@ func Duration(seconds time.Duration) Option {
 	}
 }
 
+// Timezone sets Spec.Timezone on the dashboard.
+//
+// Accepted values:
+//   - "" (empty): leave unset so lower-priority defaults apply
+//   - "local": use the browser's local timezone
+//   - any IANA timezone name (e.g. "UTC", "Europe/Paris", "America/New_York")
+//
+// When set, this value takes precedence over user preference, server default, and browser local
+// in the timezone resolution hierarchy. See docs/concepts/timezone.md.
+func Timezone(tz string) Option {
+	return func(builder *Builder) error {
+		if err := validateDashboardTimezone(tz); err != nil {
+			return err
+		}
+		builder.Dashboard.Spec.Timezone = tz
+		return nil
+	}
+}
+
+func validateDashboardTimezone(tz string) error {
+	if tz == "" || tz == "local" {
+		return nil
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		return fmt.Errorf("invalid timezone %q: %w", tz, err)
+	}
+	return nil
+}
+
 func AddPanelGroup(title string, options ...panelgroup.Option) Option {
 	return func(builder *Builder) error {
 		r, err := panelgroup.New(title, options...)

--- a/go-sdk/dashboard/options_timezone_test.go
+++ b/go-sdk/dashboard/options_timezone_test.go
@@ -1,0 +1,86 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimezoneOption(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		title         string
+		name          string
+		timezone      string
+		wantErr       bool
+		wantTimezone  string
+		checkJSONEmit bool
+	}{
+		{
+			title:         "UTC is accepted and emitted in JSON",
+			name:          "spaceview",
+			timezone:      "UTC",
+			wantTimezone:  "UTC",
+			checkJSONEmit: true,
+		},
+		{
+			title:        "local is accepted",
+			name:         "local-tz",
+			timezone:     "local",
+			wantTimezone: "local",
+		},
+		{
+			title:        "IANA zone is accepted",
+			name:         "paris-tz",
+			timezone:     "Europe/Paris",
+			wantTimezone: "Europe/Paris",
+		},
+		{
+			title:    "invalid timezone is rejected",
+			name:     "bad-tz",
+			timezone: "Not/A_Real_Place",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := New(tc.name, Timezone(tc.timezone))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantTimezone, b.Dashboard.Spec.Timezone)
+
+			if !tc.checkJSONEmit {
+				return
+			}
+			raw, err := json.Marshal(b.Dashboard)
+			require.NoError(t, err)
+			var m map[string]any
+			require.NoError(t, json.Unmarshal(raw, &m))
+			spec, ok := m["spec"].(map[string]any)
+			require.True(t, ok, "missing spec in %s", raw)
+			assert.Equal(t, tc.wantTimezone, spec["timezone"])
+		})
+	}
+}


### PR DESCRIPTION
# Description

Implementing dahboards with Dashboard-as-Code solution, I could not set spec.timezone via the Go SDK, even though the field already exists on github.com/perses/spec (dashboard.Spec.Timezone) and is part of the UI timezone resolution hierarchy:

dashboard.spec.timezone > user preference > server default > browser local

This PR adds:

- dashboard.Timezone(tz string) Option in go-sdk/dashboard
- Validation aligned with frontend preferences: empty, "local", or a valid IANA name (time.LoadLocation)
- Unit tests for UTC, local, and invalid values
- Docs update in docs/concepts/timezone.md (hierarchy + DaC example)

**Example:**

```go
builder, err := dashboard.New("MyDashboard",
    dashboard.ProjectName("myProject"),
    dashboard.Timezone("UTC"),
)
```