### PR TITLE
fix: correct 'not knowm' typo in the same_site error message

### DIFF
--- a/pkg/model/api/config/security.go
+++ b/pkg/model/api/config/security.go
@@ -46,7 +46,7 @@ func ParseSameSite(s string) (SameSite, error) {
 	case SameSiteStrictMode:
 		return SameSite(http.SameSiteStrictMode), nil
 	default:
-		return 0, fmt.Errorf("cookie same_site %q mode not knowm", s)
+		return 0, fmt.Errorf("cookie same_site %q mode not known", s)
 	}
 }
 


### PR DESCRIPTION
The error returned for an unrecognised `cookie same_site` value reads `mode not knowm`. Corrects it to `known`.

User-facing error text only, no behaviour change.