### PR TITLE
[BUGFIX] default OIDC/OAuth redirect path to api_prefix, not router basename-relative root

### DIFF
--- a/ui/app/src/model/auth/auth-client.test.ts
+++ b/ui/app/src/model/auth/auth-client.test.ts
@@ -1,0 +1,75 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { renderHook } from '@testing-library/react';
+
+import { useRedirectQueryParam } from './auth-client';
+
+const { mockUseQueryParam, mockApiPrefix } = vi.hoisted(() => ({
+  mockUseQueryParam: vi.fn(),
+  mockApiPrefix: { current: '' },
+}));
+
+vi.mock('use-query-params', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useQueryParam: mockUseQueryParam,
+}));
+
+vi.mock('../../config', () => ({
+  get PERSES_APP_CONFIG(): { api_prefix: string } {
+    return { api_prefix: mockApiPrefix.current };
+  },
+}));
+
+describe('useRedirectQueryParam', () => {
+  afterEach(() => {
+    mockApiPrefix.current = '';
+  });
+
+  it('returns the rd query param when present, regardless of api_prefix or the absolute option', () => {
+    mockApiPrefix.current = '/perses';
+    mockUseQueryParam.mockReturnValue(['/dashboards/my-dashboard']);
+
+    expect(renderHook(() => useRedirectQueryParam()).result.current).toEqual('/dashboards/my-dashboard');
+    expect(renderHook(() => useRedirectQueryParam({ absolute: true })).result.current).toEqual(
+      '/dashboards/my-dashboard',
+    );
+  });
+
+  it('falls back to "/" by default when no rd query param is present, regardless of api_prefix', () => {
+    mockApiPrefix.current = '/perses';
+    mockUseQueryParam.mockReturnValue([undefined]);
+
+    const { result } = renderHook(() => useRedirectQueryParam());
+
+    expect(result.current).toEqual('/');
+  });
+
+  it('falls back to api_prefix when absolute is true, no rd query param is present, and api_prefix is set', () => {
+    mockApiPrefix.current = '/perses';
+    mockUseQueryParam.mockReturnValue([undefined]);
+
+    const { result } = renderHook(() => useRedirectQueryParam({ absolute: true }));
+
+    expect(result.current).toEqual('/perses');
+  });
+
+  it('falls back to "/" when absolute is true, no rd query param is present, and api_prefix is empty', () => {
+    mockApiPrefix.current = '';
+    mockUseQueryParam.mockReturnValue([undefined]);
+
+    const { result } = renderHook(() => useRedirectQueryParam({ absolute: true }));
+
+    expect(result.current).toEqual('/');
+  });
+});

