### PR TITLE
[DOC] Document the Annotation plugin kind

### DIFF
--- a/docs/concepts/plugin.md
+++ b/docs/concepts/plugin.md
@@ -6,6 +6,7 @@ In Perses, the following object types are available as plugins:
 - [Datasource](./datasource.md)
 - Query
 - [Variable](./variable.md)
+- Annotation
 - Explorer
 
 The goal with this is to eventually empower users to seamlessly enhance Perses' native capabilities through custom
@@ -15,6 +16,7 @@ plugins, allowing them to:
 - Add datasource plugins to access data from new types of sources.
 - Add query plugins to retrieve data from supported sources in additional ways.
 - Add variable plugins to build variables for supported sources in additional ways.
+- Add annotation plugins to fetch events from supported sources and overlay them on the panels of a dashboard.
 - Add explorer view to customize the explorer page.
 
 While Panel plugins are relatively self-sufficient, a datasource plugin requires one or more corresponding query and/or

--- a/docs/plugins/creation.md
+++ b/docs/plugins/creation.md
@@ -12,6 +12,8 @@ Perses supports the following types of plugins:
   tables, or any other type of visualization.
 - **Variable**: A variable plugin is a plugin that can be used to create variables that can be used in queries. It can be used to
   fill data into dropdowns or replace variables in queries. Requires a schema to validate the data model.
+- **Annotation**: An annotation plugin is a plugin that can be used to fetch events from a datasource and overlay them on
+  the panels of a dashboard. Requires a schema to validate the data model.
 - **Explore**: An explore plugin is a plugin that can be used to create an explore view. It can be used to create a view that allows
   users to explore data in a specific way. It is a special type of panel plugin that is used in the explore view.
 
@@ -80,7 +82,7 @@ Perses CLI (`percli`) has a plugin option that helps you create and manage your 
   - `--module.org`: The organization name on which the plugin module will be created, useful for publishing the plugin. This is required only when the module does not exist, ignored otherwise.
   - `--plugin.name`: The plugin name. A pascal case and kebab case variants will be generated inside the templates. If a plugin with the same name already exists, it will be overwritten.
   - `--plugin.type`: The plugin type can be one of
-    `Datasource`, `TimeSeriesQuery` , `TraceQuery`, `ProfileQuery`, `LogQuery`, `Variable`, `Panel`, or `Explore`.
+    `Datasource`, `TimeSeriesQuery` , `TraceQuery`, `ProfileQuery`, `LogQuery`, `Variable`, `Annotation`, `Panel`, or `Explore`.
   - `--plugin.display-name`: The more human name of the plugin to be used in the UI. If not provided, the plugin name will be used.
   - `[<plugin module directory>]`: The plugin module directory is optional and the current directory will be used if not provided.
 - `percli plugin build`: Build the plugin module and create the archive file.
@@ -123,6 +125,11 @@ The implementation is mostly similar across all plugin types.
   - Edit the JSON example of the schema in the same folder.
 - To enable Grafana migration, create a `schemas/variables/<plugin-name>/migrate` folder and define the migration logic as a CUE schema file. This schema must belong to the `migrate` package.
 - Implement your variable as a React component located in the `src/variables/<plugin-name>` folder.
+
+#### Annotation plugin
+
+- Edit the CUE schema file in the `schemas/annotations/<plugin-name>` folder to define the data model of your plugin. This schema must belong to the `model` package.
+- Implement your annotation as a React component located in the `src/annotations/<plugin-name>` folder.
 
 #### Panel plugin
 


### PR DESCRIPTION
# Description

`Annotation` has been a first-class plugin kind (`plugin.KindAnnotation`) since the annotation support released in #4040, and `percli plugin generate` already accepts it, but the documentation never mentions it.

- `docs/concepts/plugin.md`: add `Annotation` to the object types available as plugins, plus the matching capability bullet.
- `docs/plugins/creation.md`: add `Annotation` to the plugin types and to the `--plugin.type` values, and describe the layout of an annotation plugin (`schemas/annotations/<plugin-name>` and `src/annotations/<plugin-name>`), matching `internal/cli/cmd/plugin/generate/templates/annotations`.

This covers the first bullet of the issue. The second one (listing the annotation plugin among the Prometheus plugins) belongs to `perses/plugins`, so it is handled in perses/plugins#804.

Unrelated to this change, but noticed while editing that line: the `--plugin.type` list also advertises `TraceQuery`, `ProfileQuery` and `LogQuery`, which are not part of `availablePluginTypes` in `internal/cli/cmd/plugin/generate/generate.go` and are therefore rejected by `Validate()`. I left them untouched here — happy to remove them in a follow-up if the doc is the side that is wrong.

Part of #4408

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
