### PR TITLE
[FEATURE] Add metrics+logs+traces demo dashboard to dev environment

### DIFF
--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -41,6 +41,8 @@ frontend:
     - project: "perses"
       dashboard: "Demo"
     - project: "perses"
+      dashboard: "ThreeSignals"
+    - project: "perses"
       dashboard: "NodeExporter"
     - project: "perses"
       dashboard: "Benchmark"

--- a/dev/data/9-dashboard.json
+++ b/dev/data/9-dashboard.json
@@ -12378,5 +12378,281 @@
       ],
       "duration": "1h"
     }
+  },
+  {
+    "kind": "Dashboard",
+    "metadata": {
+      "name": "ThreeSignals",
+      "project": "perses",
+      "createdAt": "2021-11-09T00:00:00Z",
+      "updatedAt": "2021-11-09T00:00:00Z",
+      "version": 0
+    },
+    "spec": {
+      "display": {
+        "name": "Three Signals: Metrics + Logs + Traces",
+        "description": "A single Perses dashboard showing all three observability signals side by side: metrics (Prometheus), traces (Tempo) and logs (Loki). Uses the local dev datasources (PrometheusLocal, TempoLocal, LokiLocal) and the generators from dev/docker-compose.yaml (profiles: prometheus, tempo, loki)."
+      },
+      "duration": "1h",
+      "refreshInterval": "15s",
+      "panels": {
+        "RequestRate": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "METRICS \u2014 HTTP requests by handler",
+              "description": "Per-handler HTTP request rate over the last 5 minutes (Prometheus)."
+            },
+            "plugin": {
+              "kind": "TimeSeriesChart",
+              "spec": {
+                "legend": {
+                  "mode": "list",
+                  "position": "bottom"
+                },
+                "visual": {
+                  "areaOpacity": 0.15,
+                  "lineWidth": 1.5
+                }
+              }
+            },
+            "queries": [
+              {
+                "kind": "TimeSeriesQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "PrometheusTimeSeriesQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "PrometheusDatasource",
+                        "name": "PrometheusLocal"
+                      },
+                      "query": "sum by (handler) (rate(prometheus_http_requests_total[5m]))",
+                      "seriesNameFormat": "{{handler}}"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "TotalRequests": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "METRICS \u2014 Total request rate",
+              "description": "Overall HTTP request rate (Prometheus)."
+            },
+            "plugin": {
+              "kind": "StatChart",
+              "spec": {
+                "calculation": "last-number",
+                "format": {
+                  "unit": "requests/sec",
+                  "decimalPlaces": 1
+                }
+              }
+            },
+            "queries": [
+              {
+                "kind": "TimeSeriesQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "PrometheusTimeSeriesQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "PrometheusDatasource",
+                        "name": "PrometheusLocal"
+                      },
+                      "query": "sum(rate(prometheus_http_requests_total[5m]))"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "RecentTraces": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "TRACES \u2014 Recent traces by duration",
+              "description": "Scatter plot of recently ingested traces (Tempo). Click a point to open the trace."
+            },
+            "plugin": {
+              "kind": "ScatterChart",
+              "spec": {}
+            },
+            "queries": [
+              {
+                "kind": "TraceQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "TempoTraceQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "TempoDatasource",
+                        "name": "TempoLocal"
+                      },
+                      "query": "{}"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "TracesTable": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "TRACES \u2014 Trace list",
+              "description": "List of recent traces returned by Tempo."
+            },
+            "plugin": {
+              "kind": "TraceTable",
+              "spec": {}
+            },
+            "queries": [
+              {
+                "kind": "TraceQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "TempoTraceQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "TempoDatasource",
+                        "name": "TempoLocal"
+                      },
+                      "query": "{}"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "GeneratedLogs": {
+          "kind": "Panel",
+          "spec": {
+            "display": {
+              "name": "LOGS \u2014 Application logs",
+              "description": "Streaming application logs from the log generator (Loki)."
+            },
+            "plugin": {
+              "kind": "LogsTable",
+              "spec": {
+                "allowWrap": true,
+                "enableDetails": true,
+                "showTime": true
+              }
+            },
+            "queries": [
+              {
+                "kind": "LogQuery",
+                "spec": {
+                  "plugin": {
+                    "kind": "LokiLogQuery",
+                    "spec": {
+                      "datasource": {
+                        "kind": "LokiDatasource",
+                        "name": "LokiLocal"
+                      },
+                      "query": "{app=\"log-generator\"}"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "layouts": [
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "Metrics",
+              "collapse": {
+                "open": true
+              }
+            },
+            "items": [
+              {
+                "x": 0,
+                "y": 0,
+                "width": 6,
+                "height": 8,
+                "content": {
+                  "$ref": "#/spec/panels/TotalRequests"
+                }
+              },
+              {
+                "x": 6,
+                "y": 0,
+                "width": 18,
+                "height": 8,
+                "content": {
+                  "$ref": "#/spec/panels/RequestRate"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "Traces",
+              "collapse": {
+                "open": true
+              }
+            },
+            "items": [
+              {
+                "x": 0,
+                "y": 0,
+                "width": 12,
+                "height": 9,
+                "content": {
+                  "$ref": "#/spec/panels/RecentTraces"
+                }
+              },
+              {
+                "x": 12,
+                "y": 0,
+                "width": 12,
+                "height": 9,
+                "content": {
+                  "$ref": "#/spec/panels/TracesTable"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "Grid",
+          "spec": {
+            "display": {
+              "title": "Logs",
+              "collapse": {
+                "open": true
+              }
+            },
+            "items": [
+              {
+                "x": 0,
+                "y": 0,
+                "width": 24,
+                "height": 10,
+                "content": {
+                  "$ref": "#/spec/panels/GeneratedLogs"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## What this does

Adds a `ThreeSignals` dashboard to the dev provisioning (`dev/data`) that shows all three observability signals in one place:

- **Metrics** (Prometheus): total request rate stat + per-handler HTTP request rate time series
- **Traces** (Tempo): recent traces scatter chart + trace list table
- **Logs** (Loki): streaming application logs table

## Why

It gives contributors a ready-made, single-dashboard demo of Perses' multi-signal capability the moment they start the dev environment — useful for demos and for exercising the Loki/Tempo/Prometheus panels together.

## How it works

- Reuses the existing local dev datasources (`PrometheusLocal`, `TempoLocal`, `LokiLocal`).
- Uses the log/trace/metric generators already defined in `dev/docker-compose.yaml` (profiles: `prometheus`, `tempo`, `loki`).
- Pinned via `frontend.important_dashboards` so it surfaces on the dev home page.

## Try it

```bash
docker compose -f dev/docker-compose.yaml --profile prometheus --profile tempo --profile loki up -d
./scripts/api_backend_dev.sh   # admin / password
# open: perses -> ThreeSignals
```

## Validation

Validated with `percli lint --online` ("your resources look good"). Diff is a pure addition (no reformatting of existing dev resources).