--- a/ui/app/src/model/auth/auth-client.test.ts
+++ b/ui/app/src/model/auth/auth-client.test.ts
@@ -41,9 +41,7 @@ describe('useRedirectQueryParam', () => {
     mockUseQueryParam.mockReturnValue(['/dashboards/my-dashboard']);
 
     expect(renderHook(() => useRedirectQueryParam()).result.current).toEqual('/dashboards/my-dashboard');
-    expect(renderHook(() => useRedirectQueryParam({ absolute: true })).result.current).toEqual(
-      '/dashboards/my-dashboard',
-    );
+    expect(renderHook(() => useRedirectQueryParam(true)).result.current).toEqual('/dashboards/my-dashboard');
   });
 
   it('falls back to "/" by default when no rd query param is present, regardless of api_prefix', () => {
@@ -59,7 +57,7 @@ describe('useRedirectQueryParam', () => {
     mockApiPrefix.current = '/perses';
     mockUseQueryParam.mockReturnValue([undefined]);
 
-    const { result } = renderHook(() => useRedirectQueryParam({ absolute: true }));
+    const { result } = renderHook(() => useRedirectQueryParam(true));
 
     expect(result.current).toEqual('/perses');
   });
@@ -68,7 +66,7 @@ describe('useRedirectQueryParam', () => {
     mockApiPrefix.current = '';
     mockUseQueryParam.mockReturnValue([undefined]);
 
-    const { result } = renderHook(() => useRedirectQueryParam({ absolute: true }));
+    const { result } = renderHook(() => useRedirectQueryParam(true));
 
     expect(result.current).toEqual('/');
   });

--- a/ui/app/src/model/auth/auth-client.ts
+++ b/ui/app/src/model/auth/auth-client.ts
@@ -28,15 +28,16 @@ const redirectQueryParam = 'rd';
  *
  * By default, the fallback path (used when there is no `rd` query param) is relative to the app's `api_prefix`,
  * which is what React Router's `navigate()`/`<Navigate>` expect since the router is created with `api_prefix` as
- * its basename. Pass `absolute: true` when the path is instead going to be used outside of React Router (e.g. a
- * raw `window.location.href` redirect to the backend), where the fallback must include `api_prefix` itself.
+ * its basename. Pass `true` when the path is instead going to be used outside of React Router (e.g. a raw
+ * `window.location.href` redirect to the backend), where the fallback must include `api_prefix` itself.
+ * @param absolute whether the fallback path must be absolute (include `api_prefix`) rather than router-relative.
  */
-export function useRedirectQueryParam(options: { absolute?: boolean } = {}): string {
+export function useRedirectQueryParam(absolute?: boolean): string {
   const [path] = useQueryParam<string | undefined>(redirectQueryParam);
   if (path !== undefined) {
     return path;
   }
-  return options.absolute ? PERSES_APP_CONFIG.api_prefix || '/' : '/';
+  return absolute ? PERSES_APP_CONFIG.api_prefix || '/' : '/';
 }
 
 /**

--- a/ui/app/src/model/auth/auth-client.ts
+++ b/ui/app/src/model/auth/auth-client.ts
@@ -14,6 +14,7 @@
 import { fetch } from '@perses-dev/client';
 import { useQueryParam } from 'use-query-params';
 
+import { PERSES_APP_CONFIG } from '../../config';
 import { HTTPHeader, HTTPMethodPOST } from '../http';
 import buildURL from '../url-builder';
 import { useCurrentUser } from '../user-client';
@@ -24,10 +25,18 @@ const redirectQueryParam = 'rd';
 /**
  * Get the redirect path from URL's query params.
  * This is used to retrieve the original path that a user desired before being redirected to the login page.
+ *
+ * By default, the fallback path (used when there is no `rd` query param) is relative to the app's `api_prefix`,
+ * which is what React Router's `navigate()`/`<Navigate>` expect since the router is created with `api_prefix` as
+ * its basename. Pass `absolute: true` when the path is instead going to be used outside of React Router (e.g. a
+ * raw `window.location.href` redirect to the backend), where the fallback must include `api_prefix` itself.
  */
-export function useRedirectQueryParam(): string {
+export function useRedirectQueryParam(options: { absolute?: boolean } = {}): string {
   const [path] = useQueryParam<string | undefined>(redirectQueryParam);
-  return path ?? '/';
+  if (path !== undefined) {
+    return path;
+  }
+  return options.absolute ? PERSES_APP_CONFIG.api_prefix || '/' : '/';
 }
 
 /**

--- a/ui/app/src/views/auth/SignWrapper.test.tsx
+++ b/ui/app/src/views/auth/SignWrapper.test.tsx
@@ -49,7 +49,9 @@ vi.mock('../../context/Config', () => ({
 }));
 
 vi.mock('../../model/auth/auth-client', () => ({
-  useRedirectQueryParam: (): string => '/',
+  // Mirrors the real implementation's `absolute` option closely enough to exercise SignWrapper's usage of it:
+  // when there is no `rd` query param, the absolute (browser-redirect-bound) path falls back to `api_prefix`.
+  useRedirectQueryParam: (options?: { absolute?: boolean }): string => (options?.absolute ? '/perses' : '/'),
   buildRedirectQueryString: (path: string): string => `rd=${encodeURIComponent(path)}`,
 }));
 
@@ -69,6 +71,8 @@ describe('SignWrapper', () => {
 
     fireEvent.click(screen.getByText('Sign in with Keycloak'));
 
-    expect(window.location.href).toEqual('/perses/api/auth/providers/oidc/keycloak/login?rd=%2F');
+    // rd must carry the absolute path (including api_prefix), since the backend's OIDC redirect is a raw
+    // browser navigation that doesn't go through React Router's basename resolution.
+    expect(window.location.href).toEqual('/perses/api/auth/providers/oidc/keycloak/login?rd=%2Fperses');
   });
 });

--- a/ui/app/src/views/auth/SignWrapper.test.tsx
+++ b/ui/app/src/views/auth/SignWrapper.test.tsx
@@ -49,9 +49,9 @@ vi.mock('../../context/Config', () => ({
 }));
 
 vi.mock('../../model/auth/auth-client', () => ({
-  // Mirrors the real implementation's `absolute` option closely enough to exercise SignWrapper's usage of it:
+  // Mirrors the real implementation's `absolute` param closely enough to exercise SignWrapper's usage of it:
   // when there is no `rd` query param, the absolute (browser-redirect-bound) path falls back to `api_prefix`.
-  useRedirectQueryParam: (options?: { absolute?: boolean }): string => (options?.absolute ? '/perses' : '/'),
+  useRedirectQueryParam: (absolute?: boolean): string => (absolute ? '/perses' : '/'),
   buildRedirectQueryString: (path: string): string => `rd=${encodeURIComponent(path)}`,
 }));
 

--- a/ui/app/src/views/auth/SignWrapper.tsx
+++ b/ui/app/src/views/auth/SignWrapper.tsx
@@ -161,7 +161,7 @@ export function SignWrapper(props: { children: ReactNode }): ReactElement {
     }));
     return [...oidcProviders, ...oauthProviders];
   }, [providers.oauth, providers.oidc, theme]);
-  const path = useRedirectQueryParam();
+  const path = useRedirectQueryParam({ absolute: true });
 
   return (
     <Stack

--- a/ui/app/src/views/auth/SignWrapper.tsx
+++ b/ui/app/src/views/auth/SignWrapper.tsx
@@ -161,7 +161,7 @@ export function SignWrapper(props: { children: ReactNode }): ReactElement {
     }));
     return [...oidcProviders, ...oauthProviders];
   }, [providers.oauth, providers.oidc, theme]);
-  const path = useRedirectQueryParam({ absolute: true });
+  const path = useRedirectQueryParam(true);
 
   return (
     <Stack


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

When Perses is deployed with a non-empty `api_prefix` (e.g. `/perses`), a user who visits the Perses landing page directly (no `rd` query param in the URL) and then signs in via an OIDC/OAuth provider button is redirected, after a successful login, to the host root `/` instead of the sub-path `/perses`. In a shared-host deployment this either 404s or lands on a different application.

Root cause: `useRedirectQueryParam()` in `ui/app/src/model/auth/auth-client.ts` hardcoded its fallback (used when there's no `rd` query param) to `'/'`. `SignWrapper.tsx` feeds that value into the `rd` query param sent to the backend's OIDC/OAuth login endpoint; the backend later issues a raw `http.Redirect` to that literal path once the OAuth flow completes, so it must be an absolute, `api_prefix`-inclusive path to land back inside the app.

`useRedirectQueryParam()` is also used by three React Router-based consumers (`SignInView.tsx`, `Router.tsx`'s `AlreadyLoggedIn`, `DelegatedAuthnErrorView.tsx`) via `navigate()`/`<Navigate>`. Those go through a router created with `api_prefix` as its `basename`, which already prepends `api_prefix` automatically — so simply changing the hook's shared default to `api_prefix` would fix `SignWrapper.tsx` but double-prefix those three (e.g. `/perses/perses`).

# Approach

Added an optional `{ absolute?: boolean }` parameter to `useRedirectQueryParam()`. When there's no `rd` query param:
- by default (`absolute` unset/false — used by the three React Router consumers, unchanged call sites), the fallback stays `'/'`, exactly matching prior behavior;
- with `absolute: true` (used only by `SignWrapper.tsx`, which redirects outside of React Router), the fallback is `PERSES_APP_CONFIG.api_prefix || '/'`, so it defaults back to `'/'` for the common no-`api_prefix` deployment too.

Only `ui/app/src/views/auth/SignWrapper.tsx` was updated to opt into `{ absolute: true }`; the other three call sites are untouched.

# Validation

Ran from `ui/`:
- `npx turbo run test --filter=@perses-dev/app` — all 152 tests pass (14 files), including new/updated tests in `ui/app/src/model/auth/auth-client.test.ts` (new — covers all four fallback branches: `rd` present, `rd` absent with `absolute` false/true, and `absolute: true` with an empty `api_prefix`) and `ui/app/src/views/auth/SignWrapper.test.tsx` (updated — asserts the OIDC login redirect URL now carries `rd=%2Fperses` instead of `rd=%2F` for a `/perses` `api_prefix` deployment).
- `npx turbo run type-check --filter=@perses-dev/app` — passes.
- `npx turbo run lint --filter=@perses-dev/app` — 0 errors (repo-wide pre-existing warnings unrelated to this change; confirmed via `git stash` that the touched files' warning set is identical before and after this diff).
- `npx oxfmt --check` on the changed files — formatted correctly.
- `npm run build` (full `ui/` workspace) — succeeds.

# Screenshots

No UI-visible change; this only affects the URL a browser is redirected to after an OIDC/OAuth login when no `rd` query param was present.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes. (N/A — no visual change, only the redirect target URL in one edge case.)
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] E2E tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

Fixes #4436