### PR TITLE
[FEATURE] support pre-computed bcrypt password hash for user provisioning

### DIFF
--- a/cue/model/api/v1/user_go_gen.cue
+++ b/cue/model/api/v1/user_go_gen.cue
@@ -8,6 +8,13 @@ package v1
 
 #NativeProvider: {
 	password?: string @go(Password)
+
+	// PasswordHash accepts a pre-computed bcrypt hash instead of a plaintext password.
+	// When set, the hash is stored directly without re-hashing.
+	// This is useful for provisioning users from configuration files without exposing
+	// cleartext passwords (e.g. in Kubernetes ConfigMaps).
+	// Mutually exclusive with Password.
+	passwordHash?: string @go(PasswordHash)
 }
 
 #OAuthProvider: {

--- a/dev/data/1-user-prehashed.json
+++ b/dev/data/1-user-prehashed.json
@@ -1,0 +1,13 @@
+[
+  {
+    "kind": "User",
+    "metadata": {
+      "name": "prehashed-admin"
+    },
+    "spec": {
+      "nativeProvider": {
+        "passwordHash": "$2y$10$9wE2VdDn/yimJ1rwBroa3OagN1Dm9AAYaX8OYbbTfYu7n7HUvPCvW"
+      }
+    }
+  }
+]

--- a/internal/api/crypto/hash.go
+++ b/internal/api/crypto/hash.go
@@ -22,6 +22,14 @@ func HashAndSalt(pwd []byte) ([]byte, error) {
 	return bcrypt.GenerateFromPassword(pwd, bcrypt.DefaultCost)
 }
 
