### PR TITLE
[IGNORE] cleanup old data for postgresql

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -123,7 +123,8 @@ jobs:
         with:
           name: plugins
           path: plugins-archive
-      - uses: actions/cache@v4
+      - name: "cache postgres installation"
+        uses: actions/cache@v4
         id: pg-cache
         with:
           path: postgres

--- a/scripts/windows/postgres/run.sh
+++ b/scripts/windows/postgres/run.sh
@@ -14,6 +14,9 @@ port=${POSTGRES_PORT:-5432}
 bin=postgres/bin
 data=postgres/data
 
+# start by removing any previous data directory, to ensure a clean state.
+rm -rf "${data}"
+
 # Write the password in a file so initdb doesn't prompt for it.
 pwfile=$(mktemp)
 echo "${password}" > "${pwfile}"


### PR DESCRIPTION
When we are installing postgresql on windows through the cache, it actually comes with data already. Something the setup to run postgresql does not like.

this PR aims to fix that by removing the previous data. See https://github.com/perses/perses/actions/runs/34582289711/job/103209062635?pr=4404 for more details about the issue:

>Run sh scripts/windows/postgres/run.sh
The files belonging to this database system will be owned by user "runneradmin".
This user must also own the server process.

>The database cluster will be initialized with locale "C".
The default text search configuration will be set to "english".

>Data page checksums are disabled.

>initdb: error: directory "postgres/data" exists but is not empty
initdb: hint: If you want to create a new database system, either remove or empty the directory "postgres/data" or run initdb with an argument other than "postgres/data".