### PR TITLE
[BUGFIX] prefix OIDC/OAuth login redirect with api_prefix

### DIFF
--- a/ui/app/src/views/auth/SignWrapper.test.tsx
+++ b/ui/app/src/views/auth/SignWrapper.test.tsx
@@ -1,0 +1,74 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SignWrapper } from './SignWrapper';
+
+vi.mock('../../config', () => ({
+  PERSES_APP_CONFIG: { api_prefix: '/perses' },
+}));
+
+vi.mock('../../context/DarkMode', () => ({
+  useDarkMode: (): { isDarkModeEnabled: boolean } => ({ isDarkModeEnabled: false }),
+}));
+
+vi.mock('../../utils/browser-size', () => ({
+  useIsLaptopSize: (): boolean => false,
+}));
+
+vi.mock('../../context/Config', () => ({
+  useConfigContext: (): {
+    config: {
+      security: { authentication: { providers: { oidc: Array<{ slug_id: string; name: string; issuer: string }> } } };
+    };
+  } => ({
+    config: {
+      security: {
+        authentication: {
+          providers: {
+            oidc: [{ slug_id: 'keycloak', name: 'Keycloak', issuer: 'https://keycloak.example.com/realms/myrealm' }],
+          },
+        },
+      },
+    },
+  }),
+  useIsNativeAuthnProviderEnabled: (): boolean => false,
+}));
+
+vi.mock('../../model/auth/auth-client', () => ({
+  useRedirectQueryParam: (): string => '/',
+  buildRedirectQueryString: (path: string): string => `rd=${encodeURIComponent(path)}`,
+}));
+
+describe('SignWrapper', () => {
+  it('prefixes the OIDC login redirect with the configured api_prefix', () => {
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+    });
+
+    const theme = createTheme();
+    render(
+      <ThemeProvider theme={theme}>
+        <SignWrapper>{null}</SignWrapper>
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Sign in with Keycloak'));
+
+    expect(window.location.href).toEqual('/perses/api/auth/providers/oidc/keycloak/login?rd=%2F');
+  });
+});

--- a/ui/app/src/views/auth/SignWrapper.tsx
+++ b/ui/app/src/views/auth/SignWrapper.tsx
@@ -47,6 +47,7 @@ import {
 import DarkThemePersesLogo from '../../components/logo/DarkThemePersesLogo';
 import LightThemePersesLogo from '../../components/logo/LightThemePersesLogo';
 import PersesLogoCropped from '../../components/logo/PersesLogoCropped';
+import { PERSES_APP_CONFIG } from '../../config';
 import { useConfigContext, useIsNativeAuthnProviderEnabled } from '../../context/Config';
 import { useDarkMode } from '../../context/DarkMode';
 import { buildRedirectQueryString, useRedirectQueryParam } from '../../model/auth/auth-client';
@@ -194,7 +195,7 @@ export function SignWrapper(props: { children: ReactNode }): ReactElement {
               fullWidth={true}
               style={{ fontSize: '1em' }}
               onClick={() => {
-                window.location.href = `/api/auth/providers/${provider.path}/login?${buildRedirectQueryString(path)}`;
+                window.location.href = `${PERSES_APP_CONFIG.api_prefix}/api/auth/providers/${provider.path}/login?${buildRedirectQueryString(path)}`;
               }}
             >
               Sign in with {provider.name}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

When Perses is deployed behind a sub-path (`api_prefix` configured, e.g. `/perses`), clicking "Sign in with OIDC/OAuth provider" redirected the browser to a URL missing the `api_prefix`, so the request 404'd at the Ingress/reverse-proxy layer instead of reaching the Perses backend.

`ui/app/src/views/auth/SignWrapper.tsx` hardcoded the login redirect as `/api/auth/providers/${provider.path}/login?...`, while other auth-related code in the same app (e.g. the logout link in `AccountMenu.tsx`) correctly prepends `PERSES_APP_CONFIG.api_prefix`. This PR applies the same convention to the login redirect.

With the default `api_prefix` of `''` (no sub-path deployment), the generated URL is unchanged.

# Screenshots

No UI-visible change; this only affects the URL the browser is redirected to when clicking a social/OIDC/OAuth sign-in button.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes. (N/A — no visual change, only the redirect target URL.)
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

Fixes #4431