### PR TITLE
[ENHANCEMENT] `percli dac preview`: add new flag `--create-project`

### DIFF
--- a/internal/cli/cmd/apply/apply.go
+++ b/internal/cli/cmd/apply/apply.go
@@ -14,12 +14,10 @@
 package apply
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/efficientgo/core/merrors"
-	apiInterface "github.com/perses/perses/internal/api/interface"
 	persesCMD "github.com/perses/perses/internal/cli/cmd"
 	"github.com/perses/perses/internal/cli/config"
 	"github.com/perses/perses/internal/cli/file"
@@ -27,7 +25,6 @@ import (
 	"github.com/perses/perses/internal/cli/resource"
 	"github.com/perses/perses/internal/cli/service"
 	"github.com/perses/perses/pkg/client/api"
-	"github.com/perses/perses/pkg/client/perseshttp"
 	modelAPI "github.com/perses/perses/pkg/model/api"
 	modelV1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/spf13/cobra"
@@ -112,16 +109,8 @@ func (o *option) applyEntity() error {
 		kind := modelV1.Kind(entity.GetKind())
 		name := entity.GetMetadata().GetName()
 		project := resource.GetProject(entity.GetMetadata(), o.Project)
-		if upsertError := o.upsertEntity(kind, project, entity); upsertError != nil {
-			// If the apply failed because the project doesn't exist, and the user has asked to auto-create the project
-			// then we will try to create the project and re-apply the resource.
-			if isProjectDoesNotExistError(upsertError) && o.createProject && !modelV1.IsGlobal(kind) {
-				if upsertError = o.applyEntityWithProjectCreation(kind, project, entity); upsertError != nil {
-					return upsertError
-				}
-			} else {
-				return upsertError
-			}
+		if upsertError := service.UpsertWithProjectCreation(o.apiClient, kind, project, entity, o.createProject); upsertError != nil {
+			return upsertError
 		}
 
 		if outputError := resource.HandleSuccessMessage(o.writer, kind, project, fmt.Sprintf("object %q %q has been applied", kind, name)); outputError != nil {
@@ -129,48 +118,6 @@ func (o *option) applyEntity() error {
 		}
 	}
 	return nil
-}
-
-func (o *option) applyEntityWithProjectCreation(kind modelV1.Kind, project string, entity modelAPI.Entity) error {
-	if len(project) == 0 {
-		return fmt.Errorf("unable to create missing project: project is not set")
-	}
-
-	projectService, projectServiceErr := service.New(modelV1.KindProject, "", o.apiClient)
-	if projectServiceErr != nil {
-		return projectServiceErr
-	}
-
-	projectEntity := &modelV1.Project{
-		Kind: modelV1.KindProject,
-		Metadata: modelV1.Metadata{
-			Name: project,
-		},
-	}
-	if _, projectCreationErr := projectService.CreateResource(projectEntity); projectCreationErr != nil && !errors.Is(projectCreationErr, perseshttp.ConflictError) {
-		return projectCreationErr
-	}
-
-	// Retry once the original request against the newly created project.
-	return o.upsertEntity(kind, project, entity)
-}
-
-func (o *option) upsertEntity(kind modelV1.Kind, project string, entity modelAPI.Entity) error {
-	svc, svcErr := service.New(kind, project, o.apiClient)
-	if svcErr != nil {
-		return svcErr
-	}
-
-	return service.Upsert(svc, entity)
-}
-
-func isProjectDoesNotExistError(err error) bool {
-	var requestErr *perseshttp.RequestError
-	if !errors.As(err, &requestErr) {
-		return false
-	}
-
-	return apiInterface.IsProjectDoesNotExistErrorMessage(requestErr.Message)
 }
 
 func (o *option) SetWriter(writer io.Writer) {

--- a/internal/cli/cmd/dac/preview/preview.go
+++ b/internal/cli/cmd/dac/preview/preview.go
@@ -63,13 +63,14 @@ type option struct {
 	opt.FileOption
 	opt.DirectoryOption
 	opt.OutputOption
-	dashboards   []*modelV1.Dashboard
-	writer       io.Writer
-	errWriter    io.Writer
-	apiClient    api.ClientInterface
-	ttl          common.Duration
-	ttlAsAString string
-	prefix       string
+	dashboards    []*modelV1.Dashboard
+	writer        io.Writer
+	errWriter     io.Writer
+	apiClient     api.ClientInterface
+	ttl           common.Duration
+	ttlAsAString  string
+	prefix        string
+	createProject bool
 }
 
 func (o *option) Complete(args []string) error {
@@ -108,12 +109,7 @@ func (o *option) Execute() error {
 			dashboard.Spec.Display.Name = fmt.Sprintf("%s-%s", o.prefix, dashboard.Spec.Display.Name)
 		}
 		ephemeralDashboard := newEphemeralDashboard(project, name, o.ttl, dashboard)
-		svc, svcErr := service.New(modelV1.KindEphemeralDashboard, project, o.apiClient)
-		if svcErr != nil {
-			return svcErr
-		}
-
-		if upsertError := service.Upsert(svc, ephemeralDashboard); upsertError != nil {
+		if upsertError := service.UpsertWithProjectCreation(o.apiClient, modelV1.KindEphemeralDashboard, project, ephemeralDashboard, o.createProject); upsertError != nil {
 			return upsertError
 		}
 		response = append(response, o.buildPreviewResponse(dashboard, ephemeralDashboard))
@@ -200,5 +196,6 @@ percli dac preview -d ./build
 	opt.AddDirectoryFlags(cmd, &o.DirectoryOption)
 	cmd.Flags().StringVar(&o.ttlAsAString, "ttl", "1d", "Time To Live of the dashboard preview")
 	cmd.Flags().StringVar(&o.prefix, "prefix", "", "If provided, it is used to prefix the dashboard preview name")
+	cmd.Flags().BoolVar(&o.createProject, "create-project", false, "If present, the command creates the resolved target project when the preview fails because the project does not exist, then retries once")
 	return cmd
 }

--- a/internal/cli/service/service.go
+++ b/internal/cli/service/service.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 
+	apiInterface "github.com/perses/perses/internal/api/interface"
 	"github.com/perses/perses/pkg/client/api"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	modelAPI "github.com/perses/perses/pkg/model/api"
@@ -50,6 +51,55 @@ func Upsert(svc Service, entity modelAPI.Entity) error {
 	}
 	_, updateErr := svc.UpdateResource(entity)
 	return updateErr
+}
+
+// UpsertWithProjectCreation behaves like Upsert, except that, when createProject is true and the upsert fails
+// because the target project doesn't exist, it will create the project and retry the upsert once.
+func UpsertWithProjectCreation(apiClient api.ClientInterface, kind modelV1.Kind, project string, entity modelAPI.Entity, createProject bool) error {
+	svc, svcErr := New(kind, project, apiClient)
+	if svcErr != nil {
+		return svcErr
+	}
+	upsertErr := Upsert(svc, entity)
+	if upsertErr == nil {
+		return nil
+	}
+	if !isProjectDoesNotExistError(upsertErr) || !createProject || modelV1.IsGlobal(kind) {
+		return upsertErr
+	}
+	if err := createProjectIfMissing(apiClient, project); err != nil {
+		return err
+	}
+	// Retry once the original request against the newly created project.
+	return Upsert(svc, entity)
+}
+
+func createProjectIfMissing(apiClient api.ClientInterface, project string) error {
+	if len(project) == 0 {
+		return fmt.Errorf("unable to create missing project: project is not set")
+	}
+	projectSvc, projectSvcErr := New(modelV1.KindProject, "", apiClient)
+	if projectSvcErr != nil {
+		return projectSvcErr
+	}
+	projectEntity := &modelV1.Project{
+		Kind: modelV1.KindProject,
+		Metadata: modelV1.Metadata{
+			Name: project,
+		},
+	}
+	if _, err := projectSvc.CreateResource(projectEntity); err != nil && !errors.Is(err, perseshttp.ConflictError) {
+		return err
+	}
+	return nil
+}
+
+func isProjectDoesNotExistError(err error) bool {
+	var requestErr *perseshttp.RequestError
+	if !errors.As(err, &requestErr) {
+		return false
+	}
+	return apiInterface.IsProjectDoesNotExistErrorMessage(requestErr.Message)
 }
 
 type Service interface {

--- a/internal/cli/service/service.go
+++ b/internal/cli/service/service.go
@@ -64,6 +64,8 @@ func UpsertWithProjectCreation(apiClient api.ClientInterface, kind modelV1.Kind,
 	if upsertErr == nil {
 		return nil
 	}
+	// If the upsert failed because the project doesn't exist and we are allowed to create the project,
+	// attempt to create the project and retry the upsert.
 	if !isProjectDoesNotExistError(upsertErr) || !createProject || modelV1.IsGlobal(kind) {
 		return upsertErr
 	}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This is how it started: I wanted to try out the new `--create-project` available on the `apply` command since v0.54.0, with the official [dac workflow](https://github.com/perses/cli-actions#dac). And this is [how it turned out](https://github.com/perses/cli-actions/actions/runs/33871408614/job/101018908892?pr=12)..

<img width="1417" height="1167" alt="image" src="https://github.com/user-attachments/assets/71645430-e516-4d23-8a8f-3cd4078d0328" />

Before applying the resources we are previewing them, and the same "create project if not exist" logic thus should be added to the `dac preview` command too.

That's what this PR does, also improving the code a bit by avoiding duplication of the upsert logic between the 2 commands.

# Screenshots

Same payload with & without the flag:

```
$ percli dac preview -f file_output.yaml 
Error: something wrong happened with the request to the API.  Message: bad request: metadata.project "cassoulet" doesn't exist StatusCode: 400
```
```
$ percli dac preview -f file_output.yaml --create-project
INFO[2026-09-04T15:55:51+02:00] No dashboard empty_dashboard found in project cassoulet, no current link to provide 
INFO[2026-09-04T15:55:51+02:00] ephemeral dashboard "empty_dashboard" has been applied in the project "cassoulet" 
- project: cassoulet
  dashboard: empty_dashboard
  preview: http://localhost:8080/projects/cassoulet/ephemeraldashboards/empty_dashboard
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
