### PR TITLE
[IGNORE] speedup windows install postgres

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -123,12 +123,16 @@ jobs:
         with:
           name: plugins
           path: plugins-archive
-      - uses: ikalnytskyi/action-setup-postgres@v8
+      - uses: actions/cache@v4
+        id: pg-cache
         with:
-          username: user
-          password: password
-          database: perses
-          postgres-version: 17
+          path: postgres
+          key: postgres-windows-17.4-1
+      - name: "install postgres"
+        if: steps.pg-cache.outputs.cache-hit != 'true'
+        run: sh scripts/windows/postgres/download.sh
+      - name: "start postgres"
+        run: sh scripts/windows/postgres/run.sh
       - name: "install prometheus"
         run: sh scripts/download-prometheus.sh
       - name: "start prometheus"

--- a/scripts/windows/postgres/download.sh
+++ b/scripts/windows/postgres/download.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script is used to download the PostgreSQL binaries in the CI for windows tests.
+# It downloads the portable zip archive published by EDB, which doesn't require any installer or Windows service.
+
+set -euo pipefail
+
+# Full version required by the EDB download URL (major.minor-build).
+version=${POSTGRES_VERSION:-17.4-1}
+
+url="https://get.enterprisedb.com/postgresql/postgresql-${version}-windows-x64-binaries.zip"
+
+echo >&2 "Downloading PostgreSQL ${version} from ${url}"
+curl --silent --show-error --fail -L "${url}" -o postgresql.zip
+
+# The archive contains a top-level "pgsql" folder.
+unzip -q postgresql.zip
+rm -f postgresql.zip
+mv pgsql postgres
+
+# Not needed for the tests, keep the workspace small.
+rm -rf postgres/pgAdmin\ 4 postgres/symbols postgres/doc postgres/include

--- a/scripts/windows/postgres/run.sh
+++ b/scripts/windows/postgres/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script is used to run PostgreSQL in the CI for windows tests.
+# Same reasoning as run-prometheus.sh: running a process in the background directly in GitHub Actions on windows is unreliable,
+# so we use pg_ctl which is designed to start the server detached.
+
+set -euo pipefail
+
+user=${POSTGRES_USER:-user}
+password=${POSTGRES_PASSWORD:-password}
+database=${POSTGRES_DB:-perses}
+port=${POSTGRES_PORT:-5432}
+
+bin=postgres/bin
+data=postgres/data
+
+# Write the password in a file so initdb doesn't prompt for it.
+pwfile=$(mktemp)
+echo "${password}" > "${pwfile}"
+
+# Create the cluster: the superuser is created directly with the wanted username/password,
+# so no additional role creation is needed afterwards.
+"${bin}/initdb.exe" \
+  --pgdata="${data}" \
+  --username="${user}" \
+  --pwfile="${pwfile}" \
+  --auth=scram-sha-256 \
+  --encoding=UTF8 \
+  --no-locale
+rm -f "${pwfile}"
+
+# Start the server detached. pg_ctl -w waits until the server accepts connections.
+"${bin}/pg_ctl.exe" \
+  --pgdata="${data}" \
+  --log=postgres/postgres.log \
+  --options="-p ${port}" \
+  --wait \
+  start
+
+# Wait until the server is really ready to accept queries.
+until "${bin}/pg_isready.exe" --host=localhost --port="${port}" --quiet; do
+    echo >&2 'PostgreSQL not ready, retrying in 1s...'
+    sleep 1
+done
+
+# Create the database used by the tests.
+PGPASSWORD="${password}" "${bin}/createdb.exe" --host=localhost --port="${port}" --username="${user}" "${database}"
+
+echo >&2 'PostgreSQL up, exiting'


### PR DESCRIPTION
Using AI I have rewritten the way we are installing PostgreSQL in the GitHub action on windows. The idea is to download the binary directly instead of using `chocolat`. This is the part that takes so much time.

Result: installation and running PostgreSQL is moving from 2m47s to 37s