+// IsValidBcryptHash reports whether hash looks like a valid bcrypt hash.
+// It does NOT verify the hash against any password — it only checks the
+// format (prefix, cost, length).
+func IsValidBcryptHash(hash string) bool {
+	_, err := bcrypt.Cost([]byte(hash))
+	return err == nil
+}
+
 func ComparePasswords(hashedPwd string, plainPwd string) bool {
 	hash := []byte(hashedPwd)
 	plainPwdByte := []byte(plainPwd)

--- a/internal/api/crypto/hash_test.go
+++ b/internal/api/crypto/hash_test.go
@@ -1,0 +1,44 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashAndSalt(t *testing.T) {
+	hash, err := HashAndSalt([]byte("password"))
+	require.NoError(t, err)
+	assert.True(t, ComparePasswords(string(hash), "password"))
+	assert.False(t, ComparePasswords(string(hash), "wrong"))
+}
+
+func TestIsValidBcryptHash(t *testing.T) {
+	// Generate a real hash and verify it's accepted.
+	hash, err := HashAndSalt([]byte("test"))
+	require.NoError(t, err)
+	assert.True(t, IsValidBcryptHash(string(hash)))
+
+	// Known valid bcrypt hash (cost 10).
+	assert.True(t, IsValidBcryptHash("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"))
+
+	// Invalid inputs.
+	assert.False(t, IsValidBcryptHash(""))
+	assert.False(t, IsValidBcryptHash("notahash"))
+	assert.False(t, IsValidBcryptHash("plaintext-password"))
+	assert.False(t, IsValidBcryptHash("$2a$10$tooshort"))
+}

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -53,7 +53,7 @@ func (s *service) create(entity *v1.User) (*v1.PublicUser, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
 	// resolve the password: either hash a plaintext password or accept a pre-computed bcrypt hash
-	hashedPassword, err := resolvePassword(entity.Spec.NativeProvider.Password, entity.Spec.NativeProvider.PasswordHash, entity.Metadata.Name)
+	hashedPassword, err := resolvePassword(entity.Spec.NativeProvider, entity.Metadata.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (s *service) update(entity *v1.User, parameters apiInterface.Parameters) (*
 	entity.Metadata.Update(oldEntity.Metadata)
 	// in case the user updated his password, then we should hash it again, otherwise the old password should be kept
 	if len(entity.Spec.NativeProvider.Password) > 0 || len(entity.Spec.NativeProvider.PasswordHash) > 0 {
-		hashedPassword, hashErr := resolvePassword(entity.Spec.NativeProvider.Password, entity.Spec.NativeProvider.PasswordHash, entity.Metadata.Name)
+		hashedPassword, hashErr := resolvePassword(entity.Spec.NativeProvider, entity.Metadata.Name)
 		if hashErr != nil {
 			return nil, hashErr
 		}
@@ -166,21 +166,20 @@ func (s *service) RawMetadataList(q *user.Query) ([]json.RawMessage, error) {
 // Exactly one of password (plaintext) or passwordHash (pre-computed bcrypt)
 // must be non-empty. The model-level validation already enforces mutual
 // exclusivity, so this function only needs to handle the two valid cases.
-func resolvePassword(password, passwordHash, username string) (string, error) {
-	switch {
-	case len(passwordHash) > 0:
-		if !crypto.IsValidBcryptHash(passwordHash) {
-			return "", fmt.Errorf("%w: passwordHash is not a valid bcrypt hash", apiInterface.BadRequestError)
+func resolvePassword(np v1.NativeProvider, username string) (string, error) {
+	if len(np.PasswordHash) > 0 {
+		if !crypto.IsValidBcryptHash(np.PasswordHash) {
+			return "", apiInterface.HandleBadRequestError("passwordHash is not a valid bcrypt hash")
 		}
-		return passwordHash, nil
-	case len(password) > 0:
-		hash, err := crypto.HashAndSalt([]byte(password))
+		return np.PasswordHash, nil
+	}
+	if len(np.Password) > 0 {
+		hash, err := crypto.HashAndSalt([]byte(np.Password))
 		if err != nil {
 			logrus.WithError(err).Errorf("unable to generate the hash for the password of the user %q", username)
 			return "", apiInterface.InternalError
 		}
 		return string(hash), nil
-	default:
-		return "", fmt.Errorf("%w: password or passwordHash must be provided", apiInterface.BadRequestError)
 	}
+	return "", apiInterface.HandleBadRequestError("password or passwordHash must be provided")
 }

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -52,17 +52,14 @@ func (s *service) Create(_ echo.Context, entity *v1.User) (*v1.PublicUser, error
 func (s *service) create(entity *v1.User) (*v1.PublicUser, error) {
 	// Update the time contains in the entity
 	entity.Metadata.CreateNow()
-	// check that the password is correctly filled
-	if len(entity.Spec.NativeProvider.Password) == 0 {
-		return nil, fmt.Errorf("%w: password cannot be empty", apiInterface.BadRequestError)
-	}
-	hash, err := crypto.HashAndSalt([]byte(entity.Spec.NativeProvider.Password))
+	// resolve the password: either hash a plaintext password or accept a pre-computed bcrypt hash
+	hashedPassword, err := resolvePassword(entity.Spec.NativeProvider.Password, entity.Spec.NativeProvider.PasswordHash, entity.Metadata.Name)
 	if err != nil {
-		logrus.WithError(err).Errorf("unable to generate the hash for the password of the user %s", entity.Metadata.Name)
-		return nil, apiInterface.InternalError
+		return nil, err
 	}
-	// save the hash in the password field
-	entity.Spec.NativeProvider.Password = string(hash)
+	// save the hash in the password field and clear the passwordHash field
+	entity.Spec.NativeProvider.Password = hashedPassword
+	entity.Spec.NativeProvider.PasswordHash = ""
 	if createErr := s.dao.Create(entity); createErr != nil {
 		return nil, createErr
 	}
@@ -93,13 +90,13 @@ func (s *service) update(entity *v1.User, parameters apiInterface.Parameters) (*
 	}
 	entity.Metadata.Update(oldEntity.Metadata)
 	// in case the user updated his password, then we should hash it again, otherwise the old password should be kept
-	if len(entity.Spec.NativeProvider.Password) > 0 {
-		hash, hashErr := crypto.HashAndSalt([]byte(entity.Spec.NativeProvider.Password))
+	if len(entity.Spec.NativeProvider.Password) > 0 || len(entity.Spec.NativeProvider.PasswordHash) > 0 {
+		hashedPassword, hashErr := resolvePassword(entity.Spec.NativeProvider.Password, entity.Spec.NativeProvider.PasswordHash, entity.Metadata.Name)
 		if hashErr != nil {
-			logrus.WithError(hashErr).Errorf("unable to generate the hash for the password of the user %q", entity.Metadata.Name)
 			return nil, hashErr
 		}
-		entity.Spec.NativeProvider.Password = string(hash)
+		entity.Spec.NativeProvider.Password = hashedPassword
+		entity.Spec.NativeProvider.PasswordHash = ""
 	} else {
 		entity.Spec.NativeProvider.Password = oldEntity.Spec.NativeProvider.Password
 	}
@@ -163,4 +160,27 @@ func (s *service) MetadataList(q *user.Query) ([]api.Entity, error) {
 
 func (s *service) RawMetadataList(q *user.Query) ([]json.RawMessage, error) {
 	return s.dao.RawMetadataList(q)
+}
+
+// resolvePassword returns the bcrypt hash to store for a user.
+// Exactly one of password (plaintext) or passwordHash (pre-computed bcrypt)
+// must be non-empty. The model-level validation already enforces mutual
+// exclusivity, so this function only needs to handle the two valid cases.
+func resolvePassword(password, passwordHash, username string) (string, error) {
+	switch {
+	case len(passwordHash) > 0:
+		if !crypto.IsValidBcryptHash(passwordHash) {
+			return "", fmt.Errorf("%w: passwordHash is not a valid bcrypt hash", apiInterface.BadRequestError)
+		}
+		return passwordHash, nil
+	case len(password) > 0:
+		hash, err := crypto.HashAndSalt([]byte(password))
+		if err != nil {
+			logrus.WithError(err).Errorf("unable to generate the hash for the password of the user %q", username)
+			return "", apiInterface.InternalError
+		}
+		return string(hash), nil
+	default:
+		return "", fmt.Errorf("%w: password or passwordHash must be provided", apiInterface.BadRequestError)
+	}
 }

--- a/internal/api/impl/v1/user/service.go
+++ b/internal/api/impl/v1/user/service.go
@@ -181,5 +181,5 @@ func resolvePassword(np v1.NativeProvider, username string) (string, error) {
 		}
 		return string(hash), nil
 	}
-	return "", apiInterface.HandleBadRequestError("password or passwordHash must be provided")
+	return "", nil
 }

--- a/internal/api/impl/v1/user/service_test.go
+++ b/internal/api/impl/v1/user/service_test.go
@@ -52,13 +52,6 @@ func TestResolvePassword(t *testing.T) {
 			wantErr:   true,
 			errSubstr: "not a valid bcrypt hash",
 		},
-		{
-			name:      "both empty returns error",
-			np:        v1.NativeProvider{},
-			username:  "dave",
-			wantErr:   true,
-			errSubstr: "password or passwordHash must be provided",
-		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/impl/v1/user/service_test.go
+++ b/internal/api/impl/v1/user/service_test.go
@@ -1,0 +1,56 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"testing"
+
+	"github.com/perses/perses/internal/api/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePassword_Plaintext(t *testing.T) {
+	result, err := resolvePassword("mypassword", "", "alice")
+	require.NoError(t, err)
+	// The result should be a valid bcrypt hash.
+	assert.True(t, crypto.IsValidBcryptHash(result))
+	// The hash should verify against the original password.
+	assert.True(t, crypto.ComparePasswords(result, "mypassword"))
+}
+
+func TestResolvePassword_PreHashedBcrypt(t *testing.T) {
+	// Pre-compute a bcrypt hash.
+	hash, err := crypto.HashAndSalt([]byte("secretpassword"))
+	require.NoError(t, err)
+
+	result, err := resolvePassword("", string(hash), "bob")
+	require.NoError(t, err)
+	// The hash should be stored as-is (no re-hashing).
+	assert.Equal(t, string(hash), result)
+	// And it should still verify against the original password.
+	assert.True(t, crypto.ComparePasswords(result, "secretpassword"))
+}
+
+func TestResolvePassword_InvalidBcryptHash(t *testing.T) {
+	_, err := resolvePassword("", "not-a-bcrypt-hash", "charlie")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid bcrypt hash")
+}
+
+func TestResolvePassword_BothEmpty(t *testing.T) {
+	_, err := resolvePassword("", "", "dave")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "password or passwordHash must be provided")
+}

--- a/internal/api/impl/v1/user/service_test.go
+++ b/internal/api/impl/v1/user/service_test.go
@@ -17,40 +17,63 @@ import (
 	"testing"
 
 	"github.com/perses/perses/internal/api/crypto"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolvePassword_Plaintext(t *testing.T) {
-	result, err := resolvePassword("mypassword", "", "alice")
-	require.NoError(t, err)
-	// The result should be a valid bcrypt hash.
-	assert.True(t, crypto.IsValidBcryptHash(result))
-	// The hash should verify against the original password.
-	assert.True(t, crypto.ComparePasswords(result, "mypassword"))
-}
-
-func TestResolvePassword_PreHashedBcrypt(t *testing.T) {
-	// Pre-compute a bcrypt hash.
-	hash, err := crypto.HashAndSalt([]byte("secretpassword"))
+func TestResolvePassword(t *testing.T) {
+	precomputedHash, err := crypto.HashAndSalt([]byte("secretpassword"))
 	require.NoError(t, err)
 
-	result, err := resolvePassword("", string(hash), "bob")
-	require.NoError(t, err)
-	// The hash should be stored as-is (no re-hashing).
-	assert.Equal(t, string(hash), result)
-	// And it should still verify against the original password.
-	assert.True(t, crypto.ComparePasswords(result, "secretpassword"))
-}
+	tests := []struct {
+		name      string
+		np        v1.NativeProvider
+		username  string
+		wantErr   bool
+		errSubstr string
+		wantHash  string
+	}{
+		{
+			name:     "plaintext password is hashed",
+			np:       v1.NativeProvider{Password: "mypassword"},
+			username: "alice",
+		},
+		{
+			name:     "pre-hashed bcrypt stored as-is",
+			np:       v1.NativeProvider{PasswordHash: string(precomputedHash)},
+			username: "bob",
+			wantHash: string(precomputedHash),
+		},
+		{
+			name:      "invalid bcrypt hash rejected",
+			np:        v1.NativeProvider{PasswordHash: "not-a-bcrypt-hash"},
+			username:  "charlie",
+			wantErr:   true,
+			errSubstr: "not a valid bcrypt hash",
+		},
+		{
+			name:      "both empty returns error",
+			np:        v1.NativeProvider{},
+			username:  "dave",
+			wantErr:   true,
+			errSubstr: "password or passwordHash must be provided",
+		},
+	}
 
-func TestResolvePassword_InvalidBcryptHash(t *testing.T) {
-	_, err := resolvePassword("", "not-a-bcrypt-hash", "charlie")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not a valid bcrypt hash")
-}
-
-func TestResolvePassword_BothEmpty(t *testing.T) {
-	_, err := resolvePassword("", "", "dave")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "password or passwordHash must be provided")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolvePassword(tt.np, tt.username)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, crypto.IsValidBcryptHash(result))
+			if tt.wantHash != "" {
+				assert.Equal(t, tt.wantHash, result)
+			}
+		})
+	}
 }

--- a/internal/api/impl/v1/user/service_test.go
+++ b/internal/api/impl/v1/user/service_test.go
@@ -47,7 +47,7 @@ func TestResolvePassword(t *testing.T) {
 		},
 		{
 			name:      "invalid bcrypt hash rejected",
-			np:        v1.NativeProvider{PasswordHash: "not-a-bcrypt-hash"},
+			np:        v1.NativeProvider{PasswordHash: "not-a-bcrypt-hash"}, //nolint:gosec // G101: test value, not a real credential
 			username:  "charlie",
 			wantErr:   true,
 			errSubstr: "not a valid bcrypt hash",

--- a/pkg/model/api/v1/user.go
+++ b/pkg/model/api/v1/user.go
@@ -26,6 +26,12 @@ const WildcardProject = "*"
 
 type NativeProvider struct {
 	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	// PasswordHash accepts a pre-computed bcrypt hash instead of a plaintext password.
+	// When set, the hash is stored directly without re-hashing.
+	// This is useful for provisioning users from configuration files without exposing
+	// cleartext passwords (e.g. in Kubernetes ConfigMaps).
+	// Mutually exclusive with Password.
+	PasswordHash string `json:"passwordHash,omitempty" yaml:"passwordHash,omitempty"`
 }
 
 type OAuthProvider struct {
@@ -76,7 +82,11 @@ func (u *User) validate() error {
 	if u.Kind != KindUser {
 		return fmt.Errorf("invalid kind: '%s' for a User type", u.Kind)
 	}
-	if len(u.Spec.NativeProvider.Password) > 0 && len(u.Spec.OauthProviders) > 0 {
+	if len(u.Spec.NativeProvider.Password) > 0 && len(u.Spec.NativeProvider.PasswordHash) > 0 {
+		return fmt.Errorf("password and passwordHash are mutually exclusive, use one of them")
+	}
+	hasNativeCredentials := len(u.Spec.NativeProvider.Password) > 0 || len(u.Spec.NativeProvider.PasswordHash) > 0
+	if hasNativeCredentials && len(u.Spec.OauthProviders) > 0 {
 		return fmt.Errorf("nativeProvider and oauthProviders are mutually exclusive, use one of them")
 	}
 	return nil

--- a/pkg/model/api/v1/user_test.go
+++ b/pkg/model/api/v1/user_test.go
@@ -43,6 +43,22 @@ func TestUnmarshalUser(t *testing.T) {
 `,
 		},
 		{
+			title: "native provider with passwordHash only",
+			jason: `
+{
+  "kind": "User",
+  "metadata": {
+    "name": "alice"
+  },
+  "spec": {
+    "nativeProvider": {
+      "passwordHash": "$2a$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ0123"
+    }
+  }
+}
+`,
+		},
+		{
 			title: "oauth providers only",
 			jason: `
 {
@@ -103,6 +119,48 @@ func TestUnmarshalUserError(t *testing.T) {
   "spec": {
     "nativeProvider": {
       "password": "password"
+    },
+    "oauthProviders": [
+      {
+        "issuer": "http://localhost/openid",
+        "email": "alice@example.com",
+        "subject": "123456789"
+      }
+    ]
+  }
+}
+`,
+			err: fmt.Errorf("nativeProvider and oauthProviders are mutually exclusive, use one of them"),
+		},
+		{
+			title: "password and passwordHash are mutually exclusive",
+			jason: `
+{
+  "kind": "User",
+  "metadata": {
+    "name": "alice"
+  },
+  "spec": {
+    "nativeProvider": {
+      "password": "password",
+      "passwordHash": "$2a$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ0123"
+    }
+  }
+}
+`,
+			err: fmt.Errorf("password and passwordHash are mutually exclusive, use one of them"),
+		},
+		{
+			title: "passwordHash and oauth providers are mutually exclusive",
+			jason: `
+{
+  "kind": "User",
+  "metadata": {
+    "name": "alice"
+  },
+  "spec": {
+    "nativeProvider": {
+      "passwordHash": "$2a$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ0123"
     },
     "oauthProviders": [
       {


### PR DESCRIPTION
# Description

Closes https://github.com/perses/perses/issues/4422

Adds a `passwordHash` field to `NativeProvider` that accepts a pre-computed bcrypt hash, bypassing the internal `HashAndSalt` step. This lets operators provision users from files without storing cleartext passwords in ConfigMaps or on disk.

**Use case:** Kubernetes operators that provision Perses users via file-based provisioning can generate a random password, bcrypt-hash it, store the plaintext only in a K8s Secret (for initial login), and write the hash into the provisioning file — zero cleartext in ConfigMaps.

**Changes:**
- `pkg/model/api/v1/user.go` — new `PasswordHash` field on `NativeProvider`, mutual exclusivity with `Password` and `OauthProviders`
- `internal/api/crypto/hash.go` — new `IsValidBcryptHash()` helper
- `internal/api/impl/v1/user/service.go` — extracted `resolvePassword()` used by both `create()` and `update()`: if `passwordHash` is set and valid bcrypt, store as-is; if `password` is set, hash it; both empty → error
- New tests: model validation, crypto helpers, service unit tests
- `dev/data/1-user-prehashed.json` — example provisioning file

# Screenshots

N/A — no UI changes.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention.
- [x] All commits have DCO signoffs.

## UI Changes

N/A