### PR TITLE
[DOC] Fix typos in troubleshooting doc, client error message and comments

### DIFF
--- a/docs/troubleshooting-tls-plain-http-datasource.md
+++ b/docs/troubleshooting-tls-plain-http-datasource.md
@@ -8,7 +8,7 @@ When you try now to create some dashboards you will see a "Load failed" error me
 
 ## Diagnostics
 
-When you use the browser inspector and look at the JavaScript console output you will find the error message: "Fetch API cannot load http://:9009/prometheus/api/v1/guery_range due to access control checks."
+When you use the browser inspector and look at the JavaScript console output you will find the error message: "Fetch API cannot load http://:9009/prometheus/api/v1/query_range due to access control checks."
 
 ![Screenshot from the fetch API error message using a HTTP datasource](https://github.com/user-attachments/assets/27b745f4-dccc-4112-bf2d-6b88cf23d0a1 "Fetch API error message")
 

--- a/internal/api/authorization/authorization.go
+++ b/internal/api/authorization/authorization.go
@@ -40,7 +40,7 @@ type Authorization interface {
 	// You should consider the case where the context can be empty and that the function can be called from an anonymous endpoint.
 	// To check if it is called from an anonymous endpoint, you can use the function utils.IsAnonymous.
 	// In case the context is not empty, and it is not an anonymous endpoint, the user information should be set in the context.
-	// If it is not the case, you should return an error. All further functions are dependant on the results of theses decisions.
+	// If it is not the case, you should return an error. All further functions are dependent on the results of these decisions.
 	GetUser(ctx echo.Context) (any, error)
 	// GetUsername returns the username/the login of the user from the context.
 	GetUsername(ctx echo.Context) (string, error)

--- a/pkg/client/perseshttp/request.go
+++ b/pkg/client/perseshttp/request.go
@@ -314,8 +314,8 @@ func (r *Response) Error() error {
 			response := &errorResponse{}
 			err := json.Unmarshal(r.body, &response)
 			if err != nil {
-				// in this case something horrible append on client side
-				e.Err = fmt.Errorf("something horrible occured when the client tried to decode the error message: %w", err)
+				// in this case something horrible happened on client side
+				e.Err = fmt.Errorf("something horrible occurred when the client tried to decode the error message: %w", err)
 			} else {
 				e.Message = response.Message
 			}


### PR DESCRIPTION
Found a few typos while reading through the repo. The troubleshooting doc for plain HTTP datasources quotes the browser error and spells the Prometheus endpoint as guery_range, it should be query_range. In pkg/client/perseshttp/request.go the returned error says "something horrible occured" and everywhere else in the codebase it is spelled occurred, so I made it consistent, and the comment right above it said "append" where it meant "happened". Last one is in internal/api/authorization/authorization.go where a doc comment says "dependant" and "theses decisions". All of these are text only, no logic changed and no test depends on the strings.