### PR TITLE
[BUGFIX] prevent infinite spinner when creating dashboards on an empty project

### DIFF
--- a/ui/app/src/validation/dashboard.ts
+++ b/ui/app/src/validation/dashboard.ts
@@ -76,7 +76,7 @@ export function useDashboardValidationSchema(projectName?: string): DashboardVal
     }
 
     if (!dashboards?.length)
-      return { schema: createDashboardDialogValidationSchema, isSchemaLoading: true, hasSchemaError: false };
+      return { schema: createDashboardDialogValidationSchema, isSchemaLoading: false, hasSchemaError: false };
 
     const refinedSchema = createDashboardDialogValidationSchema.refine(
       (schema) => {


### PR DESCRIPTION
# Description

This fixes an issue in which an infinite spinner is shown and a dashboard cannot be created in an empty project.

# Screenshots

NO UI changes:

Before:

<img width="1478" height="929" alt="Screenshot 2026-09-04 at 14 55 08" src="https://github.com/user-attachments/assets/a09eb7ca-ae2f-4bdd-a6ba-b4fd5eea26f1" />

After:

<img width="1476" height="928" alt="Screenshot 2026-09-04 at 14 55 57" src="https://github.com/user-attachments/assets/64a93bb4-7732-4adc-a227-23d819ba67d9" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
